### PR TITLE
fix(review): Codex 응답 수집 경로 안정화

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **Codex SPEC 리뷰 응답 수집 안정화** (2026-07-17): pane이 기본인 환경에서도 `codex exec` 프로바이더는 실행 전에 subprocess 수집 경로를 선택해 최종 응답 파일을 직접 읽으며, 응답을 별도 pane 파일에 쓰지 않았다는 이유로 전체 제한 시간까지 대기하던 문제를 제거했다. 명시적 `--timeout`은 provider 실행 예산에도 동일하게 적용되고, timeout 상태는 원문 stdout·stderr·경로·비밀값 없이 source, budget, elapsed, collection mode, partial-output 여부만 구조화해 기록한다. Claude, Gemini, Codex 비-`exec`, 강제 subprocess 경로는 기존 동작을 유지한다.
+
 - **Self-update 교체 트랜잭션 하드닝** (2026-07-17): 새 바이너리를 대상 파일시스템의 전용 stage에 준비하고 파일·디렉터리를 동기화한 뒤에만 교체하도록 변경했다. Darwin/Linux는 원자 교환 후 inode를 다시 확인하며, 동시 변경이나 동기화 실패 시 원자적으로 되돌리고 되돌리기마저 실패하면 복구 stage를 보존한다. 교환을 지원하지 않는 커널·파일시스템에서는 기존 바이너리를 유지한 채 안전하게 중단한다. Windows는 실행 중인 바이너리를 `target.old`에 보존하고 no-replace·write-through 이동으로 설치한다. 성공한 설치의 복구본에는 완료 marker를 남겨 다음 실행에서만 정리하고, marker가 없거나 유효하지 않은 복구본은 자동 삭제하지 않는다. Windows 런타임 CI와 모든 OS에서 실행되는 상태 머신 회귀 테스트를 추가했다. 임시 디렉터리 생성 실패, symlink·hardlink alias, target 변경, 부분 복사, chmod·xattr·sync 실패도 교체 전에 차단한다.
 
 - **v0.50.72 macOS self-update 서명 보존** (2026-07-17): v0.50.72에 포함된 새 updater는 SHA-256 검증을 마친 macOS 릴리스 바이너리를 설치한 뒤 ad hoc 서명으로 다시 쓰던 동작을 제거했다. 이 updater가 수행하는 교체는 다운로드한 Mach-O 바이트와 Developer ID 서명, Team ID를 그대로 보존하며, Darwin 전용 회귀 테스트가 바이트 해시와 코드 서명 식별자의 일치를 검증한다. A3 릴리스 게이트는 immutable `v0.50.71`의 commit, annotated tag object, checksums, Darwin archive와 manifest를 고정 검증하고 A0 공개키 record의 연속성을 유지한다. Homebrew는 `v0.50.71` Formula 마이그레이션 브리지를 동결하고 canonical Cask만 `v0.50.72`로 갱신한다.

