### PR TITLE
test(worker): 인증 오류 polling의 고정 대기를 제거한다

### DIFF
--- a/pkg/worker/a2a/rest_poller_test.go
+++ b/pkg/worker/a2a/rest_poller_test.go
@@ -180,7 +180,7 @@ func TestRESTPoller_StopsWhenWebSocketRecovers(t *testing.T) {
 func TestRESTPoller_AuthFailure_SurfacesError(t *testing.T) {
 	t.Parallel()
 
-	var authErrors atomic.Int32
+	authErrorObserved := make(chan int, 1)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
@@ -195,18 +195,25 @@ func TestRESTPoller_AuthFailure_SurfacesError(t *testing.T) {
 		PollInterval: 10 * time.Millisecond,
 		TaskHandler:  func(task PollResult) error { return nil }, // PollResult does not exist yet
 		OnAuthError: func(statusCode int) { // OnAuthError callback does not exist yet
-			authErrors.Add(1)
+			select {
+			case authErrorObserved <- statusCode:
+			default:
+			}
 		},
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	poller.Start(ctx) // method does not exist yet
 
-	time.Sleep(40 * time.Millisecond)
-
-	// Then auth error is surfaced
-	assert.Greater(t, authErrors.Load(), int32(0), "401 from poll endpoint must surface auth error (S11)")
+	// Then auth error is surfaced after the 401 response is processed.
+	select {
+	case statusCode := <-authErrorObserved:
+		cancel()
+		assert.Equal(t, http.StatusUnauthorized, statusCode, "401 from poll endpoint must surface auth error (S11)")
+	case <-time.After(time.Second):
+		require.FailNow(t, "401 from poll endpoint must surface auth error (S11)")
+	}
 }
 
 func TestRESTPoller_SetAuthToken(t *testing.T) {


### PR DESCRIPTION
## 요약

- `TestRESTPoller_AuthFailure_SurfacesError`의 40ms 고정 sleep을 제거합니다.
- 실제 `OnAuthError` callback이 전달한 HTTP 401을 buffered channel로 관찰합니다.
- production poller 동작은 변경하지 않습니다.

## 원인

main CI run 29579623465의 race+coverage 병렬 부하에서 poller goroutine이 40ms 안에 스케줄되지 않았고, 50ms context가 먼저 취소되면서 callback 횟수가 0으로 남았습니다.

## 검증

- focused race 50회 통과
- A2A package race 5회 통과
- root focused race 30회 및 package race 3회 통과
- go vet, gofmt, diff check, ignored drift, 300줄 제한 통과
- 독립 리뷰 APPROVE, P0/P1/P2 없음