### PR TITLE
test(ci): 릴리스 계보 아카이브 압축 비용을 줄인다

### DIFF
--- a/pkg/companionmanifest/release_lineage_archive_fixture_test.go
+++ b/pkg/companionmanifest/release_lineage_archive_fixture_test.go
@@ -58,7 +58,10 @@ func rewriteLineageArchive(
 		t.Fatal(err)
 	}
 	var output bytes.Buffer
-	gzipWriter := gzip.NewWriter(&output)
+	gzipWriter, err := gzip.NewWriterLevel(&output, gzip.BestSpeed)
+	if err != nil {
+		t.Fatal(err)
+	}
 	tarWriter := tar.NewWriter(gzipWriter)
 	for _, entry := range entries {
 		entryData, keep := mutate(entry.header.Name, append([]byte(nil), entry.data...))


### PR DESCRIPTION
## 변경 사항

- 테스트 전용 릴리스 계보 archive 재작성에서 기본 gzip 압축 대신 `gzip.BestSpeed`를 사용합니다.
- tar 구조, 변조 내용, fail-closed 검증과 CI의 18분 timeout 계약은 그대로 유지합니다.

## 원인

문서 동기화 PR #77의 [CI run 29642423872](https://github.com/Insajin/autopus-adk/actions/runs/29642423872)에서 `pkg/companionmanifest`가 18분 package timeout에 도달했습니다. 실패 스택은 약 23MB archive 엔트리를 기본 gzip 레벨로 다시 압축하던 `receipt_key_overlap` 변조 케이스를 가리켰습니다.

같은 내용을 병합한 main의 [CI run 29642723318](https://github.com/Insajin/autopus-adk/actions/runs/29642723318)은 test와 e2e까지 통과했으므로 제품·문서 회귀가 아니라 실행시간 마진 문제입니다.

## 영향

테스트 helper 1파일만 변경합니다. 제품 바이너리, 릴리스 자산, 검증 규칙, coverage 기준과 timeout은 바뀌지 않습니다.

## 검증

- A0 tamper race+integration 전체: PASS, 126.431초
- 변경 전 실패한 CI stack의 archive 재작성 경로: PASS
- main CI 29642723318: test 23분 1초, e2e 포함 전체 PASS
- `git diff --check`: PASS
- Lore hook, `auto check --lore`, `auto lore validate`: PASS

## 검증 경계

macOS 로컬 전체 `pkg/companionmanifest` 실행은 별도 A1→A2 bash fixture 자식 프로세스가 장기 대기해 로컬 제한에서 종료됐습니다. 이 PR의 최종 수렴 판정은 GitHub Linux CI 전체 패키지 결과로 내립니다.