--- a/internal/cli/spec_review.go
+++ b/internal/cli/spec_review.go
@@ -136,6 +136,7 @@ func runSpecReviewWithOptions(ctx context.Context, specID, strategy string, time
 	if strategy == "" && flags.MultiMode {
 		strategy = string(orchestra.StrategyDebate)
 	}
+	requestedTimeout := timeout
 	timeout = resolveSpecReviewTimeout(cfg, timeout)
 	// SPEC-SPECREV-002 REQ-003: consume the global --loop flag so the revision
 	// budget honors the loop floor (inert seam otherwise).
@@ -148,6 +149,7 @@ func runSpecReviewWithOptions(ctx context.Context, specID, strategy string, time
 
 	providerNames := resolveSpecReviewProviderNames(cfg, flags.MultiMode)
 	providers := configureSpecReviewProviders(resolveCodexProviderCapabilities(ctx, specReviewConfigProviders(cfg, providerNames)))
+	providers = applySpecReviewExecutionTimeout(providers, requestedTimeout)
 	if len(providers) == 0 {
 		return fmt.Errorf("사용 가능한 프로바이더가 없습니다. 설치를 확인하세요: %v", providerNames)
 	}

--- a/internal/cli/spec_review_provider_policy.go
+++ b/internal/cli/spec_review_provider_policy.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/orchestra"
+)
+
+var specReviewSubprocessBackendFactory = orchestra.NewSubprocessBackendImpl
+
+// selectSpecReviewProviderBackend keeps pane execution as the review default,
+// except for Codex's headless `exec` contract. That command emits its final
+// answer through subprocess-only capture and must be selected before Execute.
+func selectSpecReviewProviderBackend(
+	primary orchestra.ExecutionBackend,
+	provider orchestra.ProviderConfig,
+) orchestra.ExecutionBackend {
+	if !shouldPreselectSpecReviewSubprocess(primary, provider) {
+		return primary
+	}
+	return specReviewSubprocessBackendFactory()
+}
+
+func specReviewProviderBackendName(primary orchestra.ExecutionBackend, provider orchestra.ProviderConfig) string {
+	if shouldPreselectSpecReviewSubprocess(primary, provider) {
+		return "subprocess"
+	}
+	if primary == nil {
+		return "unknown"
+	}
+	return primary.Name()
+}
+
+func shouldPreselectSpecReviewSubprocess(
+	primary orchestra.ExecutionBackend,
+	provider orchestra.ProviderConfig,
+) bool {
+	if primary == nil || primary.Name() != "pane" || !isSpecReviewCodexProvider(provider) {
+		return false
+	}
+	for _, arg := range provider.Args {
+		if strings.TrimSpace(arg) == "" {
+			continue
+		}
+		return arg == "exec"
+	}
+	return false
+}
+
+func isSpecReviewCodexProvider(provider orchestra.ProviderConfig) bool {
+	name := strings.TrimSpace(provider.Name)
+	binary := filepath.Base(strings.TrimSpace(provider.Binary))
+	return strings.EqualFold(name, "codex") || strings.EqualFold(binary, "codex")
+}
+
+// applySpecReviewExecutionTimeout copies the provider slice before applying an
+// explicit CLI timeout. Zero means the flag was omitted, so provider defaults
+// remain authoritative.
+func applySpecReviewExecutionTimeout(providers []orchestra.ProviderConfig, requestedSeconds int) []orchestra.ProviderConfig {
+	configured := append([]orchestra.ProviderConfig(nil), providers...)
+	if requestedSeconds <= 0 {
+		return configured
+	}
+	timeout := time.Duration(requestedSeconds) * time.Second
+	for i := range configured {
+		configured[i].ExecutionTimeout = timeout
+	}
+	return configured
+}

--- a/internal/cli/spec_review_provider_policy_test.go
+++ b/internal/cli/spec_review_provider_policy_test.go
@@ -1,0 +1,210 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/orchestra"
+)
+
+type issue59ReviewBackend struct {
+	mu        sync.Mutex
+	name      string
+	responses []orchestra.ProviderResponse
+	requests  []orchestra.ProviderRequest
+	err       error
+}
+
+func (b *issue59ReviewBackend) Execute(_ context.Context, req orchestra.ProviderRequest) (*orchestra.ProviderResponse, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.requests = append(b.requests, req)
+	index := len(b.requests) - 1
+	if index >= len(b.responses) {
+		index = len(b.responses) - 1
+	}
+	if index < 0 {
+		return nil, b.err
+	}
+	response := b.responses[index]
+	response.Provider = req.Provider
+	return &response, b.err
+}
+
+func (b *issue59ReviewBackend) Name() string { return b.name }
+
+func (b *issue59ReviewBackend) requestCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.requests)
+}
+
+func TestExecuteStructuredSpecReviewProvider_CodexExecCallsOnlySubprocess(t *testing.T) {
+	pane := &issue59ReviewBackend{name: "pane"}
+	subprocess := &issue59ReviewBackend{
+		name:      "subprocess",
+		responses: []orchestra.ProviderResponse{{Output: `{"verdict":"PASS","summary":"ok","findings":[]}`}},
+	}
+	restore := stubSpecReviewSubprocessBackend(t, subprocess)
+	defer restore()
+
+	outcome := executeStructuredSpecReviewProvider(
+		context.Background(),
+		orchestra.OrchestraConfig{TimeoutSeconds: 90, Prompt: "review"},
+		pane,
+		&orchestra.OutputParser{},
+		"schema.json",
+		"{}",
+		orchestra.ProviderConfig{Name: "codex", Binary: "codex", Args: []string{"", "exec"}},
+		"parallel",
+	)
+
+	require.Nil(t, outcome.failed)
+	assert.Equal(t, "subprocess", outcome.resp.ExecutedBackend)
+	assert.Zero(t, pane.requestCount())
+	assert.Equal(t, 1, subprocess.requestCount())
+}
+
+func TestExecuteStructuredSpecReviewProvider_PreselectsSubprocessForCodexReprompt(t *testing.T) {
+	pane := &issue59ReviewBackend{name: "pane"}
+	subprocess := &issue59ReviewBackend{
+		name: "subprocess",
+		responses: []orchestra.ProviderResponse{
+			{Output: "not json"},
+			{Output: `{"verdict":"PASS","summary":"ok","findings":[]}`},
+		},
+	}
+	restore := stubSpecReviewSubprocessBackend(t, subprocess)
+	defer restore()
+
+	outcome := executeStructuredSpecReviewProvider(
+		context.Background(),
+		orchestra.OrchestraConfig{TimeoutSeconds: 90, Prompt: "review"},
+		pane,
+		&orchestra.OutputParser{},
+		"schema.json",
+		`{"type":"object"}`,
+		orchestra.ProviderConfig{
+			Name:       "codex",
+			Binary:     "codex",
+			Args:       []string{"", "exec", "--json"},
+			SchemaFlag: "--output-schema",
+		},
+		"parallel",
+	)
+
+	require.Nil(t, outcome.failed)
+	assert.Equal(t, "subprocess", outcome.resp.ExecutedBackend)
+	assert.Zero(t, pane.requestCount())
+	require.Equal(t, 2, subprocess.requestCount(), "reprompt must use the selected subprocess backend")
+	subprocess.mu.Lock()
+	defer subprocess.mu.Unlock()
+	assert.NotContains(t, subprocess.requests[0].Prompt, "Required JSON schema:")
+	assert.NotContains(t, subprocess.requests[1].Prompt, "Required JSON schema:")
+}
+
+func TestSelectSpecReviewProviderBackend_PreservesNonEligibleBackends(t *testing.T) {
+	pane := &issue59ReviewBackend{name: "pane"}
+	subprocess := &issue59ReviewBackend{name: "subprocess"}
+	created := 0
+	restore := stubSpecReviewSubprocessFactory(t, func() orchestra.ExecutionBackend {
+		created++
+		return subprocess
+	})
+	defer restore()
+
+	tests := []struct {
+		name     string
+		primary  orchestra.ExecutionBackend
+		provider orchestra.ProviderConfig
+	}{
+		{name: "claude", primary: pane, provider: orchestra.ProviderConfig{Name: "claude", Binary: "claude", Args: []string{"--print"}}},
+		{name: "gemini", primary: pane, provider: orchestra.ProviderConfig{Name: "gemini", Binary: "gemini", Args: []string{"exec"}}},
+		{name: "codex non-exec", primary: pane, provider: orchestra.ProviderConfig{Name: "codex", Binary: "codex", Args: []string{"--search", "exec"}}},
+		{name: "codex case mismatch", primary: pane, provider: orchestra.ProviderConfig{Name: "codex", Binary: "codex", Args: []string{"Exec"}}},
+		{name: "forced subprocess", primary: subprocess, provider: orchestra.ProviderConfig{Name: "codex", Binary: "codex", Args: []string{"exec"}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			selected := selectSpecReviewProviderBackend(tt.primary, tt.provider)
+			assert.Same(t, tt.primary, selected)
+		})
+	}
+	assert.Zero(t, created)
+}
+
+func TestExecuteStructuredSpecReviewProvider_UsesSelectedBackendForFailureDiagnostics(t *testing.T) {
+	pane := &issue59ReviewBackend{name: "pane"}
+	subprocess := &issue59ReviewBackend{name: "subprocess", err: errors.New("boom")}
+	restore := stubSpecReviewSubprocessBackend(t, subprocess)
+	defer restore()
+
+	outcome := executeStructuredSpecReviewProvider(
+		context.Background(),
+		orchestra.OrchestraConfig{TimeoutSeconds: 90, Prompt: "review"},
+		pane,
+		&orchestra.OutputParser{},
+		"schema.json",
+		"{}",
+		orchestra.ProviderConfig{Name: "codex", Binary: "codex", Args: []string{"exec"}},
+		"parallel",
+	)
+
+	require.NotNil(t, outcome.failed)
+	assert.Equal(t, "subprocess_stdout", outcome.failed.CollectionMode)
+	assert.Equal(t, "subprocess", outcome.resp.ExecutedBackend)
+	assert.Zero(t, pane.requestCount())
+	assert.Equal(t, 1, subprocess.requestCount())
+}
+
+func stubSpecReviewSubprocessBackend(t *testing.T, backend orchestra.ExecutionBackend) func() {
+	t.Helper()
+	return stubSpecReviewSubprocessFactory(t, func() orchestra.ExecutionBackend { return backend })
+}
+
+func stubSpecReviewSubprocessFactory(t *testing.T, factory func() orchestra.ExecutionBackend) func() {
+	t.Helper()
+	original := specReviewSubprocessBackendFactory
+	specReviewSubprocessBackendFactory = factory
+	return func() { specReviewSubprocessBackendFactory = original }
+}
+
+func TestApplySpecReviewExecutionTimeout_PreservesDefaultsAndInput(t *testing.T) {
+	input := []orchestra.ProviderConfig{
+		{Name: "codex", ExecutionTimeout: 420 * time.Second},
+		{Name: "claude", ExecutionTimeout: 480 * time.Second},
+		{Name: "gemini", ExecutionTimeout: 480 * time.Second},
+	}
+	wantInput := append([]orchestra.ProviderConfig(nil), input...)
+
+	got := applySpecReviewExecutionTimeout(input, 0)
+
+	assert.Equal(t, wantInput, got)
+	assert.Equal(t, wantInput, input)
+	assert.NotSame(t, &input[0], &got[0])
+}
+
+func TestApplySpecReviewExecutionTimeout_OverridesAllBudgetsWithoutMutation(t *testing.T) {
+	input := []orchestra.ProviderConfig{
+		{Name: "codex", ExecutionTimeout: 420 * time.Second},
+		{Name: "claude", ExecutionTimeout: 480 * time.Second},
+		{Name: "gemini", ExecutionTimeout: 480 * time.Second},
+	}
+	wantInput := append([]orchestra.ProviderConfig(nil), input...)
+
+	got := applySpecReviewExecutionTimeout(input, 90)
+
+	for _, provider := range got {
+		assert.Equal(t, 90*time.Second, provider.ExecutionTimeout)
+		assert.Equal(t, 180*time.Second, specReviewAttemptTimeoutBudget(provider, 240))
+	}
+	assert.Equal(t, 240, specReviewWatchdogSeconds(got, 240))
+	assert.Equal(t, wantInput, input)
+}

