### PR TITLE
feat(eval): 승격 공개키를 신뢰 목록에 등록한다

### DIFF
--- a/pkg/evalregression/attestation.go
+++ b/pkg/evalregression/attestation.go
@@ -1,6 +1,9 @@
 package evalregression
 
-import "crypto/ed25519"
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+)
 
 // EvalRegressionAttestationSchemaV1 is the exact schema_version this consumer
 // accepts for the out-of-band signature sidecar. It mirrors the Primary
@@ -57,7 +60,21 @@ type EvalRegressionAttestationPolicyV2 struct {
 	WorkspaceScope    string
 }
 
-// @AX:NOTE [AUTO] Source of truth for trusted signers — PUBLIC keys only; empty allowlist is intentionally fail-closed (REQ-EVP-KEYUNK-001).
+const (
+	evalRegressionPromotionKeyID        = "autopus-eval-staging-to-main-2026-07"
+	evalRegressionPromotionPublicKeyB64 = "D6euTz5IarNy68TfJ4tdzOwVomIXoiDEzEtefKmprz8="
+)
+
+func mustEvalRegressionPublicKey(encoded string) ed25519.PublicKey {
+	encoding := base64.StdEncoding.Strict()
+	raw, err := encoding.DecodeString(encoded)
+	if err != nil || len(raw) != ed25519.PublicKeySize || encoding.EncodeToString(raw) != encoded {
+		panic("invalid committed eval regression public key")
+	}
+	return ed25519.PublicKey(raw)
+}
+
+// @AX:NOTE [AUTO] Source of truth for trusted signers — PUBLIC keys only; unknown keys remain fail-closed (REQ-EVP-KEYUNK-001).
 // evalRegressionPublicKeys is the committed public-key allowlist keyed by
 // key_id. It is the SOURCE OF TRUTH for trusted signers on the consumer side.
 //
@@ -69,12 +86,16 @@ type EvalRegressionAttestationPolicyV2 struct {
 //     overlap-window key rotation (REQ-EVP-ROTATE-001): both the outgoing and
 //     incoming public keys are allowlisted during the overlap, and the outgoing
 //     entry is removed after the cutover.
-//   - It is intentionally EMPTY today. The real production public key is added
-//     by ops once LIVE-A emits real signed artifacts (Named Residual). An empty
-//     allowlist is correctly fail-closed: any present artifact resolves no key
-//     and is rejected as signature_key_unknown, and an absent attestation is
-//     rejected as artifact_unsigned. There is no unsigned-accept path.
-var evalRegressionPublicKeys = map[string]ed25519.PublicKey{}
+//   - The staging-to-main promotion signer is scoped to its dedicated key_id.
+//     Its only runtime signing source is the Autopus main-promotion GitHub
+//     Environment. An optional encrypted recovery escrow may retain a
+//     controlled copy; repositories, Railway variables, and logs must not.
+//   - Any key_id absent from this map is rejected as signature_key_unknown, and
+//     an absent attestation is rejected as artifact_unsigned. There is no
+//     unsigned-accept path.
+var evalRegressionPublicKeys = map[string]ed25519.PublicKey{
+	evalRegressionPromotionKeyID: mustEvalRegressionPublicKey(evalRegressionPromotionPublicKeyB64),
+}
 
 // CommittedEvalRegressionPublicKeys returns a defensive copy of the committed
 // public-key allowlist for the CLI production path. The copy prevents a caller

--- a/pkg/evalregression/verify_e2e_test.go
+++ b/pkg/evalregression/verify_e2e_test.go
@@ -2,7 +2,7 @@ package evalregression
 
 import (
 	"crypto/ed25519"
-	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -110,28 +110,38 @@ func TestEvalRegressionLiveGateE2EReasons(t *testing.T) {
 	})
 }
 
