### PR TITLE
feat(eval): 승격 어테스테이션 신뢰 컨텍스트를 결속한다

### DIFF
--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -29,10 +29,16 @@ func newCheckCmd() *cobra.Command {
 		gateFlag            string
 		dir                 string
 
-		evalRegressionFlag            bool
-		evalRegressionArtifactFlag    string
-		evalRegressionAttestationFlag string
-		evalRegressionMaxAgeFlag      time.Duration
+		evalRegressionFlag                          bool
+		evalRegressionArtifactFlag                  string
+		evalRegressionAttestationFlag               string
+		evalRegressionMaxAgeFlag                    time.Duration
+		evalRegressionExpectedKeyIDFlag             string
+		evalRegressionExpectedTrustLaneFlag         string
+		evalRegressionExpectedSourceEnvironmentFlag string
+		evalRegressionExpectedTargetEnvironmentFlag string
+		evalRegressionExpectedSourceRevisionFlag    string
+		evalRegressionExpectedWorkspaceScopeFlag    string
 	)
 
 	cmd := &cobra.Command{
@@ -51,6 +57,25 @@ func newCheckCmd() *cobra.Command {
 			out := cmd.OutOrStdout()
 			if !quietFlag {
 				tui.BannerWithInfo(out, "autopus-adk", "check")
+			}
+			policy := evalregression.EvalRegressionAttestationPolicyV2{
+				ExpectedKeyID:     evalRegressionExpectedKeyIDFlag,
+				TrustLane:         evalRegressionExpectedTrustLaneFlag,
+				SourceEnvironment: evalRegressionExpectedSourceEnvironmentFlag,
+				TargetEnvironment: evalRegressionExpectedTargetEnvironmentFlag,
+				SourceRevision:    evalRegressionExpectedSourceRevisionFlag,
+				WorkspaceScope:    evalRegressionExpectedWorkspaceScopeFlag,
+			}
+			if evalRegressionFlag {
+				if reason, ok := evalregression.ValidateEvalRegressionAttestationPolicyV2(policy); !ok {
+					if !quietFlag {
+						fmt.Fprintln(out, "eval-regression: "+reason)
+					}
+					return fmt.Errorf("check failed")
+				}
+				if gateFlag != "" {
+					return fmt.Errorf("--eval-regression cannot be combined with --gate")
+				}
 			}
 
 			if gateFlag != "" {
@@ -76,7 +101,7 @@ func newCheckCmd() *cobra.Command {
 			}
 
 			flags := globalFlagsFromContext(cmd.Context())
-			allOK := runChecks(flags, archFlag, cc21Flag, loreFlag, hygieneFlag, initialPromptFlag, monitorCommandsFlag, evalRegressionFlag, evalRegressionArtifactFlag, evalRegressionAttestationFlag, evalRegressionMaxAgeFlag, dir, out, quietFlag, warnOnlyFlag, stagedFlag, messageFlag)
+			allOK := runChecks(flags, archFlag, cc21Flag, loreFlag, hygieneFlag, initialPromptFlag, monitorCommandsFlag, evalRegressionFlag, evalRegressionArtifactFlag, evalRegressionAttestationFlag, evalRegressionMaxAgeFlag, policy, dir, out, quietFlag, warnOnlyFlag, stagedFlag, messageFlag)
 			if !allOK {
 				return fmt.Errorf("check failed")
 			}
@@ -98,20 +123,28 @@ func newCheckCmd() *cobra.Command {
 	cmd.Flags().StringVar(&dir, "dir", "", "Project root directory")
 	cmd.Flags().BoolVar(&evalRegressionFlag, "eval-regression", false, "Fail closed on a blocked/missing/stale/unsafe eval_regression_report.v1 artifact (SPEC-EVAL-REGRESSION-CI-001)")
 	cmd.Flags().StringVar(&evalRegressionArtifactFlag, "eval-regression-artifact", "", "Path to the eval_regression_report.v1 artifact")
-	cmd.Flags().StringVar(&evalRegressionAttestationFlag, "eval-regression-attestation", "", "Path to the eval_regression_attestation.v1 sidecar (defaults to a path derived from the artifact)")
+	cmd.Flags().StringVar(&evalRegressionAttestationFlag, "eval-regression-attestation", "", "Path to the eval_regression_attestation.v2 sidecar (defaults to a path derived from the artifact)")
 	cmd.Flags().DurationVar(&evalRegressionMaxAgeFlag, "eval-regression-max-age", 24*time.Hour, "Freshness window for the eval-regression artifact")
+	cmd.Flags().StringVar(&evalRegressionExpectedKeyIDFlag, "eval-regression-expected-key-id", "", "Required trusted key ID for the eval-regression attestation")
+	cmd.Flags().StringVar(&evalRegressionExpectedTrustLaneFlag, "eval-regression-expected-trust-lane", "", "Required trust lane for the eval-regression attestation")
+	cmd.Flags().StringVar(&evalRegressionExpectedSourceEnvironmentFlag, "eval-regression-expected-source-environment", "", "Required source environment for the eval-regression attestation")
+	cmd.Flags().StringVar(&evalRegressionExpectedTargetEnvironmentFlag, "eval-regression-expected-target-environment", "", "Required target environment for the eval-regression attestation")
+	cmd.Flags().StringVar(&evalRegressionExpectedSourceRevisionFlag, "eval-regression-expected-source-revision", "", "Required source revision for the eval-regression attestation")
+	cmd.Flags().StringVar(&evalRegressionExpectedWorkspaceScopeFlag, "eval-regression-expected-workspace-scope", "", "Required workspace scope for the eval-regression attestation")
 
 	return cmd
 }
 
 // runChecks executes the selected checks and returns true if all pass.
 // If no specific check flag is set, all checks run.
-// When warnOnly is true, violations are still printed but the function always returns true.
+// When warnOnly is true, violations are advisory except an invalid v2 trust
+// policy, which remains mandatory and fail-closed.
 // When staged is true, arch check only examines git-staged files.
 // When messageFile is non-empty, lore check validates that file instead of the last commit.
-func runChecks(flags globalFlags, archFlag, cc21Flag, loreFlag, hygieneFlag, initialPromptFlag, monitorCommandsFlag, evalRegressionFlag bool, evalRegressionArtifact, evalRegressionAttestation string, evalRegressionMaxAge time.Duration, dir string, out io.Writer, quiet, warnOnly, staged bool, messageFile string) bool {
+func runChecks(flags globalFlags, archFlag, cc21Flag, loreFlag, hygieneFlag, initialPromptFlag, monitorCommandsFlag, evalRegressionFlag bool, evalRegressionArtifact, evalRegressionAttestation string, evalRegressionMaxAge time.Duration, evalRegressionPolicy evalregression.EvalRegressionAttestationPolicyV2, dir string, out io.Writer, quiet, warnOnly, staged bool, messageFile string) bool {
 	runAll := !archFlag && !cc21Flag && !loreFlag && !hygieneFlag && !initialPromptFlag && !monitorCommandsFlag && !evalRegressionFlag
 	allOK := true
+	evalRegressionPolicyOK := true
 
 	if hygieneFlag || runAll {
 		if !checkHygiene(dir, out, quiet) {
@@ -162,16 +195,19 @@ func runChecks(flags globalFlags, archFlag, cc21Flag, loreFlag, hygieneFlag, ini
 		}
 	}
 	if evalRegressionFlag {
+		if _, ok := evalregression.ValidateEvalRegressionAttestationPolicyV2(evalRegressionPolicy); !ok {
+			evalRegressionPolicyOK = false
+		}
 		attestationPath := evalRegressionAttestation
 		if strings.TrimSpace(attestationPath) == "" {
 			attestationPath = deriveEvalRegressionAttestationPath(evalRegressionArtifact)
 		}
-		if !checkEvalRegression(dir, evalRegressionArtifact, attestationPath, evalRegressionMaxAge, time.Now(), evalregression.CommittedEvalRegressionPublicKeys(), out, quiet, warnOnly) {
+		if !checkEvalRegressionStrict(dir, evalRegressionArtifact, attestationPath, evalRegressionMaxAge, time.Now(), evalregression.CommittedEvalRegressionPublicKeys(), evalRegressionPolicy, out, quiet, warnOnly) {
 			allOK = false
 		}
 	}
 
-	if warnOnly {
+	if warnOnly && evalRegressionPolicyOK {
 		return true
 	}
 	return allOK

--- a/internal/cli/eval_regression.go
+++ b/internal/cli/eval_regression.go
@@ -124,9 +124,28 @@ func deriveEvalRegressionAttestationPath(artifactPath string) string {
 // (advisory) but still prints the verdict (REQ-ECI-WARN-001).
 func checkEvalRegression(dir, artifactPath, attestationPath string, maxAge time.Duration, now time.Time, trusted map[string]ed25519.PublicKey, out io.Writer, quiet, warnOnly bool) bool {
 	_ = dir // artifact path is absolute/explicit; dir is accepted for dispatch symmetry.
+	return writeEvalRegressionDecision(
+		evaluateEvalRegression(artifactPath, attestationPath, maxAge, now, trusted),
+		out,
+		quiet,
+		warnOnly,
+	)
+}
 
-	decision := evaluateEvalRegression(artifactPath, attestationPath, maxAge, now, trusted)
+// checkEvalRegressionStrict is the v2 production trust path. An invalid policy
+// remains mandatory even when the caller requested advisory mode.
+func checkEvalRegressionStrict(dir, artifactPath, attestationPath string, maxAge time.Duration, now time.Time, trusted map[string]ed25519.PublicKey, policy evalregression.EvalRegressionAttestationPolicyV2, out io.Writer, quiet, warnOnly bool) bool {
+	_ = dir
+	_, policyOK := evalregression.ValidateEvalRegressionAttestationPolicyV2(policy)
+	return writeEvalRegressionDecision(
+		evaluateEvalRegressionStrict(artifactPath, attestationPath, maxAge, now, trusted, policy),
+		out,
+		quiet,
+		warnOnly && policyOK,
+	)
+}
 
+func writeEvalRegressionDecision(decision evalregression.GateDecision, out io.Writer, quiet, warnOnly bool) bool {
 	if !quiet {
 		line := "eval-regression: " + decision.Reason
 		if decision.AttributedVersion != "" {
@@ -150,6 +169,35 @@ func checkEvalRegression(dir, artifactPath, attestationPath string, maxAge time.
 // before-trust chain. It is split out so checkEvalRegression only handles the
 // print/warn-only surface.
 func evaluateEvalRegression(artifactPath, attestationPath string, maxAge time.Duration, now time.Time, trusted map[string]ed25519.PublicKey) evalregression.GateDecision {
+	return evaluateEvalRegressionWithVerifier(
+		artifactPath,
+		attestationPath,
+		maxAge,
+		now,
+		func(reportBytes, attestationBytes []byte) (string, bool) {
+			return evalregression.VerifyEvalRegressionArtifact(reportBytes, attestationBytes, trusted)
+		},
+	)
+}
+
+func evaluateEvalRegressionStrict(artifactPath, attestationPath string, maxAge time.Duration, now time.Time, trusted map[string]ed25519.PublicKey, policy evalregression.EvalRegressionAttestationPolicyV2) evalregression.GateDecision {
+	if reason, ok := evalregression.ValidateEvalRegressionAttestationPolicyV2(policy); !ok {
+		return evalregression.GateDecision{Blocked: true, ExitCode: 1, Reason: reason}
+	}
+	return evaluateEvalRegressionWithVerifier(
+		artifactPath,
+		attestationPath,
+		maxAge,
+		now,
+		func(reportBytes, attestationBytes []byte) (string, bool) {
+			return evalregression.VerifyEvalRegressionArtifactV2Strict(reportBytes, attestationBytes, trusted, policy)
+		},
+	)
+}
+
+type evalRegressionVerifier func(reportBytes, attestationBytes []byte) (reason string, ok bool)
+
+func evaluateEvalRegressionWithVerifier(artifactPath, attestationPath string, maxAge time.Duration, now time.Time, verify evalRegressionVerifier) evalregression.GateDecision {
 	// 1. Read report bytes once. Missing precedes verify (fail closed).
 	reportBytes, missReason, missErr := readEvalRegressionReportBytes(artifactPath)
 	if missErr != nil {
@@ -163,7 +211,7 @@ func evaluateEvalRegression(artifactPath, attestationPath string, maxAge time.Du
 
 	// 3. Verify signature over the raw report bytes BEFORE decode. On failure the
 	// unverified report is never decoded and its blocked field is never read.
-	if reason, ok := evalregression.VerifyEvalRegressionArtifact(reportBytes, attData, trusted); !ok {
+	if reason, ok := verify(reportBytes, attData); !ok {
 		return evalregression.GateDecision{Blocked: true, ExitCode: 1, Reason: reason}
 	}
 

--- a/internal/cli/eval_regression_v2_test.go
+++ b/internal/cli/eval_regression_v2_test.go
@@ -1,0 +1,265 @@
+package cli
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/evalregression"
+)
+
+type cliV2Statement struct {
+	SchemaVersion     string `json:"schema_version"`
+	KeyID             string `json:"key_id"`
+	Algorithm         string `json:"algorithm"`
+	ReportSHA256      string `json:"report_sha256"`
+	ProducedAt        string `json:"produced_at"`
+	TrustLane         string `json:"trust_lane"`
+	SourceEnvironment string `json:"source_environment"`
+	TargetEnvironment string `json:"target_environment"`
+	SourceRevision    string `json:"source_revision"`
+	WorkspaceScope    string `json:"workspace_scope"`
+}
+
+func cliV2Policy() evalregression.EvalRegressionAttestationPolicyV2 {
+	return evalregression.EvalRegressionAttestationPolicyV2{
+		ExpectedKeyID:     "eval-cli-v2",
+		TrustLane:         "production-promotion",
+		SourceEnvironment: "staging",
+		TargetEnvironment: "production",
+		SourceRevision:    "0123456789abcdef0123456789abcdef01234567",
+		WorkspaceScope:    "autopus-primary",
+	}
+}
+
+func signArtifactV2(t *testing.T, artifactPath string, policy evalregression.EvalRegressionAttestationPolicyV2) (string, map[string]ed25519.PublicKey) {
+	t.Helper()
+	report, err := os.ReadFile(artifactPath)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate signer: %v", err)
+	}
+	sum := sha256.Sum256(report)
+	var reportContext struct {
+		ProducedAt string `json:"produced_at"`
+	}
+	if err := json.Unmarshal(report, &reportContext); err != nil {
+		t.Fatalf("decode report context: %v", err)
+	}
+	att := evalregression.EvalRegressionAttestationV2{
+		SchemaVersion:     evalregression.EvalRegressionAttestationSchemaV2,
+		KeyID:             policy.ExpectedKeyID,
+		Algorithm:         "ed25519",
+		ReportSHA256:      hex.EncodeToString(sum[:]),
+		ProducedAt:        reportContext.ProducedAt,
+		TrustLane:         policy.TrustLane,
+		SourceEnvironment: policy.SourceEnvironment,
+		TargetEnvironment: policy.TargetEnvironment,
+		SourceRevision:    policy.SourceRevision,
+		WorkspaceScope:    policy.WorkspaceScope,
+	}
+	statement, err := json.Marshal(cliV2Statement{
+		SchemaVersion:     att.SchemaVersion,
+		KeyID:             att.KeyID,
+		Algorithm:         att.Algorithm,
+		ReportSHA256:      att.ReportSHA256,
+		ProducedAt:        att.ProducedAt,
+		TrustLane:         att.TrustLane,
+		SourceEnvironment: att.SourceEnvironment,
+		TargetEnvironment: att.TargetEnvironment,
+		SourceRevision:    att.SourceRevision,
+		WorkspaceScope:    att.WorkspaceScope,
+	})
+	if err != nil {
+		t.Fatalf("marshal statement: %v", err)
+	}
+	message := append([]byte("autopus.eval-regression.attestation.v2\x00"), statement...)
+	att.SignatureB64 = base64.StdEncoding.EncodeToString(ed25519.Sign(priv, message))
+	data, err := json.Marshal(att)
+	if err != nil {
+		t.Fatalf("marshal attestation: %v", err)
+	}
+	attPath := deriveEvalRegressionAttestationPath(artifactPath)
+	if err := os.WriteFile(attPath, data, 0o600); err != nil {
+		t.Fatalf("write attestation: %v", err)
+	}
+	return attPath, map[string]ed25519.PublicKey{policy.ExpectedKeyID: pub}
+}
+
+func TestCheckEvalRegressionStrictV2PassesAndRejectsMismatch(t *testing.T) {
+	path := writeArtifact(t, `{
+		"schema_version":"eval_regression_report.v1",
+		"blocked":false,
+		"attributed_version":"candidate",
+		"produced_at":"2026-07-03T12:00:00Z",
+		"workspace_scope":"autopus-primary",
+		"raw_payload_present":false
+	}`)
+	policy := cliV2Policy()
+	attPath, trusted := signArtifactV2(t, path, policy)
+
+	var out bytes.Buffer
+	if pass := checkEvalRegressionStrict("", path, attPath, 24*time.Hour, fixedNow, trusted, policy, &out, false, false); !pass {
+		t.Fatalf("strict v2 control rejected: %q", out.String())
+	}
+
+	out.Reset()
+	mismatch := policy
+	mismatch.WorkspaceScope = "other-workspace"
+	if pass := checkEvalRegressionStrict("", path, attPath, 24*time.Hour, fixedNow, trusted, mismatch, &out, false, false); pass {
+		t.Fatalf("strict mismatch unexpectedly passed")
+	}
+	if !strings.Contains(out.String(), "attestation_policy_mismatch") {
+		t.Fatalf("expected stable mismatch reason, got %q", out.String())
+	}
+}
+
+func TestCheckEvalRegressionStrictInvalidPolicyCannotUseWarnOnly(t *testing.T) {
+	var out bytes.Buffer
+	pass := checkEvalRegressionStrict(
+		"",
+		"missing.json",
+		"missing.attestation.json",
+		24*time.Hour,
+		fixedNow,
+		nil,
+		evalregression.EvalRegressionAttestationPolicyV2{},
+		&out,
+		false,
+		true,
+	)
+	if pass {
+		t.Fatalf("invalid trust policy must fail even with warn-only")
+	}
+	if !strings.Contains(out.String(), "attestation_policy_invalid") {
+		t.Fatalf("expected stable invalid-policy reason, got %q", out.String())
+	}
+}
+
+func TestCheckCmdEvalRegressionRequiresEveryTrustFlag(t *testing.T) {
+	flags := map[string]string{
+		"--eval-regression-expected-key-id":             "eval-cli-v2",
+		"--eval-regression-expected-trust-lane":         "production-promotion",
+		"--eval-regression-expected-source-environment": "staging",
+		"--eval-regression-expected-target-environment": "production",
+		"--eval-regression-expected-source-revision":    "0123456789abcdef0123456789abcdef01234567",
+		"--eval-regression-expected-workspace-scope":    "autopus-primary",
+	}
+	for omitted := range flags {
+		t.Run(omitted, func(t *testing.T) {
+			cmd := newCheckCmd()
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			args := []string{
+				"--eval-regression",
+				"--eval-regression-artifact", "missing.json",
+				"--warn-only",
+			}
+			for flag, value := range flags {
+				if flag != omitted {
+					args = append(args, flag, value)
+				}
+			}
+			cmd.SetArgs(args)
+			if err := cmd.Execute(); err == nil {
+				t.Fatalf("missing %s must fail closed", omitted)
+			}
+			if !strings.Contains(out.String(), "attestation_policy_invalid") {
+				t.Fatalf("missing %s: expected stable reason, got %q", omitted, out.String())
+			}
+		})
+	}
+}
+
+func TestCheckCmdEvalRegressionRegistersV2TrustFlags(t *testing.T) {
+	cmd := newCheckCmd()
+	for _, name := range []string{
+		"eval-regression-expected-key-id",
+		"eval-regression-expected-trust-lane",
+		"eval-regression-expected-source-environment",
+		"eval-regression-expected-target-environment",
+		"eval-regression-expected-source-revision",
+		"eval-regression-expected-workspace-scope",
+	} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("missing --%s", name)
+		}
+	}
+}
+
+func TestCheckCmdEvalRegressionValidatesPolicyBeforeNamedGate(t *testing.T) {
+	cmd := newCheckCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--eval-regression", "--gate", "phase2", "--warn-only"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("named gate bypassed required eval-regression policy")
+	}
+	if !strings.Contains(out.String(), "attestation_policy_invalid") {
+		t.Fatalf("expected stable invalid-policy reason, got %q", out.String())
+	}
+}
+
+func TestCheckCmdEvalRegressionRejectsNamedGateBypass(t *testing.T) {
+	cmd := newCheckCmd()
+	cmd.SetArgs([]string{
+		"--eval-regression",
+		"--gate", "phase2",
+		"--eval-regression-expected-key-id", "eval-cli-v2",
+		"--eval-regression-expected-trust-lane", "production-promotion",
+		"--eval-regression-expected-source-environment", "staging",
+		"--eval-regression-expected-target-environment", "production",
+		"--eval-regression-expected-source-revision", "0123456789abcdef0123456789abcdef01234567",
+		"--eval-regression-expected-workspace-scope", "autopus-primary",
+	})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "cannot be combined") {
+		t.Fatalf("named gate bypass was not rejected: %v", err)
+	}
+}
+
+func TestCheckCmdEvalRegressionProductionPathRejectsV1Attestation(t *testing.T) {
+	path := writeArtifact(t, `{
+		"schema_version":"eval_regression_report.v1",
+		"blocked":false,
+		"attributed_version":"candidate",
+		"produced_at":"2026-07-03T12:00:00Z",
+		"workspace_scope":"autopus-primary",
+		"raw_payload_present":false
+	}`)
+	attPath, _ := signArtifact(t, path)
+	cmd := newCheckCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"--eval-regression",
+		"--eval-regression-artifact", path,
+		"--eval-regression-attestation", attPath,
+		"--eval-regression-expected-key-id", "evp-cli-1",
+		"--eval-regression-expected-trust-lane", "production-promotion",
+		"--eval-regression-expected-source-environment", "staging",
+		"--eval-regression-expected-target-environment", "production",
+		"--eval-regression-expected-source-revision", "0123456789abcdef0123456789abcdef01234567",
+		"--eval-regression-expected-workspace-scope", "autopus-primary",
+	})
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("production path accepted a v1 attestation")
+	}
+	if !strings.Contains(out.String(), "signature_invalid") {
+		t.Fatalf("expected strict v2 rejection, got %q", out.String())
+	}
+}

--- a/pkg/evalregression/attestation.go
+++ b/pkg/evalregression/attestation.go
@@ -9,6 +9,10 @@ import "crypto/ed25519"
 // (reason signature_invalid) so a mismatched sidecar can never reach trust.
 const EvalRegressionAttestationSchemaV1 = "eval_regression_attestation.v1"
 
+// EvalRegressionAttestationSchemaV2 identifies the context-bound attestation
+// envelope used by strict production consumers.
+const EvalRegressionAttestationSchemaV2 = "eval_regression_attestation.v2"
+
 // EvalRegressionAttestationV1 is the read-only consumer mirror of the producer's
 // signature sidecar. It re-declares ONLY the six public fields the verifier
 // reads; the producer single-sources signing. The json tags are the EXACT
@@ -24,6 +28,33 @@ type EvalRegressionAttestationV1 struct {
 	SignatureB64  string `json:"signature_b64"`
 	ReportSHA256  string `json:"report_sha256"`
 	ProducedAt    string `json:"produced_at"`
+}
+
+// EvalRegressionAttestationV2 binds the report digest to an explicit trust
+// lane, environment transition, source revision, and workspace scope.
+type EvalRegressionAttestationV2 struct {
+	SchemaVersion     string `json:"schema_version"`
+	KeyID             string `json:"key_id"`
+	Algorithm         string `json:"algorithm"`
+	SignatureB64      string `json:"signature_b64"`
+	ReportSHA256      string `json:"report_sha256"`
+	ProducedAt        string `json:"produced_at"`
+	TrustLane         string `json:"trust_lane"`
+	SourceEnvironment string `json:"source_environment"`
+	TargetEnvironment string `json:"target_environment"`
+	SourceRevision    string `json:"source_revision"`
+	WorkspaceScope    string `json:"workspace_scope"`
+}
+
+// EvalRegressionAttestationPolicyV2 defines the exact context a strict
+// consumer expects. Every field is mandatory and compared without coercion.
+type EvalRegressionAttestationPolicyV2 struct {
+	ExpectedKeyID     string
+	TrustLane         string
+	SourceEnvironment string
+	TargetEnvironment string
+	SourceRevision    string
+	WorkspaceScope    string
 }
 
 // @AX:NOTE [AUTO] Source of truth for trusted signers — PUBLIC keys only; empty allowlist is intentionally fail-closed (REQ-EVP-KEYUNK-001).

--- a/pkg/evalregression/verify_v2.go
+++ b/pkg/evalregression/verify_v2.go
@@ -1,0 +1,163 @@
+package evalregression
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"strings"
+)
+
+const (
+	evalRegressionAttestationV2Domain = "autopus.eval-regression.attestation.v2\x00"
+	reasonAttestationPolicyInvalid    = "attestation_policy_invalid"
+	reasonAttestationPolicyMismatch   = "attestation_policy_mismatch"
+)
+
+type evalRegressionAttestationStatementV2 struct {
+	SchemaVersion     string `json:"schema_version"`
+	KeyID             string `json:"key_id"`
+	Algorithm         string `json:"algorithm"`
+	ReportSHA256      string `json:"report_sha256"`
+	ProducedAt        string `json:"produced_at"`
+	TrustLane         string `json:"trust_lane"`
+	SourceEnvironment string `json:"source_environment"`
+	TargetEnvironment string `json:"target_environment"`
+	SourceRevision    string `json:"source_revision"`
+	WorkspaceScope    string `json:"workspace_scope"`
+}
+
+type evalRegressionReportContextV2 struct {
+	ProducedAt     string `json:"produced_at"`
+	WorkspaceScope string `json:"workspace_scope"`
+}
+
+// EvalRegressionStrictVerifyReasons exposes stable strict-policy failure
+// reasons without changing the v1 reason map contract.
+func EvalRegressionStrictVerifyReasons() map[string]string {
+	return map[string]string{
+		"policy_invalid":  reasonAttestationPolicyInvalid,
+		"policy_mismatch": reasonAttestationPolicyMismatch,
+	}
+}
+
+// ValidateEvalRegressionAttestationPolicyV2 requires every strict expectation.
+func ValidateEvalRegressionAttestationPolicyV2(policy EvalRegressionAttestationPolicyV2) (reason string, ok bool) {
+	required := [...]string{
+		policy.ExpectedKeyID,
+		policy.TrustLane,
+		policy.SourceEnvironment,
+		policy.TargetEnvironment,
+		policy.SourceRevision,
+		policy.WorkspaceScope,
+	}
+	for _, value := range required {
+		if strings.TrimSpace(value) == "" || strings.TrimSpace(value) != value {
+			return reasonAttestationPolicyInvalid, false
+		}
+	}
+	return "", true
+}
+
+// VerifyEvalRegressionArtifactV2Strict verifies a context-bound v2 envelope.
+// It preserves the v1 verifier as a separate compatibility API while making
+// policy validation and exact policy matching mandatory for v2 callers.
+func VerifyEvalRegressionArtifactV2Strict(reportBytes, attestationBytes []byte, trusted map[string]ed25519.PublicKey, policy EvalRegressionAttestationPolicyV2) (reason string, ok bool) {
+	if reason, ok := ValidateEvalRegressionAttestationPolicyV2(policy); !ok {
+		return reason, false
+	}
+	if len(bytes.TrimSpace(attestationBytes)) == 0 {
+		return reasonArtifactUnsigned, false
+	}
+
+	att, ok := decodeEvalRegressionAttestationV2(attestationBytes)
+	if !ok || att.SchemaVersion != EvalRegressionAttestationSchemaV2 || att.Algorithm != "ed25519" {
+		return reasonSignatureInvalid, false
+	}
+	if !matchesEvalRegressionAttestationPolicyV2(att, policy) {
+		return reasonAttestationPolicyMismatch, false
+	}
+
+	pub, present := trusted[att.KeyID]
+	if !present {
+		return reasonSignatureKeyUnknown, false
+	}
+	sum := sha256.Sum256(reportBytes)
+	if att.ReportSHA256 != hex.EncodeToString(sum[:]) || strings.TrimSpace(att.ProducedAt) == "" {
+		return reasonSignatureInvalid, false
+	}
+	sig, err := base64.StdEncoding.DecodeString(att.SignatureB64)
+	if err != nil || len(sig) != ed25519.SignatureSize || len(pub) != ed25519.PublicKeySize {
+		return reasonSignatureInvalid, false
+	}
+	message, err := evalRegressionAttestationV2Message(att)
+	if err != nil || !ed25519.Verify(pub, message, sig) {
+		return reasonSignatureInvalid, false
+	}
+	// Report context is intentionally read only after signature verification.
+	// This catches a signer that attached valid expected context to report bytes
+	// from a different workspace or production instant.
+	if !matchesEvalRegressionReportContextV2(reportBytes, att) {
+		return reasonAttestationPolicyMismatch, false
+	}
+	return "", true
+}
+
+func decodeEvalRegressionAttestationV2(data []byte) (EvalRegressionAttestationV2, bool) {
+	var att EvalRegressionAttestationV2
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&att); err != nil {
+		return att, false
+	}
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		return att, false
+	}
+	return att, true
+}
+
+func matchesEvalRegressionAttestationPolicyV2(att EvalRegressionAttestationV2, policy EvalRegressionAttestationPolicyV2) bool {
+	return att.KeyID == policy.ExpectedKeyID &&
+		att.TrustLane == policy.TrustLane &&
+		att.SourceEnvironment == policy.SourceEnvironment &&
+		att.TargetEnvironment == policy.TargetEnvironment &&
+		att.SourceRevision == policy.SourceRevision &&
+		att.WorkspaceScope == policy.WorkspaceScope
+}
+
+func matchesEvalRegressionReportContextV2(reportBytes []byte, att EvalRegressionAttestationV2) bool {
+	var context evalRegressionReportContextV2
+	dec := json.NewDecoder(bytes.NewReader(reportBytes))
+	if err := dec.Decode(&context); err != nil {
+		return false
+	}
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		return false
+	}
+	return context.WorkspaceScope == att.WorkspaceScope && context.ProducedAt == att.ProducedAt
+}
+
+func evalRegressionAttestationV2Message(att EvalRegressionAttestationV2) ([]byte, error) {
+	statement, err := json.Marshal(evalRegressionAttestationStatementV2{
+		SchemaVersion:     att.SchemaVersion,
+		KeyID:             att.KeyID,
+		Algorithm:         att.Algorithm,
+		ReportSHA256:      att.ReportSHA256,
+		ProducedAt:        att.ProducedAt,
+		TrustLane:         att.TrustLane,
+		SourceEnvironment: att.SourceEnvironment,
+		TargetEnvironment: att.TargetEnvironment,
+		SourceRevision:    att.SourceRevision,
+		WorkspaceScope:    att.WorkspaceScope,
+	})
+	if err != nil {
+		return nil, err
+	}
+	message := make([]byte, 0, len(evalRegressionAttestationV2Domain)+len(statement))
+	message = append(message, evalRegressionAttestationV2Domain...)
+	message = append(message, statement...)
+	return message, nil
+}

--- a/pkg/evalregression/verify_v2_invalid_test.go
+++ b/pkg/evalregression/verify_v2_invalid_test.go
@@ -1,0 +1,79 @@
+package evalregression
+
+import (
+	"crypto/ed25519"
+	"testing"
+)
+
+func TestEvalRegressionStrictVerifyReasonsStable(t *testing.T) {
+	reasons := EvalRegressionStrictVerifyReasons()
+	if reasons["policy_invalid"] != "attestation_policy_invalid" {
+		t.Fatalf("policy_invalid reason = %q", reasons["policy_invalid"])
+	}
+	if reasons["policy_mismatch"] != "attestation_policy_mismatch" {
+		t.Fatalf("policy_mismatch reason = %q", reasons["policy_mismatch"])
+	}
+	if len(reasons) != 2 {
+		t.Fatalf("strict reason count = %d, want 2", len(reasons))
+	}
+}
+
+func TestVerifyEvalRegressionArtifactV2StrictInvalidEnvelopeBoundaries(t *testing.T) {
+	policy := v2TestPolicy()
+	priv, pub := newV2Signer(t)
+	report := v2ReportJSON(policy.WorkspaceScope, v2TestProducedAt)
+	base := signV2Attestation(t, report, policy, priv)
+	trusted := map[string]ed25519.PublicKey{policy.ExpectedKeyID: pub}
+	cases := map[string]func(*EvalRegressionAttestationV2){
+		"wrong schema": func(att *EvalRegressionAttestationV2) {
+			att.SchemaVersion = "eval_regression_attestation.v99"
+		},
+		"wrong algorithm": func(att *EvalRegressionAttestationV2) {
+			att.Algorithm = "rsa"
+		},
+		"bad signature base64": func(att *EvalRegressionAttestationV2) {
+			att.SignatureB64 = "not-base64"
+		},
+		"empty produced at": func(att *EvalRegressionAttestationV2) {
+			att.ProducedAt = ""
+		},
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			att := base
+			mutate(&att)
+			reason, ok := VerifyEvalRegressionArtifactV2Strict(
+				report,
+				marshalV2Attestation(t, att),
+				trusted,
+				policy,
+			)
+			if ok || reason != reasonSignatureInvalid {
+				t.Fatalf("expected (%q, false), got (%q, %v)", reasonSignatureInvalid, reason, ok)
+			}
+		})
+	}
+}
+
+func TestVerifyEvalRegressionArtifactV2StrictInvalidPolicyPrecedesArtifact(t *testing.T) {
+	reason, ok := VerifyEvalRegressionArtifactV2Strict(nil, nil, nil, EvalRegressionAttestationPolicyV2{})
+	if ok || reason != reasonAttestationPolicyInvalid {
+		t.Fatalf("expected (%q, false), got (%q, %v)", reasonAttestationPolicyInvalid, reason, ok)
+	}
+}
+
+func TestVerifyEvalRegressionArtifactV2StrictUnreadableSignedReportContextFailsClosed(t *testing.T) {
+	policy := v2TestPolicy()
+	priv, pub := newV2Signer(t)
+	report := []byte(`{"produced_at":"2026-07-17T03:00:00Z"} trailing`)
+	att := signV2Attestation(t, report, policy, priv)
+	reason, ok := VerifyEvalRegressionArtifactV2Strict(
+		report,
+		marshalV2Attestation(t, att),
+		map[string]ed25519.PublicKey{policy.ExpectedKeyID: pub},
+		policy,
+	)
+	if ok || reason != reasonAttestationPolicyMismatch {
+		t.Fatalf("expected (%q, false), got (%q, %v)", reasonAttestationPolicyMismatch, reason, ok)
+	}
+}

--- a/pkg/evalregression/verify_v2_test.go
+++ b/pkg/evalregression/verify_v2_test.go
@@ -1,0 +1,288 @@
+package evalregression
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+)
+
+const v2SigningDomain = "autopus.eval-regression.attestation.v2\x00"
+const v2TestProducedAt = "2026-07-17T03:00:00Z"
+
+type v2TestStatement struct {
+	SchemaVersion     string `json:"schema_version"`
+	KeyID             string `json:"key_id"`
+	Algorithm         string `json:"algorithm"`
+	ReportSHA256      string `json:"report_sha256"`
+	ProducedAt        string `json:"produced_at"`
+	TrustLane         string `json:"trust_lane"`
+	SourceEnvironment string `json:"source_environment"`
+	TargetEnvironment string `json:"target_environment"`
+	SourceRevision    string `json:"source_revision"`
+	WorkspaceScope    string `json:"workspace_scope"`
+}
+
+func v2TestPolicy() EvalRegressionAttestationPolicyV2 {
+	return EvalRegressionAttestationPolicyV2{
+		ExpectedKeyID:     "eval-prod-2026-07",
+		TrustLane:         "production-promotion",
+		SourceEnvironment: "staging",
+		TargetEnvironment: "production",
+		SourceRevision:    "0123456789abcdef0123456789abcdef01234567",
+		WorkspaceScope:    "autopus-primary",
+	}
+}
+
+func signV2Attestation(t *testing.T, report []byte, policy EvalRegressionAttestationPolicyV2, priv ed25519.PrivateKey) EvalRegressionAttestationV2 {
+	t.Helper()
+	sum := sha256.Sum256(report)
+	att := EvalRegressionAttestationV2{
+		SchemaVersion:     EvalRegressionAttestationSchemaV2,
+		KeyID:             policy.ExpectedKeyID,
+		Algorithm:         "ed25519",
+		ReportSHA256:      hex.EncodeToString(sum[:]),
+		ProducedAt:        v2TestProducedAt,
+		TrustLane:         policy.TrustLane,
+		SourceEnvironment: policy.SourceEnvironment,
+		TargetEnvironment: policy.TargetEnvironment,
+		SourceRevision:    policy.SourceRevision,
+		WorkspaceScope:    policy.WorkspaceScope,
+	}
+	statement, err := json.Marshal(v2TestStatement{
+		SchemaVersion:     att.SchemaVersion,
+		KeyID:             att.KeyID,
+		Algorithm:         att.Algorithm,
+		ReportSHA256:      att.ReportSHA256,
+		ProducedAt:        att.ProducedAt,
+		TrustLane:         att.TrustLane,
+		SourceEnvironment: att.SourceEnvironment,
+		TargetEnvironment: att.TargetEnvironment,
+		SourceRevision:    att.SourceRevision,
+		WorkspaceScope:    att.WorkspaceScope,
+	})
+	if err != nil {
+		t.Fatalf("marshal v2 statement: %v", err)
+	}
+	message := append([]byte(v2SigningDomain), statement...)
+	att.SignatureB64 = base64.StdEncoding.EncodeToString(ed25519.Sign(priv, message))
+	return att
+}
+
+func marshalV2Attestation(t *testing.T, att EvalRegressionAttestationV2) []byte {
+	t.Helper()
+	data, err := json.Marshal(att)
+	if err != nil {
+		t.Fatalf("marshal v2 attestation: %v", err)
+	}
+	return data
+}
+
+func newV2Signer(t *testing.T) (ed25519.PrivateKey, ed25519.PublicKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate v2 signer: %v", err)
+	}
+	return priv, pub
+}
+
+func v2ReportJSON(workspaceScope, producedAt string) []byte {
+	return []byte(`{"schema_version":"eval_regression_report.v1","blocked":false,` +
+		`"attributed_version":"candidate","produced_at":"` + producedAt + `",` +
+		`"workspace_scope":"` + workspaceScope + `","raw_payload_present":false}`)
+}
+
+func TestVerifyEvalRegressionArtifactV2StrictValid(t *testing.T) {
+	policy := v2TestPolicy()
+	priv, pub := newV2Signer(t)
+	report := v2ReportJSON(policy.WorkspaceScope, v2TestProducedAt)
+	att := signV2Attestation(t, report, policy, priv)
+
+	if reason, ok := ValidateEvalRegressionAttestationPolicyV2(policy); !ok || reason != "" {
+		t.Fatalf("valid policy rejected: (%q, %v)", reason, ok)
+	}
+	if reason, ok := VerifyEvalRegressionArtifactV2Strict(
+		report,
+		marshalV2Attestation(t, att),
+		map[string]ed25519.PublicKey{policy.ExpectedKeyID: pub},
+		policy,
+	); !ok || reason != "" {
+		t.Fatalf("valid v2 attestation rejected: (%q, %v)", reason, ok)
+	}
+}
+
+func TestValidateEvalRegressionAttestationPolicyV2RequiresEveryField(t *testing.T) {
+	cases := map[string]func(*EvalRegressionAttestationPolicyV2){
+		"expected key id":    func(p *EvalRegressionAttestationPolicyV2) { p.ExpectedKeyID = " \t" },
+		"trust lane":         func(p *EvalRegressionAttestationPolicyV2) { p.TrustLane = "" },
+		"source environment": func(p *EvalRegressionAttestationPolicyV2) { p.SourceEnvironment = "" },
+		"target environment": func(p *EvalRegressionAttestationPolicyV2) { p.TargetEnvironment = "" },
+		"source revision":    func(p *EvalRegressionAttestationPolicyV2) { p.SourceRevision = "" },
+		"workspace scope":    func(p *EvalRegressionAttestationPolicyV2) { p.WorkspaceScope = "" },
+		"surrounding space":  func(p *EvalRegressionAttestationPolicyV2) { p.TrustLane = " staging-to-main " },
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			policy := v2TestPolicy()
+			mutate(&policy)
+			reason, ok := ValidateEvalRegressionAttestationPolicyV2(policy)
+			if ok || reason != reasonAttestationPolicyInvalid {
+				t.Fatalf("expected (%q, false), got (%q, %v)", reasonAttestationPolicyInvalid, reason, ok)
+			}
+		})
+	}
+}
+
+func TestVerifyEvalRegressionArtifactV2StrictPolicyMismatches(t *testing.T) {
+	basePolicy := v2TestPolicy()
+	priv, pub := newV2Signer(t)
+	report := v2ReportJSON(basePolicy.WorkspaceScope, v2TestProducedAt)
+	attData := marshalV2Attestation(t, signV2Attestation(t, report, basePolicy, priv))
+	cases := map[string]func(*EvalRegressionAttestationPolicyV2){
+		"expected key id":    func(p *EvalRegressionAttestationPolicyV2) { p.ExpectedKeyID = "other-key" },
+		"trust lane":         func(p *EvalRegressionAttestationPolicyV2) { p.TrustLane = "other-lane" },
+		"source environment": func(p *EvalRegressionAttestationPolicyV2) { p.SourceEnvironment = "dev" },
+		"target environment": func(p *EvalRegressionAttestationPolicyV2) { p.TargetEnvironment = "preview" },
+		"source revision":    func(p *EvalRegressionAttestationPolicyV2) { p.SourceRevision = "other-revision" },
+		"workspace scope":    func(p *EvalRegressionAttestationPolicyV2) { p.WorkspaceScope = "other-workspace" },
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			policy := basePolicy
+			mutate(&policy)
+			reason, ok := VerifyEvalRegressionArtifactV2Strict(
+				report,
+				attData,
+				map[string]ed25519.PublicKey{basePolicy.ExpectedKeyID: pub},
+				policy,
+			)
+			if ok || reason != reasonAttestationPolicyMismatch {
+				t.Fatalf("expected (%q, false), got (%q, %v)", reasonAttestationPolicyMismatch, reason, ok)
+			}
+		})
+	}
+}
+
+func TestVerifyEvalRegressionArtifactV2StrictTamperBoundaries(t *testing.T) {
+	policy := v2TestPolicy()
+	priv, pub := newV2Signer(t)
+	report := v2ReportJSON(policy.WorkspaceScope, v2TestProducedAt)
+	base := signV2Attestation(t, report, policy, priv)
+	trusted := map[string]ed25519.PublicKey{policy.ExpectedKeyID: pub}
+
+	t.Run("report bytes", func(t *testing.T) {
+		mutated := append(append([]byte(nil), report...), '\n')
+		reason, ok := VerifyEvalRegressionArtifactV2Strict(mutated, marshalV2Attestation(t, base), trusted, policy)
+		if ok || reason != reasonSignatureInvalid {
+			t.Fatalf("expected (%q, false), got (%q, %v)", reasonSignatureInvalid, reason, ok)
+		}
+	})
+
+	t.Run("uppercase report digest", func(t *testing.T) {
+		mutated := base
+		mutated.ReportSHA256 = "ABCDEF" + mutated.ReportSHA256[6:]
+		reason, ok := VerifyEvalRegressionArtifactV2Strict(report, marshalV2Attestation(t, mutated), trusted, policy)
+		if ok || reason != reasonSignatureInvalid {
+			t.Fatalf("expected lowercase digest enforcement, got (%q, %v)", reason, ok)
+		}
+	})
+
+	t.Run("signed metadata", func(t *testing.T) {
+		mutated := base
+		mutated.SourceRevision = "attacker-revision"
+		matchingPolicy := policy
+		matchingPolicy.SourceRevision = mutated.SourceRevision
+		reason, ok := VerifyEvalRegressionArtifactV2Strict(report, marshalV2Attestation(t, mutated), trusted, matchingPolicy)
+		if ok || reason != reasonSignatureInvalid {
+			t.Fatalf("metadata tamper must invalidate signature, got (%q, %v)", reason, ok)
+		}
+	})
+
+	t.Run("produced at", func(t *testing.T) {
+		mutated := base
+		mutated.ProducedAt = "2026-07-17T04:00:00Z"
+		reason, ok := VerifyEvalRegressionArtifactV2Strict(report, marshalV2Attestation(t, mutated), trusted, policy)
+		if ok || reason != reasonSignatureInvalid {
+			t.Fatalf("produced_at tamper must invalidate signature, got (%q, %v)", reason, ok)
+		}
+	})
+}
+
+func TestVerifyEvalRegressionArtifactV2StrictRejectsMalformedAndUnknownSigner(t *testing.T) {
+	policy := v2TestPolicy()
+	priv, _ := newV2Signer(t)
+	report := v2ReportJSON(policy.WorkspaceScope, v2TestProducedAt)
+	valid := marshalV2Attestation(t, signV2Attestation(t, report, policy, priv))
+
+	if reason, ok := VerifyEvalRegressionArtifactV2Strict(report, nil, nil, policy); ok || reason != reasonArtifactUnsigned {
+		t.Fatalf("unsigned: expected (%q, false), got (%q, %v)", reasonArtifactUnsigned, reason, ok)
+	}
+	if reason, ok := VerifyEvalRegressionArtifactV2Strict(report, valid, nil, policy); ok || reason != reasonSignatureKeyUnknown {
+		t.Fatalf("unknown key: expected (%q, false), got (%q, %v)", reasonSignatureKeyUnknown, reason, ok)
+	}
+	for _, malformed := range [][]byte{
+		[]byte(`{"schema_version":"eval_regression_attestation.v2","unexpected":true}`),
+		append(append([]byte(nil), valid...), []byte(` {}`)...),
+	} {
+		if reason, ok := VerifyEvalRegressionArtifactV2Strict(report, malformed, nil, policy); ok || reason != reasonSignatureInvalid {
+			t.Fatalf("malformed: expected (%q, false), got (%q, %v)", reasonSignatureInvalid, reason, ok)
+		}
+	}
+}
+
+func TestVerifyEvalRegressionArtifactV1RemainsCompatible(t *testing.T) {
+	priv, trusted := newSigner(t)
+	report := v2ReportJSON(v2TestPolicy().WorkspaceScope, v2TestProducedAt)
+	v1 := signBytes(t, report, verifyKeyID, priv)
+	if reason, ok := VerifyEvalRegressionArtifact(report, v1, trusted); !ok || reason != "" {
+		t.Fatalf("v1 verifier regression: (%q, %v)", reason, ok)
+	}
+	if reason, ok := VerifyEvalRegressionArtifactV2Strict(report, v1, trusted, v2TestPolicy()); ok || reason != reasonSignatureInvalid {
+		t.Fatalf("strict v2 accepted v1 envelope: (%q, %v)", reason, ok)
+	}
+}
+
+func TestVerifyEvalRegressionArtifactV2StrictBindsReportContextAfterSignature(t *testing.T) {
+	policy := v2TestPolicy()
+	priv, pub := newV2Signer(t)
+	trusted := map[string]ed25519.PublicKey{policy.ExpectedKeyID: pub}
+	cases := map[string][]byte{
+		"workspace scope": v2ReportJSON("other-workspace", v2TestProducedAt),
+		"produced at":     v2ReportJSON(policy.WorkspaceScope, "2026-07-17T04:00:00Z"),
+	}
+	for name, report := range cases {
+		t.Run(name, func(t *testing.T) {
+			att := signV2Attestation(t, report, policy, priv)
+			reason, ok := VerifyEvalRegressionArtifactV2Strict(
+				report,
+				marshalV2Attestation(t, att),
+				trusted,
+				policy,
+			)
+			if ok || reason != reasonAttestationPolicyMismatch {
+				t.Fatalf("expected (%q, false), got (%q, %v)", reasonAttestationPolicyMismatch, reason, ok)
+			}
+		})
+	}
+
+	t.Run("signature failure precedes report context", func(t *testing.T) {
+		validReport := v2ReportJSON(policy.WorkspaceScope, v2TestProducedAt)
+		att := signV2Attestation(t, validReport, policy, priv)
+		mismatchedReport := v2ReportJSON("other-workspace", v2TestProducedAt)
+		sum := sha256.Sum256(mismatchedReport)
+		att.ReportSHA256 = hex.EncodeToString(sum[:])
+		reason, ok := VerifyEvalRegressionArtifactV2Strict(
+			mismatchedReport,
+			marshalV2Attestation(t, att),
+			trusted,
+			policy,
+		)
+		if ok || reason != reasonSignatureInvalid {
+			t.Fatalf("signature failure must precede context, got (%q, %v)", reason, ok)
+		}
+	})
+}


### PR DESCRIPTION
## 요약

- eval regression attestation v2에 key ID, trust lane, source/target environment, PR revision, workspace, report digest를 함께 서명합니다.
- production CLI는 여섯 expected 값을 모두 요구하고 strict v2 검증만 사용합니다.
- report 내부 workspace와 produced_at도 서명 성공 후 교차 검증합니다.
- v1 공개 검증 API는 하위 호환 경계로 유지합니다.

## 보안 경계

- 공개키 allowlist는 의도적으로 비어 있어 실제 운영 키 등록 전까지 fail closed입니다.
- private key나 DB 자격 증명은 포함하지 않습니다.
- invalid policy는 warn-only 또는 named gate 조합으로 우회할 수 없습니다.

## 검증

- go test ./pkg/evalregression -count=1
- go test ./internal/cli -count=1
- go test -race ./pkg/evalregression -count=1
- go vet ./pkg/evalregression ./internal/cli
- git diff --check

Related: Autopus PR #53, SPEC-EVAL-REGRESSION-PROV-001