--- a/internal/cli/spec_review_structured_runtime.go
+++ b/internal/cli/spec_review_structured_runtime.go
@@ -54,8 +54,9 @@ func runStructuredSpecReviewProvidersSequential(
 	start := time.Now()
 	for i, provider := range cfg.Providers {
 		if err := ctx.Err(); err != nil {
-			results[i] = pendingStructuredReviewTimeoutOutcome(provider, backend.Name(), "queued", cfg.TimeoutSeconds, time.Since(start), err)
-			logStructuredReviewOutcome(provider.Name, backend.Name(), results[i], time.Since(start))
+			backendName := specReviewProviderBackendName(backend, provider)
+			results[i] = pendingStructuredReviewTimeoutOutcome(provider, backendName, "queued", cfg.TimeoutSeconds, time.Since(start), err)
+			logStructuredReviewOutcome(provider.Name, backendName, results[i], time.Since(start))
 			continue
 		}
 		results[i] = executeStructuredSpecReviewProvider(ctx, cfg, backend, parser, schemaPath, embeddedSchema, provider, mode)
@@ -104,8 +105,9 @@ func runStructuredSpecReviewProvidersParallel(
 				if done[i] {
 					continue
 				}
-				results[i] = pendingStructuredReviewTimeoutOutcome(provider, backend.Name(), "provider_execution", cfg.TimeoutSeconds, time.Since(start), ctx.Err())
-				logStructuredReviewOutcome(provider.Name, backend.Name(), results[i], time.Since(start))
+				backendName := specReviewProviderBackendName(backend, provider)
+				results[i] = pendingStructuredReviewTimeoutOutcome(provider, backendName, "provider_execution", cfg.TimeoutSeconds, time.Since(start), ctx.Err())
+				logStructuredReviewOutcome(provider.Name, backendName, results[i], time.Since(start))
 			}
 			// Drain the still-running provider goroutines before returning so they
 			// cannot write shared process globals (os.Stderr via structured review
@@ -155,12 +157,13 @@ func executeStructuredSpecReviewProvider(
 	provider orchestra.ProviderConfig,
 	mode string,
 ) specReviewStructuredOutcome {
+	selectedBackend := selectSpecReviewProviderBackend(backend, provider)
 	timeout := specReviewTimeout(provider, cfg.TimeoutSeconds)
 	start := time.Now()
 	fmt.Fprintf(os.Stderr, "SPEC 리뷰 provider 시작: %s (backend=%s, timeout=%s, mode=%s)\n",
-		provider.Name, backend.Name(), timeout, mode)
+		provider.Name, selectedBackend.Name(), timeout, mode)
 
-	prompt := buildStructuredSpecReviewPrompt(cfg.Prompt, embeddedSchema, shouldInlineStructuredReviewSchema(backend, provider))
+	prompt := buildStructuredSpecReviewPrompt(cfg.Prompt, embeddedSchema, shouldInlineStructuredReviewSchema(selectedBackend, provider))
 	req := orchestra.ProviderRequest{
 		Provider:   provider.Name,
 		Prompt:     prompt,
@@ -170,27 +173,27 @@ func executeStructuredSpecReviewProvider(
 		Config:     provider,
 	}
 
-	resp, execErr := backend.Execute(ctx, req)
+	resp, execErr := selectedBackend.Execute(ctx, req)
 	elapsed := time.Since(start)
 	if execErr != nil {
 		if ctx.Err() != nil {
-			outcome := structuredReviewTimeoutOutcome(provider.Name, backend.Name(), "provider_execution", timeout, elapsed, ctx.Err(), resp)
-			logStructuredReviewOutcome(provider.Name, backend.Name(), outcome, elapsed)
+			outcome := structuredReviewTimeoutOutcome(provider.Name, selectedBackend.Name(), "provider_execution", timeout, elapsed, ctx.Err(), resp)
+			logStructuredReviewOutcome(provider.Name, selectedBackend.Name(), outcome, elapsed)
 			return outcome
 		}
-		outcome := malformedStructuredOutcome(provider.Name, fmt.Errorf("execution failed: %w", execErr), resp, backend.Name())
+		outcome := malformedStructuredOutcome(provider.Name, fmt.Errorf("execution failed: %w", execErr), resp, selectedBackend.Name())
 		decorateStructuredFailure(&outcome, timeout, elapsed)
-		logStructuredReviewOutcome(provider.Name, backend.Name(), outcome, elapsed)
+		logStructuredReviewOutcome(provider.Name, selectedBackend.Name(), outcome, elapsed)
 		return outcome
 	}
 	if resp == nil {
-		outcome := malformedStructuredOutcome(provider.Name, fmt.Errorf("provider returned nil response"), nil, backend.Name())
+		outcome := malformedStructuredOutcome(provider.Name, fmt.Errorf("provider returned nil response"), nil, selectedBackend.Name())
 		decorateStructuredFailure(&outcome, timeout, elapsed)
-		logStructuredReviewOutcome(provider.Name, backend.Name(), outcome, elapsed)
+		logStructuredReviewOutcome(provider.Name, selectedBackend.Name(), outcome, elapsed)
 		return outcome
 	}
 	if strings.TrimSpace(resp.ExecutedBackend) == "" {
-		resp.ExecutedBackend = backend.Name()
+		resp.ExecutedBackend = selectedBackend.Name()
 	}
 	if resp.TimedOut {
 		outcome := structuredReviewTimeoutOutcome(provider.Name, resp.ExecutedBackend, "provider_execution", timeout, elapsed, fmt.Errorf("provider timed out after %s", req.Timeout), resp)
@@ -198,13 +201,13 @@ func executeStructuredSpecReviewProvider(
 		return outcome
 	}
 	if resp.EmptyOutput {
-		outcome := malformedStructuredOutcome(provider.Name, fmt.Errorf("provider returned empty output"), resp, backend.Name())
+		outcome := malformedStructuredOutcome(provider.Name, fmt.Errorf("provider returned empty output"), resp, selectedBackend.Name())
 		decorateStructuredFailure(&outcome, timeout, elapsed)
-		logStructuredReviewOutcome(provider.Name, backend.Name(), outcome, elapsed)
+		logStructuredReviewOutcome(provider.Name, selectedBackend.Name(), outcome, elapsed)
 		return outcome
 	}
 	if _, parseErr := parser.ParseReviewer(resp.Output); parseErr != nil {
-		if retryResp, retryErr := repromptStructuredReviewerJSON(ctx, backend, parser, req, resp, parseErr); retryErr == nil {
+		if retryResp, retryErr := repromptStructuredReviewerJSON(ctx, selectedBackend, parser, req, resp, parseErr); retryErr == nil {
 			outcome := specReviewStructuredOutcome{resp: *retryResp}
 			logStructuredReviewOutcome(provider.Name, retryResp.ExecutedBackend, outcome, time.Since(start))
 			return outcome
@@ -213,9 +216,9 @@ func executeStructuredSpecReviewProvider(
 			parseErr = fmt.Errorf("invalid reviewer JSON after reprompt: initial: %w; reprompt: %v", parseErr, retryErr)
 			elapsed = time.Since(start)
 		}
-		outcome := malformedStructuredOutcome(provider.Name, fmt.Errorf("invalid reviewer JSON: %w", parseErr), resp, backend.Name())
+		outcome := malformedStructuredOutcome(provider.Name, fmt.Errorf("invalid reviewer JSON: %w", parseErr), resp, selectedBackend.Name())
 		decorateStructuredFailure(&outcome, timeout, elapsed)
-		logStructuredReviewOutcome(provider.Name, backend.Name(), outcome, elapsed)
+		logStructuredReviewOutcome(provider.Name, selectedBackend.Name(), outcome, elapsed)
 		return outcome
 	}
 

--- a/internal/cli/spec_review_timeout_test.go
+++ b/internal/cli/spec_review_timeout_test.go
@@ -97,7 +97,7 @@ func TestRunSpecReview_CLITimeout480OverridesCodexRequestBudget(t *testing.T) {
 
 func TestRunSpecReview_CLITimeoutOverridesEveryProviderBudget(t *testing.T) {
 	dir, specID, _ := writeGPTReviewContextProject(t)
-	for _, name := range []string{"codex", "claude", "gemini"} {
+	for _, name := range []string{"codex", "claude", "agy"} {
 		setFakeProviderOnPath(t, dir, name)
 	}
 

--- a/internal/cli/spec_review_timeout_test.go
+++ b/internal/cli/spec_review_timeout_test.go
@@ -55,16 +55,78 @@ func TestRunSpecReview_CLITimeoutOverridesConfig(t *testing.T) {
 	defer func() { _ = os.Chdir(origWD) }()
 	require.NoError(t, os.Chdir(dir))
 
-	var capturedTimeout int
+	var capturedConfig orchestra.OrchestraConfig
 	origRunner := specReviewRunOrchestra
 	specReviewRunOrchestra = func(_ context.Context, cfg orchestra.OrchestraConfig) (*orchestra.OrchestraResult, error) {
-		capturedTimeout = cfg.TimeoutSeconds
+		capturedConfig = cfg
 		return &orchestra.OrchestraResult{Responses: []orchestra.ProviderResponse{{Provider: "claude", Output: "VERDICT: PASS"}}}, nil
 	}
 	defer func() { specReviewRunOrchestra = origRunner }()
 
 	require.NoError(t, runSpecReview(context.Background(), "SPEC-REVIEW-TIMEOUT-FLAG-001", "consensus", 90))
-	assert.Equal(t, 90, capturedTimeout)
+	assert.Equal(t, 90, capturedConfig.TimeoutSeconds)
+	require.Len(t, capturedConfig.Providers, 1)
+	assert.Equal(t, 90*time.Second, capturedConfig.Providers[0].ExecutionTimeout)
+}
+
+func TestRunSpecReview_CLITimeout480OverridesCodexRequestBudget(t *testing.T) {
+	dir, specID, _ := writeGPTReviewContextProject(t)
+	setFakeProviderOnPath(t, dir, "codex")
+
+	cfg := config.DefaultFullConfig("test-project")
+	cfg.Spec.ReviewGate.Providers = []string{"codex"}
+	require.NoError(t, config.Save(dir, cfg))
+
+	origWD, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(origWD) }()
+	require.NoError(t, os.Chdir(dir))
+
+	var capturedProvider orchestra.ProviderConfig
+	origRunner := specReviewRunOrchestra
+	specReviewRunOrchestra = func(_ context.Context, cfg orchestra.OrchestraConfig) (*orchestra.OrchestraResult, error) {
+		require.Len(t, cfg.Providers, 1)
+		capturedProvider = cfg.Providers[0]
+		return &orchestra.OrchestraResult{Responses: []orchestra.ProviderResponse{{Provider: "codex", Output: "VERDICT: PASS"}}}, nil
+	}
+	defer func() { specReviewRunOrchestra = origRunner }()
+
+	require.NoError(t, runSpecReview(context.Background(), specID, "consensus", 480))
+	assert.Equal(t, 480*time.Second, capturedProvider.ExecutionTimeout)
+}
+
+func TestRunSpecReview_CLITimeoutOverridesEveryProviderBudget(t *testing.T) {
+	dir, specID, _ := writeGPTReviewContextProject(t)
+	for _, name := range []string{"codex", "claude", "gemini"} {
+		setFakeProviderOnPath(t, dir, name)
+	}
+
+	cfg := config.DefaultFullConfig("test-project")
+	cfg.Spec.ReviewGate.Providers = []string{"codex", "claude", "gemini"}
+	require.NoError(t, config.Save(dir, cfg))
+
+	origWD, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(origWD) }()
+	require.NoError(t, os.Chdir(dir))
+
+	var captured []orchestra.ProviderConfig
+	origRunner := specReviewRunOrchestra
+	specReviewRunOrchestra = func(_ context.Context, cfg orchestra.OrchestraConfig) (*orchestra.OrchestraResult, error) {
+		captured = append([]orchestra.ProviderConfig(nil), cfg.Providers...)
+		return &orchestra.OrchestraResult{Responses: []orchestra.ProviderResponse{
+			{Provider: "codex", Output: "VERDICT: PASS"},
+			{Provider: "claude", Output: "VERDICT: PASS"},
+			{Provider: "gemini", Output: "VERDICT: PASS"},
+		}}, nil
+	}
+	defer func() { specReviewRunOrchestra = origRunner }()
+
+	require.NoError(t, runSpecReview(context.Background(), specID, "consensus", 90))
+	require.Len(t, captured, 3)
+	for _, provider := range captured {
+		assert.Equalf(t, 90*time.Second, provider.ExecutionTimeout, "provider %s", provider.Name)
+	}
 }
 
 func TestRunSpecReview_AppliesOrchestraMigrationToClaudeProvider(t *testing.T) {

--- a/pkg/spec/provider_health.go
+++ b/pkg/spec/provider_health.go
@@ -89,6 +89,15 @@ func classifyFailedProvider(name string, f orchestra.FailedProvider) ProviderSta
 		status = providerStatusTimeout
 	}
 	note := f.FailureClass
+	if status == providerStatusTimeout {
+		note = timeoutProviderHealthNote(
+			f.TimeoutSource,
+			f.ConfiguredDuration,
+			f.ElapsedDuration,
+			f.CollectionMode,
+			hasPartialProviderOutput(f.OutputPreview),
+		)
+	}
 	if note == "" {
 		note = emptyNotePlaceholder
 	}
@@ -111,7 +120,14 @@ const noteMaxLen = 200
 func classifyResponse(name string, r orchestra.ProviderResponse) ProviderStatus {
 	switch {
 	case r.TimedOut:
-		return ProviderStatus{Provider: name, Status: providerStatusTimeout, Note: emptyNotePlaceholder}
+		note := timeoutProviderHealthNote(
+			"",
+			0,
+			r.Duration,
+			collectionModeFromBackend(r.ExecutedBackend),
+			hasPartialProviderOutput(r.Output),
+		)
+		return ProviderStatus{Provider: name, Status: providerStatusTimeout, Note: note}
 	case r.ExitCode != 0:
 		note := sanitizeNote(r.Error)
 		if note == "" {

--- a/pkg/spec/provider_health_issue59_test.go
+++ b/pkg/spec/provider_health_issue59_test.go
@@ -1,0 +1,79 @@
+package spec_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/orchestra"
+	"github.com/insajin/autopus-adk/pkg/spec"
+)
+
+func TestBuildProviderStatuses_TimeoutNoteUsesStructuredSafeMetadata(t *testing.T) {
+	t.Parallel()
+
+	responses := []orchestra.ProviderResponse{{
+		Provider: "codex",
+		Output:   "raw output /Users/alice/private token=secret-value",
+		Error:    "raw stderr API_KEY=secret-value",
+		TimedOut: true,
+	}}
+	failed := []orchestra.FailedProvider{{
+		Name:               "codex",
+		FailureClass:       "timeout",
+		TimeoutSource:      "spec_review_timeout",
+		ConfiguredDuration: 90 * time.Second,
+		ElapsedDuration:    89500 * time.Millisecond,
+		CollectionMode:     "subprocess_stdout",
+		StderrPreview:      "/Users/alice/private API_KEY=secret-value",
+		OutputPreview:      "private review body",
+	}}
+
+	got := spec.BuildProviderStatuses(responses, failed, []string{"codex"})
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "timeout; source=spec_review_timeout; budget=1m30s; elapsed=1m29.5s; collection=subprocess_stdout; partial_output=true", got[0].Note)
+	assert.NotContains(t, got[0].Note, "/Users/")
+	assert.NotContains(t, got[0].Note, "secret-value")
+	assert.NotContains(t, got[0].Note, "private review body")
+	assert.NotContains(t, got[0].Note, "raw stderr")
+	assert.NotContains(t, got[0].Note, "raw output")
+}
+
+func TestBuildProviderStatuses_TimeoutNoteAllowListsUntrustedMetadata(t *testing.T) {
+	t.Parallel()
+
+	failed := []orchestra.FailedProvider{{
+		Name:               "codex",
+		FailureClass:       "timeout",
+		TimeoutSource:      "/Users/alice/private?token=secret",
+		ConfiguredDuration: -time.Second,
+		ElapsedDuration:    -time.Second,
+		CollectionMode:     "../../private/output",
+	}}
+
+	got := spec.BuildProviderStatuses(nil, failed, []string{"codex"})
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "timeout; source=unknown; budget=unknown; elapsed=unknown; collection=unknown; partial_output=false", got[0].Note)
+}
+
+func TestBuildProviderStatuses_ResponseOnlyTimeoutStillUsesStructuredNote(t *testing.T) {
+	t.Parallel()
+
+	responses := []orchestra.ProviderResponse{{
+		Provider:        "codex",
+		Output:          "partial body",
+		Error:           "/Users/alice/private API_KEY=secret",
+		Duration:        7 * time.Second,
+		TimedOut:        true,
+		ExecutedBackend: "pane",
+	}}
+
+	got := spec.BuildProviderStatuses(responses, nil, []string{"codex"})
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "timeout; source=unknown; budget=unknown; elapsed=7s; collection=pane; partial_output=true", got[0].Note)
+}

--- a/pkg/spec/provider_health_note.go
+++ b/pkg/spec/provider_health_note.go
@@ -1,0 +1,72 @@
+package spec
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+func timeoutProviderHealthNote(
+	source string,
+	budget time.Duration,
+	elapsed time.Duration,
+	collection string,
+	partialOutput bool,
+) string {
+	return fmt.Sprintf(
+		"timeout; source=%s; budget=%s; elapsed=%s; collection=%s; partial_output=%t",
+		allowTimeoutSource(source),
+		formatHealthDuration(budget),
+		formatHealthDuration(elapsed),
+		allowCollectionMode(collection),
+		partialOutput,
+	)
+}
+
+func allowTimeoutSource(source string) string {
+	switch strings.TrimSpace(source) {
+	case "spec_review_timeout",
+		"provider_execution_timeout",
+		"orchestra_timeout_seconds",
+		"default_provider_execution_timeout":
+		return strings.TrimSpace(source)
+	default:
+		return "unknown"
+	}
+}
+
+func allowCollectionMode(collection string) string {
+	switch strings.TrimSpace(collection) {
+	case "hook", "poll", "file_ipc", "subprocess_stdout", "pane", "pane_receipt":
+		return strings.TrimSpace(collection)
+	default:
+		return "unknown"
+	}
+}
+
+func collectionModeFromBackend(backend string) string {
+	switch strings.TrimSpace(backend) {
+	case "subprocess":
+		return "subprocess_stdout"
+	case "pane":
+		return "pane"
+	default:
+		return "unknown"
+	}
+}
+
+func formatHealthDuration(duration time.Duration) string {
+	if duration <= 0 {
+		return "unknown"
+	}
+	return duration.String()
+}
+
+func hasPartialProviderOutput(values ...string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/spec/provider_health_test.go
+++ b/pkg/spec/provider_health_test.go
@@ -154,7 +154,7 @@ func TestBuildProviderStatuses_OrchestraResponses(t *testing.T) {
 	require := assert.New(t)
 	require.Len(got, 4)
 	require.Equal(spec.ProviderStatus{Provider: "claude", Status: "success", Note: "-"}, got[0])
-	require.Equal(spec.ProviderStatus{Provider: "gemini", Status: "timeout", Note: "-"}, got[1])
+	require.Equal(spec.ProviderStatus{Provider: "gemini", Status: "timeout", Note: "timeout; source=unknown; budget=unknown; elapsed=unknown; collection=unknown; partial_output=false"}, got[1])
 	require.Equal(spec.ProviderStatus{Provider: "codex", Status: "error", Note: "subprocess crashed"}, got[2])
 	require.Equal(spec.ProviderStatus{Provider: "opus2", Status: "error", Note: "exit=137"}, got[3])
 }


### PR DESCRIPTION
## 요약

- pane 기본 환경의 `codex exec` SPEC 리뷰를 실행 전에 subprocess 구조화 수집으로 선택합니다.
- 명시적 `--timeout`을 모든 provider 실행 예산에 적용하되 미지정 기본값은 보존합니다.
- timeout 진단은 allowlist 기반 구조화 metadata만 기록해 stdout, stderr, 경로, 비밀값을 노출하지 않습니다.
- Claude, Gemini, Codex 비-`exec`, 강제 subprocess 의미론은 유지합니다.

## 검증

- `go test -race ./internal/cli ./pkg/orchestra ./pkg/spec -count=1`
- `go vet ./internal/cli ./pkg/orchestra ./pkg/spec`
- 독립 리뷰: P0/P1/P2 없음, APPROVE
- 실제 GPT/Codex canary: 호출 1회, 33초, 첫 응답 PASS, checklist 23/23, backend=subprocess
- `git diff --check`, `gofmt`, tracked-but-ignored drift 점검 통과

Closes #59

🐙 Autopus