-func TestCommittedAllowlistEmptyAndDefensiveForE2E(t *testing.T) {
+func TestCommittedAllowlistContainsPromotionKeyAndIsDefensiveForE2E(t *testing.T) {
+	const (
+		wantKeyID        = "autopus-eval-staging-to-main-2026-07"
+		wantPublicKeyB64 = "D6euTz5IarNy68TfJ4tdzOwVomIXoiDEzEtefKmprz8="
+	)
+
 	keys := CommittedEvalRegressionPublicKeys()
-	if len(keys) != 0 {
-		t.Fatalf("committed allowlist length = %d, want 0", len(keys))
+	if len(keys) != 1 {
+		t.Fatalf("committed allowlist length = %d, want 1", len(keys))
+	}
+	publicKey, present := keys[wantKeyID]
+	if !present {
+		t.Fatalf("committed allowlist missing promotion key_id %q", wantKeyID)
+	}
+	if len(publicKey) != ed25519.PublicKeySize {
+		t.Fatalf("committed public key length = %d, want %d", len(publicKey), ed25519.PublicKeySize)
+	}
+	if got := base64.StdEncoding.EncodeToString(publicKey); got != wantPublicKeyB64 {
+		t.Fatalf("committed public key = %q, want %q", got, wantPublicKeyB64)
 	}
 
-	pub, _, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatalf("generate public key: %v", err)
-	}
-	keys["egl-should-not-stick"] = pub
-
+	publicKey[0] ^= 0xff
+	delete(keys, wantKeyID)
+	keys["egl-should-not-stick"] = ed25519.PublicKey("attacker")
 	again := CommittedEvalRegressionPublicKeys()
-	if len(again) != 0 {
-		t.Fatalf("committed allowlist mutated through defensive copy: length = %d, want 0", len(again))
+	if len(again) != 1 {
+		t.Fatalf("committed allowlist mutated through defensive copy: length = %d, want 1", len(again))
 	}
-
-	priv, _ := newSigner(t)
-	report := e2eReportJSON(false, e2eFixedNow.Add(-1*time.Hour).Format(time.RFC3339), "candidate")
-	att := signBytes(t, report, e2eKeyID, priv)
-	reason, exitCode := evaluateE2E(t, report, att, again)
-	if reason != reasonSignatureKeyUnknown || exitCode != 1 {
-		t.Fatalf("empty committed allowlist: expected (%q, 1), got (%q, %d)", reasonSignatureKeyUnknown, reason, exitCode)
+	if _, present := again["egl-should-not-stick"]; present {
+		t.Fatalf("committed allowlist accepted injected key through defensive copy")
+	}
+	if got := base64.StdEncoding.EncodeToString(again[wantKeyID]); got != wantPublicKeyB64 {
+		t.Fatalf("committed public key mutated through defensive copy: got %q, want %q", got, wantPublicKeyB64)
 	}
 }


### PR DESCRIPTION
## 변경 내용

- `staging-to-main` 승격 signer의 Ed25519 공개키를 committed allowlist에 등록합니다.
- key ID를 `autopus-eval-staging-to-main-2026-07`로 고정합니다.
- strict canonical Base64와 정확한 32바이트 길이를 초기화 시 검증합니다.
- committed allowlist의 exact key와 deep defensive-copy 계약을 회귀 테스트로 고정합니다.

## 보안 경계

- 저장소에는 공개키와 공개 key ID만 포함합니다.
- runtime private key는 Autopus의 protected `main-promotion` GitHub Environment에서만 읽습니다.
- repository secret, Railway variable, 로그 또는 artifact에 private key를 복제하지 않습니다.
- unknown key, unsigned artifact, 변조된 artifact는 기존처럼 fail closed입니다.

## 공개 검증값

- public key raw length: `32 bytes`
- public key SHA-256: `8e589d78370408b3a4c6cab61bbf11d2a79d49e1f4cb340bd9eceeb623928292`

## 검증

- `go test ./pkg/evalregression -run 'TestCommittedAllowlistContainsPromotionKeyAndIsDefensiveForE2E|TestCommittedPublicKeysLoopBodyDefensiveCopy|TestEvalRegressionLiveGateE2EReasons' -count=1`
- `go test -race ./pkg/evalregression -count=1`
- `go vet ./pkg/evalregression`
- `go test ./internal/cli -run EvalRegression -count=1`
- `go test ./pkg/evalregression/... ./internal/cli/... -count=1`
- `auto check --lore`
- secret-pattern scan 및 공개키 fingerprint 독립 검증

## 후속 작업

병합 후 Autopus gate가 이 공개키를 포함한 ADK 병합 commit의 전체 SHA를 사용하도록 별도 pin PR에서 갱신합니다. staging DB URL과 workspace scope를 연결한 live producer/gate 검증은 그 다음 bootstrap 단계입니다.
