### PR TITLE
test(ci): 비결정적 계약 fixture 안정화

### DIFF
--- a/pkg/worker/a2a/rest_poller_test.go
+++ b/pkg/worker/a2a/rest_poller_test.go
@@ -129,9 +129,14 @@ func TestRESTPoller_StopsWhenWebSocketRecovers(t *testing.T) {
 	t.Parallel()
 
 	var pollCount atomic.Int32
+	pollObserved := make(chan struct{}, 2)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		pollCount.Add(1)
+		select {
+		case pollObserved <- struct{}{}:
+		default:
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode([]interface{}{})
 	}))
@@ -150,18 +155,23 @@ func TestRESTPoller_StopsWhenWebSocketRecovers(t *testing.T) {
 	defer cancel()
 	poller.Start(ctx) // method does not exist yet
 
-	// Wait for polling to start
-	time.Sleep(35 * time.Millisecond)
-	countBeforeStop := pollCount.Load()
-	assert.GreaterOrEqual(t, countBeforeStop, int32(2), "polling should have started")
+	// Observe two requests so the recurring polling contract is established
+	// independently of goroutine scheduling latency.
+	for range 2 {
+		select {
+		case <-pollObserved:
+		case <-time.After(time.Second):
+			require.FailNow(t, "polling should have started")
+		}
+	}
 
 	// When WebSocket recovers — Stop() is called (method does not exist yet — compile error)
 	poller.Stop() // method does not exist yet
+	countAfterStop := pollCount.Load()
 
 	// Then polling stops
 	time.Sleep(50 * time.Millisecond)
-	countAfterStop := pollCount.Load()
-	assert.Equal(t, countBeforeStop, countAfterStop, "polling must stop when WS recovers (S10)")
+	assert.Equal(t, countAfterStop, pollCount.Load(), "polling must stop when WS recovers (S10)")
 }
 
 // TestRESTPoller_AuthFailure_DoesNotRetry asserts S11 (worker side):

--- a/pkg/worker/poll/poller_test.go
+++ b/pkg/worker/poll/poller_test.go
@@ -127,19 +127,11 @@ func TestTaskPoller_LargeResponseTruncated(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	var receivedLen atomic.Int64
-	ctx, cancel := context.WithCancel(context.Background())
-	p := NewTaskPoller(srv.URL, "tok", "ws", func(data []byte) {
-		receivedLen.Store(int64(len(data)))
-	})
-	p.backoff = &AdaptiveBackoff{min: time.Millisecond, max: time.Millisecond, factor: 1, current: time.Millisecond}
+	p := NewTaskPoller(srv.URL, "tok", "ws", func([]byte) {})
+	body, err := p.fetchPending(context.Background())
 
-	go p.Start(ctx)
-
-	require.Eventually(t, func() bool { return receivedLen.Load() > 0 }, 500*time.Millisecond, 10*time.Millisecond)
-	cancel()
-
-	assert.LessOrEqual(t, receivedLen.Load(), int64(10<<20), "body should be limited to 10MB")
+	require.NoError(t, err)
+	assert.Len(t, body, maxBodyBytes, "body should be limited to 10MB")
 }
 
 func TestTaskPoller_ContextCancellation(t *testing.T) {

--- a/scripts/companion-release/tests/release-hardening-test.sh
+++ b/scripts/companion-release/tests/release-hardening-test.sh
@@ -147,7 +147,24 @@ fi
 printf 'tamper\n' >>"$temp/manifest/auto"
 if "$verifier" "${signing_verify_args[@]}" >/dev/null 2>&1; then fail 'tampered artifact passed'; fi
 printf 'signed companion artifact\n' >"$temp/manifest/auto"
-printf '\001' | dd of="$temp/manifest/adk-companion-manifest.sig" bs=1 seek=0 conv=notrunc 2>/dev/null
+manifest_signature="$temp/manifest/adk-companion-manifest.sig"
+signature_size_before=$(wc -c <"$manifest_signature")
+(( signature_size_before == 64 )) || fail 'fixture manifest signature length drifted'
+signature_byte_before=$(od -An -tu1 -N1 "$manifest_signature" | tr -d '[:space:]')
+case "$signature_byte_before" in
+  1) signature_byte_replacement=2 ;;
+  ''|*[!0-9]*) fail 'fixture manifest signature byte could not be read' ;;
+  *) signature_byte_replacement=1 ;;
+esac
+if (( signature_byte_replacement == 1 )); then printf '\001'; else printf '\002'; fi |
+  dd of="$manifest_signature" bs=1 seek=0 conv=notrunc 2>/dev/null
+signature_size_after=$(wc -c <"$manifest_signature")
+(( signature_size_after == signature_size_before )) || fail 'manifest signature tamper changed length'
+signature_byte_after=$(od -An -tu1 -N1 "$manifest_signature" | tr -d '[:space:]')
+[[ "$signature_byte_after" == "$signature_byte_replacement" ]] ||
+  fail 'manifest signature tamper did not write the replacement byte'
+[[ "$signature_byte_after" != "$signature_byte_before" ]] ||
+  fail 'manifest signature tamper was a no-op'
 if "$verifier" "${signing_verify_args[@]}" >/dev/null 2>&1; then fail 'tampered manifest signature passed'; fi
 go run "$tests_dir/testdata/generate-manifest-fixture.go" "$temp/manifest" \
   'attacker replacement artifact'


### PR DESCRIPTION
## 요약

- REST fallback 중단 테스트가 임의 35ms 대신 실제 HTTP 요청 두 건을 channel로 관측하도록 변경합니다.
- 11MiB 응답 제한 테스트가 비동기 scheduler/callback 대신 production `fetchPending` 경로에서 정확한 10MiB cap을 검증하도록 변경합니다.
- Ed25519 signature fixture가 기존 첫 바이트와 반드시 다른 바이트를 쓰고 64바이트 길이·실제 기록값을 검증하도록 변경합니다.
- 제품 코드와 production verifier/generator는 변경하지 않습니다.

## 원인

- main run 29571920694: 고정 35ms/500ms 가정으로 worker polling 테스트 2건이 race+병렬 부하에서 간헐 실패했습니다.
- PR run 29573778481: raw Ed25519 첫 바이트가 이미 `0x01`이면 고정 `0x01` overwrite가 no-op인 약 1/256 fixture 결함이 드러났습니다.

## 검증

- worker focused race 30회, 패키지 전체 race 5회
- release hardening contract 20회, race 10회
- root 및 독립 reviewer 추가 반복 검증
- vet, bash syntax, gofmt, diff-check, tracked-but-ignored drift 점검
- 독립 리뷰 2회: P0/P1/P2 없음, APPROVE

🐙 Autopus