### PR TITLE
feat(qa): 데스크톱 접근성 관찰 계약을 통합한다

### DIFF
--- a/internal/cli/qa_full.go
+++ b/internal/cli/qa_full.go
@@ -12,14 +12,15 @@ import (
 )
 
 type qaFullOptions struct {
-	ProjectDir    string
-	Profile       string
-	Output        string
-	RunOutputRoot string
-	Run           bool
-	Bootstrap     bool
-	JSONOut       bool
-	Format        string
+	ProjectDir       string
+	Profile          string
+	Output           string
+	RunOutputRoot    string
+	Run              bool
+	Bootstrap        bool
+	RuntimeProviders []string
+	JSONOut          bool
+	Format           string
 }
 
 func newQAFullCmd() *cobra.Command {
@@ -38,6 +39,7 @@ func newQAFullCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.RunOutputRoot, "run-output", "", "QAMESH run output root")
 	cmd.Flags().BoolVar(&opts.Run, "run", false, "Execute the full gate instead of planning only")
 	cmd.Flags().BoolVar(&opts.Bootstrap, "bootstrap", false, "Create safe QA starter files before planning or running")
+	cmd.Flags().StringArrayVar(&opts.RuntimeProviders, "runtime-provider", nil, "Desktop observation runtime provider (local or orca; exactly one)")
 	addJSONFlags(cmd, &opts.JSONOut, &opts.Format)
 	return cmd
 }
@@ -45,6 +47,13 @@ func newQAFullCmd() *cobra.Command {
 func runQAFull(cmd *cobra.Command, opts qaFullOptions) error {
 	jsonMode, err := resolveJSONMode(opts.JSONOut, opts.Format)
 	if err != nil {
+		return err
+	}
+	runtimeProvider, err := parseQARuntimeProvider(cmd, jsonMode, opts.RuntimeProviders)
+	if err != nil {
+		return err
+	}
+	if err := requireQARuntimeProvider(cmd, jsonMode, runtimeProvider, projectRequiresQARuntimeProvider(opts.ProjectDir)); err != nil {
 		return err
 	}
 	if opts.Output != "" {
@@ -71,6 +80,9 @@ func runQAFull(cmd *cobra.Command, opts qaFullOptions) error {
 	if selection != nil && selection.ProjectDir != "" {
 		opts.ProjectDir = selection.ProjectDir
 	}
+	if err := requireQARuntimeProvider(cmd, jsonMode, runtimeProvider, projectRequiresQARuntimeProvider(opts.ProjectDir)); err != nil {
+		return err
+	}
 	var bootstrap *qascaffold.Result
 	if opts.Bootstrap {
 		result, err := qascaffold.Init(qascaffold.Options{
@@ -85,11 +97,12 @@ func runQAFull(cmd *cobra.Command, opts qaFullOptions) error {
 		bootstrap = &result
 	}
 	releaseOpts := qarelease.Options{
-		ProjectDir:    opts.ProjectDir,
-		Profile:       opts.Profile,
-		Output:        opts.Output,
-		RunOutputRoot: opts.RunOutputRoot,
-		Command:       qaFullCommandString(opts, jsonMode),
+		ProjectDir:      opts.ProjectDir,
+		Profile:         opts.Profile,
+		Output:          opts.Output,
+		RunOutputRoot:   opts.RunOutputRoot,
+		Command:         qaFullCommandString(opts, jsonMode),
+		RuntimeProvider: runtimeProvider,
 	}
 	domain := loadQAFullDomainReadiness(opts.ProjectDir)
 	if opts.Run {

--- a/internal/cli/qa_full_payload.go
+++ b/internal/cli/qa_full_payload.go
@@ -200,9 +200,9 @@ func domainScenarioCount(domain qaFullDomainReadiness) int {
 }
 
 func qaFullNextCommands(opts qaFullOptions, plan qarelease.Plan, domain qaFullDomainReadiness) []string {
-	commands := []string{qaFullCommandString(qaFullOptions{ProjectDir: opts.ProjectDir, Profile: plan.Profile, Output: opts.Output, RunOutputRoot: opts.RunOutputRoot, Run: true}, false)}
+	commands := []string{qaFullCommandString(qaFullOptions{ProjectDir: opts.ProjectDir, Profile: plan.Profile, Output: opts.Output, RunOutputRoot: opts.RunOutputRoot, Run: true, RuntimeProviders: opts.RuntimeProviders}, false)}
 	if len(plan.JourneyPacks) == 0 || len(plan.SetupGaps) > 0 {
-		commands = append(commands, qaFullCommandString(qaFullOptions{ProjectDir: opts.ProjectDir, Profile: plan.Profile, Output: opts.Output, RunOutputRoot: opts.RunOutputRoot, Bootstrap: true}, false))
+		commands = append(commands, qaFullCommandString(qaFullOptions{ProjectDir: opts.ProjectDir, Profile: plan.Profile, Output: opts.Output, RunOutputRoot: opts.RunOutputRoot, Bootstrap: true, RuntimeProviders: opts.RuntimeProviders}, false))
 		commands = append(commands, "auto qa init --project-dir "+shellWord(opts.ProjectDir)+" --format json")
 	}
 	if domain.Status != "ready" {
@@ -232,8 +232,8 @@ func qaFullProjectCandidateCommands(opts qaFullOptions, candidates []qaFullProje
 		if project == "" {
 			project = candidate.ProjectDir
 		}
-		commands = append(commands, qaFullCommandString(qaFullOptions{ProjectDir: project, Profile: opts.Profile, Bootstrap: true}, true))
-		commands = append(commands, qaFullCommandString(qaFullOptions{ProjectDir: project, Profile: opts.Profile}, true))
+		commands = append(commands, qaFullCommandString(qaFullOptions{ProjectDir: project, Profile: opts.Profile, Bootstrap: true, RuntimeProviders: opts.RuntimeProviders}, true))
+		commands = append(commands, qaFullCommandString(qaFullOptions{ProjectDir: project, Profile: opts.Profile, RuntimeProviders: opts.RuntimeProviders}, true))
 	}
 	return uniqueCommands(commands)
 }
@@ -257,6 +257,9 @@ func qaFullCommandString(opts qaFullOptions, jsonMode bool) string {
 	}
 	if opts.RunOutputRoot != "" {
 		parts = append(parts, "--run-output", shellWord(opts.RunOutputRoot))
+	}
+	if len(opts.RuntimeProviders) == 1 {
+		parts = append(parts, "--runtime-provider", opts.RuntimeProviders[0])
 	}
 	if jsonMode {
 		parts = append(parts, "--format", "json")

--- a/internal/cli/qa_release.go
+++ b/internal/cli/qa_release.go
@@ -26,25 +26,35 @@ func newQAReleaseCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.RunOutputRoot, "run-output", "", "QAMESH run output root")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Plan without executing lanes")
 	cmd.Flags().BoolVar(&opts.Roadmap, "roadmap", false, "Print release QA roadmap")
+	cmd.Flags().StringArrayVar(&opts.RuntimeProviders, "runtime-provider", nil, "Desktop observation runtime provider (local or orca; exactly one)")
 	addJSONFlags(cmd, &opts.JSONOut, &opts.Format)
 	return cmd
 }
 
 type qaReleaseOptions struct {
-	ProjectDir    string
-	Profile       string
-	Output        string
-	RunOutputRoot string
-	DryRun        bool
-	Roadmap       bool
-	JSONOut       bool
-	Format        string
+	ProjectDir       string
+	Profile          string
+	Output           string
+	RunOutputRoot    string
+	DryRun           bool
+	Roadmap          bool
+	RuntimeProviders []string
+	JSONOut          bool
+	Format           string
 }
 
 // @AX:NOTE [AUTO] @AX:SPEC: SPEC-QAMESH-004: CLI release command is the user-facing release gate orchestration boundary.
 func runQARelease(cmd *cobra.Command, opts qaReleaseOptions) error {
 	jsonMode, err := resolveJSONMode(opts.JSONOut, opts.Format)
 	if err != nil {
+		return err
+	}
+	runtimeProvider, err := parseQARuntimeProvider(cmd, jsonMode, opts.RuntimeProviders)
+	if err != nil {
+		return err
+	}
+	required := !opts.Roadmap && projectRequiresQARuntimeProvider(opts.ProjectDir)
+	if err := requireQARuntimeProvider(cmd, jsonMode, runtimeProvider, required); err != nil {
 		return err
 	}
 	if opts.Output != "" {
@@ -65,12 +75,13 @@ func runQARelease(cmd *cobra.Command, opts qaReleaseOptions) error {
 		return qaReleaseJSONError(cmd, jsonMode, err, "qa_release_invalid_profile", map[string]any{"profile": opts.Profile})
 	}
 	releaseOpts := qarelease.Options{
-		ProjectDir:    opts.ProjectDir,
-		Profile:       opts.Profile,
-		Output:        opts.Output,
-		RunOutputRoot: opts.RunOutputRoot,
-		Command:       command,
-		DryRun:        opts.DryRun,
+		ProjectDir:      opts.ProjectDir,
+		Profile:         opts.Profile,
+		Output:          opts.Output,
+		RunOutputRoot:   opts.RunOutputRoot,
+		Command:         command,
+		DryRun:          opts.DryRun,
+		RuntimeProvider: runtimeProvider,
 	}
 	if opts.DryRun {
 		plan, err := qarelease.BuildPlan(releaseOpts)
@@ -119,6 +130,9 @@ func releaseCommandString(opts qaReleaseOptions, jsonMode bool) string {
 	}
 	if opts.Roadmap {
 		parts = append(parts, "--roadmap")
+	}
+	if len(opts.RuntimeProviders) == 1 {
+		parts = append(parts, "--runtime-provider", opts.RuntimeProviders[0])
 	}
 	if jsonMode {
 		parts = append(parts, "--format", "json")

--- a/internal/cli/qa_release_readiness.go
+++ b/internal/cli/qa_release_readiness.go
@@ -11,11 +11,12 @@ import (
 
 // qaReleaseReadinessOptions holds the flags for `auto qa release-readiness`.
 type qaReleaseReadinessOptions struct {
-	ProjectDir string
-	Approve    bool
-	Decline    bool
-	JSONOut    bool
-	Format     string
+	ProjectDir       string
+	Approve          bool
+	Decline          bool
+	RuntimeProviders []string
+	JSONOut          bool
+	Format           string
 }
 
 // newQAReleaseReadinessCmd constructs the explicit `auto qa release-readiness`
@@ -34,6 +35,7 @@ func newQAReleaseReadinessCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.ProjectDir, "project-dir", ".", "Project directory to analyze")
 	cmd.Flags().BoolVar(&opts.Approve, "approve", false, "Approve the diff, persist regenerated packs, and dispatch cross-surface execution")
 	cmd.Flags().BoolVar(&opts.Decline, "decline", false, "Explicitly decline the diff (no write, no execution)")
+	cmd.Flags().StringArrayVar(&opts.RuntimeProviders, "runtime-provider", nil, "Desktop observation runtime provider (local or orca; exactly one)")
 	addJSONFlags(cmd, &opts.JSONOut, &opts.Format)
 	return cmd
 }
@@ -45,11 +47,19 @@ func runQAReleaseReadiness(cmd *cobra.Command, opts qaReleaseReadinessOptions) e
 	if err != nil {
 		return err
 	}
+	runtimeProvider, err := parseQARuntimeProvider(cmd, jsonMode, opts.RuntimeProviders)
+	if err != nil {
+		return err
+	}
+	if err := requireQARuntimeProvider(cmd, jsonMode, runtimeProvider, projectRequiresQARuntimeProvider(opts.ProjectDir)); err != nil {
+		return err
+	}
 
 	payload, err := releasereadiness.Orchestrate(releasereadiness.Options{
-		ProjectDir: opts.ProjectDir,
-		Approve:    opts.Approve,
-		Decline:    opts.Decline,
+		ProjectDir:      opts.ProjectDir,
+		Approve:         opts.Approve,
+		Decline:         opts.Decline,
+		RuntimeProvider: runtimeProvider,
 	})
 	if err != nil {
 		if jsonMode {

--- a/internal/cli/qa_run.go
+++ b/internal/cli/qa_run.go
@@ -25,28 +25,37 @@ func newQARunCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.Output, "output", "", "Run output root")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Plan without executing adapters")
 	cmd.Flags().BoolVar(&opts.ManagedDevice, "managed-device", false, "Opt into managed device boot/install for the mobile-scripted lane")
+	cmd.Flags().StringArrayVar(&opts.RuntimeProviders, "runtime-provider", nil, "Desktop observation runtime provider (local or orca; exactly one)")
 	cmd.Flags().StringVar(&opts.FeedbackTo, "feedback-to", "", "Feedback target")
 	addJSONFlags(cmd, &opts.JSONOut, &opts.Format)
 	return cmd
 }
 
 type qaRunOptions struct {
-	ProjectDir    string
-	Profile       string
-	Lane          string
-	JourneyID     string
-	AdapterID     string
-	Output        string
-	DryRun        bool
-	ManagedDevice bool
-	FeedbackTo    string
-	JSONOut       bool
-	Format        string
+	ProjectDir       string
+	Profile          string
+	Lane             string
+	JourneyID        string
+	AdapterID        string
+	Output           string
+	DryRun           bool
+	ManagedDevice    bool
+	RuntimeProviders []string
+	FeedbackTo       string
+	JSONOut          bool
+	Format           string
 }
 
 func runQARun(cmd *cobra.Command, opts qaRunOptions) error {
 	jsonMode, err := resolveJSONMode(opts.JSONOut, opts.Format)
 	if err != nil {
+		return err
+	}
+	runtimeProvider, err := parseQARuntimeProvider(cmd, jsonMode, opts.RuntimeProviders)
+	if err != nil {
+		return err
+	}
+	if err := requireQARuntimeProvider(cmd, jsonMode, runtimeProvider, runRequiresQARuntimeProvider(opts)); err != nil {
 		return err
 	}
 	if opts.Output != "" {
@@ -55,15 +64,16 @@ func runQARun(cmd *cobra.Command, opts qaRunOptions) error {
 		}
 	}
 	result, err := qarun.Execute(qarun.Options{
-		ProjectDir:    opts.ProjectDir,
-		Profile:       opts.Profile,
-		Lane:          opts.Lane,
-		JourneyID:     opts.JourneyID,
-		AdapterID:     opts.AdapterID,
-		Output:        opts.Output,
-		DryRun:        opts.DryRun,
-		ManagedDevice: opts.ManagedDevice,
-		FeedbackTo:    opts.FeedbackTo,
+		ProjectDir:      opts.ProjectDir,
+		Profile:         opts.Profile,
+		Lane:            opts.Lane,
+		JourneyID:       opts.JourneyID,
+		AdapterID:       opts.AdapterID,
+		Output:          opts.Output,
+		DryRun:          opts.DryRun,
+		ManagedDevice:   opts.ManagedDevice,
+		RuntimeProvider: runtimeProvider,
+		FeedbackTo:      opts.FeedbackTo,
 	})
 	if err != nil {
 		if jsonMode {

--- a/internal/cli/qa_runtime_provider.go
+++ b/internal/cli/qa_runtime_provider.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+	"github.com/insajin/autopus-adk/pkg/qa/journey"
+)
+
+const qaDesktopObservationAdapterID = "desktop-accessibility-observe"
+
+var errQARuntimeProviderConflict = errors.New("exactly one --runtime-provider selection is allowed")
+
+func parseQARuntimeProvider(
+	cmd *cobra.Command,
+	jsonMode bool,
+	values []string,
+) (desktopobserve.RuntimeProvider, error) {
+	if len(values) > 1 {
+		return "", qaCommandError(cmd, jsonMode, errQARuntimeProviderConflict, "qa_runtime_provider_conflict", nil)
+	}
+	if len(values) == 0 {
+		return "", nil
+	}
+	provider := desktopobserve.RuntimeProvider(values[0])
+	if provider != desktopobserve.RuntimeProviderLocal && provider != desktopobserve.RuntimeProviderOrca {
+		return "", qaCommandError(cmd, jsonMode, desktopobserve.ErrRuntimeProviderInvalid, "qa_runtime_provider_invalid", nil)
+	}
+	return provider, nil
+}
+
+func requireQARuntimeProvider(
+	cmd *cobra.Command,
+	jsonMode bool,
+	provider desktopobserve.RuntimeProvider,
+	required bool,
+) error {
+	if provider != "" || !required {
+		return nil
+	}
+	return qaCommandError(
+		cmd,
+		jsonMode,
+		desktopobserve.ErrRuntimeProviderRequired,
+		"qa_runtime_provider_required",
+		nil,
+	)
+}
+
+func projectRequiresQARuntimeProvider(projectDir string) bool {
+	packs, err := journey.LoadDir(projectDir)
+	if err != nil {
+		return false
+	}
+	for _, pack := range packs {
+		if pack.Adapter.ID == qaDesktopObservationAdapterID {
+			return true
+		}
+	}
+	return false
+}
+
+func runRequiresQARuntimeProvider(opts qaRunOptions) bool {
+	if opts.AdapterID != "" {
+		return opts.AdapterID == qaDesktopObservationAdapterID
+	}
+	packs, err := journey.LoadDir(opts.ProjectDir)
+	if err != nil {
+		return false
+	}
+	for _, pack := range packs {
+		if pack.Adapter.ID != qaDesktopObservationAdapterID {
+			continue
+		}
+		if opts.JourneyID != "" && pack.ID != opts.JourneyID {
+			continue
+		}
+		if opts.Lane != "" && !journey.HasLane(pack, opts.Lane) {
+			continue
+		}
+		return true
+	}
+	return false
+}

--- a/internal/cli/qa_runtime_provider_matrix_test.go
+++ b/internal/cli/qa_runtime_provider_matrix_test.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQARuntimeProvider_AllFourSurfacesRejectInvalidDuplicateAndConflictWithoutSideEffects(t *testing.T) {
+	t.Parallel()
+
+	surfaces := []string{"run", "release", "release-readiness", "full"}
+	cases := []struct {
+		name      string
+		providers []string
+		wantCode  string
+	}{
+		{name: "invalid", providers: []string{"automatic"}, wantCode: "qa_runtime_provider_invalid"},
+		{name: "duplicate", providers: []string{"local", "local"}, wantCode: "qa_runtime_provider_conflict"},
+		{name: "conflict", providers: []string{"local", "orca"}, wantCode: "qa_runtime_provider_conflict"},
+	}
+
+	for _, surface := range surfaces {
+		surface := surface
+		for _, test := range cases {
+			test := test
+			t.Run(surface+"/"+test.name, func(t *testing.T) {
+				t.Parallel()
+				dir := writeCLIDesktopObservationProject(t)
+				before := snapshotCLIProjectFiles(t, dir)
+				output := filepath.Join(dir, "qa-output")
+				command := newQACmd()
+				var stdout bytes.Buffer
+				command.SetOut(&stdout)
+				command.SetErr(&bytes.Buffer{})
+				command.SetArgs(runtimeProviderSurfaceArgs(surface, dir, output, test.providers))
+
+				err := command.Execute()
+				require.Error(t, err)
+				payload := decodeJSONMap(t, stdout.Bytes())
+				assert.Equal(t, test.wantCode, payload["error"].(map[string]any)["code"])
+				assert.Equal(t, before, snapshotCLIProjectFiles(t, dir))
+				assert.NoDirExists(t, output)
+				assert.NoDirExists(t, filepath.Join(dir, ".autopus", "qa", "_release_readiness"))
+			})
+		}
+	}
+}
+
+func runtimeProviderSurfaceArgs(surface, dir, output string, providers []string) []string {
+	var args []string
+	switch surface {
+	case "run":
+		args = []string{"run", "--project-dir", dir, "--lane", "desktop-native", "--journey", "desktop-accessibility-observe", "--adapter", "desktop-accessibility-observe", "--output", output, "--dry-run", "--format", "json"}
+	case "release":
+		args = []string{"release", "--project-dir", dir, "--output", output, "--dry-run", "--format", "json"}
+	case "release-readiness":
+		args = []string{"release-readiness", "--project-dir", dir, "--format", "json"}
+	case "full":
+		args = []string{"full", "--project-dir", dir, "--output", output, "--format", "json"}
+	}
+	for _, provider := range providers {
+		args = append(args, "--runtime-provider", provider)
+	}
+	return args
+}
+
+func snapshotCLIProjectFiles(t *testing.T, root string) []string {
+	t.Helper()
+	paths := []string{}
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if relative == "." {
+			return nil
+		}
+		relative = filepath.ToSlash(relative)
+		if entry.IsDir() {
+			paths = append(paths, relative+"/")
+			return nil
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		paths = append(paths, fmt.Sprintf("%s:%x", relative, sha256.Sum256(body)))
+		return nil
+	})
+	require.NoError(t, err)
+	sort.Strings(paths)
+	return paths
+}
+
+func assertRuntimeProviderFlagOnce(t *testing.T, command, provider string) {
+	t.Helper()
+	assert.Equal(t, 1, strings.Count(command, "--runtime-provider"), command)
+	tokens := strings.Fields(command)
+	matched := 0
+	for index, token := range tokens {
+		if token == "--runtime-provider" {
+			matched++
+			require.Less(t, index+1, len(tokens))
+			assert.Equal(t, provider, tokens[index+1])
+		}
+	}
+	assert.Equal(t, 1, matched, command)
+}

--- a/internal/cli/qa_runtime_provider_test.go
+++ b/internal/cli/qa_runtime_provider_test.go
@@ -1,0 +1,190 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	qarelease "github.com/insajin/autopus-adk/pkg/qa/release"
+)
+
+func TestQARuntimeProvider_FlagRegisteredOnEveryExecutionSurface(t *testing.T) {
+	t.Parallel()
+
+	commands := map[string]func() *cobra.Command{
+		"run":               newQARunCmd,
+		"release":           newQAReleaseCmd,
+		"release-readiness": newQAReleaseReadinessCmd,
+		"full":              newQAFullCmd,
+	}
+	for name, factory := range commands {
+		name, factory := name, factory
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			flag := factory().Flags().Lookup("runtime-provider")
+			require.NotNil(t, flag)
+			assert.Equal(t, "stringArray", flag.Value.Type())
+		})
+	}
+}
+
+func TestQARuntimeProvider_MissingObservationSelectionUsesStablePublicCode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args func(string, string) []string
+	}{
+		{name: "run", args: func(dir, output string) []string {
+			return []string{"run", "--project-dir", dir, "--lane", "desktop-native", "--journey", "desktop-accessibility-observe", "--adapter", "desktop-accessibility-observe", "--output", output, "--dry-run", "--format", "json"}
+		}},
+		{name: "release", args: func(dir, output string) []string {
+			return []string{"release", "--project-dir", dir, "--output", output, "--dry-run", "--format", "json"}
+		}},
+		{name: "release-readiness", args: func(dir, _ string) []string {
+			return []string{"release-readiness", "--project-dir", dir, "--format", "json"}
+		}},
+		{name: "full", args: func(dir, output string) []string {
+			return []string{"full", "--project-dir", dir, "--output", output, "--format", "json"}
+		}},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			dir := writeCLIDesktopObservationProject(t)
+			output := filepath.Join(dir, "qa-output")
+			cmd := newQACmd()
+			var stdout bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetArgs(test.args(dir, output))
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			payload := decodeJSONMap(t, stdout.Bytes())
+			assert.Equal(t, "qa_runtime_provider_required", payload["error"].(map[string]any)["code"])
+			assert.NoDirExists(t, output)
+		})
+	}
+}
+
+func TestQARuntimeProvider_InvalidDuplicateAndConflictFailBeforeExecution(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		providers []string
+		wantCode  string
+	}{
+		{name: "invalid", providers: []string{"automatic"}, wantCode: "qa_runtime_provider_invalid"},
+		{name: "duplicate", providers: []string{"local", "local"}, wantCode: "qa_runtime_provider_conflict"},
+		{name: "conflict", providers: []string{"local", "orca"}, wantCode: "qa_runtime_provider_conflict"},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			dir := writeCLIDesktopObservationProject(t)
+			output := filepath.Join(dir, "qa-output")
+			args := []string{"run", "--project-dir", dir, "--adapter", "desktop-accessibility-observe", "--lane", "desktop-native", "--output", output, "--format", "json"}
+			for _, provider := range test.providers {
+				args = append(args, "--runtime-provider", provider)
+			}
+			cmd := newQACmd()
+			var stdout bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetArgs(args)
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			payload := decodeJSONMap(t, stdout.Bytes())
+			assert.Equal(t, test.wantCode, payload["error"].(map[string]any)["code"])
+			assert.NoDirExists(t, output)
+		})
+	}
+}
+
+func TestQARuntimeProvider_NonObservationAdapterNeedsNoSelection(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module fixture.test\n"), 0o600))
+	cmd := newQACmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"run", "--project-dir", dir, "--adapter", "go-test", "--dry-run", "--format", "json"})
+
+	require.NoError(t, cmd.Execute())
+	payload := decodeJSONMap(t, stdout.Bytes())
+	assert.NotEqual(t, "qa_runtime_provider_required", payload["error"])
+}
+
+func TestQARuntimeProvider_ReconstructedCommandsPreserveSelection(t *testing.T) {
+	t.Parallel()
+
+	releaseCommand := releaseCommandString(qaReleaseOptions{
+		Profile: "prelaunch", RuntimeProviders: []string{"orca"},
+	}, true)
+	assertRuntimeProviderFlagOnce(t, releaseCommand, "orca")
+
+	fullOpts := qaFullOptions{ProjectDir: "desktop", RuntimeProviders: []string{"local"}}
+	assertRuntimeProviderFlagOnce(t, qaFullCommandString(fullOpts, true), "local")
+	next := qaFullNextCommands(fullOpts, qarelease.Plan{
+		Profile: "prelaunch",
+		JourneyPacks: []qarelease.JourneyPackRow{{
+			Lane: "desktop-native", JourneyID: "desktop-accessibility-observe",
+		}},
+	}, qaFullDomainReadiness{Status: "ready"})
+	require.NotEmpty(t, next)
+	assertRuntimeProviderFlagOnce(t, next[0], "local")
+
+	candidates := qaFullProjectCandidateCommands(fullOpts, []qaFullProjectCandidate{{RelPath: "desktop"}})
+	require.NotEmpty(t, candidates)
+	for _, command := range candidates {
+		assertRuntimeProviderFlagOnce(t, command, "local")
+	}
+}
+
+func writeCLIDesktopObservationProject(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".autopus", "qa", "journeys"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "src-tauri"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src-tauri", "Cargo.toml"), []byte("[package]\nname='fixture'\n"), 0o600))
+	yaml := strings.TrimSpace(`
+id: desktop-accessibility-observe
+title: Desktop accessibility observation
+surface: desktop
+lanes: [desktop-native]
+adapter: {id: desktop-accessibility-observe}
+command: {}
+checks:
+  - {id: semantic-landmarks, type: desktop_accessibility_semantic}
+artifacts: []
+desktop_observation:
+  platform: macos
+  operations: [capabilities, permissions, list_apps, list_windows, get_state]
+  app_ref: autopus-desktop
+  window_ref: main-window
+  required_landmarks:
+    - {role: AXApplication, name: Autopus, required_state: enabled}
+    - {role: AXWindow, name: Autopus, required_state: focused}
+source_refs:
+  source_spec: SPEC-QAMESH-012
+  acceptance_refs: [AC-QAMESH12-012]
+pass_fail_authority: deterministic
+`) + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".autopus", "qa", "journeys", "desktop-accessibility-observe.yaml"), []byte(yaml), 0o600))
+	return dir
+}

--- a/internal/cli/qa_runtime_provider_unit_test.go
+++ b/internal/cli/qa_runtime_provider_unit_test.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQARuntimeProvider_RequirementDetectionUsesSelectedExecutionScope(t *testing.T) {
+	t.Parallel()
+
+	dir := writeRuntimeProviderUnitJourney(t)
+	assert.True(t, projectRequiresQARuntimeProvider(dir))
+	assert.False(t, projectRequiresQARuntimeProvider(t.TempDir()))
+
+	tests := []struct {
+		name string
+		opts qaRunOptions
+		want bool
+	}{
+		{name: "explicit observation adapter", opts: qaRunOptions{AdapterID: qaDesktopObservationAdapterID}, want: true},
+		{name: "explicit generic adapter", opts: qaRunOptions{AdapterID: "custom-command"}},
+		{name: "unfiltered project", opts: qaRunOptions{ProjectDir: dir}, want: true},
+		{name: "matching journey", opts: qaRunOptions{ProjectDir: dir, JourneyID: qaDesktopObservationAdapterID}, want: true},
+		{name: "other journey", opts: qaRunOptions{ProjectDir: dir, JourneyID: "other"}},
+		{name: "matching lane", opts: qaRunOptions{ProjectDir: dir, Lane: "desktop-native"}, want: true},
+		{name: "other lane", opts: qaRunOptions{ProjectDir: dir, Lane: "fast"}},
+		{name: "no observation pack", opts: qaRunOptions{ProjectDir: t.TempDir()}},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.want, runRequiresQARuntimeProvider(test.opts))
+		})
+	}
+}
+
+func TestQARuntimeProvider_InvalidJourneyLoadDoesNotMaskDownstreamValidation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	journeyDir := filepath.Join(dir, ".autopus", "qa", "journeys")
+	require.NoError(t, os.MkdirAll(journeyDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(journeyDir, "invalid.yaml"), []byte("id:\tinvalid\n"), 0o600))
+
+	assert.False(t, projectRequiresQARuntimeProvider(dir))
+	assert.False(t, runRequiresQARuntimeProvider(qaRunOptions{ProjectDir: dir}))
+}
+
+func TestQARuntimeProvider_FullSingleChildValidatesBeforeBootstrap(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	child := filepath.Join(root, "desktop")
+	require.NoError(t, os.MkdirAll(filepath.Join(child, ".git"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(child, "src-tauri"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(child, "src-tauri", "Cargo.toml"), []byte("[package]\nname='fixture'\n"), 0o600))
+	writeRuntimeProviderUnitJourneyAt(t, child)
+	cmd := newQAFullCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+
+	err := runQAFull(cmd, qaFullOptions{ProjectDir: root, Bootstrap: true, Format: "json"})
+
+	require.Error(t, err)
+	payload := decodeJSONMap(t, output.Bytes())
+	assert.Equal(t, "qa_runtime_provider_required", payload["error"].(map[string]any)["code"])
+	assert.NoFileExists(t, filepath.Join(child, ".autopus", "qa", "domain-readiness", "catalog.json"))
+}
+
+func writeRuntimeProviderUnitJourney(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	writeRuntimeProviderUnitJourneyAt(t, dir)
+	return dir
+}
+
+func writeRuntimeProviderUnitJourneyAt(t *testing.T, dir string) {
+	t.Helper()
+	journeyDir := filepath.Join(dir, ".autopus", "qa", "journeys")
+	require.NoError(t, os.MkdirAll(journeyDir, 0o755))
+	body := []byte(`id: desktop-accessibility-observe
+title: Desktop accessibility observation
+surface: desktop
+lanes: [desktop-native]
+adapter: {id: desktop-accessibility-observe}
+command: {}
+checks: [{id: semantic-landmarks, type: desktop_accessibility_semantic}]
+artifacts: []
+desktop_observation:
+  platform: macos
+  operations: [capabilities, permissions, list_apps, list_windows, get_state]
+  app_ref: autopus-desktop
+  window_ref: main-window
+  required_landmarks:
+    - {role: AXApplication, name: Autopus, required_state: enabled}
+    - {role: AXWindow, name: Autopus, required_state: focused}
+source_refs:
+  source_spec: SPEC-QAMESH-012
+  acceptance_refs: [AC-QAMESH12-012]
+pass_fail_authority: deterministic
+`)
+	require.NoError(t, os.WriteFile(filepath.Join(journeyDir, "desktop-accessibility-observe.yaml"), body, 0o600))
+}

--- a/pkg/qa/adapter/desktop_observe_registry_test.go
+++ b/pkg/qa/adapter/desktop_observe_registry_test.go
@@ -1,0 +1,57 @@
+package adapter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDesktopObserveRegistry_ExactReadOnlyMetadata(t *testing.T) {
+	t.Parallel()
+
+	metadata, ok := ByID("desktop-accessibility-observe")
+	require.True(t, ok)
+	assert.Equal(t, "desktop-accessibility-observe", metadata.ID)
+	assert.Equal(t, []string{"desktop"}, metadata.Surfaces)
+	assert.Equal(t, []string{"macos"}, metadata.SupportedPlatforms)
+	assert.Equal(t, []string{"desktop-native"}, metadata.DefaultLanes)
+	assert.Empty(t, metadata.RequiredBinaries)
+	assert.Equal(t, []string{
+		"capabilities",
+		"get_state",
+		"list_apps",
+		"list_windows",
+		"permissions",
+	}, metadata.ReadOnlyOperations)
+	assert.Equal(t, []string{
+		"semantic_projection",
+		"deterministic_checks",
+		"runtime_receipt",
+	}, metadata.ArtifactCapabilities)
+	assert.NotContains(t, metadata.ArtifactCapabilities, "stdout")
+	assert.NotContains(t, metadata.ArtifactCapabilities, "stderr")
+}
+
+func TestDesktopObserveRegistry_ExactFailureTaxonomyWithoutOrcaDependency(t *testing.T) {
+	t.Parallel()
+
+	metadata, ok := ByID("desktop-accessibility-observe")
+	require.True(t, ok)
+	assert.Equal(t, []string{
+		"provider_unavailable",
+		"capability_unsupported",
+		"accessibility_permission_missing",
+		"target_app_not_found",
+		"target_window_not_found",
+		"stale_state",
+		"semantic_projection_unavailable",
+		"redaction_failed",
+		"evidence_quarantined",
+		"provider_protocol_mismatch",
+	}, metadata.SetupGapReasonCodes)
+	assert.NotEmpty(t, metadata.SetupGapReason)
+	for _, binary := range metadata.RequiredBinaries {
+		assert.NotEqual(t, "orca", binary)
+	}
+}

--- a/pkg/qa/adapter/registry.go
+++ b/pkg/qa/adapter/registry.go
@@ -24,6 +24,7 @@ type Metadata struct {
 	SupportedPlatforms   []string `json:"supported_platforms,omitempty"`
 	DefaultLanes         []string `json:"default_lanes"`
 	ArtifactCapabilities []string `json:"artifact_capabilities"`
+	ReadOnlyOperations   []string `json:"read_only_operations,omitempty"`
 	ReadinessFields      []string `json:"readiness_fields,omitempty"`
 	SetupGapReason       string   `json:"setup_gap_reason,omitempty"`
 	SetupGapReasonCodes  []string `json:"setup_gap_reason_codes,omitempty"`
@@ -46,6 +47,7 @@ func Registry() []Metadata {
 		metadata("auto-verify", []string{"frontend"}, []string{"auto"}),
 		metadata("canary-template", []string{"multi"}, nil),
 		metadata("custom-command", []string{"custom"}, nil),
+		desktopObservationMetadata(),
 	}
 }
 
@@ -135,4 +137,38 @@ func metadata(id string, surfaces, binaries []string) Metadata {
 		item.SetupGapReason = "mobile readiness requires device inventory, simulator/emulator target, app artifact digest, opaque credentials, and cloud lab policy when used"
 	}
 	return item
+}
+
+func desktopObservationMetadata() Metadata {
+	return Metadata{
+		ID:                 "desktop-accessibility-observe",
+		Surfaces:           []string{"desktop"},
+		SupportedPlatforms: []string{"macos"},
+		DefaultLanes:       []string{"desktop-native"},
+		ReadOnlyOperations: []string{
+			"capabilities",
+			"get_state",
+			"list_apps",
+			"list_windows",
+			"permissions",
+		},
+		ArtifactCapabilities: []string{
+			"semantic_projection",
+			"deterministic_checks",
+			"runtime_receipt",
+		},
+		SetupGapReason: "desktop accessibility observation requires the explicitly selected read-only runtime provider",
+		SetupGapReasonCodes: []string{
+			"provider_unavailable",
+			"capability_unsupported",
+			"accessibility_permission_missing",
+			"target_app_not_found",
+			"target_window_not_found",
+			"stale_state",
+			"semantic_projection_unavailable",
+			"redaction_failed",
+			"evidence_quarantined",
+			"provider_protocol_mismatch",
+		},
+	}
 }

--- a/pkg/qa/desktopobserve/canonical.go
+++ b/pkg/qa/desktopobserve/canonical.go
@@ -1,0 +1,252 @@
+package desktopobserve
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+	"unicode/utf16"
+	"unicode/utf8"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+const (
+	canonicalSchemaVersion = "qamesh.desktop_observation.canonical.v1"
+	maxSemanticNodes       = 256
+	maxSemanticDepth       = 32
+	maxFrameLogicalPoint   = 100_000
+)
+
+var (
+	canonicalAXNamePattern = regexp.MustCompile(`^AX[A-Za-z]+$`)
+	canonicalDigestPattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
+)
+
+type Redactor func(string) (string, error)
+
+type canonicalProjection struct {
+	Root          canonicalNode `json:"root"`
+	SchemaVersion string        `json:"schema_version"`
+}
+
+type canonicalNode struct {
+	AdvertisedActions []Action        `json:"advertised_actions"`
+	Children          []canonicalNode `json:"children"`
+	Name              string          `json:"name"`
+	Occurrence        int             `json:"occurrence"`
+	Role              Role            `json:"role"`
+	SemanticState     SemanticState   `json:"semantic_state"`
+}
+
+type preparedNode struct {
+	public    SemanticNode
+	canonical canonicalNode
+	primary   string
+	full      string
+}
+
+func NormalizeProjection(projection SemanticProjection, redact Redactor) (SemanticProjection, error) {
+	if redact == nil {
+		return SemanticProjection{}, ErrRedactionFailed
+	}
+	if projection.SchemaVersion != SemanticProjectionSchemaVersion ||
+		!safePublicRef(projection.ProviderRef) || !safePublicRef(projection.AppRef) ||
+		!safePublicRef(projection.WindowRef) || !safePublicRef(projection.StateRef) {
+		return SemanticProjection{}, fmt.Errorf("%w: projection scope", ErrMalformedEnvelope)
+	}
+	count := 0
+	prepared, err := prepareNode(projection.Root, redact, 1, &count)
+	if err != nil {
+		return SemanticProjection{}, err
+	}
+	canonical := canonicalProjection{
+		SchemaVersion: canonicalSchemaVersion,
+		Root:          prepared.canonical,
+	}
+	canonicalJSON, _ := json.Marshal(canonical)
+	digestBytes := sha256.Sum256(canonicalJSON)
+	publicScope := strings.Join([]string{
+		projection.ProviderRef, projection.AppRef, projection.WindowRef, projection.StateRef,
+	}, "\x00")
+	assignNodeRefs(&prepared.public, prepared.canonical, publicScope)
+	return SemanticProjection{
+		SchemaVersion: projection.SchemaVersion,
+		ProviderRef:   projection.ProviderRef,
+		AppRef:        projection.AppRef,
+		WindowRef:     projection.WindowRef,
+		StateRef:      projection.StateRef,
+		Digest:        hex.EncodeToString(digestBytes[:]),
+		Root:          prepared.public,
+		CanonicalJSON: canonicalJSON,
+	}, nil
+}
+
+func prepareNode(node SemanticNode, redact Redactor, depth int, count *int) (preparedNode, error) {
+	*count++
+	if depth > maxSemanticDepth || *count > maxSemanticNodes || !validRole(node.Role) ||
+		!validFrame(node.Frame) {
+		return preparedNode{}, fmt.Errorf("%w: semantic node bounds", ErrMalformedEnvelope)
+	}
+	name, err := normalizeText(node.Name)
+	if err != nil {
+		return preparedNode{}, err
+	}
+	name, err = redact(name)
+	if err != nil {
+		return preparedNode{}, fmt.Errorf("%w: name", ErrRedactionFailed)
+	}
+	name, err = normalizeText(name)
+	if err != nil {
+		return preparedNode{}, err
+	}
+	state, err := normalizeState(node.SemanticState)
+	if err != nil {
+		return preparedNode{}, err
+	}
+	actions, err := normalizeActions(node.AdvertisedActions)
+	if err != nil {
+		return preparedNode{}, err
+	}
+	children := make([]preparedNode, 0, len(node.Children))
+	for _, child := range node.Children {
+		prepared, childErr := prepareNode(child, redact, depth+1, count)
+		if childErr != nil {
+			return preparedNode{}, childErr
+		}
+		children = append(children, prepared)
+	}
+	sort.SliceStable(children, func(left, right int) bool {
+		if comparison := compareCanonicalText(children[left].primary, children[right].primary); comparison != 0 {
+			return comparison < 0
+		}
+		return compareCanonicalText(children[left].full, children[right].full) < 0
+	})
+	publicChildren := make([]SemanticNode, 0, len(children))
+	canonicalChildren := make([]canonicalNode, 0, len(children))
+	occurrences := make(map[string]int)
+	for _, child := range children {
+		child.canonical.Occurrence = occurrences[child.primary]
+		occurrences[child.primary]++
+		child.full = marshalCanonicalKey(child.canonical)
+		publicChildren = append(publicChildren, child.public)
+		canonicalChildren = append(canonicalChildren, child.canonical)
+	}
+	public := SemanticNode{
+		Role: node.Role, Name: name, SemanticState: state, Frame: copyFrame(node.Frame),
+		AdvertisedActions: actions, Children: publicChildren,
+	}
+	canonicalNode := canonicalNode{
+		Role: node.Role, Name: name, SemanticState: state,
+		AdvertisedActions: actions, Children: canonicalChildren,
+	}
+	return preparedNode{
+		public: public, canonical: canonicalNode, primary: canonicalIdentity(canonicalNode),
+		full: marshalCanonicalKey(canonicalNode),
+	}, nil
+}
+
+func assignNodeRefs(public *SemanticNode, canonical canonicalNode, parentPath string) {
+	identity := fmt.Sprintf("%s\x00%s\x00%d", parentPath, canonicalIdentity(canonical), canonical.Occurrence)
+	digest := sha256.Sum256([]byte(identity))
+	public.NodeRef = "n_" + hex.EncodeToString(digest[:])
+	for index := range public.Children {
+		assignNodeRefs(&public.Children[index], canonical.Children[index], public.NodeRef)
+	}
+}
+
+func canonicalIdentity(node canonicalNode) string {
+	return marshalCanonicalKey([]any{
+		node.Role, node.Name, node.SemanticState, node.AdvertisedActions,
+	})
+}
+
+func normalizeActions(actions []Action) ([]Action, error) {
+	values := make([]Action, 0, len(actions))
+	for _, action := range actions {
+		normalized, err := normalizeText(string(action))
+		if err != nil || !validAction(Action(normalized)) {
+			return nil, fmt.Errorf("%w: action", ErrMalformedEnvelope)
+		}
+		values = append(values, Action(normalized))
+	}
+	sort.Slice(values, func(left, right int) bool {
+		return compareCanonicalText(string(values[left]), string(values[right])) < 0
+	})
+	result := values[:0]
+	for _, value := range values {
+		if len(result) == 0 || result[len(result)-1] != value {
+			result = append(result, value)
+		}
+	}
+	return result, nil
+}
+
+func validAction(action Action) bool {
+	return action == ActionPress || action == ActionRaise || action == ActionShowMenu
+}
+
+func normalizeState(state SemanticState) (SemanticState, error) {
+	return SemanticState{
+		Enabled:  copyPointer(state.Enabled),
+		Expanded: copyPointer(state.Expanded),
+		Focused:  copyPointer(state.Focused),
+		Selected: copyPointer(state.Selected),
+	}, nil
+}
+
+func normalizeText(value string) (string, error) {
+	if !utf8.ValidString(value) || strings.ContainsRune(value, '\x00') {
+		return "", fmt.Errorf("%w: invalid text", ErrRedactionFailed)
+	}
+	value = strings.ReplaceAll(value, "\r\n", "\n")
+	value = strings.ReplaceAll(value, "\r", "\n")
+	return norm.NFC.String(value), nil
+}
+
+func compareCanonicalText(left, right string) int {
+	return slices.Compare(utf16.Encode([]rune(left)), utf16.Encode([]rune(right)))
+}
+
+func marshalCanonicalKey(value any) string {
+	encoded, _ := json.Marshal(value)
+	return string(encoded)
+}
+
+func copyFrame(frame *Frame) *Frame {
+	return copyPointer(frame)
+}
+
+func validFrame(frame *Frame) bool {
+	return frame == nil || frame.X >= 0 && frame.Y >= 0 && frame.Width > 0 && frame.Height > 0 &&
+		frame.X <= maxFrameLogicalPoint && frame.Y <= maxFrameLogicalPoint &&
+		frame.Width <= maxFrameLogicalPoint && frame.Height <= maxFrameLogicalPoint
+}
+
+func copyPointer[T any](value *T) *T {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+func validRole(role Role) bool {
+	return canonicalAXNamePattern.MatchString(string(role))
+}
+
+func validateProjection(projection SemanticProjection) error {
+	if !canonicalDigestPattern.MatchString(projection.Digest) {
+		return ErrMalformedEnvelope
+	}
+	normalized, err := NormalizeProjection(projection, func(value string) (string, error) { return value, nil })
+	if err != nil || normalized.Digest != projection.Digest ||
+		marshalCanonicalKey(normalized.Root) != marshalCanonicalKey(projection.Root) {
+		return ErrMalformedEnvelope
+	}
+	return nil
+}

--- a/pkg/qa/desktopobserve/canonical_refs_test.go
+++ b/pkg/qa/desktopobserve/canonical_refs_test.go
@@ -1,0 +1,105 @@
+package desktopobserve
+
+import (
+	"regexp"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodeRefs_AreOpaqueDeterministicAndRawReferenceIndependent(t *testing.T) {
+	t.Parallel()
+
+	first := recursiveProjectionFixture()
+	second := recursiveProjectionFixture()
+	setRawNodeRefs(&first.Root, []string{"AXUIElement:0x123 index=7", "orca-4", "handle:/tmp/a", "node-provider-99"})
+	setRawNodeRefs(&second.Root, []string{"AXUIElement:0x999 index=1", "orca-88", "handle:/tmp/b", "node-provider-2"})
+
+	normalizedFirst, err := NormalizeProjection(first, identityRedactor)
+	require.NoError(t, err)
+	normalizedSecond, err := NormalizeProjection(second, identityRedactor)
+	require.NoError(t, err)
+	firstRefs := collectNodeRefs(normalizedFirst.Root)
+	secondRefs := collectNodeRefs(normalizedSecond.Root)
+	assert.Equal(t, firstRefs, secondRefs)
+	require.Len(t, firstRefs, 4)
+	for _, ref := range firstRefs {
+		assert.Regexp(t, opaqueRefPattern, ref)
+		assert.False(t, unsafeRefPattern.MatchString(ref), ref)
+	}
+}
+
+func TestNodeRefs_DuplicateOccurrenceAndRecursiveAncestryStayDistinct(t *testing.T) {
+	t.Parallel()
+
+	projection := recursiveProjectionFixture()
+	duplicate := projection.Root.Children[0].Children[0]
+	duplicate.NodeRef = "raw-duplicate"
+	projection.Root.Children[0].Children = append(projection.Root.Children[0].Children, duplicate)
+	projection.Root.Children[1].Children = []SemanticNode{duplicate}
+
+	normalized, err := NormalizeProjection(projection, identityRedactor)
+	require.NoError(t, err)
+	refs := collectNodeRefs(normalized.Root)
+	unique := map[string]bool{}
+	for _, ref := range refs {
+		unique[ref] = true
+	}
+	assert.Len(t, unique, len(refs), "same-key occurrences and different ancestry need unique refs")
+
+	variant := projection
+	setRawNodeRefs(&variant.Root, []string{"one", "two", "three", "four", "five", "six"})
+	normalizedVariant, err := NormalizeProjection(variant, identityRedactor)
+	require.NoError(t, err)
+	want, got := collectNodeRefs(normalized.Root), collectNodeRefs(normalizedVariant.Root)
+	sort.Strings(want)
+	sort.Strings(got)
+	assert.Equal(t, want, got)
+}
+
+var (
+	opaqueRefPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{16,}$`)
+	unsafeRefPattern = regexp.MustCompile(`(?i)(0x[0-9a-f]+|index|handle|socket|/tmp/|provider|orca-[0-9]+)`)
+)
+
+func recursiveProjectionFixture() SemanticProjection {
+	projection := semanticFixture()
+	projection.Root.Children = []SemanticNode{
+		{
+			Role: RoleGroup, Name: "Primary",
+			Children: []SemanticNode{{Role: RoleStaticText, Name: "Ready"}},
+		},
+		{Role: RoleGroup, Name: "Secondary"},
+	}
+	return projection
+}
+
+func setRawNodeRefs(node *SemanticNode, refs []string) {
+	index := 0
+	var walk func(*SemanticNode)
+	walk = func(current *SemanticNode) {
+		if index < len(refs) {
+			current.NodeRef = refs[index]
+		}
+		index++
+		for child := range current.Children {
+			walk(&current.Children[child])
+		}
+	}
+	walk(node)
+}
+
+func collectNodeRefs(root SemanticNode) []string {
+	refs := []string{}
+	var walk func(SemanticNode)
+	walk = func(node SemanticNode) {
+		refs = append(refs, node.NodeRef)
+		for _, child := range node.Children {
+			walk(child)
+		}
+	}
+	walk(root)
+	return refs
+}

--- a/pkg/qa/desktopobserve/canonical_structure_test.go
+++ b/pkg/qa/desktopobserve/canonical_structure_test.go
@@ -1,0 +1,70 @@
+package desktopobserve
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalDigest_PreservesMultiplicity(t *testing.T) {
+	t.Parallel()
+
+	one := semanticFixture()
+	two := semanticFixture()
+	duplicate := two.Root.Children[0]
+	duplicate.NodeRef = "provider-duplicate"
+	two.Root.Children = append(two.Root.Children, duplicate)
+
+	normalizedOne, err := NormalizeProjection(one, identityRedactor)
+	require.NoError(t, err)
+	normalizedTwo, err := NormalizeProjection(two, identityRedactor)
+	require.NoError(t, err)
+	assert.NotEqual(t, normalizedOne.Digest, normalizedTwo.Digest)
+
+	two.Root.Children = two.Root.Children[:1]
+	recovered, err := NormalizeProjection(two, identityRedactor)
+	require.NoError(t, err)
+	assert.Equal(t, normalizedOne.Digest, recovered.Digest)
+}
+
+func TestCanonicalDigest_PreservesParentChildAncestry(t *testing.T) {
+	t.Parallel()
+
+	underPrimary := ancestryProjection(true)
+	underSecondary := ancestryProjection(false)
+	primaryDigest, err := NormalizeProjection(underPrimary, identityRedactor)
+	require.NoError(t, err)
+	secondaryDigest, err := NormalizeProjection(underSecondary, identityRedactor)
+	require.NoError(t, err)
+
+	assert.Equal(t, semanticInventory(underPrimary.Root), semanticInventory(underSecondary.Root))
+	assert.NotEqual(t, primaryDigest.Digest, secondaryDigest.Digest)
+}
+
+func ancestryProjection(primary bool) SemanticProjection {
+	projection := semanticFixture()
+	leaf := SemanticNode{Role: RoleStaticText, Name: "Ready"}
+	left := SemanticNode{Role: RoleGroup, Name: "Primary"}
+	right := SemanticNode{Role: RoleGroup, Name: "Secondary"}
+	if primary {
+		left.Children = []SemanticNode{leaf}
+	} else {
+		right.Children = []SemanticNode{leaf}
+	}
+	projection.Root.Children = []SemanticNode{left, right}
+	return projection
+}
+
+func semanticInventory(root SemanticNode) map[string]int {
+	inventory := map[string]int{}
+	var walk func(SemanticNode)
+	walk = func(node SemanticNode) {
+		inventory[string(node.Role)+"\x00"+node.Name]++
+		for _, child := range node.Children {
+			walk(child)
+		}
+	}
+	walk(root)
+	return inventory
+}

--- a/pkg/qa/desktopobserve/canonical_test.go
+++ b/pkg/qa/desktopobserve/canonical_test.go
@@ -1,0 +1,179 @@
+package desktopobserve
+
+import (
+	"errors"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeProjection_NFCLineEndingsActionsAndMultiplicity(t *testing.T) {
+	t.Parallel()
+
+	projection := semanticFixture()
+	projection.Root.Name = "Autopus\r\nCafe\u0301"
+	projection.Root.AdvertisedActions = []Action{ActionShowMenu, ActionPress, ActionPress}
+	duplicate := projection.Root.Children[0]
+	duplicate.NodeRef = "node-provider-duplicate"
+	projection.Root.Children = append(projection.Root.Children, duplicate)
+
+	normalized, err := NormalizeProjection(projection, identityRedactor)
+	require.NoError(t, err)
+	assert.Equal(t, "Autopus\nCafé", normalized.Root.Name)
+	assert.Equal(t, []Action{ActionPress, ActionShowMenu}, normalized.Root.AdvertisedActions)
+	require.Len(t, normalized.Root.Children, 2)
+	assert.NotEqual(t, normalized.Root.Children[0].NodeRef, normalized.Root.Children[1].NodeRef)
+	assert.NotEmpty(t, normalized.Digest)
+	assert.Regexp(t, regexp.MustCompile(`^[0-9a-f]{64}$`), normalized.Digest)
+}
+
+func TestNormalizeProjection_RedactsBeforeDigestAndEmitsNoPayloadOnFailure(t *testing.T) {
+	t.Parallel()
+
+	raw := semanticFixture()
+	raw.Root.Name = "private account title"
+	redacted, err := NormalizeProjection(raw, func(value string) (string, error) {
+		if value == "private account title" {
+			return "Autopus", nil
+		}
+		return value, nil
+	})
+	require.NoError(t, err)
+	allowed, err := NormalizeProjection(semanticFixture(), identityRedactor)
+	require.NoError(t, err)
+	assert.Equal(t, allowed.Digest, redacted.Digest)
+	assert.Equal(t, "Autopus", redacted.Root.Name)
+
+	failed, err := NormalizeProjection(raw, func(string) (string, error) {
+		return "", errors.New("redaction failed")
+	})
+	require.Error(t, err)
+	assert.Empty(t, failed.Digest)
+	assert.Empty(t, failed.Root)
+}
+
+func TestNormalizeProjection_RefsFrameAndProviderOrderDoNotAffectDigest(t *testing.T) {
+	t.Parallel()
+
+	first := semanticFixture()
+	second := semanticFixture()
+	second.ProviderRef = "provider-other"
+	second.AppRef = "app-other"
+	second.WindowRef = "window-other"
+	second.StateRef = "state-other"
+	second.Root.NodeRef = "root-other"
+	second.Root.Frame = &Frame{X: 900, Y: 400, Width: 1, Height: 2}
+	second.Root.Children[0].NodeRef = "child-other"
+	second.Root.Children[0].Frame = &Frame{X: 19, Y: 27, Width: 901, Height: 703}
+	second.Root.Children = append(second.Root.Children, SemanticNode{
+		NodeRef:       "status-other",
+		Role:          RoleStaticText,
+		Name:          "Ready",
+		SemanticState: SemanticState{Enabled: boolPointer(true)},
+	})
+	first.Root.Children = append([]SemanticNode{second.Root.Children[1]}, first.Root.Children...)
+	assert.Equal(t, RoleStaticText, first.Root.Children[0].Role)
+	assert.Equal(t, RoleWindow, second.Root.Children[0].Role)
+
+	normalizedFirst, err := NormalizeProjection(first, identityRedactor)
+	require.NoError(t, err)
+	normalizedSecond, err := NormalizeProjection(second, identityRedactor)
+	require.NoError(t, err)
+	assert.Equal(t, normalizedFirst.Digest, normalizedSecond.Digest)
+	assert.Equal(t, normalizedFirst.CanonicalJSON, normalizedSecond.CanonicalJSON)
+}
+
+func TestNormalizeProjection_RejectsOutOfRangeWindowRelativeFrames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		frame Frame
+	}{
+		{name: "negative x", frame: Frame{X: -1, Y: 0, Width: 1, Height: 1}},
+		{name: "negative y", frame: Frame{X: 0, Y: -1, Width: 1, Height: 1}},
+		{name: "zero width", frame: Frame{X: 0, Y: 0, Width: 0, Height: 1}},
+		{name: "zero height", frame: Frame{X: 0, Y: 0, Width: 1, Height: 0}},
+		{name: "x above bound", frame: Frame{X: 100_001, Y: 0, Width: 1, Height: 1}},
+		{name: "height above bound", frame: Frame{X: 0, Y: 0, Width: 1, Height: 100_001}},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			projection := semanticFixture()
+			projection.Root.Frame = &test.frame
+			_, err := NormalizeProjection(projection, identityRedactor)
+			require.ErrorIs(t, err, ErrMalformedEnvelope)
+		})
+	}
+}
+
+func TestNormalizeProjection_SemanticChangeChangesAndRecoveryRestoresDigest(t *testing.T) {
+	t.Parallel()
+
+	before := semanticFixture()
+	before.Root.Children[0].SemanticState.Expanded = boolPointer(false)
+	changed := semanticFixture()
+	changed.Root.Children[0].SemanticState.Expanded = boolPointer(true)
+	recovered := semanticFixture()
+	recovered.Root.Children[0].SemanticState.Expanded = boolPointer(false)
+
+	normalizedBefore, err := NormalizeProjection(before, identityRedactor)
+	require.NoError(t, err)
+	normalizedChanged, err := NormalizeProjection(changed, identityRedactor)
+	require.NoError(t, err)
+	normalizedRecovered, err := NormalizeProjection(recovered, identityRedactor)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, normalizedBefore.Digest, normalizedChanged.Digest)
+	assert.Equal(t, normalizedBefore.Digest, normalizedRecovered.Digest)
+}
+
+func TestNormalizeProjection_UnknownAdvertisedActionFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	projection := semanticFixture()
+	projection.Root.AdvertisedActions = []Action{ActionPress, Action("AXUnsafe")}
+	normalized, err := NormalizeProjection(projection, identityRedactor)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMalformedEnvelope)
+	assert.Empty(t, normalized.Digest)
+	assert.Empty(t, normalized.Root)
+}
+
+func semanticFixture() SemanticProjection {
+	return SemanticProjection{
+		SchemaVersion: SemanticProjectionSchemaVersion,
+		ProviderRef:   "provider-local",
+		AppRef:        "autopus-desktop",
+		WindowRef:     "main-window",
+		StateRef:      "state-001",
+		Root: SemanticNode{
+			NodeRef:           "node-app",
+			Role:              RoleApplication,
+			Name:              "Autopus",
+			SemanticState:     SemanticState{Enabled: boolPointer(true)},
+			Frame:             &Frame{X: 0, Y: 0, Width: 1440, Height: 900},
+			AdvertisedActions: []Action{ActionShowMenu, ActionPress},
+			Children: []SemanticNode{{
+				NodeRef:           "node-window",
+				Role:              RoleWindow,
+				Name:              "Autopus",
+				SemanticState:     SemanticState{Focused: boolPointer(true)},
+				Frame:             &Frame{X: 20, Y: 30, Width: 900, Height: 700},
+				AdvertisedActions: []Action{ActionRaise},
+			}},
+		},
+	}
+}
+
+func identityRedactor(value string) (string, error) {
+	return value, nil
+}
+
+func boolPointer(value bool) *bool {
+	return &value
+}

--- a/pkg/qa/desktopobserve/contract_golden_test.go
+++ b/pkg/qa/desktopobserve/contract_golden_test.go
@@ -1,0 +1,118 @@
+package desktopobserve
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProtocolV1GoldenExchange_AllFiveOperationsDecodeStrictly(t *testing.T) {
+	t.Parallel()
+
+	projection, err := NormalizeProjection(semanticFixture(), identityRedactor)
+	require.NoError(t, err)
+	projectionBody, err := json.Marshal(projection)
+	require.NoError(t, err)
+	tests := []struct {
+		operation Operation
+		scope     ReceiptScope
+		payload   string
+	}{
+		{OperationCapabilities, ReceiptScope{Kind: ScopeProvider, PublicRef: "autopus-desktop-local"}, `{"capabilities":[{"name":"capabilities","status":"supported"},{"name":"get_state","status":"supported"},{"name":"list_apps","status":"supported"},{"name":"list_windows","status":"supported"},{"name":"permissions","status":"supported"}]}`},
+		{OperationPermissions, ReceiptScope{Kind: ScopeProvider, PublicRef: "autopus-desktop-local"}, `{"accessibility_granted":true}`},
+		{OperationListApps, ReceiptScope{Kind: ScopeProvider, PublicRef: "autopus-desktop-local"}, `{"apps":[{"app_ref":"autopus-desktop"}]}`},
+		{OperationListWindows, ReceiptScope{Kind: ScopeApplication, PublicRef: "autopus-desktop"}, `{"windows":[{"window_ref":"main-window"}]}`},
+		{OperationGetState, ReceiptScope{Kind: ScopeWindow, PublicRef: "main-window"}, fmt.Sprintf(`{"semantic_projection":%s}`, projectionBody)},
+	}
+
+	for index, test := range tests {
+		test := test
+		t.Run(string(test.operation), func(t *testing.T) {
+			t.Parallel()
+			requestID := fmt.Sprintf("req-%d", index+1)
+			requestRaw := []byte(fmt.Sprintf(
+				`{"protocol_version":1,"request_id":%q,"operation":%q,"scope":{"kind":%q,"public_ref":%q}}`,
+				requestID, test.operation, test.scope.Kind, test.scope.PublicRef,
+			))
+			resultRaw := goldenResultEnvelope(t, requestID, test.operation, test.scope, test.payload)
+			exchange, err := DecodeExchange(requestRaw, resultRaw)
+			require.NoError(t, err)
+			assert.Equal(t, test.operation, exchange.Request.Operation)
+			assert.Equal(t, "passed", string(exchange.Result.Status))
+			assert.JSONEq(t, test.payload, string(exchange.Result.Payload))
+			require.NoError(t, exchange.Result.RuntimeReceipt.Validate())
+		})
+	}
+}
+
+func TestProtocolV1GoldenExchange_RejectsMissingNestedDuplicateAndInvalidStatus(t *testing.T) {
+	t.Parallel()
+
+	validRequest := `{"protocol_version":1,"request_id":"req-1","operation":"permissions","scope":{"kind":"provider","public_ref":"autopus-desktop-local"}}`
+	validResult := string(goldenResultEnvelope(
+		t, "req-1", OperationPermissions,
+		ReceiptScope{Kind: ScopeProvider, PublicRef: "autopus-desktop-local"},
+		`{"accessibility_granted":true}`,
+	))
+	tests := []struct {
+		name       string
+		requestRaw string
+		resultRaw  string
+		want       error
+	}{
+		{name: "missing request protocol", requestRaw: strings.Replace(validRequest, `"protocol_version":1,`, "", 1), resultRaw: validResult, want: ErrMissingField},
+		{name: "missing request id", requestRaw: strings.Replace(validRequest, `"request_id":"req-1",`, "", 1), resultRaw: validResult, want: ErrMissingField},
+		{name: "missing operation", requestRaw: strings.Replace(validRequest, `,"operation":"permissions"`, "", 1), resultRaw: validResult, want: ErrMissingField},
+		{name: "missing scope", requestRaw: strings.Replace(validRequest, `,"scope":{"kind":"provider","public_ref":"autopus-desktop-local"}`, "", 1), resultRaw: validResult, want: ErrMissingField},
+		{name: "missing nested public ref", requestRaw: strings.Replace(validRequest, `,"public_ref":"autopus-desktop-local"`, "", 1), resultRaw: validResult, want: ErrMissingField},
+		{name: "nested request unknown", requestRaw: strings.Replace(validRequest, `"public_ref":"autopus-desktop-local"`, `"public_ref":"autopus-desktop-local","pid":42`, 1), resultRaw: validResult, want: ErrUnknownField},
+		{name: "nested request duplicate", requestRaw: strings.Replace(validRequest, `"kind":"provider"`, `"kind":"provider","kind":"window"`, 1), resultRaw: validResult, want: ErrDuplicateKey},
+		{name: "missing result protocol", requestRaw: validRequest, resultRaw: strings.Replace(validResult, `"protocol_version":1,`, "", 1), want: ErrMissingField},
+		{name: "missing result request id", requestRaw: validRequest, resultRaw: strings.Replace(validResult, `"request_id":"req-1",`, "", 1), want: ErrMissingField},
+		{name: "missing status", requestRaw: validRequest, resultRaw: strings.Replace(validResult, `"status":"passed",`, "", 1), want: ErrMissingField},
+		{name: "invalid status", requestRaw: validRequest, resultRaw: strings.Replace(validResult, `"status":"passed"`, `"status":"warning"`, 1), want: ErrInvalidStatus},
+		{name: "missing payload", requestRaw: validRequest, resultRaw: strings.Replace(validResult, `,"payload":{"accessibility_granted":true}`, "", 1), want: ErrMissingField},
+		{name: "missing runtime receipt", requestRaw: validRequest, resultRaw: `{"protocol_version":1,"request_id":"req-1","status":"passed","payload":{"accessibility_granted":true}}`, want: ErrMissingField},
+		{name: "operation payload mismatch", requestRaw: validRequest, resultRaw: strings.Replace(validResult, `{"accessibility_granted":true}`, `{"apps":[{"app_ref":"autopus-desktop"}]}`, 1), want: ErrUnknownField},
+		{name: "nested payload unknown", requestRaw: validRequest, resultRaw: strings.Replace(validResult, `"accessibility_granted":true`, `"accessibility_granted":true,"raw_action":"press"`, 1), want: ErrUnknownField},
+		{name: "nested payload duplicate", requestRaw: validRequest, resultRaw: strings.Replace(validResult, `"accessibility_granted":true`, `"accessibility_granted":true,"accessibility_granted":false`, 1), want: ErrDuplicateKey},
+		{name: "nested receipt unknown", requestRaw: validRequest, resultRaw: strings.Replace(validResult, `"protocol_version":1},"scope"`, `"protocol_version":1,"helper_path":"/tmp/helper"},"scope"`, 1), want: ErrUnknownField},
+		{name: "nested receipt duplicate", requestRaw: validRequest, resultRaw: strings.Replace(validResult, `"name":"autopus-desktop-local"`, `"name":"autopus-desktop-local","name":"orca-computer-use-macos"`, 1), want: ErrDuplicateKey},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := DecodeExchange([]byte(test.requestRaw), []byte(test.resultRaw))
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, test.want), "error = %v, want %v", err, test.want)
+		})
+	}
+}
+
+func goldenResultEnvelope(
+	t *testing.T,
+	requestID string,
+	operation Operation,
+	scope ReceiptScope,
+	payload string,
+) []byte {
+	t.Helper()
+	runtimeReceipt := successfulReceiptForScope(RuntimeProviderLocal, scope)
+	if operation == OperationGetState {
+		runtimeReceipt.Redaction.Status = RedactionApplied
+		runtimeReceipt.Quarantine.Status = QuarantineCleared
+	}
+	receipt, err := json.Marshal(runtimeReceipt)
+	require.NoError(t, err)
+	return []byte(fmt.Sprintf(
+		`{"protocol_version":1,"request_id":%q,"status":"passed","payload":%s,"runtime_receipt":%s}`,
+		requestID, payload, receipt,
+	))
+}

--- a/pkg/qa/desktopobserve/contract_test.go
+++ b/pkg/qa/desktopobserve/contract_test.go
@@ -1,0 +1,181 @@
+package desktopobserve
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadOnlyOperationAllowlist_ExactFiveSorted(t *testing.T) {
+	t.Parallel()
+
+	want := []Operation{
+		OperationCapabilities,
+		OperationGetState,
+		OperationListApps,
+		OperationListWindows,
+		OperationPermissions,
+	}
+
+	assert.Equal(t, want, ReadOnlyOperations())
+	assert.True(t, IsReadOnlyOperation(OperationGetState))
+	for _, operation := range []Operation{"click", "screenshot", "raw_tree", "shell", "file"} {
+		assert.False(t, IsReadOnlyOperation(operation), operation)
+	}
+}
+
+func TestDecodeRequest_StrictEnvelope(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{
+		"protocol_version":1,
+		"request_id":"req-001",
+		"operation":"get_state",
+		"scope":{"kind":"window","public_ref":"main-window"},
+		"expected_state_ref":"state-001"
+	}`)
+
+	request, err := DecodeRequest(raw)
+	require.NoError(t, err)
+	assert.Equal(t, ProtocolVersion, request.ProtocolVersion)
+	assert.Equal(t, "req-001", request.RequestID)
+	assert.Equal(t, OperationGetState, request.Operation)
+	assert.Equal(t, ScopeWindow, request.Scope.Kind)
+	assert.Equal(t, "main-window", request.Scope.PublicRef)
+	assert.Equal(t, "state-001", request.ExpectedStateRef)
+}
+
+func TestDecodeRequest_RejectsUnsafeOrMalformedInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  []byte
+		want error
+	}{
+		{
+			name: "unknown field",
+			raw:  []byte(`{"protocol_version":1,"request_id":"r","operation":"permissions","scope":{"kind":"provider","public_ref":"local"},"screenshot":true}`),
+			want: ErrUnknownField,
+		},
+		{
+			name: "duplicate key",
+			raw:  []byte(`{"protocol_version":1,"request_id":"r","request_id":"other","operation":"permissions","scope":{"kind":"provider","public_ref":"local"}}`),
+			want: ErrDuplicateKey,
+		},
+		{
+			name: "unsupported operation",
+			raw:  []byte(`{"protocol_version":1,"request_id":"r","operation":"click","scope":{"kind":"window","public_ref":"main-window"}}`),
+			want: ErrUnsupportedOperation,
+		},
+		{
+			name: "protocol mismatch",
+			raw:  []byte(`{"protocol_version":2,"request_id":"r","operation":"permissions","scope":{"kind":"provider","public_ref":"local"}}`),
+			want: ErrProtocolMismatch,
+		},
+		{
+			name: "malformed json",
+			raw:  []byte(`{"protocol_version":1`),
+			want: ErrMalformedEnvelope,
+		},
+		{
+			name: "malformed utf8",
+			raw:  append([]byte(`{"protocol_version":1,"request_id":"`), 0xff),
+			want: ErrMalformedEnvelope,
+		},
+		{
+			name: "oversized",
+			raw:  bytes.Repeat([]byte("x"), MaxEnvelopeBytes+1),
+			want: ErrEnvelopeTooLarge,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := DecodeRequest(test.raw)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, test.want), "error = %v, want %v", err, test.want)
+		})
+	}
+}
+
+func TestDecodeResult_ValidatesProtocolAndRequestBeforePayload(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		raw       string
+		requestID string
+		want      error
+	}{
+		{
+			name:      "protocol mismatch",
+			raw:       `{"protocol_version":2,"request_id":"req-1","status":"failed","runtime_receipt":{}}`,
+			requestID: "req-1",
+			want:      ErrProtocolMismatch,
+		},
+		{
+			name:      "request id mismatch",
+			raw:       `{"protocol_version":1,"request_id":"req-2","status":"failed","runtime_receipt":{}}`,
+			requestID: "req-1",
+			want:      ErrRequestIDMismatch,
+		},
+		{
+			name:      "unknown field",
+			raw:       `{"protocol_version":1,"request_id":"req-1","status":"failed","runtime_receipt":{},"raw_tree":{}}`,
+			requestID: "req-1",
+			want:      ErrUnknownField,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := DecodeResult([]byte(test.raw), test.requestID)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, test.want), "error = %v, want %v", err, test.want)
+		})
+	}
+}
+
+func TestDecodeResult_RejectsDuplicateOversizedAndMalformedEnvelopes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  []byte
+		want error
+	}{
+		{
+			name: "duplicate key",
+			raw:  []byte(`{"protocol_version":1,"request_id":"req-1","request_id":"req-2","status":"failed","runtime_receipt":{}}`),
+			want: ErrDuplicateKey,
+		},
+		{
+			name: "oversized",
+			raw:  bytes.Repeat([]byte("x"), MaxEnvelopeBytes+1),
+			want: ErrEnvelopeTooLarge,
+		},
+		{
+			name: "malformed utf8",
+			raw:  append([]byte(`{"protocol_version":1,"request_id":"`), 0xff),
+			want: ErrMalformedEnvelope,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := DecodeResult(test.raw, "req-1")
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, test.want), "error = %v, want %v", err, test.want)
+		})
+	}
+}

--- a/pkg/qa/desktopobserve/copy.go
+++ b/pkg/qa/desktopobserve/copy.go
@@ -1,0 +1,37 @@
+package desktopobserve
+
+func cloneProjection(source SemanticProjection) SemanticProjection {
+	clone := source
+	clone.Root = cloneSemanticNode(source.Root)
+	clone.CanonicalJSON = append([]byte(nil), source.CanonicalJSON...)
+	return clone
+}
+
+func cloneSemanticNode(source SemanticNode) SemanticNode {
+	clone := source
+	clone.SemanticState = SemanticState{
+		Enabled:  copyPointer(source.SemanticState.Enabled),
+		Expanded: copyPointer(source.SemanticState.Expanded),
+		Focused:  copyPointer(source.SemanticState.Focused),
+		Selected: copyPointer(source.SemanticState.Selected),
+	}
+	clone.Frame = copyFrame(source.Frame)
+	clone.AdvertisedActions = append([]Action(nil), source.AdvertisedActions...)
+	clone.Children = make([]SemanticNode, len(source.Children))
+	for index := range source.Children {
+		clone.Children[index] = cloneSemanticNode(source.Children[index])
+	}
+	return clone
+}
+
+func cloneRuntimeReceipt(source RuntimeReceipt) RuntimeReceipt {
+	clone := source
+	clone.CapabilitySummary = cloneCapabilities(source.CapabilitySummary)
+	clone.ReasonCode = copyPointer(source.ReasonCode)
+	clone.NextStep = copyPointer(source.NextStep)
+	return clone
+}
+
+func cloneCapabilities(source []CapabilityStatus) []CapabilityStatus {
+	return append([]CapabilityStatus(nil), source...)
+}

--- a/pkg/qa/desktopobserve/errors.go
+++ b/pkg/qa/desktopobserve/errors.go
@@ -1,0 +1,29 @@
+package desktopobserve
+
+import "errors"
+
+var (
+	ErrDuplicateKey            = errors.New("desktop observation envelope contains a duplicate key")
+	ErrEnvelopeTooLarge        = errors.New("desktop observation envelope exceeds the byte limit")
+	ErrFailureSignalInvalid    = errors.New("desktop observation failure signal is invalid")
+	ErrInvalidStatus           = errors.New("desktop observation result status is invalid")
+	ErrMalformedEnvelope       = errors.New("desktop observation envelope is malformed")
+	ErrMissingField            = errors.New("desktop observation envelope is missing a required field")
+	ErrProtocolMismatch        = errors.New("desktop observation protocol version mismatch")
+	ErrRequestIDMismatch       = errors.New("desktop observation request ID mismatch")
+	ErrRuntimeProviderInvalid  = errors.New("desktop observation runtime provider is invalid")
+	ErrRuntimeProviderRequired = errors.New("desktop observation runtime provider is required")
+	ErrScopeMismatch           = errors.New("desktop observation scope binding mismatch")
+	ErrUnknownField            = errors.New("desktop observation envelope contains an unknown field")
+	ErrUnsupportedOperation    = errors.New("desktop observation operation is not read-only")
+	ErrRawOnlyEvidence         = errors.New("desktop observation has only quarantined raw evidence")
+	ErrRedactionFailed         = errors.New("desktop observation redaction failed")
+)
+
+type reasonError struct {
+	code ReasonCode
+}
+
+func (err reasonError) Error() string {
+	return string(err.code)
+}

--- a/pkg/qa/desktopobserve/failure_mapping_test.go
+++ b/pkg/qa/desktopobserve/failure_mapping_test.go
@@ -1,0 +1,67 @@
+package desktopobserve
+
+import (
+	"encoding/json"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFailureNormalizer_MapsTenSignalsToSafeNonPassOutcomes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		condition FailureCondition
+		reason    ReasonCode
+	}{
+		{FailureProviderStart, ReasonProviderUnavailable},
+		{FailureOperationMissing, ReasonCapabilityUnsupported},
+		{FailureAccessibilityDenied, ReasonAccessibilityPermissionMissing},
+		{FailureAppAliasUnmatched, ReasonTargetAppNotFound},
+		{FailureWindowAliasUnmatched, ReasonTargetWindowNotFound},
+		{FailureStateRefRejected, ReasonStaleState},
+		{FailureLandmarksInsufficient, ReasonSemanticProjectionUnavailable},
+		{FailureRedaction, ReasonRedactionFailed},
+		{FailureRawOnlyQuarantine, ReasonEvidenceQuarantined},
+		{FailureProtocolVersion, ReasonProviderProtocolMismatch},
+	}
+	emitted := make([]ReasonCode, 0, len(tests))
+	for _, test := range tests {
+		test := test
+		t.Run(string(test.condition), func(t *testing.T) {
+			capabilities := supportedCapabilities()
+			requestedOperation := Operation("")
+			if test.condition == FailureOperationMissing {
+				capabilities[1].Status = CapabilityUnsupported
+				requestedOperation = OperationGetState
+			}
+			outcome, err := NormalizeFailure(FailureSignal{
+				Condition: test.condition,
+				Provider: ProviderIdentity{
+					Name: "autopus-desktop-local", Version: "1.0.0", ProtocolVersion: ProtocolVersion,
+				},
+				Scope:              ReceiptScope{Kind: ScopeWindow, PublicRef: "main-window"},
+				CapabilitySummary:  capabilities,
+				RequestedOperation: requestedOperation,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, outcome.ReasonCode)
+			assert.Equal(t, test.reason, *outcome.ReasonCode)
+			emitted = append(emitted, *outcome.ReasonCode)
+			assert.NotEqual(t, VerdictPassed, outcome.Verdict)
+			assert.Nil(t, outcome.SemanticProjection)
+			assert.Zero(t, passedCheckCount(outcome.DeterministicChecks))
+			require.NotNil(t, outcome.RuntimeReceipt.NextStep)
+			assert.NotEmpty(t, *outcome.RuntimeReceipt.NextStep)
+			require.NoError(t, outcome.RuntimeReceipt.Validate())
+			body, err := json.Marshal(outcome)
+			require.NoError(t, err)
+			assert.False(t, unsafeFailureDetail.Match(body), string(body))
+		})
+	}
+	assert.Equal(t, ReasonCodes(), emitted)
+}
+
+var unsafeFailureDetail = regexp.MustCompile(`(?i)(provider error|raw_tree|screenshot bytes|0x[0-9a-f]+|/Users/|/private/var/|pid[=:]|socket[=:]|secret[=:])`)

--- a/pkg/qa/desktopobserve/model.go
+++ b/pkg/qa/desktopobserve/model.go
@@ -1,0 +1,192 @@
+package desktopobserve
+
+import "encoding/json"
+
+const (
+	ProtocolVersion                 = 1
+	MaxEnvelopeBytes                = 8_192
+	RuntimeReceiptSchemaVersion     = "qamesh.runtime_receipt.v1"
+	SemanticProjectionSchemaVersion = "qamesh.desktop_observation.semantic_projection.v1"
+)
+
+type Operation string
+
+const (
+	OperationCapabilities Operation = "capabilities"
+	OperationGetState     Operation = "get_state"
+	OperationListApps     Operation = "list_apps"
+	OperationListWindows  Operation = "list_windows"
+	OperationPermissions  Operation = "permissions"
+)
+
+type RuntimeProvider string
+
+const (
+	RuntimeProviderLocal RuntimeProvider = "local"
+	RuntimeProviderOrca  RuntimeProvider = "orca"
+)
+
+type ScopeKind string
+
+const (
+	ScopeProvider    ScopeKind = "provider"
+	ScopeApplication ScopeKind = "application"
+	ScopeWindow      ScopeKind = "window"
+	ScopeState       ScopeKind = "state"
+)
+
+type ReceiptScope struct {
+	Kind      ScopeKind `json:"kind"`
+	PublicRef string    `json:"public_ref"`
+}
+
+type ProviderIdentity struct {
+	Name            string `json:"name"`
+	Version         string `json:"version"`
+	ProtocolVersion int    `json:"protocol_version"`
+}
+
+type CapabilityState string
+
+const (
+	CapabilitySupported   CapabilityState = "supported"
+	CapabilityUnsupported CapabilityState = "unsupported"
+)
+
+type CapabilityStatus struct {
+	Name   Operation       `json:"name"`
+	Status CapabilityState `json:"status"`
+}
+
+type RedactionStatus string
+
+const (
+	RedactionApplied     RedactionStatus = "applied"
+	RedactionNotRequired RedactionStatus = "not_required"
+	RedactionFailed      RedactionStatus = "failed"
+)
+
+type QuarantineStatus string
+
+const (
+	QuarantineEmpty     QuarantineStatus = "empty"
+	QuarantineLocalOnly QuarantineStatus = "local_only"
+	QuarantineCleared   QuarantineStatus = "cleared"
+	QuarantineBlocked   QuarantineStatus = "blocked"
+)
+
+type RedactionReceipt struct {
+	Status RedactionStatus `json:"status"`
+}
+
+type QuarantineReceipt struct {
+	Status QuarantineStatus `json:"status"`
+}
+
+type Role string
+
+const (
+	RoleApplication Role = "AXApplication"
+	RoleCanvas      Role = "AXCanvas"
+	RoleGroup       Role = "AXGroup"
+	RoleStaticText  Role = "AXStaticText"
+	RoleWindow      Role = "AXWindow"
+)
+
+type Action string
+
+const (
+	ActionPress    Action = "AXPress"
+	ActionRaise    Action = "AXRaise"
+	ActionShowMenu Action = "AXShowMenu"
+)
+
+type Frame struct {
+	X      int `json:"x"`
+	Y      int `json:"y"`
+	Width  int `json:"width"`
+	Height int `json:"height"`
+}
+
+type SemanticState struct {
+	Enabled  *bool `json:"enabled,omitempty"`
+	Expanded *bool `json:"expanded,omitempty"`
+	Focused  *bool `json:"focused,omitempty"`
+	Selected *bool `json:"selected,omitempty"`
+}
+
+type SemanticNode struct {
+	NodeRef           string         `json:"node_ref"`
+	Role              Role           `json:"role"`
+	Name              string         `json:"name"`
+	SemanticState     SemanticState  `json:"semantic_state"`
+	Frame             *Frame         `json:"frame,omitempty"`
+	AdvertisedActions []Action       `json:"advertised_actions,omitempty"`
+	Children          []SemanticNode `json:"children,omitempty"`
+}
+
+type SemanticProjection struct {
+	SchemaVersion string       `json:"schema_version"`
+	ProviderRef   string       `json:"provider_ref"`
+	AppRef        string       `json:"app_ref"`
+	WindowRef     string       `json:"window_ref"`
+	StateRef      string       `json:"state_ref"`
+	Digest        string       `json:"digest"`
+	Root          SemanticNode `json:"root"`
+	CanonicalJSON []byte       `json:"-"`
+}
+
+type ObservationEvidence struct {
+	SemanticProjection  *SemanticProjection  `json:"semantic_projection,omitempty"`
+	DeterministicChecks []DeterministicCheck `json:"deterministic_checks"`
+	RuntimeReceipt      RuntimeReceipt       `json:"runtime_receipt"`
+}
+
+type PermissionResult struct {
+	AccessibilityGranted bool `json:"accessibility_granted"`
+}
+
+type AppSummary struct {
+	AppRef string `json:"app_ref"`
+}
+
+type WindowSummary struct {
+	WindowRef string `json:"window_ref"`
+}
+
+type Request struct {
+	ProtocolVersion  int          `json:"protocol_version"`
+	RequestID        string       `json:"request_id"`
+	Operation        Operation    `json:"operation"`
+	Scope            ReceiptScope `json:"scope"`
+	ExpectedStateRef string       `json:"expected_state_ref,omitempty"`
+}
+
+type ResultStatus string
+
+const (
+	ResultPassed ResultStatus = "passed"
+	ResultFailed ResultStatus = "failed"
+)
+
+type Result struct {
+	ProtocolVersion int             `json:"protocol_version"`
+	RequestID       string          `json:"request_id"`
+	Status          ResultStatus    `json:"status"`
+	Payload         json.RawMessage `json:"payload,omitempty"`
+	RuntimeReceipt  RuntimeReceipt  `json:"runtime_receipt"`
+}
+
+type Exchange struct {
+	Request Request
+	Result  Result
+}
+
+type SemanticStateKey string
+
+const (
+	StateEnabled  SemanticStateKey = "enabled"
+	StateFocused  SemanticStateKey = "focused"
+	StateSelected SemanticStateKey = "selected"
+	StateExpanded SemanticStateKey = "expanded"
+)

--- a/pkg/qa/desktopobserve/observation_evidence.go
+++ b/pkg/qa/desktopobserve/observation_evidence.go
@@ -1,0 +1,130 @@
+package desktopobserve
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"regexp"
+)
+
+const DeterministicCheckSemanticLandmarks = "desktop-semantic-landmarks"
+
+var forbiddenObservationEvidence = regexp.MustCompile(
+	`(?i)(raw[_ -]?ax|raw_tree|screenshot|\.png|0x[0-9a-f]+|/users/|/tmp/|/private/var/|/var/folders/|/volumes/|/applications/|sk-proj-)`,
+)
+
+type observationEvidenceWire struct {
+	SemanticProjection  json.RawMessage `json:"semantic_projection,omitempty"`
+	DeterministicChecks json.RawMessage `json:"deterministic_checks"`
+	RuntimeReceipt      json.RawMessage `json:"runtime_receipt"`
+}
+
+func DecodeObservationEvidence(raw []byte) (ObservationEvidence, error) {
+	var wire observationEvidenceWire
+	if err := decodeStrict(raw, MaxEnvelopeBytes, &wire); err != nil {
+		return ObservationEvidence{}, err
+	}
+	keys, err := objectKeys(raw)
+	if err != nil {
+		return ObservationEvidence{}, err
+	}
+	if !hasRequiredKeys(keys, "deterministic_checks", "runtime_receipt") {
+		return ObservationEvidence{}, fmt.Errorf("%w: observation evidence", ErrMissingField)
+	}
+
+	receipt, err := DecodeRuntimeReceipt(wire.RuntimeReceipt)
+	if err != nil {
+		return ObservationEvidence{}, err
+	}
+	checks, err := decodeDeterministicChecks(wire.DeterministicChecks)
+	if err != nil {
+		return ObservationEvidence{}, err
+	}
+	projection, err := decodeEvidenceProjection(wire.SemanticProjection)
+	if err != nil {
+		return ObservationEvidence{}, err
+	}
+	evidence := ObservationEvidence{
+		SemanticProjection: projection, DeterministicChecks: checks, RuntimeReceipt: receipt,
+	}
+	if err := validateObservationEvidence(evidence); err != nil {
+		return ObservationEvidence{}, err
+	}
+	normalizedBody, err := json.Marshal(evidence)
+	if err != nil {
+		return ObservationEvidence{}, fmt.Errorf("%w: observation evidence", ErrMalformedEnvelope)
+	}
+	if forbiddenObservationEvidence.Match(normalizedBody) {
+		return ObservationEvidence{}, ErrRedactionFailed
+	}
+	return evidence, nil
+}
+
+func decodeEvidenceProjection(raw json.RawMessage) (*SemanticProjection, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, fmt.Errorf("%w: semantic_projection", ErrMalformedEnvelope)
+	}
+	var projection SemanticProjection
+	if err := decodeStrict(raw, MaxEnvelopeBytes, &projection); err != nil {
+		return nil, err
+	}
+	if err := validateProjectionJSONShape(raw); err != nil {
+		return nil, err
+	}
+	if err := validateProjection(projection); err != nil {
+		return nil, fmt.Errorf("%w: semantic_projection", ErrMalformedEnvelope)
+	}
+	normalized, err := NormalizeProjection(projection, func(value string) (string, error) {
+		return value, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &normalized, nil
+}
+
+func decodeDeterministicChecks(raw json.RawMessage) ([]DeterministicCheck, error) {
+	if len(raw) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, fmt.Errorf("%w: deterministic_checks", ErrMissingField)
+	}
+	var checks []DeterministicCheck
+	if err := decodeStrict(raw, MaxEnvelopeBytes, &checks); err != nil {
+		return nil, err
+	}
+	if len(checks) != 1 || checks[0].ID != DeterministicCheckSemanticLandmarks {
+		return nil, fmt.Errorf("%w: deterministic_checks", ErrMalformedEnvelope)
+	}
+	if checks[0].Status != CheckPassed && checks[0].Status != CheckBlocked {
+		return nil, fmt.Errorf("%w: deterministic check status", ErrInvalidStatus)
+	}
+	return checks, nil
+}
+
+func validateObservationEvidence(evidence ObservationEvidence) error {
+	check := evidence.DeterministicChecks[0]
+	receipt := evidence.RuntimeReceipt
+	if receipt.ReasonCode == nil {
+		if evidence.SemanticProjection == nil || check.Status != CheckPassed || check.ReasonCode != nil {
+			return fmt.Errorf("%w: contradictory success evidence", ErrMalformedEnvelope)
+		}
+		request := Request{
+			ProtocolVersion: ProtocolVersion, RequestID: "evidence-validation",
+			Operation: OperationGetState, Scope: ReceiptScope{Kind: ScopeWindow, PublicRef: "main-window"},
+		}
+		result := Result{RuntimeReceipt: receipt, Status: ResultPassed}
+		if err := validateSuccessBinding(request, result, *evidence.SemanticProjection); err != nil {
+			return err
+		}
+		return nil
+	}
+	if evidence.SemanticProjection != nil || check.Status != CheckBlocked {
+		return fmt.Errorf("%w: contradictory failure evidence", ErrMalformedEnvelope)
+	}
+	if check.ReasonCode == nil || *check.ReasonCode != *receipt.ReasonCode {
+		return fmt.Errorf("%w: deterministic check reason", ErrMalformedEnvelope)
+	}
+	return nil
+}

--- a/pkg/qa/desktopobserve/observation_evidence_test.go
+++ b/pkg/qa/desktopobserve/observation_evidence_test.go
@@ -1,0 +1,269 @@
+package desktopobserve
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeObservationEvidence_ValidSuccessAndFailureRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		evidence ObservationEvidence
+	}{
+		{name: "success", evidence: successfulObservationFixture(t)},
+		{name: "failure", evidence: failedObservationFixture()},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			body, err := json.Marshal(test.evidence)
+			require.NoError(t, err)
+
+			decoded, err := DecodeObservationEvidence(body)
+			require.NoError(t, err)
+			assert.Equal(t, test.evidence.RuntimeReceipt, decoded.RuntimeReceipt)
+			assert.Equal(t, test.evidence.DeterministicChecks, decoded.DeterministicChecks)
+			if test.evidence.SemanticProjection == nil {
+				assert.Nil(t, decoded.SemanticProjection)
+				return
+			}
+			require.NotNil(t, decoded.SemanticProjection)
+			assert.Equal(t, test.evidence.SemanticProjection.Digest, decoded.SemanticProjection.Digest)
+			assert.NotEmpty(t, decoded.SemanticProjection.CanonicalJSON)
+		})
+	}
+}
+
+func TestDecodeObservationEvidence_RejectsNestedUnknownAndDuplicateFields(t *testing.T) {
+	t.Parallel()
+
+	body, err := json.Marshal(successfulObservationFixture(t))
+	require.NoError(t, err)
+	tests := []struct {
+		name        string
+		old         string
+		replacement string
+		want        error
+	}{
+		{name: "top level unknown", old: `{"semantic_projection":`, replacement: `{"raw_tree":{},"semantic_projection":`, want: ErrUnknownField},
+		{name: "projection unknown", old: `"provider_ref":"provider-local"`, replacement: `"provider_ref":"provider-local","raw_handle":"0x42"`, want: ErrUnknownField},
+		{name: "node unknown", old: `"role":"AXApplication"`, replacement: `"role":"AXApplication","index":7`, want: ErrUnknownField},
+		{name: "state unknown", old: `"enabled":true`, replacement: `"enabled":true,"raw_value":"secret"`, want: ErrUnknownField},
+		{name: "check unknown", old: `"id":"desktop-semantic-landmarks"`, replacement: `"id":"desktop-semantic-landmarks","error_text":"secret"`, want: ErrUnknownField},
+		{name: "receipt unknown", old: `"name":"autopus-desktop-local"`, replacement: `"name":"autopus-desktop-local","helper_path":"/tmp/helper"`, want: ErrUnknownField},
+		{name: "nested duplicate", old: `"provider_ref":"provider-local"`, replacement: `"provider_ref":"provider-local","provider_ref":"provider-other"`, want: ErrDuplicateKey},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mutated := bytes.Replace(body, []byte(test.old), []byte(test.replacement), 1)
+			require.NotEqual(t, body, mutated)
+			_, err := DecodeObservationEvidence(mutated)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, test.want)
+		})
+	}
+}
+
+func TestDecodeObservationEvidence_RejectsMissingRecursiveRequiredKeys(t *testing.T) {
+	t.Parallel()
+
+	evidence := successfulObservationFixture(t)
+	evidence.SemanticProjection.Root.SemanticState = SemanticState{}
+	normalized, err := NormalizeProjection(*evidence.SemanticProjection, identityRedactor)
+	require.NoError(t, err)
+	evidence.SemanticProjection = &normalized
+	body, err := json.Marshal(evidence)
+	require.NoError(t, err)
+	tests := []struct {
+		name        string
+		old         string
+		replacement string
+	}{
+		{name: "semantic state", old: `,"semantic_state":{}`, replacement: ``},
+		{name: "frame width", old: `,"width":1440`, replacement: ``},
+		{name: "deterministic checks", old: `,"deterministic_checks":`, replacement: `,"removed_checks":`},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mutated := bytes.Replace(body, []byte(test.old), []byte(test.replacement), 1)
+			require.NotEqual(t, body, mutated)
+			_, err := DecodeObservationEvidence(mutated)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestDecodeObservationEvidence_RejectsTamperedDigestAndRawSensitiveValue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("digest", func(t *testing.T) {
+		t.Parallel()
+		evidence := successfulObservationFixture(t)
+		evidence.SemanticProjection.Digest = strings.Repeat("0", 64)
+		body, err := json.Marshal(evidence)
+		require.NoError(t, err)
+		_, err = DecodeObservationEvidence(body)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrMalformedEnvelope)
+	})
+
+	t.Run("secret name", func(t *testing.T) {
+		t.Parallel()
+		evidence := successfulObservationFixture(t)
+		evidence.SemanticProjection.Root.Name = "sk-proj-qamesh-secret-1234567890"
+		normalized, err := NormalizeProjection(*evidence.SemanticProjection, identityRedactor)
+		require.NoError(t, err)
+		evidence.SemanticProjection = &normalized
+		body, err := json.Marshal(evidence)
+		require.NoError(t, err)
+		_, err = DecodeObservationEvidence(body)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrRedactionFailed)
+	})
+
+	t.Run("escaped secret name", func(t *testing.T) {
+		t.Parallel()
+		evidence := successfulObservationFixture(t)
+		evidence.SemanticProjection.Root.Name = "sk-proj-qamesh-secret-1234567890"
+		normalized, err := NormalizeProjection(*evidence.SemanticProjection, identityRedactor)
+		require.NoError(t, err)
+		evidence.SemanticProjection = &normalized
+		body, err := json.Marshal(evidence)
+		require.NoError(t, err)
+		body = bytes.Replace(body, []byte("sk-proj-"), []byte(`sk\u002dproj\u002d`), 1)
+		require.NotContains(t, string(body), "sk-proj-")
+		_, err = DecodeObservationEvidence(body)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrRedactionFailed)
+	})
+}
+
+func TestDecodeObservationEvidence_UnknownAdvertisedActionEmitsNoSemanticPayload(t *testing.T) {
+	t.Parallel()
+
+	evidence := successfulObservationFixture(t)
+	body, err := json.Marshal(evidence)
+	require.NoError(t, err)
+	body = bytes.Replace(body, []byte(`"AXPress"`), []byte(`"AXUnsafe"`), 1)
+	require.Contains(t, string(body), "AXUnsafe")
+
+	decoded, err := DecodeObservationEvidence(body)
+	require.Error(t, err)
+	assert.Nil(t, decoded.SemanticProjection)
+}
+
+func TestDecodeObservationEvidence_RejectsContradictoryChecksReceiptAndPayload(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(*ObservationEvidence)
+	}{
+		{name: "unknown check", mutate: func(evidence *ObservationEvidence) { evidence.DeterministicChecks[0].ID = "other-check" }},
+		{name: "duplicate check", mutate: func(evidence *ObservationEvidence) {
+			evidence.DeterministicChecks = append(evidence.DeterministicChecks, evidence.DeterministicChecks[0])
+		}},
+		{name: "success blocked", mutate: func(evidence *ObservationEvidence) { evidence.DeterministicChecks[0].Status = CheckBlocked }},
+		{name: "success reason", mutate: func(evidence *ObservationEvidence) {
+			reason := ReasonStaleState
+			evidence.DeterministicChecks[0].ReasonCode = &reason
+		}},
+		{name: "success projection absent", mutate: func(evidence *ObservationEvidence) { evidence.SemanticProjection = nil }},
+		{name: "success redaction proof absent", mutate: func(evidence *ObservationEvidence) {
+			evidence.RuntimeReceipt.Redaction.Status = RedactionNotRequired
+			evidence.RuntimeReceipt.Quarantine.Status = QuarantineEmpty
+		}},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			evidence := successfulObservationFixture(t)
+			test.mutate(&evidence)
+			body, err := json.Marshal(evidence)
+			require.NoError(t, err)
+			_, err = DecodeObservationEvidence(body)
+			require.Error(t, err)
+		})
+	}
+
+	failureTests := []struct {
+		name   string
+		mutate func(*ObservationEvidence)
+	}{
+		{name: "failure carries projection", mutate: func(evidence *ObservationEvidence) {
+			success := successfulObservationFixture(t)
+			evidence.SemanticProjection = success.SemanticProjection
+		}},
+		{name: "failure check passed", mutate: func(evidence *ObservationEvidence) { evidence.DeterministicChecks[0].Status = CheckPassed }},
+		{name: "failure check reason absent", mutate: func(evidence *ObservationEvidence) {
+			evidence.DeterministicChecks[0].ReasonCode = nil
+		}},
+		{name: "failure contradictory reason", mutate: func(evidence *ObservationEvidence) {
+			reason := ReasonProviderUnavailable
+			evidence.DeterministicChecks[0].ReasonCode = &reason
+		}},
+	}
+	for _, test := range failureTests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			evidence := failedObservationFixture()
+			test.mutate(&evidence)
+			body, err := json.Marshal(evidence)
+			require.NoError(t, err)
+			_, err = DecodeObservationEvidence(body)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestDecodeObservationEvidence_RejectsMalformedAndOversizedInput(t *testing.T) {
+	t.Parallel()
+
+	_, err := DecodeObservationEvidence([]byte(`{"semantic_projection":`))
+	require.ErrorIs(t, err, ErrMalformedEnvelope)
+	_, err = DecodeObservationEvidence(bytes.Repeat([]byte("x"), MaxEnvelopeBytes+1))
+	require.ErrorIs(t, err, ErrEnvelopeTooLarge)
+}
+
+func successfulObservationFixture(t *testing.T) ObservationEvidence {
+	t.Helper()
+	projection, err := NormalizeProjection(semanticFixture(), identityRedactor)
+	require.NoError(t, err)
+	return ObservationEvidence{
+		SemanticProjection: &projection,
+		DeterministicChecks: []DeterministicCheck{{
+			ID: "desktop-semantic-landmarks", Status: CheckPassed,
+		}},
+		RuntimeReceipt: successfulStateReceipt(RuntimeProviderLocal),
+	}
+}
+
+func failedObservationFixture() ObservationEvidence {
+	reason := ReasonEvidenceQuarantined
+	nextStep := NextStep(reason)
+	receipt := successfulReceipt(RuntimeProviderLocal)
+	receipt.ReasonCode = &reason
+	receipt.NextStep = &nextStep
+	receipt.Redaction.Status = RedactionApplied
+	receipt.Quarantine.Status = QuarantineLocalOnly
+	return ObservationEvidence{
+		DeterministicChecks: []DeterministicCheck{{
+			ID: "desktop-semantic-landmarks", Status: CheckBlocked, ReasonCode: &reason,
+		}},
+		RuntimeReceipt: receipt,
+	}
+}

--- a/pkg/qa/desktopobserve/observation_shape.go
+++ b/pkg/qa/desktopobserve/observation_shape.go
@@ -1,0 +1,106 @@
+package desktopobserve
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+func validateProjectionJSONShape(raw json.RawMessage) error {
+	keys, err := objectKeys(raw)
+	if err != nil {
+		return err
+	}
+	if !hasExactKeys(keys,
+		"schema_version", "provider_ref", "app_ref", "window_ref", "state_ref", "digest", "root",
+	) {
+		return fmt.Errorf("%w: semantic_projection", ErrMissingField)
+	}
+	for _, key := range []string{
+		"schema_version", "provider_ref", "app_ref", "window_ref", "state_ref", "digest", "root",
+	} {
+		if isJSONNull(keys[key]) {
+			return fmt.Errorf("%w: semantic_projection.%s", ErrMalformedEnvelope, key)
+		}
+	}
+	return validateSemanticNodeJSONShape(keys["root"])
+}
+
+func validateSemanticNodeJSONShape(raw json.RawMessage) error {
+	keys, err := objectKeys(raw)
+	if err != nil {
+		return err
+	}
+	if !hasRequiredKeys(keys, "node_ref", "role", "name", "semantic_state") {
+		return fmt.Errorf("%w: semantic node", ErrMissingField)
+	}
+	for _, key := range []string{"node_ref", "role", "name", "semantic_state"} {
+		if isJSONNull(keys[key]) {
+			return fmt.Errorf("%w: semantic node.%s", ErrMalformedEnvelope, key)
+		}
+	}
+	if err := validateSemanticStateJSONShape(keys["semantic_state"]); err != nil {
+		return err
+	}
+	if frame, present := keys["frame"]; present {
+		if err := validateFrameJSONShape(frame); err != nil {
+			return err
+		}
+	}
+	if actions, present := keys["advertised_actions"]; present && isJSONNull(actions) {
+		return fmt.Errorf("%w: advertised_actions", ErrMalformedEnvelope)
+	}
+	if children, present := keys["children"]; present {
+		if isJSONNull(children) {
+			return fmt.Errorf("%w: children", ErrMalformedEnvelope)
+		}
+		var values []json.RawMessage
+		if err := decodeStrict(children, MaxEnvelopeBytes, &values); err != nil {
+			return err
+		}
+		for _, child := range values {
+			if err := validateSemanticNodeJSONShape(child); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateSemanticStateJSONShape(raw json.RawMessage) error {
+	keys, err := objectKeys(raw)
+	if err != nil {
+		return err
+	}
+	for key, value := range keys {
+		switch key {
+		case "enabled", "expanded", "focused", "selected":
+			if isJSONNull(value) {
+				return fmt.Errorf("%w: semantic_state.%s", ErrMalformedEnvelope, key)
+			}
+		default:
+			return fmt.Errorf("%w: semantic_state.%s", ErrUnknownField, key)
+		}
+	}
+	return nil
+}
+
+func validateFrameJSONShape(raw json.RawMessage) error {
+	keys, err := objectKeys(raw)
+	if err != nil {
+		return err
+	}
+	if !hasExactKeys(keys, "x", "y", "width", "height") {
+		return fmt.Errorf("%w: frame", ErrMissingField)
+	}
+	for key, value := range keys {
+		if isJSONNull(value) {
+			return fmt.Errorf("%w: frame.%s", ErrMalformedEnvelope, key)
+		}
+	}
+	return nil
+}
+
+func isJSONNull(raw json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(raw), []byte("null"))
+}

--- a/pkg/qa/desktopobserve/oracle.go
+++ b/pkg/qa/desktopobserve/oracle.go
@@ -1,0 +1,275 @@
+package desktopobserve
+
+import "fmt"
+
+type FailureCondition string
+
+const (
+	FailureProviderStart         FailureCondition = "provider_start"
+	FailureOperationMissing      FailureCondition = "operation_missing"
+	FailureAccessibilityDenied   FailureCondition = "accessibility_denied"
+	FailureAppAliasUnmatched     FailureCondition = "app_alias_unmatched"
+	FailureWindowAliasUnmatched  FailureCondition = "window_alias_unmatched"
+	FailureStateRefRejected      FailureCondition = "state_ref_rejected"
+	FailureLandmarksInsufficient FailureCondition = "landmarks_insufficient"
+	FailureRedaction             FailureCondition = "redaction"
+	FailureRawOnlyQuarantine     FailureCondition = "raw_only_quarantine"
+	FailureProtocolVersion       FailureCondition = "protocol_version"
+)
+
+var failureReasons = map[FailureCondition]ReasonCode{
+	FailureProviderStart:         ReasonProviderUnavailable,
+	FailureOperationMissing:      ReasonCapabilityUnsupported,
+	FailureAccessibilityDenied:   ReasonAccessibilityPermissionMissing,
+	FailureAppAliasUnmatched:     ReasonTargetAppNotFound,
+	FailureWindowAliasUnmatched:  ReasonTargetWindowNotFound,
+	FailureStateRefRejected:      ReasonStaleState,
+	FailureLandmarksInsufficient: ReasonSemanticProjectionUnavailable,
+	FailureRedaction:             ReasonRedactionFailed,
+	FailureRawOnlyQuarantine:     ReasonEvidenceQuarantined,
+	FailureProtocolVersion:       ReasonProviderProtocolMismatch,
+}
+
+type Verdict string
+
+const (
+	VerdictPassed  Verdict = "passed"
+	VerdictBlocked Verdict = "blocked"
+)
+
+type CheckStatus string
+
+const (
+	CheckPassed  CheckStatus = "passed"
+	CheckBlocked CheckStatus = "blocked"
+)
+
+type DeterministicCheck struct {
+	ID         string      `json:"id"`
+	Status     CheckStatus `json:"status"`
+	ReasonCode *ReasonCode `json:"reason_code,omitempty"`
+}
+
+type LandmarkRequirement struct {
+	Role          Role
+	Name          string
+	RequiredState SemanticStateKey
+}
+
+type OraclePolicy struct {
+	MinimumLandmarks []LandmarkRequirement
+	AllowedNames     []string
+}
+
+type OracleInput struct {
+	Projection SemanticProjection
+	Ledger     *StateLedger
+	Policy     OraclePolicy
+	Receipt    RuntimeReceipt
+}
+
+type OracleOutcome struct {
+	Verdict             Verdict              `json:"verdict"`
+	ReasonCode          *ReasonCode          `json:"reason_code,omitempty"`
+	SemanticProjection  *SemanticProjection  `json:"semantic_projection,omitempty"`
+	DeterministicChecks []DeterministicCheck `json:"deterministic_checks"`
+	RuntimeReceipt      RuntimeReceipt       `json:"runtime_receipt"`
+	FailureCondition    FailureCondition     `json:"-"`
+}
+
+type FailureSignal struct {
+	Condition          FailureCondition
+	Provider           ProviderIdentity
+	Scope              ReceiptScope
+	CapabilitySummary  []CapabilityStatus
+	RequestedOperation Operation
+}
+
+func EvaluateOracle(input OracleInput) (OracleOutcome, error) {
+	if err := input.Receipt.Validate(); err != nil {
+		return OracleOutcome{}, fmt.Errorf("oracle receipt: %w", err)
+	}
+	if err := validateStateReceipt(input.Receipt); err != nil {
+		return OracleOutcome{}, err
+	}
+	if err := validateProjection(input.Projection); err != nil {
+		return OracleOutcome{}, fmt.Errorf("oracle projection: %w", err)
+	}
+	binding := StateBinding{
+		StateRef: input.Projection.StateRef, ProviderRef: input.Projection.ProviderRef,
+		AppRef: input.Projection.AppRef, WindowRef: input.Projection.WindowRef,
+		Digest: input.Projection.Digest,
+	}
+	if input.Ledger == nil || input.Ledger.Consume(binding) != nil {
+		return normalizedOracleFailure(FailureStateRefRejected, input.Receipt)
+	}
+	if !namesAreAllowlisted(input.Projection.Root, input.Policy.AllowedNames) {
+		return normalizedOracleFailure(FailureRedaction, input.Receipt)
+	}
+	if !meetsLandmarkPolicy(input.Projection.Root, input.Policy) {
+		return normalizedOracleFailure(FailureLandmarksInsufficient, input.Receipt)
+	}
+	projection := cloneProjection(input.Projection)
+	return OracleOutcome{
+		Verdict:            VerdictPassed,
+		SemanticProjection: &projection,
+		DeterministicChecks: []DeterministicCheck{{
+			ID: "desktop-semantic-landmarks", Status: CheckPassed,
+		}},
+		RuntimeReceipt: cloneRuntimeReceipt(input.Receipt),
+	}, nil
+}
+
+func NormalizeFailure(signal FailureSignal) (OracleOutcome, error) {
+	reason, ok := failureReasons[signal.Condition]
+	if !ok || !validProvider(signal.Provider) || !validReceiptScope(signal.Scope) ||
+		!validCapabilities(signal.CapabilitySummary) {
+		return OracleOutcome{}, ErrFailureSignalInvalid
+	}
+	if signal.Condition == FailureOperationMissing &&
+		(!IsReadOnlyOperation(signal.RequestedOperation) ||
+			capabilityState(signal.CapabilitySummary, signal.RequestedOperation) != CapabilityUnsupported) {
+		return OracleOutcome{}, ErrFailureSignalInvalid
+	}
+	receipt := failureReceipt(signal.Provider, signal.Scope, signal.CapabilitySummary, reason)
+	if err := receipt.Validate(); err != nil {
+		return OracleOutcome{}, fmt.Errorf("failure receipt: %w", err)
+	}
+	return OracleOutcome{
+		Verdict: VerdictBlocked, ReasonCode: &reason,
+		DeterministicChecks: []DeterministicCheck{{
+			ID: "desktop-semantic-landmarks", Status: CheckBlocked, ReasonCode: &reason,
+		}},
+		RuntimeReceipt: receipt, FailureCondition: signal.Condition,
+	}, nil
+}
+
+func normalizedOracleFailure(condition FailureCondition, receipt RuntimeReceipt) (OracleOutcome, error) {
+	return NormalizeFailure(FailureSignal{
+		Condition: condition, Provider: receipt.Provider, Scope: receipt.Scope,
+		CapabilitySummary: receipt.CapabilitySummary,
+	})
+}
+
+func failureReceipt(
+	provider ProviderIdentity,
+	scope ReceiptScope,
+	capabilities []CapabilityStatus,
+	reason ReasonCode,
+) RuntimeReceipt {
+	nextStep := NextStep(reason)
+	receipt := RuntimeReceipt{
+		SchemaVersion: RuntimeReceiptSchemaVersion, Provider: provider, Scope: scope,
+		CapabilitySummary: cloneCapabilities(capabilities), ReasonCode: &reason, NextStep: &nextStep,
+		Redaction:  RedactionReceipt{Status: RedactionNotRequired},
+		Quarantine: QuarantineReceipt{Status: QuarantineEmpty},
+	}
+	switch reason {
+	case ReasonRedactionFailed:
+		receipt.Redaction.Status = RedactionFailed
+		receipt.Quarantine.Status = QuarantineBlocked
+	case ReasonEvidenceQuarantined:
+		receipt.Redaction.Status = RedactionApplied
+		receipt.Quarantine.Status = QuarantineLocalOnly
+	}
+	return receipt
+}
+
+func supportedCapabilities() []CapabilityStatus {
+	operations := ReadOnlyOperations()
+	capabilities := make([]CapabilityStatus, 0, len(operations))
+	for _, operation := range operations {
+		capabilities = append(capabilities, CapabilityStatus{
+			Name: operation, Status: CapabilitySupported,
+		})
+	}
+	return capabilities
+}
+
+func unsupportedCapabilities() []CapabilityStatus {
+	capabilities := supportedCapabilities()
+	for index := range capabilities {
+		capabilities[index].Status = CapabilityUnsupported
+	}
+	return capabilities
+}
+
+func capabilityState(capabilities []CapabilityStatus, operation Operation) CapabilityState {
+	for _, capability := range capabilities {
+		if capability.Name == operation {
+			return capability.Status
+		}
+	}
+	return ""
+}
+
+func validateStateReceipt(receipt RuntimeReceipt) error {
+	if receipt.ReasonCode != nil || receipt.Redaction.Status != RedactionApplied ||
+		receipt.Quarantine.Status != QuarantineCleared {
+		return ErrRedactionFailed
+	}
+	return nil
+}
+
+func namesAreAllowlisted(root SemanticNode, allowedNames []string) bool {
+	if len(allowedNames) == 0 {
+		return false
+	}
+	allowed := make(map[string]struct{}, len(allowedNames))
+	for _, name := range allowedNames {
+		normalized, err := normalizeText(name)
+		if err != nil {
+			return false
+		}
+		allowed[normalized] = struct{}{}
+	}
+	var walk func(SemanticNode) bool
+	walk = func(node SemanticNode) bool {
+		if _, ok := allowed[node.Name]; !ok {
+			return false
+		}
+		for _, child := range node.Children {
+			if !walk(child) {
+				return false
+			}
+		}
+		return true
+	}
+	return walk(root)
+}
+
+func meetsLandmarkPolicy(root SemanticNode, policy OraclePolicy) bool {
+	if len(policy.MinimumLandmarks) == 0 {
+		return false
+	}
+	for _, requirement := range policy.MinimumLandmarks {
+		if !containsLandmark(root, requirement) {
+			return false
+		}
+	}
+	return true
+}
+
+func containsLandmark(node SemanticNode, requirement LandmarkRequirement) bool {
+	if node.Role == requirement.Role && node.Name == requirement.Name &&
+		stateSatisfies(node.SemanticState, requirement.RequiredState) {
+		return true
+	}
+	for _, child := range node.Children {
+		if containsLandmark(child, requirement) {
+			return true
+		}
+	}
+	return false
+}
+
+func stateSatisfies(state SemanticState, key SemanticStateKey) bool {
+	return map[SemanticStateKey]bool{
+		StateEnabled: boolState(state.Enabled), StateFocused: boolState(state.Focused),
+		StateSelected: boolState(state.Selected), StateExpanded: boolState(state.Expanded),
+	}[key]
+}
+
+func boolState(value *bool) bool {
+	return value != nil && *value
+}

--- a/pkg/qa/desktopobserve/oracle_test.go
+++ b/pkg/qa/desktopobserve/oracle_test.go
@@ -1,0 +1,96 @@
+package desktopobserve
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanvasMinimumLandmarks_MissingSemanticCoverageCannotPass(t *testing.T) {
+	t.Parallel()
+
+	projection := semanticFixture()
+	projection.Root = SemanticNode{
+		NodeRef: "canvas",
+		Role:    RoleCanvas,
+		Frame:   &Frame{X: 0, Y: 0, Width: 900, Height: 700},
+	}
+	normalized, err := NormalizeProjection(projection, identityRedactor)
+	require.NoError(t, err)
+	ledger := NewStateLedger()
+	require.NoError(t, ledger.Register(bindingForProjection(normalized)))
+
+	outcome, err := EvaluateOracle(OracleInput{
+		Projection: normalized,
+		Ledger:     ledger,
+		Policy:     signedAppOraclePolicy(),
+		Receipt:    successfulStateReceipt(RuntimeProviderLocal),
+	})
+	require.NoError(t, err)
+
+	assert.NotEqual(t, VerdictPassed, outcome.Verdict)
+	require.NotNil(t, outcome.ReasonCode)
+	assert.Equal(t, ReasonSemanticProjectionUnavailable, *outcome.ReasonCode)
+	assert.Nil(t, outcome.SemanticProjection)
+	assert.Zero(t, passedCheckCount(outcome.DeterministicChecks))
+}
+
+func TestDeterministicOracle_FreshMinimumLandmarksPassOnce(t *testing.T) {
+	t.Parallel()
+
+	normalized, err := NormalizeProjection(semanticFixture(), identityRedactor)
+	require.NoError(t, err)
+	ledger := NewStateLedger()
+	binding := bindingForProjection(normalized)
+	require.NoError(t, ledger.Register(binding))
+	input := OracleInput{
+		Projection: normalized,
+		Ledger:     ledger,
+		Policy:     signedAppOraclePolicy(),
+		Receipt:    successfulStateReceipt(RuntimeProviderLocal),
+	}
+
+	first, err := EvaluateOracle(input)
+	require.NoError(t, err)
+	assert.Equal(t, VerdictPassed, first.Verdict)
+	require.NotNil(t, first.SemanticProjection)
+	assert.NotZero(t, passedCheckCount(first.DeterministicChecks))
+
+	second, err := EvaluateOracle(input)
+	require.NoError(t, err)
+	assert.NotEqual(t, VerdictPassed, second.Verdict)
+	require.NotNil(t, second.ReasonCode)
+	assert.Equal(t, ReasonStaleState, *second.ReasonCode)
+	assert.Nil(t, second.SemanticProjection)
+}
+
+func signedAppOraclePolicy() OraclePolicy {
+	return OraclePolicy{
+		MinimumLandmarks: []LandmarkRequirement{
+			{Role: RoleApplication, Name: "Autopus", RequiredState: StateEnabled},
+			{Role: RoleWindow, Name: "Autopus", RequiredState: StateFocused},
+		},
+		AllowedNames: []string{"", "Autopus"},
+	}
+}
+
+func bindingForProjection(projection SemanticProjection) StateBinding {
+	return StateBinding{
+		StateRef:    projection.StateRef,
+		ProviderRef: projection.ProviderRef,
+		AppRef:      projection.AppRef,
+		WindowRef:   projection.WindowRef,
+		Digest:      projection.Digest,
+	}
+}
+
+func passedCheckCount(checks []DeterministicCheck) int {
+	count := 0
+	for _, check := range checks {
+		if check.Status == CheckPassed {
+			count++
+		}
+	}
+	return count
+}

--- a/pkg/qa/desktopobserve/protocol.go
+++ b/pkg/qa/desktopobserve/protocol.go
@@ -1,0 +1,272 @@
+package desktopobserve
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+func ReadOnlyOperations() []Operation {
+	return []Operation{
+		OperationCapabilities,
+		OperationGetState,
+		OperationListApps,
+		OperationListWindows,
+		OperationPermissions,
+	}
+}
+
+func IsReadOnlyOperation(operation Operation) bool {
+	for _, allowed := range ReadOnlyOperations() {
+		if operation == allowed {
+			return true
+		}
+	}
+	return false
+}
+
+func DecodeRequest(raw []byte) (Request, error) {
+	var request Request
+	if err := decodeStrict(raw, MaxEnvelopeBytes, &request); err != nil {
+		return Request{}, err
+	}
+	keys, err := objectKeys(raw)
+	if err != nil {
+		return Request{}, err
+	}
+	if !hasRequiredKeys(keys, "protocol_version", "request_id", "operation", "scope") {
+		return Request{}, fmt.Errorf("%w: request", ErrMissingField)
+	}
+	if request.ProtocolVersion != ProtocolVersion {
+		return Request{}, ErrProtocolMismatch
+	}
+	if request.RequestID == "" {
+		return Request{}, fmt.Errorf("%w: request_id", ErrMissingField)
+	}
+	if request.Operation == "" {
+		return Request{}, fmt.Errorf("%w: operation", ErrMissingField)
+	}
+	if !IsReadOnlyOperation(request.Operation) {
+		return Request{}, ErrUnsupportedOperation
+	}
+	if request.Scope.Kind == "" || request.Scope.PublicRef == "" {
+		return Request{}, fmt.Errorf("%w: scope", ErrMissingField)
+	}
+	if !validRequestScope(request.Operation, request.Scope) {
+		return Request{}, fmt.Errorf("%w: scope", ErrMalformedEnvelope)
+	}
+	if expected, present := keys["expected_state_ref"]; present {
+		if bytes.Equal(bytes.TrimSpace(expected), []byte("null")) ||
+			!validOpaqueRef(request.ExpectedStateRef, "state-") {
+			return Request{}, fmt.Errorf("%w: expected_state_ref", ErrMalformedEnvelope)
+		}
+		if request.Operation != OperationGetState {
+			return Request{}, ErrUnsupportedOperation
+		}
+	}
+	return request, nil
+}
+
+func DecodeResult(raw []byte, requestID string) (Result, error) {
+	type resultWire struct {
+		ProtocolVersion int             `json:"protocol_version"`
+		RequestID       string          `json:"request_id"`
+		Status          ResultStatus    `json:"status"`
+		Payload         json.RawMessage `json:"payload,omitempty"`
+		RuntimeReceipt  json.RawMessage `json:"runtime_receipt"`
+	}
+	var wire resultWire
+	if err := decodeStrict(raw, MaxEnvelopeBytes, &wire); err != nil {
+		return Result{}, err
+	}
+	keys, err := objectKeys(raw)
+	if err != nil {
+		return Result{}, err
+	}
+	if !hasRequiredKeys(keys, "protocol_version", "request_id", "status", "runtime_receipt") {
+		return Result{}, fmt.Errorf("%w: result", ErrMissingField)
+	}
+	if wire.ProtocolVersion != ProtocolVersion {
+		return Result{}, ErrProtocolMismatch
+	}
+	if wire.RequestID == "" {
+		return Result{}, fmt.Errorf("%w: request_id", ErrMissingField)
+	}
+	if wire.RequestID != requestID {
+		return Result{}, ErrRequestIDMismatch
+	}
+	if wire.Status != ResultPassed && wire.Status != ResultFailed {
+		return Result{}, ErrInvalidStatus
+	}
+	if wire.Status == ResultPassed && len(wire.Payload) == 0 {
+		return Result{}, fmt.Errorf("%w: payload", ErrMissingField)
+	}
+	if wire.Status == ResultFailed && len(wire.Payload) != 0 {
+		return Result{}, fmt.Errorf("%w: failed payload", ErrUnknownField)
+	}
+	if len(wire.RuntimeReceipt) == 0 || bytes.Equal(bytes.TrimSpace(wire.RuntimeReceipt), []byte("null")) {
+		return Result{}, fmt.Errorf("%w: runtime_receipt", ErrMissingField)
+	}
+	receipt, err := DecodeRuntimeReceipt(wire.RuntimeReceipt)
+	if err != nil {
+		return Result{}, err
+	}
+	if (wire.Status == ResultPassed) != (receipt.ReasonCode == nil) {
+		return Result{}, fmt.Errorf("%w: result receipt status", ErrMalformedEnvelope)
+	}
+	return Result{
+		ProtocolVersion: wire.ProtocolVersion,
+		RequestID:       wire.RequestID,
+		Status:          wire.Status,
+		Payload:         wire.Payload,
+		RuntimeReceipt:  receipt,
+	}, nil
+}
+
+func DecodeExchange(requestRaw, resultRaw []byte) (Exchange, error) {
+	request, err := DecodeRequest(requestRaw)
+	if err != nil {
+		return Exchange{}, err
+	}
+	result, err := DecodeResult(resultRaw, request.RequestID)
+	if err != nil {
+		return Exchange{}, err
+	}
+	if result.Status == ResultPassed {
+		projection, err := validateOperationPayload(request.Operation, result.Payload)
+		if err != nil {
+			return Exchange{}, err
+		}
+		if err := validateSuccessBinding(request, result, projection); err != nil {
+			return Exchange{}, err
+		}
+	}
+	return Exchange{Request: request, Result: result}, nil
+}
+
+func validRequestScope(operation Operation, scope ReceiptScope) bool {
+	expected := ScopeProvider
+	switch operation {
+	case OperationListWindows:
+		return scope.Kind == ScopeApplication && scope.PublicRef == "autopus-desktop"
+	case OperationGetState:
+		return scope.Kind == ScopeWindow && scope.PublicRef == "main-window"
+	}
+	return scope.Kind == expected &&
+		(scope.PublicRef == "autopus-desktop-local" || scope.PublicRef == "orca-computer-use-macos")
+}
+
+func validateOperationPayload(operation Operation, raw json.RawMessage) (SemanticProjection, error) {
+	switch operation {
+	case OperationCapabilities:
+		var payload struct {
+			Capabilities []CapabilityStatus `json:"capabilities"`
+		}
+		if err := decodeStrict(raw, MaxEnvelopeBytes, &payload); err != nil {
+			return SemanticProjection{}, err
+		}
+		if !validCapabilities(payload.Capabilities) {
+			return SemanticProjection{}, fmt.Errorf("%w: capabilities", ErrMalformedEnvelope)
+		}
+	case OperationPermissions:
+		var payload struct {
+			AccessibilityGranted *bool `json:"accessibility_granted"`
+		}
+		if err := decodeStrict(raw, MaxEnvelopeBytes, &payload); err != nil {
+			return SemanticProjection{}, err
+		}
+		if payload.AccessibilityGranted == nil || !*payload.AccessibilityGranted {
+			return SemanticProjection{}, fmt.Errorf("%w: accessibility_granted", ErrMalformedEnvelope)
+		}
+	case OperationListApps:
+		var payload struct {
+			Apps []AppSummary `json:"apps"`
+		}
+		if err := decodeStrict(raw, MaxEnvelopeBytes, &payload); err != nil {
+			return SemanticProjection{}, err
+		}
+		if !validApps(payload.Apps) {
+			return SemanticProjection{}, fmt.Errorf("%w: apps", ErrMalformedEnvelope)
+		}
+	case OperationListWindows:
+		var payload struct {
+			Windows []WindowSummary `json:"windows"`
+		}
+		if err := decodeStrict(raw, MaxEnvelopeBytes, &payload); err != nil {
+			return SemanticProjection{}, err
+		}
+		if !validWindows(payload.Windows) {
+			return SemanticProjection{}, fmt.Errorf("%w: windows", ErrMalformedEnvelope)
+		}
+	case OperationGetState:
+		var payload struct {
+			SemanticProjection *SemanticProjection `json:"semantic_projection"`
+		}
+		if err := decodeStrict(raw, MaxEnvelopeBytes, &payload); err != nil {
+			return SemanticProjection{}, err
+		}
+		if payload.SemanticProjection == nil || validateProjection(*payload.SemanticProjection) != nil {
+			return SemanticProjection{}, fmt.Errorf("%w: semantic_projection", ErrMalformedEnvelope)
+		}
+		return *payload.SemanticProjection, nil
+	default:
+		return SemanticProjection{}, ErrUnsupportedOperation
+	}
+	return SemanticProjection{}, nil
+}
+
+func validApps(apps []AppSummary) bool {
+	return len(apps) == 1 && apps[0].AppRef == "autopus-desktop"
+}
+
+func validWindows(windows []WindowSummary) bool {
+	return len(windows) == 1 && windows[0].WindowRef == "main-window"
+}
+
+func validateSuccessBinding(request Request, result Result, projection SemanticProjection) error {
+	receipt := result.RuntimeReceipt
+	switch request.Operation {
+	case OperationCapabilities, OperationPermissions, OperationListApps:
+		if request.Scope.Kind != ScopeProvider || request.Scope.PublicRef != receipt.Provider.Name ||
+			receipt.Scope != request.Scope {
+			return ErrScopeMismatch
+		}
+	case OperationListWindows:
+		if request.Scope.Kind != ScopeApplication || request.Scope.PublicRef != "autopus-desktop" ||
+			receipt.Scope != request.Scope {
+			return ErrScopeMismatch
+		}
+	case OperationGetState:
+		if err := validateStateReceipt(receipt); err != nil {
+			return err
+		}
+		if projection.ProviderRef != providerRef(receipt.Provider.Name) ||
+			projection.AppRef != "autopus-desktop" || projection.WindowRef != request.Scope.PublicRef ||
+			!validOpaqueRef(projection.StateRef, "state-") {
+			return ErrScopeMismatch
+		}
+		windowScope := receipt.Scope == request.Scope
+		stateScope := receipt.Scope.Kind == ScopeState && receipt.Scope.PublicRef == projection.StateRef
+		if !windowScope && !stateScope {
+			return ErrScopeMismatch
+		}
+	default:
+		return ErrUnsupportedOperation
+	}
+	return nil
+}
+
+func providerRef(providerName string) string {
+	switch providerName {
+	case "autopus-desktop-local":
+		return "provider-local"
+	case "orca-computer-use-macos":
+		return "provider-orca"
+	default:
+		return ""
+	}
+}
+
+func safePublicRef(value string) bool {
+	return len(value) <= 96 && safePublicRefPattern.MatchString(value)
+}

--- a/pkg/qa/desktopobserve/protocol_binding_test.go
+++ b/pkg/qa/desktopobserve/protocol_binding_test.go
@@ -1,0 +1,128 @@
+package desktopobserve
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeExchange_GetStateBindsRequestProjectionReceiptAndProvider(t *testing.T) {
+	t.Parallel()
+
+	request := []byte(`{"protocol_version":1,"request_id":"req-bind","operation":"get_state","scope":{"kind":"window","public_ref":"main-window"}}`)
+	tests := []struct {
+		name   string
+		mutate func(*SemanticProjection, *RuntimeReceipt)
+	}{
+		{name: "projection window", mutate: func(projection *SemanticProjection, _ *RuntimeReceipt) { projection.WindowRef = "other-window" }},
+		{name: "projection app", mutate: func(projection *SemanticProjection, _ *RuntimeReceipt) { projection.AppRef = "other-app" }},
+		{name: "projection provider", mutate: func(projection *SemanticProjection, _ *RuntimeReceipt) { projection.ProviderRef = "provider-orca" }},
+		{name: "receipt state", mutate: func(_ *SemanticProjection, receipt *RuntimeReceipt) {
+			receipt.Scope = ReceiptScope{Kind: ScopeState, PublicRef: "state-other"}
+		}},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			projection := semanticFixture()
+			receipt := successfulStateReceipt(RuntimeProviderLocal)
+			test.mutate(&projection, &receipt)
+			normalized, err := NormalizeProjection(projection, identityRedactor)
+			require.NoError(t, err)
+			result := passedResultEnvelope(t, "req-bind", map[string]any{"semantic_projection": normalized}, receipt)
+
+			_, err = DecodeExchange(request, result)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrScopeMismatch)
+		})
+	}
+}
+
+func TestDecodeExchange_GetStateRequiresAppliedRedactionProof(t *testing.T) {
+	t.Parallel()
+
+	projection, err := NormalizeProjection(semanticFixture(), identityRedactor)
+	require.NoError(t, err)
+	receipt := successfulReceipt(RuntimeProviderLocal)
+	result := passedResultEnvelope(t, "req-redaction", map[string]any{"semantic_projection": projection}, receipt)
+	request := []byte(`{"protocol_version":1,"request_id":"req-redaction","operation":"get_state","scope":{"kind":"window","public_ref":"main-window"}}`)
+
+	_, err = DecodeExchange(request, result)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrRedactionFailed)
+}
+
+func TestDecodeExchange_GetStateAcceptsBoundLocalAndOrcaProviders(t *testing.T) {
+	t.Parallel()
+
+	for _, provider := range []RuntimeProvider{RuntimeProviderLocal, RuntimeProviderOrca} {
+		provider := provider
+		t.Run(string(provider), func(t *testing.T) {
+			t.Parallel()
+			projection := semanticFixture()
+			projection.ProviderRef = providerRef(providerIdentity(provider).Name)
+			projection.StateRef = "state-bound-" + string(provider)
+			normalized, err := NormalizeProjection(projection, identityRedactor)
+			require.NoError(t, err)
+			receipt := successfulStateReceipt(provider)
+			receipt.Scope = ReceiptScope{Kind: ScopeState, PublicRef: normalized.StateRef}
+			result := passedResultEnvelope(
+				t, "req-provider", map[string]any{"semantic_projection": normalized}, receipt,
+			)
+			request := []byte(`{"protocol_version":1,"request_id":"req-provider","operation":"get_state","scope":{"kind":"window","public_ref":"main-window"}}`)
+
+			exchange, err := DecodeExchange(request, result)
+			require.NoError(t, err)
+			assert.Equal(t, providerIdentity(provider), exchange.Result.RuntimeReceipt.Provider)
+		})
+	}
+}
+
+func TestDecodeExchange_PassedPayloadCannotRepresentFailureState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		operation Operation
+		scope     ReceiptScope
+		payload   any
+	}{
+		{name: "permission false", operation: OperationPermissions, scope: ReceiptScope{Kind: ScopeProvider, PublicRef: "autopus-desktop-local"}, payload: map[string]any{"accessibility_granted": false}},
+		{name: "apps empty", operation: OperationListApps, scope: ReceiptScope{Kind: ScopeProvider, PublicRef: "autopus-desktop-local"}, payload: map[string]any{"apps": []AppSummary{}}},
+		{name: "apps duplicate", operation: OperationListApps, scope: ReceiptScope{Kind: ScopeProvider, PublicRef: "autopus-desktop-local"}, payload: map[string]any{"apps": []AppSummary{{AppRef: "autopus-desktop"}, {AppRef: "autopus-desktop"}}}},
+		{name: "windows empty", operation: OperationListWindows, scope: ReceiptScope{Kind: ScopeApplication, PublicRef: "autopus-desktop"}, payload: map[string]any{"windows": []WindowSummary{}}},
+		{name: "windows duplicate", operation: OperationListWindows, scope: ReceiptScope{Kind: ScopeApplication, PublicRef: "autopus-desktop"}, payload: map[string]any{"windows": []WindowSummary{{WindowRef: "main-window"}, {WindowRef: "main-window"}}}},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			request := []byte(fmt.Sprintf(
+				`{"protocol_version":1,"request_id":"req-failure","operation":%q,"scope":{"kind":%q,"public_ref":%q}}`,
+				test.operation, test.scope.Kind, test.scope.PublicRef,
+			))
+			receipt := successfulReceiptForScope(RuntimeProviderLocal, test.scope)
+			result := passedResultEnvelope(t, "req-failure", test.payload, receipt)
+
+			_, err := DecodeExchange(request, result)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrMalformedEnvelope)
+		})
+	}
+}
+
+func passedResultEnvelope(t *testing.T, requestID string, payload any, receipt RuntimeReceipt) []byte {
+	t.Helper()
+	payloadBody, err := json.Marshal(payload)
+	require.NoError(t, err)
+	receiptBody, err := json.Marshal(receipt)
+	require.NoError(t, err)
+	return []byte(fmt.Sprintf(
+		`{"protocol_version":1,"request_id":%q,"status":"passed","payload":%s,"runtime_receipt":%s}`,
+		requestID, payloadBody, receiptBody,
+	))
+}

--- a/pkg/qa/desktopobserve/reasons.go
+++ b/pkg/qa/desktopobserve/reasons.go
@@ -1,0 +1,65 @@
+package desktopobserve
+
+import "errors"
+
+type ReasonCode string
+
+const (
+	ReasonProviderUnavailable            ReasonCode = "provider_unavailable"
+	ReasonCapabilityUnsupported          ReasonCode = "capability_unsupported"
+	ReasonAccessibilityPermissionMissing ReasonCode = "accessibility_permission_missing"
+	ReasonTargetAppNotFound              ReasonCode = "target_app_not_found"
+	ReasonTargetWindowNotFound           ReasonCode = "target_window_not_found"
+	ReasonStaleState                     ReasonCode = "stale_state"
+	ReasonSemanticProjectionUnavailable  ReasonCode = "semantic_projection_unavailable"
+	ReasonRedactionFailed                ReasonCode = "redaction_failed"
+	ReasonEvidenceQuarantined            ReasonCode = "evidence_quarantined"
+	ReasonProviderProtocolMismatch       ReasonCode = "provider_protocol_mismatch"
+)
+
+var reasonOrder = []ReasonCode{
+	ReasonProviderUnavailable,
+	ReasonCapabilityUnsupported,
+	ReasonAccessibilityPermissionMissing,
+	ReasonTargetAppNotFound,
+	ReasonTargetWindowNotFound,
+	ReasonStaleState,
+	ReasonSemanticProjectionUnavailable,
+	ReasonRedactionFailed,
+	ReasonEvidenceQuarantined,
+	ReasonProviderProtocolMismatch,
+}
+
+var safeNextSteps = map[ReasonCode]string{
+	ReasonProviderUnavailable:            "Check the selected provider lifecycle, then rerun with the same explicit selection.",
+	ReasonCapabilityUnsupported:          "Inspect the capability summary and select a supporting provider version explicitly.",
+	ReasonAccessibilityPermissionMissing: "Grant Accessibility to the displayed signed identity in Privacy & Security, then rerun.",
+	ReasonTargetAppNotFound:              "Start the expected signed app and verify its project-local public alias.",
+	ReasonTargetWindowNotFound:           "Open the expected window and verify its project-local public alias.",
+	ReasonStaleState:                     "Capture fresh state and evaluate the new state reference exactly once.",
+	ReasonSemanticProjectionUnavailable:  "Fix the target surface Accessibility landmarks without using an OCR fallback.",
+	ReasonRedactionFailed:                "Keep the payload unpublished and correct the local redaction policy finding.",
+	ReasonEvidenceQuarantined:            "Keep raw material local and regenerate a safe semantic projection.",
+	ReasonProviderProtocolMismatch:       "Align the explicitly selected provider and adapter protocol versions.",
+}
+
+func ReasonCodes() []ReasonCode {
+	return append([]ReasonCode(nil), reasonOrder...)
+}
+
+func NextStep(reason ReasonCode) string {
+	return safeNextSteps[reason]
+}
+
+func validReason(reason ReasonCode) bool {
+	_, ok := safeNextSteps[reason]
+	return ok
+}
+
+func ReasonCodeOf(err error) ReasonCode {
+	var normalized reasonError
+	if errors.As(err, &normalized) {
+		return normalized.code
+	}
+	return ""
+}

--- a/pkg/qa/desktopobserve/reasons_test.go
+++ b/pkg/qa/desktopobserve/reasons_test.go
@@ -1,0 +1,34 @@
+package desktopobserve
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExactReasonTaxonomy_HasTenSafeNonEmptyNextSteps(t *testing.T) {
+	t.Parallel()
+
+	want := []ReasonCode{
+		ReasonProviderUnavailable,
+		ReasonCapabilityUnsupported,
+		ReasonAccessibilityPermissionMissing,
+		ReasonTargetAppNotFound,
+		ReasonTargetWindowNotFound,
+		ReasonStaleState,
+		ReasonSemanticProjectionUnavailable,
+		ReasonRedactionFailed,
+		ReasonEvidenceQuarantined,
+		ReasonProviderProtocolMismatch,
+	}
+	assert.Equal(t, want, ReasonCodes())
+	assert.Len(t, ReasonCodes(), 10)
+
+	unsafe := regexp.MustCompile(`(?i)(/users/|/tmp/|pid\s*[=:]|socket\s*[=:]|handle\s*[=:]|raw[_ -]?title|secret\s*[=:]|\b(?:sh|bash|zsh)\s+-c\b|\brm\s+-rf\b)`)
+	for _, reason := range ReasonCodes() {
+		next := NextStep(reason)
+		assert.NotEmpty(t, next, reason)
+		assert.False(t, unsafe.MatchString(next), "%s next_step is unsafe: %s", reason, next)
+	}
+}

--- a/pkg/qa/desktopobserve/receipt.go
+++ b/pkg/qa/desktopobserve/receipt.go
@@ -1,0 +1,143 @@
+package desktopobserve
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type RuntimeReceipt struct {
+	SchemaVersion     string             `json:"schema_version"`
+	Provider          ProviderIdentity   `json:"provider"`
+	Scope             ReceiptScope       `json:"scope"`
+	CapabilitySummary []CapabilityStatus `json:"capability_summary"`
+	ReasonCode        *ReasonCode        `json:"reason_code"`
+	NextStep          *string            `json:"next_step"`
+	Redaction         RedactionReceipt   `json:"redaction"`
+	Quarantine        QuarantineReceipt  `json:"quarantine"`
+}
+
+var safeVersion = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][a-z0-9][a-z0-9.-]*)?$`)
+var safePublicRefPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`)
+
+func (receipt RuntimeReceipt) Validate() error {
+	if receipt.SchemaVersion != RuntimeReceiptSchemaVersion {
+		return fmt.Errorf("%w: schema_version", ErrMissingField)
+	}
+	if !validProvider(receipt.Provider) {
+		return fmt.Errorf("%w: provider", ErrMalformedEnvelope)
+	}
+	if !validReceiptScope(receipt.Scope) {
+		return fmt.Errorf("%w: scope", ErrMalformedEnvelope)
+	}
+	if !validCapabilities(receipt.CapabilitySummary) {
+		return fmt.Errorf("%w: capability_summary", ErrMalformedEnvelope)
+	}
+	if !validRedactionStatus(receipt.Redaction.Status) ||
+		!validQuarantineStatus(receipt.Quarantine.Status) {
+		return fmt.Errorf("%w: receipt status", ErrMalformedEnvelope)
+	}
+	return validateReceiptOutcome(receipt)
+}
+
+func DecodeRuntimeReceipt(raw []byte) (RuntimeReceipt, error) {
+	var receipt RuntimeReceipt
+	if err := decodeStrict(raw, MaxEnvelopeBytes, &receipt); err != nil {
+		return RuntimeReceipt{}, err
+	}
+	keys, err := objectKeys(raw)
+	if err != nil {
+		return RuntimeReceipt{}, err
+	}
+	if !hasExactKeys(keys, "schema_version", "provider", "scope", "capability_summary",
+		"reason_code", "next_step", "redaction", "quarantine") {
+		return RuntimeReceipt{}, fmt.Errorf("%w: runtime_receipt", ErrMissingField)
+	}
+	if err := receipt.Validate(); err != nil {
+		return RuntimeReceipt{}, err
+	}
+	return receipt, nil
+}
+
+func validProvider(provider ProviderIdentity) bool {
+	if provider.Name != "autopus-desktop-local" && provider.Name != "orca-computer-use-macos" {
+		return false
+	}
+	return safeVersion.MatchString(provider.Version) && provider.ProtocolVersion == ProtocolVersion
+}
+
+func validReceiptScope(scope ReceiptScope) bool {
+	switch scope.Kind {
+	case ScopeProvider:
+		return scope.PublicRef == "autopus-desktop-local" || scope.PublicRef == "orca-computer-use-macos"
+	case ScopeApplication:
+		return scope.PublicRef == "autopus-desktop"
+	case ScopeWindow:
+		return scope.PublicRef == "main-window"
+	case ScopeState:
+		return validOpaqueRef(scope.PublicRef, "state-")
+	default:
+		return false
+	}
+}
+
+func validCapabilities(capabilities []CapabilityStatus) bool {
+	operations := ReadOnlyOperations()
+	if len(capabilities) != len(operations) {
+		return false
+	}
+	for index, capability := range capabilities {
+		if capability.Name != operations[index] ||
+			(capability.Status != CapabilitySupported && capability.Status != CapabilityUnsupported) {
+			return false
+		}
+	}
+	return true
+}
+
+func validateReceiptOutcome(receipt RuntimeReceipt) error {
+	if receipt.ReasonCode == nil {
+		if receipt.NextStep != nil {
+			return fmt.Errorf("%w: success next_step", ErrMalformedEnvelope)
+		}
+		if (receipt.Redaction.Status == RedactionNotRequired && receipt.Quarantine.Status == QuarantineEmpty) ||
+			(receipt.Redaction.Status == RedactionApplied && receipt.Quarantine.Status == QuarantineCleared) {
+			return nil
+		}
+		return fmt.Errorf("%w: inconsistent success receipt", ErrMalformedEnvelope)
+	}
+	reason := *receipt.ReasonCode
+	if !validReason(reason) || receipt.NextStep == nil || *receipt.NextStep != NextStep(reason) {
+		return fmt.Errorf("%w: normalized failure", ErrMalformedEnvelope)
+	}
+	switch reason {
+	case ReasonRedactionFailed:
+		if receipt.Redaction.Status != RedactionFailed || receipt.Quarantine.Status != QuarantineBlocked {
+			return fmt.Errorf("%w: redaction failure status", ErrMalformedEnvelope)
+		}
+	case ReasonEvidenceQuarantined:
+		if receipt.Redaction.Status != RedactionApplied ||
+			(receipt.Quarantine.Status != QuarantineLocalOnly && receipt.Quarantine.Status != QuarantineBlocked) {
+			return fmt.Errorf("%w: quarantine failure status", ErrMalformedEnvelope)
+		}
+	default:
+		if receipt.Redaction.Status != RedactionNotRequired || receipt.Quarantine.Status != QuarantineEmpty {
+			return fmt.Errorf("%w: ordinary failure status", ErrMalformedEnvelope)
+		}
+	}
+	return nil
+}
+
+func validRedactionStatus(status RedactionStatus) bool {
+	return status == RedactionApplied || status == RedactionNotRequired || status == RedactionFailed
+}
+
+func validQuarantineStatus(status QuarantineStatus) bool {
+	return status == QuarantineEmpty || status == QuarantineLocalOnly ||
+		status == QuarantineCleared || status == QuarantineBlocked
+}
+
+func validOpaqueRef(value, prefix string) bool {
+	return len(value) > len(prefix) && len(value) <= 96 &&
+		strings.HasPrefix(value, prefix) && safePublicRefPattern.MatchString(value)
+}

--- a/pkg/qa/desktopobserve/receipt_test.go
+++ b/pkg/qa/desktopobserve/receipt_test.go
@@ -1,0 +1,137 @@
+package desktopobserve
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRuntimeReceiptV1_ExactAllowlistAndNullSuccessReason(t *testing.T) {
+	t.Parallel()
+
+	receipt := successfulReceipt(RuntimeProviderLocal)
+	require.NoError(t, receipt.Validate())
+	body, err := json.Marshal(receipt)
+	require.NoError(t, err)
+
+	var object map[string]any
+	require.NoError(t, json.Unmarshal(body, &object))
+	assert.ElementsMatch(t, []string{
+		"schema_version",
+		"provider",
+		"scope",
+		"capability_summary",
+		"reason_code",
+		"next_step",
+		"redaction",
+		"quarantine",
+	}, mapKeys(object))
+	assert.Contains(t, object, "reason_code")
+	assert.Nil(t, object["reason_code"])
+	assert.Contains(t, object, "next_step")
+	assert.Nil(t, object["next_step"])
+
+	provider := object["provider"].(map[string]any)
+	assert.ElementsMatch(t, []string{"name", "version", "protocol_version"}, mapKeys(provider))
+	scope := object["scope"].(map[string]any)
+	assert.ElementsMatch(t, []string{"kind", "public_ref"}, mapKeys(scope))
+	redaction := object["redaction"].(map[string]any)
+	assert.ElementsMatch(t, []string{"status"}, mapKeys(redaction))
+	quarantine := object["quarantine"].(map[string]any)
+	assert.ElementsMatch(t, []string{"status"}, mapKeys(quarantine))
+}
+
+func TestRuntimeReceiptV1_RejectsUnknownOrSensitiveFields(t *testing.T) {
+	t.Parallel()
+
+	unknown := []byte(`{
+		"schema_version":"qamesh.runtime_receipt.v1",
+		"provider":{"name":"autopus-desktop-local","version":"1.0.0","protocol_version":1},
+		"scope":{"kind":"window","public_ref":"main-window"},
+		"capability_summary":[],
+		"reason_code":null,
+		"next_step":null,
+		"redaction":{"status":"not_required"},
+		"quarantine":{"status":"empty"},
+		"extensions":{"pid":42}
+	}`)
+	_, err := DecodeRuntimeReceipt(unknown)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnknownField)
+
+	receipt := successfulReceipt(RuntimeProviderLocal)
+	receipt.Provider.Name = "/Users/alice/bin/provider --socket /tmp/private.sock"
+	err = receipt.Validate()
+	require.Error(t, err)
+}
+
+func TestRuntimeReceiptV1_FailureContainsOnlyNormalizedReason(t *testing.T) {
+	t.Parallel()
+
+	reason := ReasonRedactionFailed
+	receipt := successfulReceipt(RuntimeProviderOrca)
+	receipt.ReasonCode = &reason
+	nextStep := NextStep(reason)
+	receipt.NextStep = &nextStep
+	receipt.Redaction.Status = RedactionFailed
+	receipt.Quarantine.Status = QuarantineBlocked
+
+	require.NoError(t, receipt.Validate())
+	body, err := json.Marshal(receipt)
+	require.NoError(t, err)
+	assert.NotContains(t, string(body), "provider error")
+	assert.NotContains(t, string(body), "raw_tree")
+	assert.NotContains(t, string(body), "screenshot")
+	assert.NotContains(t, string(body), "/Users/")
+}
+
+func successfulReceipt(provider RuntimeProvider) RuntimeReceipt {
+	return successfulReceiptForScope(provider, ReceiptScope{Kind: ScopeWindow, PublicRef: "main-window"})
+}
+
+func successfulStateReceipt(provider RuntimeProvider) RuntimeReceipt {
+	receipt := successfulReceipt(provider)
+	receipt.Redaction.Status = RedactionApplied
+	receipt.Quarantine.Status = QuarantineCleared
+	return receipt
+}
+
+func successfulReceiptForScope(provider RuntimeProvider, scope ReceiptScope) RuntimeReceipt {
+	identity := providerIdentity(provider)
+	return RuntimeReceipt{
+		SchemaVersion: RuntimeReceiptSchemaVersion,
+		Provider:      identity,
+		Scope:         scope,
+		CapabilitySummary: []CapabilityStatus{
+			{Name: OperationCapabilities, Status: CapabilitySupported},
+			{Name: OperationGetState, Status: CapabilitySupported},
+			{Name: OperationListApps, Status: CapabilitySupported},
+			{Name: OperationListWindows, Status: CapabilitySupported},
+			{Name: OperationPermissions, Status: CapabilitySupported},
+		},
+		ReasonCode: nil,
+		NextStep:   nil,
+		Redaction:  RedactionReceipt{Status: RedactionNotRequired},
+		Quarantine: QuarantineReceipt{Status: QuarantineEmpty},
+	}
+}
+
+func providerIdentity(provider RuntimeProvider) ProviderIdentity {
+	name := "autopus-desktop-local"
+	if provider == RuntimeProviderOrca {
+		name = "orca-computer-use-macos"
+	}
+	return ProviderIdentity{
+		Name: name, Version: "1.0.0", ProtocolVersion: ProtocolVersion,
+	}
+}
+
+func mapKeys(values map[string]any) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	return keys
+}

--- a/pkg/qa/desktopobserve/receipt_values_test.go
+++ b/pkg/qa/desktopobserve/receipt_values_test.go
@@ -1,0 +1,182 @@
+package desktopobserve
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRuntimeReceipt_ProviderIdentityAndScopeValuesAreStrict(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(*RuntimeReceipt)
+	}{
+		{name: "schema", mutate: func(value *RuntimeReceipt) { value.SchemaVersion = "v2" }},
+		{name: "local public name", mutate: func(value *RuntimeReceipt) { value.Provider.Name = "autopus-local" }},
+		{name: "unknown provider", mutate: func(value *RuntimeReceipt) { value.Provider.Name = "other-provider" }},
+		{name: "empty provider version", mutate: func(value *RuntimeReceipt) { value.Provider.Version = "" }},
+		{name: "provider path", mutate: func(value *RuntimeReceipt) { value.Provider.Version = "/Applications/helper" }},
+		{name: "protocol", mutate: func(value *RuntimeReceipt) { value.Provider.ProtocolVersion++ }},
+		{name: "scope kind", mutate: func(value *RuntimeReceipt) { value.Scope.Kind = "process" }},
+		{name: "scope alias", mutate: func(value *RuntimeReceipt) { value.Scope.PublicRef = "window-42" }},
+		{name: "scope path", mutate: func(value *RuntimeReceipt) { value.Scope.PublicRef = "/Users/alice/window" }},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			receipt := successfulReceipt(RuntimeProviderLocal)
+			test.mutate(&receipt)
+			require.Error(t, receipt.Validate())
+		})
+	}
+
+	require.NoError(t, successfulReceipt(RuntimeProviderLocal).Validate())
+	require.NoError(t, successfulReceipt(RuntimeProviderOrca).Validate())
+}
+
+func TestRuntimeReceipt_AllFourPublicScopeKindsAcceptOnlyPublicRefs(t *testing.T) {
+	t.Parallel()
+
+	tests := []ReceiptScope{
+		{Kind: ScopeProvider, PublicRef: "autopus-desktop-local"},
+		{Kind: ScopeApplication, PublicRef: "autopus-desktop"},
+		{Kind: ScopeWindow, PublicRef: "main-window"},
+		{Kind: ScopeState, PublicRef: "state-001"},
+	}
+	for _, scope := range tests {
+		scope := scope
+		t.Run(string(scope.Kind), func(t *testing.T) {
+			t.Parallel()
+			receipt := successfulReceipt(RuntimeProviderLocal)
+			receipt.Scope = scope
+			require.NoError(t, receipt.Validate())
+		})
+	}
+}
+
+func TestRuntimeReceipt_CapabilitySummaryIsExactSortedSafeAllowlist(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(*RuntimeReceipt)
+	}{
+		{name: "missing", mutate: func(value *RuntimeReceipt) { value.CapabilitySummary = value.CapabilitySummary[:4] }},
+		{name: "duplicate", mutate: func(value *RuntimeReceipt) { value.CapabilitySummary[4] = value.CapabilitySummary[3] }},
+		{name: "unsorted", mutate: func(value *RuntimeReceipt) {
+			value.CapabilitySummary[0], value.CapabilitySummary[1] = value.CapabilitySummary[1], value.CapabilitySummary[0]
+		}},
+		{name: "unsafe operation", mutate: func(value *RuntimeReceipt) {
+			value.CapabilitySummary[0].Name = Operation("screenshot")
+		}},
+		{name: "invalid status", mutate: func(value *RuntimeReceipt) {
+			value.CapabilitySummary[0].Status = "unknown"
+		}},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			receipt := successfulReceipt(RuntimeProviderLocal)
+			test.mutate(&receipt)
+			require.Error(t, receipt.Validate())
+		})
+	}
+}
+
+func TestRuntimeReceipt_ReasonNextStepAndFailClosedStatusesAreConsistent(t *testing.T) {
+	t.Parallel()
+
+	next := "retry"
+	reason := ReasonProviderUnavailable
+	tests := []struct {
+		name   string
+		mutate func(*RuntimeReceipt)
+	}{
+		{name: "success next step", mutate: func(value *RuntimeReceipt) { value.NextStep = &next }},
+		{name: "failure missing next step", mutate: func(value *RuntimeReceipt) { value.ReasonCode = &reason }},
+		{name: "unknown reason", mutate: func(value *RuntimeReceipt) {
+			unknown := ReasonCode("provider_internal_error")
+			value.ReasonCode, value.NextStep = &unknown, &next
+		}},
+		{name: "wrong normalized next step", mutate: func(value *RuntimeReceipt) {
+			value.ReasonCode, value.NextStep = &reason, &next
+		}},
+		{name: "redaction status", mutate: func(value *RuntimeReceipt) { value.Redaction.Status = "partial" }},
+		{name: "quarantine status", mutate: func(value *RuntimeReceipt) { value.Quarantine.Status = "uploaded" }},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			receipt := successfulReceipt(RuntimeProviderLocal)
+			test.mutate(&receipt)
+			assert.Error(t, receipt.Validate())
+		})
+	}
+
+	failure := successfulReceipt(RuntimeProviderLocal)
+	failure.ReasonCode = &reason
+	normalized := NextStep(reason)
+	failure.NextStep = &normalized
+	require.NoError(t, failure.Validate())
+}
+
+func TestRuntimeReceipt_ValidEnumsStillRequireMeaningfullyConsistentCombinations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		reason     ReasonCode
+		redaction  RedactionStatus
+		quarantine QuarantineStatus
+		valid      bool
+	}{
+		{name: "success not required empty", redaction: RedactionNotRequired, quarantine: QuarantineEmpty, valid: true},
+		{name: "success applied cleared", redaction: RedactionApplied, quarantine: QuarantineCleared, valid: true},
+		{name: "success redaction failed", redaction: RedactionFailed, quarantine: QuarantineBlocked},
+		{name: "success local only", redaction: RedactionApplied, quarantine: QuarantineLocalOnly},
+		{name: "success quarantine blocked", redaction: RedactionApplied, quarantine: QuarantineBlocked},
+		{name: "ordinary failure clean", reason: ReasonProviderUnavailable, redaction: RedactionNotRequired, quarantine: QuarantineEmpty, valid: true},
+		{name: "ordinary failure claims redaction", reason: ReasonProviderUnavailable, redaction: RedactionFailed, quarantine: QuarantineBlocked},
+		{name: "ordinary failure claims quarantine", reason: ReasonProviderUnavailable, redaction: RedactionApplied, quarantine: QuarantineLocalOnly},
+		{name: "redaction failure exact", reason: ReasonRedactionFailed, redaction: RedactionFailed, quarantine: QuarantineBlocked, valid: true},
+		{name: "redaction failure not required", reason: ReasonRedactionFailed, redaction: RedactionNotRequired, quarantine: QuarantineBlocked},
+		{name: "redaction failure applied", reason: ReasonRedactionFailed, redaction: RedactionApplied, quarantine: QuarantineBlocked},
+		{name: "redaction failure local only", reason: ReasonRedactionFailed, redaction: RedactionFailed, quarantine: QuarantineLocalOnly},
+		{name: "redaction failure cleared", reason: ReasonRedactionFailed, redaction: RedactionFailed, quarantine: QuarantineCleared},
+		{name: "evidence quarantined local only", reason: ReasonEvidenceQuarantined, redaction: RedactionApplied, quarantine: QuarantineLocalOnly, valid: true},
+		{name: "evidence quarantined blocked", reason: ReasonEvidenceQuarantined, redaction: RedactionApplied, quarantine: QuarantineBlocked, valid: true},
+		{name: "evidence quarantined empty", reason: ReasonEvidenceQuarantined, redaction: RedactionApplied, quarantine: QuarantineEmpty},
+		{name: "evidence quarantined cleared", reason: ReasonEvidenceQuarantined, redaction: RedactionApplied, quarantine: QuarantineCleared},
+		{name: "evidence quarantined wrong reason status", reason: ReasonEvidenceQuarantined, redaction: RedactionFailed, quarantine: QuarantineBlocked},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			receipt := successfulReceipt(RuntimeProviderLocal)
+			receipt.Redaction.Status = test.redaction
+			receipt.Quarantine.Status = test.quarantine
+			if test.reason != "" {
+				reason := test.reason
+				next := NextStep(reason)
+				receipt.ReasonCode, receipt.NextStep = &reason, &next
+			}
+			err := receipt.Validate()
+			if test.valid {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+		})
+	}
+}

--- a/pkg/qa/desktopobserve/security_regression_test.go
+++ b/pkg/qa/desktopobserve/security_regression_test.go
@@ -1,0 +1,183 @@
+package desktopobserve
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSemanticProjection_RejectsRawStateStringsAndUnallowlistedNames(t *testing.T) {
+	t.Parallel()
+
+	t.Run("raw state value", func(t *testing.T) {
+		t.Parallel()
+		projection, err := NormalizeProjection(semanticFixture(), identityRedactor)
+		require.NoError(t, err)
+		body, err := json.Marshal(projection)
+		require.NoError(t, err)
+		body = replaceOnce(t, body, `"semantic_state":{"enabled":true}`, `"semantic_state":{"enabled":true,"value":"secret@example.com"}`)
+
+		var decoded SemanticProjection
+		err = decodeStrict(body, MaxEnvelopeBytes, &decoded)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrUnknownField)
+	})
+
+	t.Run("unallowlisted accessible name", func(t *testing.T) {
+		t.Parallel()
+		projection := semanticFixture()
+		projection.Root.Children = append(projection.Root.Children, SemanticNode{
+			Role: RoleStaticText, Name: "secret@example.com",
+		})
+		normalized, err := NormalizeProjection(projection, identityRedactor)
+		require.NoError(t, err)
+		ledger := NewStateLedger()
+		require.NoError(t, ledger.Register(bindingForProjection(normalized)))
+
+		outcome, err := EvaluateOracle(OracleInput{
+			Projection: normalized,
+			Ledger:     ledger,
+			Policy: OraclePolicy{
+				MinimumLandmarks: signedAppOraclePolicy().MinimumLandmarks,
+				AllowedNames:     []string{"Autopus"},
+			},
+			Receipt: successfulStateReceipt(RuntimeProviderLocal),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, VerdictBlocked, outcome.Verdict)
+		require.NotNil(t, outcome.ReasonCode)
+		assert.Equal(t, ReasonRedactionFailed, *outcome.ReasonCode)
+		assert.Nil(t, outcome.SemanticProjection)
+	})
+}
+
+func TestEvaluateOracle_PassedOutcomeDoesNotAliasInput(t *testing.T) {
+	t.Parallel()
+
+	normalized, err := NormalizeProjection(semanticFixture(), identityRedactor)
+	require.NoError(t, err)
+	ledger := NewStateLedger()
+	require.NoError(t, ledger.Register(bindingForProjection(normalized)))
+	input := OracleInput{
+		Projection: normalized,
+		Ledger:     ledger,
+		Policy:     signedAppOraclePolicy(),
+		Receipt:    successfulStateReceipt(RuntimeProviderLocal),
+	}
+	outcome, err := EvaluateOracle(input)
+	require.NoError(t, err)
+	require.Equal(t, VerdictPassed, outcome.Verdict)
+	before, err := json.Marshal(outcome)
+	require.NoError(t, err)
+	beforeCanonical := append([]byte(nil), outcome.SemanticProjection.CanonicalJSON...)
+
+	input.Projection.Root.Children[0].Name = "mutated"
+	*input.Projection.Root.SemanticState.Enabled = false
+	input.Projection.Root.AdvertisedActions[0] = Action("AXUnsafe")
+	input.Projection.Root.Frame.X = 999
+	input.Projection.CanonicalJSON[0] = 'x'
+	input.Receipt.CapabilitySummary[0].Name = Operation("screenshot")
+
+	after, err := json.Marshal(outcome)
+	require.NoError(t, err)
+	assert.Equal(t, before, after)
+	assert.Equal(t, beforeCanonical, outcome.SemanticProjection.CanonicalJSON)
+	assert.Equal(t, "Autopus", outcome.SemanticProjection.Root.Children[0].Name)
+	assert.True(t, *outcome.SemanticProjection.Root.SemanticState.Enabled)
+	assert.Equal(t, OperationCapabilities, outcome.RuntimeReceipt.CapabilitySummary[0].Name)
+}
+
+func TestFailureNormalizer_InvalidSignalsFailClosedWithoutReceipt(t *testing.T) {
+	t.Parallel()
+
+	valid := FailureSignal{
+		Condition:         FailureProviderStart,
+		Provider:          providerIdentity(RuntimeProviderLocal),
+		Scope:             ReceiptScope{Kind: ScopeWindow, PublicRef: "main-window"},
+		CapabilitySummary: unsupportedCapabilities(),
+	}
+	tests := []struct {
+		name   string
+		mutate func(*FailureSignal)
+	}{
+		{name: "unknown condition", mutate: func(signal *FailureSignal) { signal.Condition = "unknown" }},
+		{name: "invalid provider", mutate: func(signal *FailureSignal) { signal.Provider.Name = "orca-secret-path" }},
+		{name: "invalid scope", mutate: func(signal *FailureSignal) { signal.Scope.PublicRef = "other-window" }},
+		{name: "invalid capabilities", mutate: func(signal *FailureSignal) { signal.CapabilitySummary = nil }},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			signal := valid
+			signal.CapabilitySummary = append([]CapabilityStatus(nil), valid.CapabilitySummary...)
+			test.mutate(&signal)
+			outcome, err := NormalizeFailure(signal)
+			require.Error(t, err)
+			assert.Empty(t, outcome.RuntimeReceipt.SchemaVersion)
+			assert.Nil(t, outcome.SemanticProjection)
+		})
+	}
+}
+
+func TestFailureNormalizer_CapabilityUnsupportedReceiptIsTruthful(t *testing.T) {
+	t.Parallel()
+
+	capabilities := supportedCapabilities()
+	capabilities[1].Status = CapabilityUnsupported
+	outcome, err := NormalizeFailure(FailureSignal{
+		Condition:          FailureOperationMissing,
+		Provider:           providerIdentity(RuntimeProviderLocal),
+		Scope:              ReceiptScope{Kind: ScopeWindow, PublicRef: "main-window"},
+		CapabilitySummary:  capabilities,
+		RequestedOperation: OperationGetState,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, outcome.ReasonCode)
+	assert.Equal(t, ReasonCapabilityUnsupported, *outcome.ReasonCode)
+	assert.Equal(t, CapabilityUnsupported, outcome.RuntimeReceipt.CapabilitySummary[1].Status)
+
+	capabilities[1].Status = CapabilitySupported
+	invalid, err := NormalizeFailure(FailureSignal{
+		Condition:          FailureOperationMissing,
+		Provider:           providerIdentity(RuntimeProviderLocal),
+		Scope:              ReceiptScope{Kind: ScopeWindow, PublicRef: "main-window"},
+		CapabilitySummary:  capabilities,
+		RequestedOperation: OperationGetState,
+	})
+	require.Error(t, err)
+	assert.Empty(t, invalid.RuntimeReceipt.SchemaVersion)
+}
+
+func TestEvaluateOracle_InvalidReceiptReturnsTypedErrorWithoutConsumingState(t *testing.T) {
+	t.Parallel()
+
+	normalized, err := NormalizeProjection(semanticFixture(), identityRedactor)
+	require.NoError(t, err)
+	ledger := NewStateLedger()
+	binding := bindingForProjection(normalized)
+	require.NoError(t, ledger.Register(binding))
+	receipt := successfulStateReceipt(RuntimeProviderLocal)
+	receipt.Provider.Name = "invalid-provider"
+
+	outcome, err := EvaluateOracle(OracleInput{
+		Projection: normalized,
+		Ledger:     ledger,
+		Policy:     signedAppOraclePolicy(),
+		Receipt:    receipt,
+	})
+	require.Error(t, err)
+	assert.Empty(t, outcome.RuntimeReceipt.SchemaVersion)
+	assert.Nil(t, outcome.SemanticProjection)
+	require.NoError(t, ledger.Consume(binding), "invalid receipt must fail before oracle consumption")
+}
+
+func replaceOnce(t *testing.T, body []byte, old, replacement string) []byte {
+	t.Helper()
+	bodyString := string(body)
+	require.Contains(t, bodyString, old)
+	return []byte(strings.Replace(bodyString, old, replacement, 1))
+}

--- a/pkg/qa/desktopobserve/state.go
+++ b/pkg/qa/desktopobserve/state.go
@@ -1,0 +1,78 @@
+package desktopobserve
+
+import (
+	"fmt"
+	"sync"
+)
+
+type StateBinding struct {
+	StateRef    string
+	ProviderRef string
+	AppRef      string
+	WindowRef   string
+	Digest      string
+}
+
+type stateRecord struct {
+	binding StateBinding
+	active  bool
+}
+
+type StateLedger struct {
+	mu      sync.Mutex
+	records map[string]stateRecord
+	active  map[string]string
+}
+
+func NewStateLedger() *StateLedger {
+	return &StateLedger{
+		records: make(map[string]stateRecord),
+		active:  make(map[string]string),
+	}
+}
+
+func (ledger *StateLedger) Register(binding StateBinding) error {
+	if ledger == nil || !validStateBinding(binding) {
+		return reasonError{code: ReasonStaleState}
+	}
+	ledger.mu.Lock()
+	defer ledger.mu.Unlock()
+	if _, exists := ledger.records[binding.StateRef]; exists {
+		return reasonError{code: ReasonStaleState}
+	}
+	scope := binding.scopeKey()
+	if previousRef, exists := ledger.active[scope]; exists {
+		previous := ledger.records[previousRef]
+		previous.active = false
+		ledger.records[previousRef] = previous
+	}
+	ledger.records[binding.StateRef] = stateRecord{binding: binding, active: true}
+	ledger.active[scope] = binding.StateRef
+	return nil
+}
+
+func (ledger *StateLedger) Consume(binding StateBinding) error {
+	if ledger == nil || !validStateBinding(binding) {
+		return reasonError{code: ReasonStaleState}
+	}
+	ledger.mu.Lock()
+	defer ledger.mu.Unlock()
+	record, exists := ledger.records[binding.StateRef]
+	if !exists || !record.active || record.binding != binding ||
+		ledger.active[binding.scopeKey()] != binding.StateRef {
+		return reasonError{code: ReasonStaleState}
+	}
+	record.active = false
+	ledger.records[binding.StateRef] = record
+	delete(ledger.active, binding.scopeKey())
+	return nil
+}
+
+func (binding StateBinding) scopeKey() string {
+	return fmt.Sprintf("%s\x00%s\x00%s", binding.ProviderRef, binding.AppRef, binding.WindowRef)
+}
+
+func validStateBinding(binding StateBinding) bool {
+	return safePublicRef(binding.StateRef) && safePublicRef(binding.ProviderRef) &&
+		safePublicRef(binding.AppRef) && safePublicRef(binding.WindowRef) && binding.Digest != ""
+}

--- a/pkg/qa/desktopobserve/state_test.go
+++ b/pkg/qa/desktopobserve/state_test.go
@@ -1,0 +1,122 @@
+package desktopobserve
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateRefOneUse_ConsumedAndSupersededRefsAreStale(t *testing.T) {
+	t.Parallel()
+
+	ledger := NewStateLedger()
+	first := stateBinding("state-1", "provider-local", "digest-1")
+	require.NoError(t, ledger.Register(first))
+	require.NoError(t, ledger.Consume(first))
+	assert.Equal(t, ReasonStaleState, ReasonCodeOf(ledger.Consume(first)))
+
+	second := stateBinding("state-2", "provider-local", "digest-2")
+	third := stateBinding("state-3", "provider-local", "digest-3")
+	require.NoError(t, ledger.Register(second))
+	require.NoError(t, ledger.Register(third))
+	assert.Equal(t, ReasonStaleState, ReasonCodeOf(ledger.Consume(second)))
+	require.NoError(t, ledger.Consume(third))
+}
+
+func TestStateRefOneUse_ConcurrentConsumeHasExactlyOneWinner(t *testing.T) {
+	t.Parallel()
+
+	ledger := NewStateLedger()
+	binding := stateBinding("state-1", "provider-local", "digest-1")
+	require.NoError(t, ledger.Register(binding))
+	var passed atomic.Int32
+	var stale atomic.Int32
+	var group sync.WaitGroup
+	for range 32 {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			if err := ledger.Consume(binding); err == nil {
+				passed.Add(1)
+			} else if ReasonCodeOf(err) == ReasonStaleState {
+				stale.Add(1)
+			}
+		}()
+	}
+	group.Wait()
+	assert.Equal(t, int32(1), passed.Load())
+	assert.Equal(t, int32(31), stale.Load())
+}
+
+func TestStateRefOneUse_ScopeAndProviderMismatchAreStale(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(*StateBinding)
+	}{
+		{name: "provider", mutate: func(binding *StateBinding) { binding.ProviderRef = "provider-orca" }},
+		{name: "application", mutate: func(binding *StateBinding) { binding.AppRef = "other-app" }},
+		{name: "window", mutate: func(binding *StateBinding) { binding.WindowRef = "other-window" }},
+		{name: "digest", mutate: func(binding *StateBinding) { binding.Digest = "other-digest" }},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ledger := NewStateLedger()
+			registered := stateBinding("state-1", "provider-local", "digest-1")
+			require.NoError(t, ledger.Register(registered))
+			candidate := registered
+			test.mutate(&candidate)
+			assert.Equal(t, ReasonStaleState, ReasonCodeOf(ledger.Consume(candidate)))
+		})
+	}
+}
+
+func TestStateRefRegister_DuplicateLiveAndConsumedReuseAreRejected(t *testing.T) {
+	t.Parallel()
+
+	t.Run("duplicate live ref", func(t *testing.T) {
+		t.Parallel()
+		ledger := NewStateLedger()
+		binding := stateBinding("state-1", "provider-local", "digest-1")
+		require.NoError(t, ledger.Register(binding))
+		assert.Equal(t, ReasonStaleState, ReasonCodeOf(ledger.Register(binding)))
+		require.NoError(t, ledger.Consume(binding), "rejected duplicate must not corrupt the live ref")
+	})
+
+	t.Run("consumed ref reuse", func(t *testing.T) {
+		t.Parallel()
+		ledger := NewStateLedger()
+		binding := stateBinding("state-1", "provider-local", "digest-1")
+		require.NoError(t, ledger.Register(binding))
+		require.NoError(t, ledger.Consume(binding))
+		assert.Equal(t, ReasonStaleState, ReasonCodeOf(ledger.Register(binding)))
+	})
+
+	t.Run("same ref different scope", func(t *testing.T) {
+		t.Parallel()
+		ledger := NewStateLedger()
+		binding := stateBinding("state-1", "provider-local", "digest-1")
+		require.NoError(t, ledger.Register(binding))
+		mismatch := binding
+		mismatch.WindowRef = "other-window"
+		assert.Equal(t, ReasonStaleState, ReasonCodeOf(ledger.Register(mismatch)))
+		require.NoError(t, ledger.Consume(binding), "scope mismatch must not replace the live binding")
+	})
+}
+
+func stateBinding(stateRef, providerRef, digest string) StateBinding {
+	return StateBinding{
+		StateRef:    stateRef,
+		ProviderRef: providerRef,
+		AppRef:      "autopus-desktop",
+		WindowRef:   "main-window",
+		Digest:      digest,
+	}
+}

--- a/pkg/qa/desktopobserve/strictjson.go
+++ b/pkg/qa/desktopobserve/strictjson.go
@@ -1,0 +1,135 @@
+package desktopobserve
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"unicode/utf8"
+)
+
+func decodeStrict(raw []byte, limit int, target any) error {
+	if len(raw) == 0 || !utf8.Valid(raw) {
+		return ErrMalformedEnvelope
+	}
+	if len(raw) > limit {
+		return ErrEnvelopeTooLarge
+	}
+	if err := rejectDuplicateKeys(raw); err != nil {
+		return err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		if strings.Contains(err.Error(), "unknown field") {
+			return fmt.Errorf("%w: %v", ErrUnknownField, err)
+		}
+		return fmt.Errorf("%w: %v", ErrMalformedEnvelope, err)
+	}
+	if err := requireJSONEOF(decoder); err != nil {
+		return err
+	}
+	return nil
+}
+
+func rejectDuplicateKeys(raw []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	if err := consumeUniqueValue(decoder); err != nil {
+		return err
+	}
+	if err := requireJSONEOF(decoder); err != nil {
+		return err
+	}
+	return nil
+}
+
+func consumeUniqueValue(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrMalformedEnvelope, err)
+	}
+	delimiter, structured := token.(json.Delim)
+	if !structured {
+		return nil
+	}
+	switch delimiter {
+	case '{':
+		return consumeUniqueObject(decoder)
+	case '[':
+		for decoder.More() {
+			if err := consumeUniqueValue(decoder); err != nil {
+				return err
+			}
+		}
+		return consumeClosingDelimiter(decoder, ']')
+	default:
+		return ErrMalformedEnvelope
+	}
+}
+
+func consumeUniqueObject(decoder *json.Decoder) error {
+	seen := make(map[string]struct{})
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return fmt.Errorf("%w: %v", ErrMalformedEnvelope, err)
+		}
+		key, ok := token.(string)
+		if !ok {
+			return ErrMalformedEnvelope
+		}
+		if _, duplicate := seen[key]; duplicate {
+			return fmt.Errorf("%w: %s", ErrDuplicateKey, key)
+		}
+		seen[key] = struct{}{}
+		if err := consumeUniqueValue(decoder); err != nil {
+			return err
+		}
+	}
+	return consumeClosingDelimiter(decoder, '}')
+}
+
+func consumeClosingDelimiter(decoder *json.Decoder, expected json.Delim) error {
+	token, err := decoder.Token()
+	if err != nil || token != expected {
+		return ErrMalformedEnvelope
+	}
+	return nil
+}
+
+func requireJSONEOF(decoder *json.Decoder) error {
+	if _, err := decoder.Token(); err != io.EOF {
+		return ErrMalformedEnvelope
+	}
+	return nil
+}
+
+func objectKeys(raw []byte) (map[string]json.RawMessage, error) {
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &object); err != nil || object == nil {
+		return nil, ErrMalformedEnvelope
+	}
+	return object, nil
+}
+
+func hasExactKeys(keys map[string]json.RawMessage, expected ...string) bool {
+	if len(keys) != len(expected) {
+		return false
+	}
+	for _, key := range expected {
+		if _, ok := keys[key]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func hasRequiredKeys(keys map[string]json.RawMessage, required ...string) bool {
+	for _, key := range required {
+		if _, ok := keys[key]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/qa/evidence/contract.go
+++ b/pkg/qa/evidence/contract.go
@@ -7,6 +7,9 @@ import (
 )
 
 func validateSurfaceContract(manifest Manifest) error {
+	if isDesktopObservationContract(manifest) {
+		return validateDesktopObservationContract(manifest)
+	}
 	if manifest.SchemaVersion == SchemaVersionV2 && manifest.Surface == "mobile" {
 		return validateMobileContract(manifest)
 	}

--- a/pkg/qa/evidence/desktop_observation.go
+++ b/pkg/qa/evidence/desktop_observation.go
@@ -1,0 +1,225 @@
+package evidence
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+const (
+	desktopObservationAdapterID      = "desktop-accessibility-observe"
+	desktopObservationArtifact       = "desktop_observation"
+	desktopObservationArtifactName   = "desktop-observation.json"
+	desktopObservationCheckType      = "desktop_accessibility_semantic"
+	desktopObservationFailureSummary = "desktop observation blocked"
+	desktopObservationLane           = "desktop-native"
+	desktopObservationSourceSpec     = "SPEC-QAMESH-012"
+	desktopObservationStepID         = "step-1"
+)
+
+func isDesktopObservationContract(manifest Manifest) bool {
+	if manifest.OracleResults.DesktopObservation != nil ||
+		equalDesktopMarker(manifest.SourceRefs.Adapter, desktopObservationAdapterID) ||
+		equalDesktopMarker(manifest.SourceRefs.SourceSpec, desktopObservationSourceSpec) {
+		return true
+	}
+	if manifest.SchemaVersion != SchemaVersionV2 {
+		return false
+	}
+	if equalDesktopMarker(manifest.SourceRefs.JourneyID, desktopObservationAdapterID) ||
+		equalDesktopMarker(manifest.ScenarioRef, desktopObservationAdapterID) ||
+		equalDesktopMarker(manifest.Runner.Name, desktopObservationAdapterID) {
+		return true
+	}
+	for _, check := range manifest.OracleResults.Checks {
+		if check.ID == desktopobserve.DeterministicCheckSemanticLandmarks ||
+			equalDesktopMarker(check.Type, desktopObservationCheckType) {
+			return true
+		}
+	}
+	for _, artifact := range manifest.Artifacts {
+		if equalDesktopMarker(artifact.Kind, desktopObservationArtifact) {
+			return true
+		}
+	}
+	for _, ref := range manifest.SourceRefs.AcceptanceRefs {
+		if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(ref)), "AC-QAMESH12-") {
+			return true
+		}
+	}
+	return false
+}
+
+func validateDesktopObservationContract(manifest Manifest) error {
+	if manifest.OracleResults.DesktopObservation == nil {
+		return fmt.Errorf("desktop observation manifest provenance or typed oracle contract is invalid")
+	}
+	observation, _, err := canonicalDesktopObservation(*manifest.OracleResults.DesktopObservation)
+	if err != nil {
+		return err
+	}
+	if !validDesktopObservationStructure(manifest, observation) {
+		return fmt.Errorf("desktop observation manifest provenance or typed oracle contract is invalid")
+	}
+	return validateDesktopObservationOutcome(manifest, observation)
+}
+
+func validDesktopObservationStructure(manifest Manifest, observation desktopobserve.ObservationEvidence) bool {
+	if len(manifest.Artifacts) != 1 || len(manifest.OracleResults.Checks) != 1 ||
+		len(observation.DeterministicChecks) != 1 {
+		return false
+	}
+	artifact := manifest.Artifacts[0]
+	check := manifest.OracleResults.Checks[0]
+	typedCheck := observation.DeterministicChecks[0]
+	wantStatus, wantSummary := string(typedCheck.Status), ""
+	if typedCheck.Status == desktopobserve.CheckBlocked {
+		wantSummary = desktopObservationFailureSummary
+	}
+	return check.ID == typedCheck.ID && check.Type == desktopObservationCheckType &&
+		check.Status == wantStatus && check.Expected == "" && check.Actual == "" &&
+		len(check.ArtifactRefs) == 0 && check.FailureSummary == wantSummary &&
+		manifest.SchemaVersion == SchemaVersionV2 && manifest.Surface == "desktop" &&
+		manifest.Lane == desktopObservationLane && manifest.ScenarioRef == desktopObservationAdapterID &&
+		manifest.Runner == (Runner{Name: desktopObservationAdapterID}) &&
+		manifest.SourceRefs.Adapter == desktopObservationAdapterID &&
+		manifest.SourceRefs.SourceSpec == desktopObservationSourceSpec &&
+		manifest.SourceRefs.JourneyID == desktopObservationAdapterID &&
+		manifest.SourceRefs.StepID == desktopObservationStepID && validDesktopObservationAcceptanceRefs(manifest.SourceRefs.AcceptanceRefs) &&
+		len(manifest.SourceRefs.OwnedPaths) == 0 && len(manifest.SourceRefs.DoNotModifyPaths) == 0 &&
+		len(manifest.SourceRefs.OracleThresholds) == 0 && manifest.SourceRefs.Mobile == nil &&
+		manifest.RepairPromptRef == "" && manifest.ReproductionCommand == "" &&
+		manifest.OracleResults.DesktopObservation != nil && manifest.OracleResults.A11y == nil &&
+		manifest.OracleResults.Desktop == nil && len(manifest.RedactionStatus.Findings) == 0 &&
+		artifact.Kind == desktopObservationArtifact && artifact.Publishable &&
+		(artifact.Redaction == "pre_redacted_and_scanned" || artifact.Redaction == "typed_allowlist_and_scanned") &&
+		strings.ToLower(filepath.Ext(artifact.Path)) == ".json"
+}
+
+func validateDesktopObservationOutcome(manifest Manifest, observation desktopobserve.ObservationEvidence) error {
+	check := manifest.OracleResults.Checks[0]
+	passed := observation.RuntimeReceipt.ReasonCode == nil
+	consistent := passed && manifest.Status == "passed" && check.Status == "passed" ||
+		!passed && manifest.Status == "blocked" && check.Status == "blocked"
+	if !consistent {
+		return fmt.Errorf("desktop observation manifest, check, receipt, and projection outcomes are inconsistent")
+	}
+	return nil
+}
+
+func canonicalDesktopObservation(
+	observation desktopobserve.ObservationEvidence,
+) (desktopobserve.ObservationEvidence, []byte, error) {
+	body, _ := json.Marshal(observation)
+	decoded, err := desktopobserve.DecodeObservationEvidence(body)
+	if err != nil {
+		return desktopobserve.ObservationEvidence{}, nil, fmt.Errorf("validate desktop observation: %w", err)
+	}
+	canonical, _ := json.Marshal(decoded)
+	return decoded, canonical, nil
+}
+
+func copyDesktopObservationArtifact(
+	artifact ArtifactRef,
+	inlineBody []byte,
+	outputDir string,
+) (ArtifactRef, error) {
+	raw, err := readDesktopObservationArtifact(artifact.Path, desktopObservationFileOps{
+		lstat: os.Lstat,
+		open:  os.Open,
+	})
+	if err != nil || RedactText(string(raw)) != string(raw) || AssertSafeText(string(raw), artifact.Path) != nil {
+		return ArtifactRef{}, fmt.Errorf("desktop observation artifact is not pre-redacted safe text")
+	}
+	decodedArtifact, err := desktopobserve.DecodeObservationEvidence(raw)
+	if err != nil {
+		return ArtifactRef{}, fmt.Errorf("decode desktop observation artifact: %w", err)
+	}
+	artifactBody, _ := json.Marshal(decodedArtifact)
+	if !bytes.Equal(inlineBody, artifactBody) {
+		return ArtifactRef{}, fmt.Errorf("desktop observation inline and artifact payloads differ")
+	}
+
+	artifactDir := filepath.Join(outputDir, "artifacts", desktopObservationArtifact)
+	target := filepath.Join(artifactDir, desktopObservationArtifactName)
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		return ArtifactRef{}, err
+	}
+	if err := os.WriteFile(target, append(artifactBody, '\n'), 0o644); err != nil {
+		return ArtifactRef{}, err
+	}
+	artifact.Path = filepath.ToSlash(filepath.Join("artifacts", desktopObservationArtifact, desktopObservationArtifactName))
+	return artifact, nil
+}
+
+type desktopObservationFileOps struct {
+	lstat func(string) (os.FileInfo, error)
+	open  func(string) (*os.File, error)
+}
+
+func readDesktopObservationArtifact(path string, ops desktopObservationFileOps) ([]byte, error) {
+	pathInfo, err := ops.lstat(path)
+	if err != nil || pathInfo.Mode()&os.ModeSymlink != 0 || !pathInfo.Mode().IsRegular() {
+		return nil, fmt.Errorf("desktop observation artifact must be a regular file")
+	}
+	if pathInfo.Size() < 0 || pathInfo.Size() > desktopobserve.MaxEnvelopeBytes {
+		return nil, desktopobserve.ErrEnvelopeTooLarge
+	}
+	file, err := ops.open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open desktop observation artifact: %w", err)
+	}
+	defer file.Close()
+	fileInfo, err := file.Stat()
+	if err != nil || !fileInfo.Mode().IsRegular() {
+		return nil, fmt.Errorf("desktop observation artifact descriptor must be regular")
+	}
+	currentInfo, currentErr := ops.lstat(path)
+	if currentErr != nil || currentInfo.Mode()&os.ModeSymlink != 0 || !currentInfo.Mode().IsRegular() ||
+		!os.SameFile(pathInfo, fileInfo) || !os.SameFile(currentInfo, fileInfo) {
+		return nil, fmt.Errorf("desktop observation artifact identity changed before read")
+	}
+	if fileInfo.Size() < 0 || fileInfo.Size() > desktopobserve.MaxEnvelopeBytes {
+		return nil, desktopobserve.ErrEnvelopeTooLarge
+	}
+	raw, err := io.ReadAll(io.LimitReader(file, desktopobserve.MaxEnvelopeBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read desktop observation artifact: %w", err)
+	}
+	if len(raw) > desktopobserve.MaxEnvelopeBytes {
+		return nil, desktopobserve.ErrEnvelopeTooLarge
+	}
+	return raw, nil
+}
+
+func validDesktopObservationAcceptanceRefs(refs []string) bool {
+	if len(refs) == 0 {
+		return false
+	}
+	seen := make(map[string]struct{}, len(refs))
+	for _, ref := range refs {
+		if !strings.HasPrefix(ref, "AC-QAMESH12-") || len(ref) != len("AC-QAMESH12-000") {
+			return false
+		}
+		value, err := strconv.Atoi(strings.TrimPrefix(ref, "AC-QAMESH12-"))
+		if err != nil || value < 1 || value > 18 {
+			return false
+		}
+		if _, duplicate := seen[ref]; duplicate {
+			return false
+		}
+		seen[ref] = struct{}{}
+	}
+	return true
+}
+
+func equalDesktopMarker(value, marker string) bool {
+	return strings.EqualFold(strings.TrimSpace(value), marker)
+}

--- a/pkg/qa/evidence/desktop_observation_consistency_test.go
+++ b/pkg/qa/evidence/desktop_observation_consistency_test.go
@@ -1,0 +1,101 @@
+package evidence
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+func TestDesktopObservationConsistency_PassedManifestRejectsContradictoryTypedEvidence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(*Manifest)
+	}{
+		{name: "semantic projection absent", mutate: func(manifest *Manifest) {
+			manifest.OracleResults.DesktopObservation.SemanticProjection = nil
+		}},
+		{name: "receipt has failure reason", mutate: func(manifest *Manifest) {
+			reason := desktopobserve.ReasonProviderUnavailable
+			next := desktopobserve.NextStep(reason)
+			receipt := &manifest.OracleResults.DesktopObservation.RuntimeReceipt
+			receipt.ReasonCode, receipt.NextStep = &reason, &next
+		}},
+		{name: "receipt redaction failed", mutate: func(manifest *Manifest) {
+			manifest.OracleResults.DesktopObservation.RuntimeReceipt.Redaction.Status = desktopobserve.RedactionFailed
+		}},
+		{name: "receipt quarantine blocked", mutate: func(manifest *Manifest) {
+			manifest.OracleResults.DesktopObservation.RuntimeReceipt.Quarantine.Status = desktopobserve.QuarantineBlocked
+		}},
+		{name: "deterministic observation check blocked", mutate: func(manifest *Manifest) {
+			manifest.OracleResults.DesktopObservation.DeterministicChecks[0].Status = desktopobserve.CheckBlocked
+		}},
+		{name: "manifest check blocked", mutate: func(manifest *Manifest) {
+			manifest.OracleResults.Checks[0].Status = "blocked"
+			manifest.OracleResults.Checks[0].FailureSummary = "blocked by typed oracle"
+		}},
+		{name: "digest tampered", mutate: func(manifest *Manifest) {
+			manifest.OracleResults.DesktopObservation.SemanticProjection.Digest = strings.Repeat("0", 64)
+		}},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			manifest := desktopObservationManifest(t, dir, successfulObservationEvidence(t), "passed")
+			test.mutate(&manifest)
+			syncDesktopObservationArtifact(t, manifest)
+			output := filepath.Join(dir, "published")
+			_, err := WriteFinalManifest(manifest, output)
+			require.Error(t, err)
+			assert.NoDirExists(t, output)
+		})
+	}
+}
+
+func TestDesktopObservationConsistency_InlineArtifactMismatchFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifest := desktopObservationManifest(t, dir, successfulObservationEvidence(t), "passed")
+	body, err := os.ReadFile(manifest.Artifacts[0].Path)
+	require.NoError(t, err)
+	body = []byte(strings.Replace(string(body), `"name":"Autopus"`, `"name":"Other"`, 1))
+	require.NoError(t, os.WriteFile(manifest.Artifacts[0].Path, body, 0o600))
+	output := filepath.Join(dir, "published")
+
+	_, err = WriteFinalManifest(manifest, output)
+	require.Error(t, err)
+	assert.NoDirExists(t, output)
+}
+
+func TestDesktopObservationConsistency_NonPassManifestCannotCarryPassingOracle(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifest := desktopObservationManifest(t, dir, successfulObservationEvidence(t), "failed")
+	manifest.OracleResults.Checks[0].Status = "passed"
+	manifest.OracleResults.Checks[0].FailureSummary = ""
+	output := filepath.Join(dir, "published")
+
+	_, err := WriteFinalManifest(manifest, output)
+	require.Error(t, err)
+	assert.NoDirExists(t, output)
+}
+
+func syncDesktopObservationArtifact(t *testing.T, manifest Manifest) {
+	t.Helper()
+	body, err := json.Marshal(manifest.OracleResults.DesktopObservation)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(manifest.Artifacts[0].Path, body, 0o600))
+}

--- a/pkg/qa/evidence/desktop_observation_file_security_test.go
+++ b/pkg/qa/evidence/desktop_observation_file_security_test.go
@@ -1,0 +1,143 @@
+package evidence
+
+import (
+	"bytes"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+func TestReadDesktopObservationArtifact_RejectsDescriptorSwap(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "desktop-observation.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"original":true}`), 0o600))
+	ops := desktopObservationFileOps{
+		lstat: os.Lstat,
+		open: func(name string) (*os.File, error) {
+			if err := os.Rename(name, name+".original"); err != nil {
+				return nil, err
+			}
+			if err := os.WriteFile(name, []byte(`{"replacement":true}`), 0o600); err != nil {
+				return nil, err
+			}
+			return os.Open(name)
+		},
+	}
+
+	_, err := readDesktopObservationArtifact(path, ops)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "identity")
+}
+
+func TestReadDesktopObservationArtifact_RejectsSymlinkSwapToSameIdentity(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "desktop-observation.json")
+	target := filepath.Join(dir, "original.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"original":true}`), 0o600))
+	ops := desktopObservationFileOps{
+		lstat: os.Lstat,
+		open: func(name string) (*os.File, error) {
+			if err := os.Rename(name, target); err != nil {
+				return nil, err
+			}
+			if err := os.Symlink(target, name); err != nil {
+				return nil, err
+			}
+			return os.Open(name)
+		},
+	}
+
+	_, err := readDesktopObservationArtifact(path, ops)
+
+	require.Error(t, err)
+}
+
+func TestReadDesktopObservationArtifact_DoesNotOpenNonRegularInput(t *testing.T) {
+	openCalls := 0
+	ops := desktopObservationFileOps{
+		lstat: func(string) (fs.FileInfo, error) { return staticFileInfo{mode: os.ModeNamedPipe}, nil },
+		open: func(string) (*os.File, error) {
+			openCalls++
+			return nil, errors.New("must not open")
+		},
+	}
+
+	_, err := readDesktopObservationArtifact("named-pipe", ops)
+
+	require.Error(t, err)
+	assert.Zero(t, openCalls)
+}
+
+func TestDesktopObservationArtifact_RejectsOversizeBeforePublication(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifest := desktopObservationManifest(t, dir, successfulObservationEvidence(t), "passed")
+	require.NoError(t, os.WriteFile(
+		manifest.Artifacts[0].Path,
+		bytes.Repeat([]byte("x"), desktopobserve.MaxEnvelopeBytes+1),
+		0o600,
+	))
+	output := filepath.Join(dir, "published")
+
+	_, err := WriteFinalManifest(manifest, output)
+
+	require.Error(t, err)
+	assert.NoDirExists(t, output)
+}
+
+func TestDesktopObservationArtifact_DoesNotReadSymlinkTarget(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifest := desktopObservationManifest(t, dir, successfulObservationEvidence(t), "passed")
+	target := manifest.Artifacts[0].Path
+	link := filepath.Join(dir, "linked-observation.json")
+	require.NoError(t, os.Symlink(target, link))
+	manifest.Artifacts[0].Path = link
+	output := filepath.Join(dir, "published")
+
+	_, err := WriteFinalManifest(manifest, output)
+
+	require.Error(t, err)
+	assert.NoDirExists(t, output)
+}
+
+func TestDesktopObservationArtifact_PublishedNameIsFixed(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifest := desktopObservationManifest(t, dir, successfulObservationEvidence(t), "passed")
+	injectedName := filepath.Join(dir, "provider_dump.json")
+	require.NoError(t, os.Rename(manifest.Artifacts[0].Path, injectedName))
+	manifest.Artifacts[0].Path = injectedName
+
+	manifestPath, err := WriteFinalManifest(manifest, filepath.Join(dir, "published"))
+
+	require.NoError(t, err)
+	loaded, err := LoadManifest(manifestPath)
+	require.NoError(t, err)
+	require.Len(t, loaded.Artifacts, 1)
+	assert.Equal(t, "artifacts/desktop_observation/desktop-observation.json", loaded.Artifacts[0].Path)
+	assert.NotContains(t, loaded.Artifacts[0].Path, "provider_dump")
+}
+
+type staticFileInfo struct {
+	mode fs.FileMode
+}
+
+func (info staticFileInfo) Name() string       { return "named-pipe" }
+func (info staticFileInfo) Size() int64        { return 0 }
+func (info staticFileInfo) Mode() fs.FileMode  { return info.mode }
+func (info staticFileInfo) ModTime() time.Time { return time.Time{} }
+func (info staticFileInfo) IsDir() bool        { return false }
+func (info staticFileInfo) Sys() any           { return nil }

--- a/pkg/qa/evidence/desktop_observation_publication_test.go
+++ b/pkg/qa/evidence/desktop_observation_publication_test.go
@@ -1,0 +1,171 @@
+package evidence
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+func TestDesktopObservationPublication_WalksEntireRootWithExactRecursiveAllowlist(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	observation := successfulObservationEvidence(t)
+	manifest := desktopObservationManifest(t, dir, observation, "passed")
+	output := filepath.Join(dir, "published")
+	manifestPath, err := WriteFinalManifest(manifest, output)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(output, "manifest.json"), manifestPath)
+
+	files := []string{}
+	err = filepath.WalkDir(output, func(path string, entry fs.DirEntry, walkErr error) error {
+		require.NoError(t, walkErr)
+		if entry.IsDir() {
+			return nil
+		}
+		relative, relErr := filepath.Rel(output, path)
+		require.NoError(t, relErr)
+		files = append(files, filepath.ToSlash(relative))
+		body, readErr := os.ReadFile(path)
+		require.NoError(t, readErr)
+		assertForbiddenDesktopInventoryZero(t, body)
+		assertPublishedObservationAllowlist(t, relative, body)
+		return nil
+	})
+	require.NoError(t, err)
+	sort.Strings(files)
+	assert.Equal(t, []string{
+		"artifacts/desktop_observation/desktop-observation.json",
+		"manifest.json",
+	}, files)
+}
+
+func TestDesktopObservationPublication_NestedUnknownAndDuplicateFieldsFailClosed(t *testing.T) {
+	t.Parallel()
+
+	body, err := json.Marshal(successfulObservationEvidence(t))
+	require.NoError(t, err)
+	tests := []struct {
+		name        string
+		old         string
+		replacement string
+		want        error
+	}{
+		{name: "projection", old: `"provider_ref":"provider-local"`, replacement: `"provider_ref":"provider-local","raw_handle":"0x42"`, want: desktopobserve.ErrUnknownField},
+		{name: "node", old: `"role":"AXApplication"`, replacement: `"role":"AXApplication","index":7`, want: desktopobserve.ErrUnknownField},
+		{name: "semantic state", old: `"enabled":true`, replacement: `"enabled":true,"raw_value":"secret"`, want: desktopobserve.ErrUnknownField},
+		{name: "frame", old: `"x":0`, replacement: `"x":0,"screen_x":99`, want: desktopobserve.ErrUnknownField},
+		{name: "provider", old: `"name":"autopus-desktop-local"`, replacement: `"name":"autopus-desktop-local","helper_path":"/tmp/helper"`, want: desktopobserve.ErrUnknownField},
+		{name: "capability", old: `"name":"capabilities"`, replacement: `"name":"capabilities","raw_action":"press"`, want: desktopobserve.ErrUnknownField},
+		{name: "check", old: `"id":"desktop-semantic-landmarks"`, replacement: `"id":"desktop-semantic-landmarks","error_text":"provider secret"`, want: desktopobserve.ErrUnknownField},
+		{name: "redaction", old: `"redaction":{"status":"applied"}`, replacement: `"redaction":{"status":"applied","raw_payload":true}`, want: desktopobserve.ErrUnknownField},
+		{name: "quarantine", old: `"quarantine":{"status":"cleared"}`, replacement: `"quarantine":{"status":"cleared","raw_path":"/Users/alice/raw"}`, want: desktopobserve.ErrUnknownField},
+		{name: "duplicate nested key", old: `"provider_ref":"provider-local"`, replacement: `"provider_ref":"provider-local","provider_ref":"other"`, want: desktopobserve.ErrDuplicateKey},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mutated := bytes.Replace(body, []byte(test.old), []byte(test.replacement), 1)
+			require.NotEqual(t, body, mutated)
+			_, err := desktopobserve.DecodeObservationEvidence(mutated)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, test.want)
+		})
+	}
+}
+
+func assertPublishedObservationAllowlist(t *testing.T, relative string, body []byte) {
+	t.Helper()
+	var root map[string]any
+	require.NoError(t, json.Unmarshal(body, &root))
+	observation := root
+	if filepath.Base(relative) == "manifest.json" {
+		oracleResults := requireObject(t, root, "oracle_results")
+		observation = requireObject(t, oracleResults, "desktop_observation")
+	}
+	assertObjectKeys(t, observation, []string{"semantic_projection", "deterministic_checks", "runtime_receipt"})
+	projection := requireObject(t, observation, "semantic_projection")
+	assertObjectKeys(t, projection, []string{"schema_version", "provider_ref", "app_ref", "window_ref", "state_ref", "digest", "root"})
+	assertSemanticNodeAllowlist(t, requireObject(t, projection, "root"))
+
+	checks := requireArray(t, observation, "deterministic_checks")
+	for _, item := range checks {
+		check := item.(map[string]any)
+		assertAllowedObjectKeys(t, check, []string{"id", "status", "reason_code"})
+		assertRequiredObjectKeys(t, check, []string{"id", "status"})
+	}
+	receipt := requireObject(t, observation, "runtime_receipt")
+	assertObjectKeys(t, receipt, []string{"schema_version", "provider", "scope", "capability_summary", "reason_code", "next_step", "redaction", "quarantine"})
+	assertObjectKeys(t, requireObject(t, receipt, "provider"), []string{"name", "version", "protocol_version"})
+	assertObjectKeys(t, requireObject(t, receipt, "scope"), []string{"kind", "public_ref"})
+	for _, item := range requireArray(t, receipt, "capability_summary") {
+		assertObjectKeys(t, item.(map[string]any), []string{"name", "status"})
+	}
+	assertObjectKeys(t, requireObject(t, receipt, "redaction"), []string{"status"})
+	assertObjectKeys(t, requireObject(t, receipt, "quarantine"), []string{"status"})
+}
+
+func assertSemanticNodeAllowlist(t *testing.T, node map[string]any) {
+	t.Helper()
+	assertAllowedObjectKeys(t, node, []string{"node_ref", "role", "name", "semantic_state", "frame", "advertised_actions", "children"})
+	assertRequiredObjectKeys(t, node, []string{"node_ref", "role", "name", "semantic_state"})
+	state := requireObject(t, node, "semantic_state")
+	assertAllowedObjectKeys(t, state, []string{"enabled", "focused", "selected", "expanded", "checked", "value"})
+	if frame, ok := node["frame"].(map[string]any); ok {
+		assertObjectKeys(t, frame, []string{"x", "y", "width", "height"})
+	}
+	if children, ok := node["children"].([]any); ok {
+		for _, child := range children {
+			assertSemanticNodeAllowlist(t, child.(map[string]any))
+		}
+	}
+}
+
+func assertObjectKeys(t *testing.T, object map[string]any, allowed []string) {
+	t.Helper()
+	assertAllowedObjectKeys(t, object, allowed)
+	assertRequiredObjectKeys(t, object, allowed)
+}
+
+func assertAllowedObjectKeys(t *testing.T, object map[string]any, allowed []string) {
+	t.Helper()
+	allowedSet := map[string]bool{}
+	for _, key := range allowed {
+		allowedSet[key] = true
+	}
+	for key := range object {
+		assert.True(t, allowedSet[key], "unknown published key %q", key)
+	}
+}
+
+func assertRequiredObjectKeys(t *testing.T, object map[string]any, required []string) {
+	t.Helper()
+	for _, key := range required {
+		assert.Contains(t, object, key)
+	}
+}
+
+func requireObject(t *testing.T, object map[string]any, key string) map[string]any {
+	t.Helper()
+	value, ok := object[key].(map[string]any)
+	require.True(t, ok, "%s is not an object", key)
+	return value
+}
+
+func requireArray(t *testing.T, object map[string]any, key string) []any {
+	t.Helper()
+	value, ok := object[key].([]any)
+	require.True(t, ok, "%s is not an array", key)
+	return value
+}

--- a/pkg/qa/evidence/desktop_observation_receipt_test.go
+++ b/pkg/qa/evidence/desktop_observation_receipt_test.go
@@ -1,0 +1,48 @@
+package evidence
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+func TestRuntimeReceipt_DesktopEvidenceRoundTripPreservesStrictSafeValues(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	observation := successfulObservationEvidence(t)
+	path, err := WriteFinalManifest(
+		desktopObservationManifest(t, dir, observation, "passed"),
+		filepath.Join(dir, "published"),
+	)
+	require.NoError(t, err)
+	manifest, err := LoadManifest(path)
+	require.NoError(t, err)
+	require.NotNil(t, manifest.OracleResults.DesktopObservation)
+	receipt := manifest.OracleResults.DesktopObservation.RuntimeReceipt
+	require.NoError(t, receipt.Validate())
+	assert.Equal(t, "autopus-desktop-local", receipt.Provider.Name)
+	assert.Equal(t, desktopobserve.ProtocolVersion, receipt.Provider.ProtocolVersion)
+	assert.Equal(t, desktopobserve.ScopeWindow, receipt.Scope.Kind)
+	assert.Equal(t, "main-window", receipt.Scope.PublicRef)
+	assert.Equal(t, desktopobserve.ReadOnlyOperations(), receiptCapabilityNames(receipt))
+	assert.Nil(t, receipt.ReasonCode)
+	assert.Nil(t, receipt.NextStep)
+
+	body, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assertForbiddenDesktopInventoryZero(t, body)
+}
+
+func receiptCapabilityNames(receipt desktopobserve.RuntimeReceipt) []desktopobserve.Operation {
+	values := make([]desktopobserve.Operation, 0, len(receipt.CapabilitySummary))
+	for _, capability := range receipt.CapabilitySummary {
+		values = append(values, capability.Name)
+	}
+	return values
+}

--- a/pkg/qa/evidence/desktop_observation_security_test.go
+++ b/pkg/qa/evidence/desktop_observation_security_test.go
@@ -1,0 +1,300 @@
+package evidence
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+func TestDesktopObservationProfile_AnyQ12MarkerRejectsStrippedTypedContract(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		marker func(*Manifest)
+	}{
+		{name: "source spec", marker: func(manifest *Manifest) { manifest.SourceRefs.SourceSpec = "SPEC-QAMESH-012" }},
+		{name: "adapter", marker: func(manifest *Manifest) { manifest.SourceRefs.Adapter = "desktop-accessibility-observe" }},
+		{name: "journey", marker: func(manifest *Manifest) { manifest.SourceRefs.JourneyID = "desktop-accessibility-observe" }},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			manifest := fixtureV2Manifest(t, "desktop")
+			rawAX := filepath.Join(dir, "raw-ax.json")
+			require.NoError(t, os.WriteFile(rawAX, []byte(`{"raw_ax":{"pid":42}}`), 0o600))
+			manifest.Artifacts[0] = ArtifactRef{
+				Kind: "stdout", Path: rawAX, Publishable: true, Redaction: "text_redacted_and_scanned",
+			}
+			test.marker(&manifest)
+			output := filepath.Join(dir, "published")
+
+			_, err := WriteFinalManifest(manifest, output)
+
+			require.Error(t, err)
+			assert.NoDirExists(t, output)
+		})
+	}
+}
+
+func TestDesktopObservationProfile_RejectsFreeFormPublicationChannels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(*Manifest)
+	}{
+		{name: "runner name", mutate: func(manifest *Manifest) { manifest.Runner.Name = "provider_dump" }},
+		{name: "runner command", mutate: func(manifest *Manifest) { manifest.Runner.Command = "provider_dump" }},
+		{name: "runner version", mutate: func(manifest *Manifest) { manifest.Runner.Version = "provider_dump" }},
+		{name: "check expected", mutate: func(manifest *Manifest) { manifest.OracleResults.Checks[0].Expected = "provider_dump" }},
+		{name: "check actual", mutate: func(manifest *Manifest) { manifest.OracleResults.Checks[0].Actual = "provider_dump" }},
+		{name: "check failure summary", mutate: func(manifest *Manifest) { manifest.OracleResults.Checks[0].FailureSummary = "provider_dump" }},
+		{name: "check artifact traversal", mutate: func(manifest *Manifest) {
+			manifest.OracleResults.Checks[0].ArtifactRefs = []string{"../../provider_dump"}
+		}},
+		{name: "acceptance ref", mutate: func(manifest *Manifest) { manifest.SourceRefs.AcceptanceRefs = []string{"provider_dump"} }},
+		{name: "journey step", mutate: func(manifest *Manifest) { manifest.SourceRefs.StepID = "provider_dump" }},
+		{name: "owned paths", mutate: func(manifest *Manifest) { manifest.SourceRefs.OwnedPaths = []string{"provider_dump/**"} }},
+		{name: "do not modify paths", mutate: func(manifest *Manifest) {
+			manifest.SourceRefs.DoNotModifyPaths = []string{"provider_dump/**"}
+		}},
+		{name: "oracle thresholds", mutate: func(manifest *Manifest) {
+			manifest.SourceRefs.OracleThresholds = map[string]any{"provider_dump": "bytes"}
+		}},
+		{name: "mobile refs", mutate: func(manifest *Manifest) {
+			manifest.SourceRefs.Mobile = &MobileRefs{FlowID: "provider_dump", AppArtifactDigest: "bytes", DeviceRef: "device"}
+		}},
+		{name: "reproduction command", mutate: func(manifest *Manifest) { manifest.ReproductionCommand = "provider_dump" }},
+		{name: "repair prompt ref", mutate: func(manifest *Manifest) { manifest.RepairPromptRef = "provider_dump" }},
+		{name: "redaction findings", mutate: func(manifest *Manifest) {
+			manifest.RedactionStatus.Findings = []Finding{{Type: "provider_dump", Source: "provider_dump", Sample: "bytes"}}
+		}},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			manifest := desktopObservationManifest(t, dir, successfulObservationEvidence(t), "passed")
+			test.mutate(&manifest)
+			output := filepath.Join(dir, "published")
+
+			require.Error(t, manifest.Validate())
+			_, err := WriteFinalManifest(manifest, output)
+
+			require.Error(t, err)
+			assert.NoDirExists(t, output)
+		})
+	}
+}
+
+func TestDesktopObservationProfile_MarkerDetectionIsFailClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		manifest Manifest
+		want     bool
+	}{
+		{name: "legacy lane is not marker", manifest: Manifest{SchemaVersion: SchemaVersionV1, Lane: desktopObservationLane}},
+		{name: "generic v2 desktop native lane is not marker", manifest: Manifest{SchemaVersion: SchemaVersionV2, Lane: desktopObservationLane}},
+		{name: "runner", manifest: Manifest{SchemaVersion: SchemaVersionV2, Runner: Runner{Name: desktopObservationAdapterID}}, want: true},
+		{name: "check id", manifest: Manifest{SchemaVersion: SchemaVersionV2, OracleResults: OracleResults{Checks: []CheckResult{{ID: desktopobserve.DeterministicCheckSemanticLandmarks}}}}, want: true},
+		{name: "check type", manifest: Manifest{SchemaVersion: SchemaVersionV2, OracleResults: OracleResults{Checks: []CheckResult{{Type: desktopObservationCheckType}}}}, want: true},
+		{name: "artifact", manifest: Manifest{SchemaVersion: SchemaVersionV2, Artifacts: []ArtifactRef{{Kind: desktopObservationArtifact}}}, want: true},
+		{name: "acceptance", manifest: Manifest{SchemaVersion: SchemaVersionV2, SourceRefs: SourceRefs{AcceptanceRefs: []string{"AC-QAMESH12-018"}}}, want: true},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.want, isDesktopObservationContract(test.manifest))
+		})
+	}
+}
+
+func TestDesktopObservationProfile_GenericV2DesktopNativeRemainsCompatible(t *testing.T) {
+	t.Parallel()
+	manifest := fixtureV2Manifest(t, "desktop")
+	manifest.Lane, manifest.ScenarioRef = desktopObservationLane, "desktop:generic"
+	manifest.Runner = Runner{Name: "custom-command", Command: "false"}
+	manifest.SourceRefs.SourceSpec, manifest.SourceRefs.JourneyID = "SPEC-QAMESH-011", "generic-desktop"
+	manifest.SourceRefs.AcceptanceRefs = []string{"AC-QAMESH11-009"}
+	manifest.SourceRefs.Adapter = "custom-command"
+	path, err := WriteFinalManifest(manifest, filepath.Join(t.TempDir(), "published"))
+	require.NoError(t, err)
+	assert.FileExists(t, path)
+}
+
+func TestDesktopObservationProfile_AcceptanceRefsUseBoundedAllowlist(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		refs []string
+		want bool
+	}{
+		{name: "missing"},
+		{name: "wrong prefix", refs: []string{"AC-OTHER12-001"}},
+		{name: "non numeric", refs: []string{"AC-QAMESH12-ABC"}},
+		{name: "below range", refs: []string{"AC-QAMESH12-000"}},
+		{name: "above range", refs: []string{"AC-QAMESH12-019"}},
+		{name: "duplicate", refs: []string{"AC-QAMESH12-001", "AC-QAMESH12-001"}},
+		{name: "allowed", refs: []string{"AC-QAMESH12-001", "AC-QAMESH12-018"}, want: true},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.want, validDesktopObservationAcceptanceRefs(test.refs))
+		})
+	}
+}
+
+func TestLoadManifest_RejectsDuplicateKeysAcrossWholeDocument(t *testing.T) {
+	t.Parallel()
+
+	manifest := fixtureV2Manifest(t, "package")
+	body, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	body = bytes.Replace(body, []byte(`{"schema_version":`), []byte(`{"schema_version":"qamesh.evidence.v2","schema_version":`), 1)
+	path := filepath.Join(t.TempDir(), "manifest.json")
+	require.NoError(t, os.WriteFile(path, body, 0o600))
+
+	_, err = LoadManifest(path)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, desktopobserve.ErrDuplicateKey)
+}
+
+func TestLoadManifest_Q12ProfileIsStrictAndValidated(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func([]byte) []byte
+		want   error
+	}{
+		{name: "top level unknown", mutate: func(body []byte) []byte {
+			return bytes.Replace(body, []byte(`{"schema_version":`), []byte(`{"provider_dump":"bytes","schema_version":`), 1)
+		}, want: desktopobserve.ErrUnknownField},
+		{name: "nested raw payload", mutate: func(body []byte) []byte {
+			return bytes.Replace(body, []byte(`"provider_ref":"provider-local"`), []byte(`"provider_ref":"provider-local","raw_payload":"bytes"`), 1)
+		}, want: desktopobserve.ErrUnknownField},
+		{name: "nested duplicate", mutate: func(body []byte) []byte {
+			return bytes.Replace(body, []byte(`"provider_ref":"provider-local"`), []byte(`"provider_ref":"provider-local","provider_ref":"provider-local"`), 1)
+		}, want: desktopobserve.ErrDuplicateKey},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			manifest := desktopObservationManifest(t, dir, successfulObservationEvidence(t), "passed")
+			body, err := json.Marshal(manifest)
+			require.NoError(t, err)
+			body = test.mutate(body)
+			path := filepath.Join(dir, "manifest.json")
+			require.NoError(t, os.WriteFile(path, body, 0o600))
+
+			_, err = LoadManifest(path)
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, test.want)
+		})
+	}
+}
+
+func TestLoadManifest_Q12MarkerIncompleteDocumentFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	manifest := fixtureV2Manifest(t, "desktop")
+	manifest.SourceRefs.SourceSpec = "SPEC-QAMESH-012"
+	body, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "manifest.json")
+	require.NoError(t, os.WriteFile(path, body, 0o600))
+
+	_, err = LoadManifest(path)
+
+	require.Error(t, err)
+}
+
+func TestLoadManifest_NullInlineQ12MarkerFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	manifest := fixtureV2Manifest(t, "desktop")
+	body, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	body = bytes.Replace(
+		body,
+		[]byte(`"oracle_results":{`),
+		[]byte(`"oracle_results":{"desktop_observation":null,`),
+		1,
+	)
+	path := filepath.Join(t.TempDir(), "manifest.json")
+	require.NoError(t, os.WriteFile(path, body, 0o600))
+
+	_, err = LoadManifest(path)
+
+	require.Error(t, err)
+}
+
+func TestLoadManifest_GenericV1AndV2UnknownExtensionsRemainCompatible(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		manifest Manifest
+	}{
+		{name: "generic v2 desktop", manifest: fixtureV2Manifest(t, "desktop")},
+		{name: "legacy v1", manifest: legacyDesktopObservationManifest()},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			body, err := json.Marshal(test.manifest)
+			require.NoError(t, err)
+			body = bytes.Replace(body, []byte(`{"schema_version":`), []byte(`{"extension":{"provider_dump":"generic-compatible"},"schema_version":`), 1)
+			path := filepath.Join(t.TempDir(), "manifest.json")
+			require.NoError(t, os.WriteFile(path, body, 0o600))
+
+			loaded, err := LoadManifest(path)
+
+			require.NoError(t, err)
+			assert.Equal(t, test.manifest.SchemaVersion, loaded.SchemaVersion)
+		})
+	}
+}
+
+func legacyDesktopObservationManifest() Manifest {
+	return Manifest{
+		SchemaVersion: SchemaVersionV1, QAResultID: "legacy-desktop", Surface: "desktop",
+		Lane: "desktop-native", ScenarioRef: "desktop:legacy", Runner: Runner{Name: "appium"},
+		Status: "passed", StartedAt: "2026-07-18T00:00:00Z", EndedAt: "2026-07-18T00:00:01Z",
+		RetentionClass: "local-redacted",
+		Artifacts: []ArtifactRef{
+			{Kind: "screenshot", Path: "shot.json"}, {Kind: "app_log", Path: "app.log"},
+			{Kind: "driver_log", Path: "driver.log"}, {Kind: "command_output", Path: "command.log"},
+		},
+		OracleResults:   OracleResults{Desktop: &DesktopOracle{TimeoutClassification: "none"}},
+		RedactionStatus: RedactionStatus{Status: "passed"},
+		SourceRefs: SourceRefs{
+			SourceSpec: "SPEC-DESKTOP-017", AcceptanceRefs: []string{"AC-DESKTOP17-001"},
+		},
+	}
+}

--- a/pkg/qa/evidence/desktop_observation_test.go
+++ b/pkg/qa/evidence/desktop_observation_test.go
@@ -1,0 +1,244 @@
+package evidence
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+func TestDesktopObservationEvidence_V2TypedPayloadRoundTripsWithExactAllowlist(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	observation := successfulObservationEvidence(t)
+	manifest := desktopObservationManifest(t, dir, observation, "passed")
+
+	manifestPath, err := WriteFinalManifest(manifest, filepath.Join(dir, "published"))
+	require.NoError(t, err)
+	loaded, err := LoadManifest(manifestPath)
+	require.NoError(t, err)
+	require.NotNil(t, loaded.OracleResults.DesktopObservation)
+	assert.Equal(t, observation.SemanticProjection.Digest, loaded.OracleResults.DesktopObservation.SemanticProjection.Digest)
+
+	body, err := os.ReadFile(manifestPath)
+	require.NoError(t, err)
+	var object map[string]any
+	require.NoError(t, json.Unmarshal(body, &object))
+	oracles := object["oracle_results"].(map[string]any)
+	desktop := oracles["desktop_observation"].(map[string]any)
+	assert.ElementsMatch(t, []string{"semantic_projection", "deterministic_checks", "runtime_receipt"}, keysOf(desktop))
+	assertElevenSemanticConcepts(t, desktop["semantic_projection"].(map[string]any))
+	assertForbiddenDesktopInventoryZero(t, body)
+}
+
+func TestDesktopObservationEvidence_UnknownRawPayloadFieldsAreRejected(t *testing.T) {
+	t.Parallel()
+
+	observation := successfulObservationEvidence(t)
+	body, err := json.Marshal(observation)
+	require.NoError(t, err)
+	body = bytes.Replace(body, []byte("{"), []byte(`{"raw_tree":{"pid":42},"screenshot":"bytes",`), 1)
+
+	_, err = desktopobserve.DecodeObservationEvidence(body)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, desktopobserve.ErrUnknownField)
+}
+
+func TestRedactionFailClosed_PublishTimeRedactionMustBeNoOp(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	observation := successfulObservationEvidence(t)
+	projection := observation.SemanticProjection
+	projection.Root.Name = "sk-proj-qamesh-secret-1234567890"
+	normalized, err := desktopobserve.NormalizeProjection(*projection, func(value string) (string, error) { return value, nil })
+	require.NoError(t, err)
+	observation.SemanticProjection = &normalized
+	manifest := desktopObservationManifest(t, dir, observation, "passed")
+	output := filepath.Join(dir, "published")
+
+	_, err = WriteFinalManifest(manifest, output)
+	require.Error(t, err)
+	assert.NoDirExists(t, output)
+}
+
+func TestQuarantineFailClosed_ReceiptOnlyFailurePublishesNoSemanticPayload(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		reason     desktopobserve.ReasonCode
+		redaction  desktopobserve.RedactionStatus
+		quarantine desktopobserve.QuarantineStatus
+	}{
+		{name: "redaction", reason: desktopobserve.ReasonRedactionFailed, redaction: desktopobserve.RedactionFailed, quarantine: desktopobserve.QuarantineBlocked},
+		{name: "quarantine", reason: desktopobserve.ReasonEvidenceQuarantined, redaction: desktopobserve.RedactionApplied, quarantine: desktopobserve.QuarantineLocalOnly},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			reason := test.reason
+			receipt := observationReceipt(desktopobserve.RuntimeProviderLocal)
+			receipt.ReasonCode = &reason
+			nextStep := desktopobserve.NextStep(reason)
+			receipt.NextStep = &nextStep
+			receipt.Redaction.Status = test.redaction
+			receipt.Quarantine.Status = test.quarantine
+			observation := desktopobserve.ObservationEvidence{
+				SemanticProjection: nil,
+				DeterministicChecks: []desktopobserve.DeterministicCheck{{
+					ID: "desktop-semantic-landmarks", Status: desktopobserve.CheckBlocked,
+					ReasonCode: &reason,
+				}},
+				RuntimeReceipt: receipt,
+			}
+			manifest := desktopObservationManifest(t, dir, observation, "blocked")
+			path, err := WriteFinalManifest(manifest, filepath.Join(dir, "published"))
+			require.NoError(t, err)
+			body, err := os.ReadFile(path)
+			require.NoError(t, err)
+			assert.NotContains(t, string(body), `"semantic_projection"`)
+			assert.NotContains(t, string(body), "provider error")
+			assertForbiddenDesktopInventoryZero(t, body)
+		})
+	}
+}
+
+func TestDesktopObservationEvidence_V1DesktopContractUnchanged(t *testing.T) {
+	t.Parallel()
+
+	manifest := Manifest{
+		SchemaVersion: SchemaVersionV1, QAResultID: "legacy-desktop", Surface: "desktop",
+		Lane: "desktop-native", ScenarioRef: "desktop:legacy", Runner: Runner{Name: "appium"},
+		Status: "passed", StartedAt: "2026-07-18T00:00:00Z", EndedAt: "2026-07-18T00:00:01Z",
+		RetentionClass: "local-redacted",
+		Artifacts: []ArtifactRef{
+			{Kind: "screenshot", Path: "shot.json"}, {Kind: "app_log", Path: "app.log"},
+			{Kind: "driver_log", Path: "driver.log"}, {Kind: "command_output", Path: "command.log"},
+		},
+		OracleResults:   OracleResults{Desktop: &DesktopOracle{TimeoutClassification: "none"}},
+		RedactionStatus: RedactionStatus{Status: "passed"},
+		SourceRefs: SourceRefs{
+			SourceSpec: "SPEC-DESKTOP-017", AcceptanceRefs: []string{"AC-DESKTOP17-001"},
+		},
+	}
+	require.NoError(t, manifest.Validate())
+}
+
+func successfulObservationEvidence(t *testing.T) desktopobserve.ObservationEvidence {
+	t.Helper()
+	enabled, focused := true, true
+	projection := desktopobserve.SemanticProjection{
+		SchemaVersion: desktopobserve.SemanticProjectionSchemaVersion,
+		ProviderRef:   "provider-local", AppRef: "autopus-desktop", WindowRef: "main-window", StateRef: "state-1",
+		Root: desktopobserve.SemanticNode{
+			Role: desktopobserve.RoleApplication, Name: "Autopus",
+			SemanticState:     desktopobserve.SemanticState{Enabled: &enabled},
+			Frame:             &desktopobserve.Frame{X: 0, Y: 0, Width: 1440, Height: 900},
+			AdvertisedActions: []desktopobserve.Action{desktopobserve.ActionPress},
+			Children: []desktopobserve.SemanticNode{{
+				Role: desktopobserve.RoleWindow, Name: "Autopus",
+				SemanticState: desktopobserve.SemanticState{Focused: &focused},
+			}},
+		},
+	}
+	normalized, err := desktopobserve.NormalizeProjection(projection, func(value string) (string, error) { return value, nil })
+	require.NoError(t, err)
+	return desktopobserve.ObservationEvidence{
+		SemanticProjection:  &normalized,
+		DeterministicChecks: []desktopobserve.DeterministicCheck{{ID: "desktop-semantic-landmarks", Status: desktopobserve.CheckPassed}},
+		RuntimeReceipt:      observationReceipt(desktopobserve.RuntimeProviderLocal),
+	}
+}
+
+func observationReceipt(provider desktopobserve.RuntimeProvider) desktopobserve.RuntimeReceipt {
+	name := "autopus-desktop-local"
+	if provider == desktopobserve.RuntimeProviderOrca {
+		name = "orca-computer-use-macos"
+	}
+	capabilities := make([]desktopobserve.CapabilityStatus, 0, 5)
+	for _, operation := range desktopobserve.ReadOnlyOperations() {
+		capabilities = append(capabilities, desktopobserve.CapabilityStatus{Name: operation, Status: desktopobserve.CapabilitySupported})
+	}
+	return desktopobserve.RuntimeReceipt{
+		SchemaVersion:     desktopobserve.RuntimeReceiptSchemaVersion,
+		Provider:          desktopobserve.ProviderIdentity{Name: name, Version: "1.0.0", ProtocolVersion: desktopobserve.ProtocolVersion},
+		Scope:             desktopobserve.ReceiptScope{Kind: desktopobserve.ScopeWindow, PublicRef: "main-window"},
+		CapabilitySummary: capabilities,
+		Redaction:         desktopobserve.RedactionReceipt{Status: desktopobserve.RedactionApplied},
+		Quarantine:        desktopobserve.QuarantineReceipt{Status: desktopobserve.QuarantineCleared},
+	}
+}
+
+func desktopObservationManifest(t *testing.T, dir string, observation desktopobserve.ObservationEvidence, status string) Manifest {
+	t.Helper()
+	body, err := json.Marshal(observation)
+	require.NoError(t, err)
+	artifact := filepath.Join(dir, "desktop-observation.json")
+	require.NoError(t, os.WriteFile(artifact, body, 0o600))
+	checkStatus := status
+	if checkStatus != "passed" {
+		checkStatus = "blocked"
+	}
+	return Manifest{
+		SchemaVersion: SchemaVersionV2, QAResultID: "qa-desktop-observe", Surface: "desktop",
+		Lane: "desktop-native", ScenarioRef: "desktop-accessibility-observe", Runner: Runner{Name: "desktop-accessibility-observe"},
+		Status: status, StartedAt: "2026-07-18T00:00:00Z", EndedAt: "2026-07-18T00:00:01Z",
+		RetentionClass: "local-redacted",
+		Artifacts:      []ArtifactRef{{Kind: "desktop_observation", Path: artifact, Publishable: true, Redaction: "pre_redacted_and_scanned"}},
+		OracleResults: OracleResults{
+			DesktopObservation: &observation,
+			Checks:             []CheckResult{{ID: "desktop-semantic-landmarks", Type: "desktop_accessibility_semantic", Status: checkStatus, FailureSummary: failureSummary(checkStatus)}},
+		},
+		RedactionStatus: RedactionStatus{Status: "passed"},
+		SourceRefs:      SourceRefs{SourceSpec: "SPEC-QAMESH-012", AcceptanceRefs: []string{"AC-QAMESH12-008", "AC-QAMESH12-009"}, JourneyID: "desktop-accessibility-observe", StepID: "step-1", Adapter: "desktop-accessibility-observe"},
+	}
+}
+
+func failureSummary(status string) string {
+	if status == "blocked" {
+		return "desktop observation blocked"
+	}
+	return ""
+}
+
+func keysOf(values map[string]any) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func assertElevenSemanticConcepts(t *testing.T, projection map[string]any) {
+	t.Helper()
+	for _, key := range []string{"provider_ref", "app_ref", "window_ref", "state_ref", "digest"} {
+		assert.Contains(t, projection, key)
+	}
+	root := projection["root"].(map[string]any)
+	for _, key := range []string{"node_ref", "role", "name", "semantic_state", "frame", "advertised_actions"} {
+		assert.Contains(t, root, key)
+	}
+}
+
+func assertForbiddenDesktopInventoryZero(t *testing.T, body []byte) {
+	t.Helper()
+	for _, pattern := range []*regexp.Regexp{
+		regexp.MustCompile(`(?i)raw[_ -]?ax|raw_tree|screenshot|\.png`),
+		regexp.MustCompile(`(?i)"(pid|handle|socket|helper_path|index)"\s*:`),
+		regexp.MustCompile(`/Users/|/tmp/|/private/var/|/var/folders/|/Volumes/|/Applications/|sk-proj-`),
+	} {
+		assert.Zero(t, len(pattern.FindAll(body, -1)), pattern.String())
+	}
+}

--- a/pkg/qa/evidence/desktop_publication_scan.go
+++ b/pkg/qa/evidence/desktop_publication_scan.go
@@ -1,0 +1,168 @@
+package evidence
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+var forbiddenDesktopPublicationText = regexp.MustCompile(
+	`(?i)(raw[_ -]?ax|raw_tree|screen[_ -]?shot|\.(?:png|jpe?g|gif|webp|tiff?|bmp|heic|mov|mp4)\b|` +
+		`(?:file://)?/(?:Users|home)/|/tmp/|/private/(?:tmp|var)/|/var/folders/|/Volumes/|/Applications/|` +
+		`[A-Za-z]:\\+Users\\+|0x[0-9a-f]{4,})`,
+)
+
+var forbiddenDesktopPublicationKeys = map[string]struct{}{
+	"binarypath":      {},
+	"errortext":       {},
+	"handle":          {},
+	"helperpath":      {},
+	"index":           {},
+	"pid":             {},
+	"processid":       {},
+	"providerpayload": {},
+	"rawax":           {},
+	"rawhandle":       {},
+	"rawindex":        {},
+	"rawpayload":      {},
+	"rawstderr":       {},
+	"rawstdout":       {},
+	"rawtree":         {},
+	"screenshot":      {},
+	"screenshots":     {},
+	"socket":          {},
+	"stderr":          {},
+	"stdout":          {},
+}
+
+func scanDesktopObservationPublication(root string, manifest Manifest) error {
+	expected := map[string]struct{}{
+		"manifest.json": {},
+		filepath.ToSlash(manifest.Artifacts[0].Path): {},
+	}
+	seen := make(map[string]struct{}, len(expected))
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		relative, _ := filepath.Rel(root, path)
+		relative = filepath.ToSlash(relative)
+		_, allowed := expected[relative]
+		if walkErr != nil || entry == nil ||
+			(!entry.IsDir() && (entry.Type()&os.ModeSymlink != 0 || !entry.Type().IsRegular() || !allowed)) {
+			return fmt.Errorf("desktop observation publication inventory contains an unsafe output")
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		seen[relative] = struct{}{}
+		return scanDesktopObservationFile(path, relative)
+	})
+	if err != nil || len(seen) != len(expected) {
+		return fmt.Errorf("desktop observation publication inventory is incomplete")
+	}
+	return nil
+}
+
+func scanDesktopObservationFile(path, source string) error {
+	body, err := os.ReadFile(path)
+	text := string(body)
+	var value any
+	parseErr := json.Unmarshal(body, &value)
+	if err != nil || parseErr != nil || RedactText(text) != text || AssertSafeText(text, source) != nil ||
+		forbiddenDesktopPublicationText.MatchString(text) || containsForbiddenDesktopObservationValue(value) {
+		return fmt.Errorf("desktop observation publication contains forbidden raw, local, or malformed data")
+	}
+	return nil
+}
+
+func containsForbiddenDesktopObservationValue(value any) bool {
+	switch typed := value.(type) {
+	case map[string]any:
+		found := false
+		for key, child := range typed {
+			normalized := strings.NewReplacer("_", "", "-", "", " ", "").Replace(strings.ToLower(key))
+			_, forbidden := forbiddenDesktopPublicationKeys[normalized]
+			found = found || forbidden || containsForbiddenDesktopObservationValue(child)
+		}
+		return found
+	case []any:
+		found := false
+		for _, child := range typed {
+			found = found || containsForbiddenDesktopObservationValue(child)
+		}
+		return found
+	case string:
+		return forbiddenDesktopPublicationText.MatchString(typed)
+	}
+	return false
+}
+
+func rejectManifestDuplicateKeys(body []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	if err := consumeUniqueManifestValue(decoder); err != nil {
+		return err
+	}
+	return requireManifestJSONEOF(decoder)
+}
+
+func consumeUniqueManifestValue(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return fmt.Errorf("%w: %v", desktopobserve.ErrMalformedEnvelope, err)
+	}
+	delimiter, structured := token.(json.Delim)
+	if !structured {
+		return nil
+	}
+	if delimiter == '[' {
+		for decoder.More() {
+			if err := consumeUniqueManifestValue(decoder); err != nil {
+				return err
+			}
+		}
+		return consumeManifestDelimiter(decoder, ']')
+	}
+	if delimiter != '{' {
+		return desktopobserve.ErrMalformedEnvelope
+	}
+	seen := make(map[string]struct{})
+	for decoder.More() {
+		key, err := decoder.Token()
+		if err != nil {
+			return fmt.Errorf("%w: %v", desktopobserve.ErrMalformedEnvelope, err)
+		}
+		name, ok := key.(string)
+		if !ok {
+			return desktopobserve.ErrMalformedEnvelope
+		}
+		if _, duplicate := seen[name]; duplicate {
+			return fmt.Errorf("%w: %s", desktopobserve.ErrDuplicateKey, name)
+		}
+		seen[name] = struct{}{}
+		if err := consumeUniqueManifestValue(decoder); err != nil {
+			return err
+		}
+	}
+	return consumeManifestDelimiter(decoder, '}')
+}
+
+func consumeManifestDelimiter(decoder *json.Decoder, expected json.Delim) error {
+	token, err := decoder.Token()
+	if err != nil || token != expected {
+		return desktopobserve.ErrMalformedEnvelope
+	}
+	return nil
+}
+
+func requireManifestJSONEOF(decoder *json.Decoder) error {
+	if _, err := decoder.Token(); err != io.EOF {
+		return desktopobserve.ErrMalformedEnvelope
+	}
+	return nil
+}

--- a/pkg/qa/evidence/manifest.go
+++ b/pkg/qa/evidence/manifest.go
@@ -1,11 +1,14 @@
 package evidence
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
 )
 
 func LoadManifest(path string) (Manifest, error) {
@@ -13,11 +16,73 @@ func LoadManifest(path string) (Manifest, error) {
 	if err != nil {
 		return Manifest{}, err
 	}
+	if err := rejectManifestDuplicateKeys(body); err != nil {
+		return Manifest{}, fmt.Errorf("parse manifest: %w", err)
+	}
 	var manifest Manifest
 	if err := json.Unmarshal(body, &manifest); err != nil {
 		return Manifest{}, fmt.Errorf("parse manifest: %w", err)
 	}
+	if isDesktopObservationContract(manifest) || hasDesktopObservationJSONMarker(body) {
+		return decodeDesktopObservationManifest(body)
+	}
 	return manifest, nil
+}
+
+func decodeDesktopObservationManifest(body []byte) (Manifest, error) {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	var manifest Manifest
+	if err := decoder.Decode(&manifest); err != nil {
+		if strings.Contains(err.Error(), "unknown field") {
+			return Manifest{}, fmt.Errorf("parse Q12 manifest: %w: %v", desktopobserve.ErrUnknownField, err)
+		}
+		return Manifest{}, fmt.Errorf("parse Q12 manifest: %w", err)
+	}
+	if err := requireManifestJSONEOF(decoder); err != nil {
+		return Manifest{}, fmt.Errorf("parse Q12 manifest: %w", err)
+	}
+	if manifest.OracleResults.DesktopObservation == nil {
+		return Manifest{}, fmt.Errorf("validate Q12 manifest: desktop observation typed oracle is required")
+	}
+	raw, err := rawDesktopObservation(body)
+	if err != nil {
+		return Manifest{}, fmt.Errorf("parse Q12 manifest: %w", err)
+	}
+	observation, err := desktopobserve.DecodeObservationEvidence(raw)
+	if err != nil {
+		return Manifest{}, fmt.Errorf("parse Q12 manifest: %w", err)
+	}
+	manifest.OracleResults.DesktopObservation = &observation
+	if err := manifest.Validate(); err != nil {
+		return Manifest{}, fmt.Errorf("validate Q12 manifest: %w", err)
+	}
+	return manifest, nil
+}
+
+func rawDesktopObservation(body []byte) ([]byte, error) {
+	var document struct {
+		OracleResults struct {
+			DesktopObservation json.RawMessage `json:"desktop_observation"`
+		} `json:"oracle_results"`
+	}
+	if err := json.Unmarshal(body, &document); err != nil || len(document.OracleResults.DesktopObservation) == 0 {
+		return nil, desktopobserve.ErrMalformedEnvelope
+	}
+	return document.OracleResults.DesktopObservation, nil
+}
+
+func hasDesktopObservationJSONMarker(body []byte) bool {
+	var document map[string]json.RawMessage
+	if json.Unmarshal(body, &document) != nil {
+		return false
+	}
+	var oracleResults map[string]json.RawMessage
+	if json.Unmarshal(document["oracle_results"], &oracleResults) != nil {
+		return false
+	}
+	_, exists := oracleResults["desktop_observation"]
+	return exists
 }
 
 func ResolveArtifactPaths(manifest Manifest, baseDir string) (Manifest, error) {
@@ -102,6 +167,16 @@ func WriteFinalManifest(manifest Manifest, outputDir string) (string, error) {
 		return "", err
 	}
 	normalized := manifest
+	desktopObservation := isDesktopObservationContract(manifest)
+	var desktopObservationBody []byte
+	if desktopObservation {
+		observation, canonicalBody, err := canonicalDesktopObservation(*manifest.OracleResults.DesktopObservation)
+		if err != nil {
+			return "", err
+		}
+		normalized.OracleResults.DesktopObservation = &observation
+		desktopObservationBody = canonicalBody
+	}
 	normalized.Artifacts = make([]ArtifactRef, 0, len(manifest.Artifacts))
 	parentDir := filepath.Dir(outputDir)
 	if err := os.MkdirAll(parentDir, 0o755); err != nil {
@@ -118,11 +193,40 @@ func WriteFinalManifest(manifest Manifest, outputDir string) (string, error) {
 		}
 	}()
 	for _, artifact := range manifest.Artifacts {
-		copied, err := sanitizeArtifact(artifact, tempDir)
+		var copied ArtifactRef
+		if desktopObservation {
+			copied, err = copyDesktopObservationArtifact(artifact, desktopObservationBody, tempDir)
+		} else {
+			copied, err = sanitizeArtifact(artifact, tempDir)
+		}
 		if err != nil {
 			return "", err
 		}
 		normalized.Artifacts = append(normalized.Artifacts, copied)
+	}
+	path := filepath.Join(tempDir, "manifest.json")
+	body, err := json.MarshalIndent(normalized, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	text := string(body)
+	if desktopObservation {
+		if RedactText(text) != text {
+			return "", fmt.Errorf("desktop observation requires publication-time redaction to be a no-op")
+		}
+	} else {
+		text = RedactText(text)
+	}
+	if err := AssertSafeText(text, path); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(path, append([]byte(text), '\n'), 0o644); err != nil {
+		return "", err
+	}
+	if desktopObservation {
+		if err := scanDesktopObservationPublication(tempDir, normalized); err != nil {
+			return "", err
+		}
 	}
 	if entries, err := os.ReadDir(outputDir); err == nil {
 		if len(entries) > 0 {
@@ -132,18 +236,6 @@ func WriteFinalManifest(manifest Manifest, outputDir string) (string, error) {
 			return "", err
 		}
 	} else if !os.IsNotExist(err) {
-		return "", err
-	}
-	path := filepath.Join(tempDir, "manifest.json")
-	body, err := json.MarshalIndent(normalized, "", "  ")
-	if err != nil {
-		return "", err
-	}
-	text := RedactText(string(body))
-	if err := AssertSafeText(text, path); err != nil {
-		return "", err
-	}
-	if err := os.WriteFile(path, append([]byte(text), '\n'), 0o644); err != nil {
 		return "", err
 	}
 	if err := os.Rename(tempDir, outputDir); err != nil {

--- a/pkg/qa/evidence/manifest_types.go
+++ b/pkg/qa/evidence/manifest_types.go
@@ -1,6 +1,10 @@
 package evidence
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
 
 // @AX:ANCHOR [AUTO] @AX:SPEC: SPEC-QAMESH-001: QAMESH manifest schema is shared by CLI, browser, and desktop evidence producers.
 // @AX:REASON: Changing schema_version or JSON field contracts breaks cross-surface evidence ingestion and feedback generation.
@@ -44,9 +48,10 @@ type ArtifactRef struct {
 }
 
 type OracleResults struct {
-	A11y    *A11yOracle    `json:"a11y,omitempty"`
-	Desktop *DesktopOracle `json:"desktop,omitempty"`
-	Checks  []CheckResult  `json:"checks,omitempty"`
+	A11y               *A11yOracle                         `json:"a11y,omitempty"`
+	Desktop            *DesktopOracle                      `json:"desktop,omitempty"`
+	DesktopObservation *desktopobserve.ObservationEvidence `json:"desktop_observation,omitempty"`
+	Checks             []CheckResult                       `json:"checks,omitempty"`
 }
 
 type CheckResult struct {

--- a/pkg/qa/journey/desktop_observation_policy.go
+++ b/pkg/qa/journey/desktop_observation_policy.go
@@ -1,0 +1,72 @@
+package journey
+
+import "slices"
+
+const (
+	desktopObservationAdapterID  = "desktop-accessibility-observe"
+	desktopObservationPolicyCode = "qa_journey_desktop_observation_policy_invalid"
+)
+
+var (
+	desktopObservationOperations = []string{
+		"capabilities",
+		"permissions",
+		"list_apps",
+		"list_windows",
+		"get_state",
+	}
+	desktopObservationLandmarks = []DesktopObservationLandmark{
+		{Role: "AXApplication", Name: "Autopus", RequiredState: "enabled"},
+		{Role: "AXWindow", Name: "Autopus", RequiredState: "focused"},
+	}
+)
+
+func validateDesktopObservationPolicy(pack Pack) error {
+	if pack.Adapter.ID != desktopObservationAdapterID {
+		return nil
+	}
+	invalid := func(message string) error {
+		return validationError(desktopObservationPolicyCode, message)
+	}
+	if pack.Surface != "desktop" {
+		return invalid("desktop observation surface must be desktop")
+	}
+	if !slices.Equal(pack.Lanes, []string{"desktop-native"}) {
+		return invalid("desktop observation lane must be exactly desktop-native")
+	}
+	if pack.PassFailAuthority != "deterministic" {
+		return invalid("desktop observation pass/fail authority must be deterministic")
+	}
+	if !emptyDesktopObservationCommand(pack.Command) {
+		return invalid("desktop observation journey must not declare a command")
+	}
+	if len(pack.Artifacts) != 0 {
+		return invalid("desktop observation journey must not declare artifacts")
+	}
+
+	policy := pack.DesktopObservation
+	if policy.Platform != "macos" {
+		return invalid("desktop observation platform must be macos")
+	}
+	if !slices.Equal(policy.Operations, desktopObservationOperations) {
+		return invalid("desktop observation operations must match the read-only sequence")
+	}
+	if policy.AppRef != "autopus-desktop" {
+		return invalid("desktop observation app_ref must be autopus-desktop")
+	}
+	if policy.WindowRef != "main-window" {
+		return invalid("desktop observation window_ref must be main-window")
+	}
+	if !slices.Equal(policy.RequiredLandmarks, desktopObservationLandmarks) {
+		return invalid("desktop observation required_landmarks must match the canonical landmarks")
+	}
+	return nil
+}
+
+func emptyDesktopObservationCommand(command Command) bool {
+	return command.Run == "" &&
+		command.Argv == nil &&
+		command.CWD == "" &&
+		command.Timeout == "" &&
+		command.EnvAllowlist == nil
+}

--- a/pkg/qa/journey/desktop_observation_policy_test.go
+++ b/pkg/qa/journey/desktop_observation_policy_test.go
@@ -1,0 +1,201 @@
+package journey
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestDesktopObservationPolicy_CommandFreeNativePackIsValid(t *testing.T) {
+	t.Parallel()
+
+	pack := validDesktopObservationPack()
+	require.NoError(t, Validate(pack, t.TempDir()))
+	assert.Empty(t, pack.Command)
+	assert.Empty(t, pack.Artifacts)
+	assert.Equal(t, []string{
+		"capabilities",
+		"permissions",
+		"list_apps",
+		"list_windows",
+		"get_state",
+	}, pack.DesktopObservation.Operations)
+	assert.Equal(t, "autopus-desktop", pack.DesktopObservation.AppRef)
+	assert.Equal(t, "main-window", pack.DesktopObservation.WindowRef)
+	assert.Equal(t, []DesktopObservationLandmark{
+		{Role: "AXApplication", Name: "Autopus", RequiredState: "enabled"},
+		{Role: "AXWindow", Name: "Autopus", RequiredState: "focused"},
+	}, pack.DesktopObservation.RequiredLandmarks)
+
+	body, err := yaml.Marshal(pack)
+	require.NoError(t, err)
+	assert.NotContains(t, string(body), "runtime_provider")
+}
+
+func TestDesktopObservationPolicy_UnsafeCommandArtifactOrOperationFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(*Pack)
+	}{
+		{name: "shell run", mutate: func(pack *Pack) { pack.Command.Run = "sh -c whoami" }},
+		{name: "argv", mutate: func(pack *Pack) { pack.Command.Argv = []string{"auto", "qa", "run"} }},
+		{name: "file cwd", mutate: func(pack *Pack) { pack.Command.CWD = "." }},
+		{name: "timeout", mutate: func(pack *Pack) { pack.Command.Timeout = "10s" }},
+		{name: "environment", mutate: func(pack *Pack) { pack.Command.EnvAllowlist = []string{"PATH"} }},
+		{name: "raw artifact", mutate: func(pack *Pack) { pack.Artifacts = []Artifact{{Kind: "raw_ax", Path: "raw.json"}} }},
+		{name: "safe artifact still forbidden", mutate: func(pack *Pack) { pack.Artifacts = []Artifact{{Kind: "summary", Path: "summary.json"}} }},
+		{name: "click", mutate: func(pack *Pack) { pack.DesktopObservation.Operations[4] = "click" }},
+		{name: "screenshot", mutate: func(pack *Pack) { pack.DesktopObservation.Operations[4] = "screenshot" }},
+		{name: "raw tree", mutate: func(pack *Pack) { pack.DesktopObservation.Operations[4] = "raw_tree" }},
+		{name: "shell", mutate: func(pack *Pack) { pack.DesktopObservation.Operations[4] = "shell" }},
+		{name: "file", mutate: func(pack *Pack) { pack.DesktopObservation.Operations[4] = "file" }},
+		{name: "missing operation", mutate: func(pack *Pack) { pack.DesktopObservation.Operations = pack.DesktopObservation.Operations[:4] }},
+		{name: "extra operation", mutate: func(pack *Pack) {
+			pack.DesktopObservation.Operations = append(pack.DesktopObservation.Operations, "permissions")
+		}},
+		{name: "duplicate operation", mutate: func(pack *Pack) { pack.DesktopObservation.Operations[4] = "permissions" }},
+		{name: "reordered operation", mutate: func(pack *Pack) {
+			pack.DesktopObservation.Operations[0], pack.DesktopObservation.Operations[1] = pack.DesktopObservation.Operations[1], pack.DesktopObservation.Operations[0]
+		}},
+		{name: "missing app alias", mutate: func(pack *Pack) { pack.DesktopObservation.AppRef = "" }},
+		{name: "noncanonical app alias", mutate: func(pack *Pack) { pack.DesktopObservation.AppRef = "com.autopus.desktop" }},
+		{name: "missing window alias", mutate: func(pack *Pack) { pack.DesktopObservation.WindowRef = "" }},
+		{name: "noncanonical window alias", mutate: func(pack *Pack) { pack.DesktopObservation.WindowRef = "window-1" }},
+		{name: "missing landmarks", mutate: func(pack *Pack) { pack.DesktopObservation.RequiredLandmarks = nil }},
+		{name: "incomplete landmarks", mutate: func(pack *Pack) { pack.DesktopObservation.RequiredLandmarks[1].RequiredState = "" }},
+		{name: "duplicate landmark", mutate: func(pack *Pack) {
+			pack.DesktopObservation.RequiredLandmarks[1] = pack.DesktopObservation.RequiredLandmarks[0]
+		}},
+		{name: "noncanonical landmark role", mutate: func(pack *Pack) { pack.DesktopObservation.RequiredLandmarks[0].Role = "application" }},
+		{name: "noncanonical landmark name", mutate: func(pack *Pack) { pack.DesktopObservation.RequiredLandmarks[0].Name = "Other" }},
+		{name: "noncanonical landmark state", mutate: func(pack *Pack) { pack.DesktopObservation.RequiredLandmarks[0].RequiredState = "focused" }},
+		{name: "wrong lane", mutate: func(pack *Pack) { pack.Lanes = []string{"fast"} }},
+		{name: "wrong surface", mutate: func(pack *Pack) { pack.Surface = "frontend" }},
+		{name: "ai authority", mutate: func(pack *Pack) { pack.PassFailAuthority = "ai" }},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			pack := validDesktopObservationPack()
+			test.mutate(&pack)
+			err := Validate(pack, t.TempDir())
+			require.Error(t, err)
+			var validationErr *ValidationError
+			require.True(t, errors.As(err, &validationErr))
+			assert.Equal(t, "qa_journey_desktop_observation_policy_invalid", validationErr.Code)
+		})
+	}
+}
+
+func TestDesktopObservationPolicy_GoldenYAMLLoadsThroughValidator(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "desktop-observe.yaml")
+	raw := strings.Replace(validDesktopObservationYAML(), "__EXTRA__", "", 1)
+	require.NoError(t, os.WriteFile(path, []byte(raw), 0o600))
+	pack, err := LoadFile(path)
+	require.NoError(t, err)
+	require.NoError(t, Validate(pack, dir))
+	assert.Empty(t, pack.Artifacts)
+	assert.Equal(t, validDesktopObservationPack().DesktopObservation, pack.DesktopObservation)
+}
+
+func TestDesktopObservationPolicy_UnknownMutationAndRuntimeYAMLFieldsFailClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		extra string
+	}{
+		{name: "click", extra: "  click: true\n"},
+		{name: "screenshot", extra: "  screenshot: true\n"},
+		{name: "raw tree", extra: "  raw_tree: true\n"},
+		{name: "shell", extra: "  shell: whoami\n"},
+		{name: "file", extra: "  file: /tmp/raw.json\n"},
+		{name: "runtime provider", extra: "runtime_provider: local\n"},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			path := filepath.Join(dir, "desktop-observe.yaml")
+			raw := strings.Replace(validDesktopObservationYAML(), "__EXTRA__", test.extra, 1)
+			require.NoError(t, os.WriteFile(path, []byte(raw), 0o600))
+			_, err := LoadFile(path)
+			require.Error(t, err)
+		})
+	}
+}
+
+func validDesktopObservationPack() Pack {
+	return Pack{
+		ID:      "desktop-accessibility-observe",
+		Title:   "Observe signed Autopus Desktop accessibility state",
+		Surface: "desktop",
+		Lanes:   []string{"desktop-native"},
+		Adapter: AdapterRef{ID: "desktop-accessibility-observe"},
+		Checks: []Check{{
+			ID:   "desktop-semantic-landmarks",
+			Type: "desktop_accessibility_semantic",
+		}},
+		DesktopObservation: DesktopObservationPolicy{
+			Platform:   "macos",
+			Operations: []string{"capabilities", "permissions", "list_apps", "list_windows", "get_state"},
+			AppRef:     "autopus-desktop",
+			WindowRef:  "main-window",
+			RequiredLandmarks: []DesktopObservationLandmark{
+				{Role: "AXApplication", Name: "Autopus", RequiredState: "enabled"},
+				{Role: "AXWindow", Name: "Autopus", RequiredState: "focused"},
+			},
+		},
+		SourceRefs: SourceRefs{
+			SourceSpec:     "SPEC-QAMESH-012",
+			AcceptanceRefs: []string{"AC-QAMESH12-001", "AC-QAMESH12-017"},
+		},
+		PassFailAuthority: "deterministic",
+	}
+}
+
+func validDesktopObservationYAML() string {
+	return `id: desktop-accessibility-observe
+title: Observe signed Autopus Desktop accessibility state
+surface: desktop
+lanes: [desktop-native]
+adapter:
+  id: desktop-accessibility-observe
+command: {}
+checks:
+  - id: desktop-semantic-landmarks
+    type: desktop_accessibility_semantic
+artifacts: []
+desktop_observation:
+  platform: macos
+  operations: [capabilities, permissions, list_apps, list_windows, get_state]
+  app_ref: autopus-desktop
+  window_ref: main-window
+  required_landmarks:
+    - role: AXApplication
+      name: Autopus
+      required_state: enabled
+    - role: AXWindow
+      name: Autopus
+      required_state: focused
+__EXTRA__source_refs:
+  source_spec: SPEC-QAMESH-012
+  acceptance_refs: [AC-QAMESH12-001, AC-QAMESH12-017]
+pass_fail_authority: deterministic
+`
+}

--- a/pkg/qa/journey/load.go
+++ b/pkg/qa/journey/load.go
@@ -1,6 +1,7 @@
 package journey
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"sort"
@@ -40,7 +41,15 @@ func LoadFile(path string) (Pack, error) {
 	if err := yaml.Unmarshal(body, &pack); err != nil {
 		return Pack{}, err
 	}
-	if strings.TrimSpace(pack.Command.CWD) == "" {
+	if pack.Adapter.ID == desktopObservationAdapterID {
+		var strictPack Pack
+		decoder := yaml.NewDecoder(bytes.NewReader(body))
+		decoder.KnownFields(true)
+		if err := decoder.Decode(&strictPack); err != nil {
+			return Pack{}, err
+		}
+		pack = strictPack
+	} else if strings.TrimSpace(pack.Command.CWD) == "" {
 		pack.Command.CWD = "."
 	}
 	return pack, nil

--- a/pkg/qa/journey/types.go
+++ b/pkg/qa/journey/types.go
@@ -1,21 +1,22 @@
 package journey
 
 type Pack struct {
-	ID                  string              `yaml:"id" json:"id"`
-	Title               string              `yaml:"title" json:"title"`
-	Surface             string              `yaml:"surface" json:"surface"`
-	Lanes               []string            `yaml:"lanes" json:"lanes"`
-	Adapter             AdapterRef          `yaml:"adapter" json:"adapter"`
-	Command             Command             `yaml:"command" json:"command"`
-	Checks              []Check             `yaml:"checks" json:"checks"`
-	Artifacts           []Artifact          `yaml:"artifacts" json:"artifacts"`
-	SourceRefs          SourceRefs          `yaml:"source_refs" json:"source_refs"`
-	ProfileRequirements ProfileRequirements `yaml:"profile_requirements" json:"profile_requirements"`
-	GUI                 GUIPolicy           `yaml:"gui,omitempty" json:"gui,omitempty"`
-	Mobile              MobilePolicy        `yaml:"mobile,omitempty" json:"mobile,omitempty"`
-	PassFailAuthority   string              `yaml:"pass_fail_authority,omitempty" json:"pass_fail_authority,omitempty"`
-	InputSource         string              `yaml:"source,omitempty" json:"input_source,omitempty"`
-	Source              string              `yaml:"-" json:"source"`
+	ID                  string                   `yaml:"id" json:"id"`
+	Title               string                   `yaml:"title" json:"title"`
+	Surface             string                   `yaml:"surface" json:"surface"`
+	Lanes               []string                 `yaml:"lanes" json:"lanes"`
+	Adapter             AdapterRef               `yaml:"adapter" json:"adapter"`
+	Command             Command                  `yaml:"command" json:"command"`
+	Checks              []Check                  `yaml:"checks" json:"checks"`
+	Artifacts           []Artifact               `yaml:"artifacts" json:"artifacts"`
+	SourceRefs          SourceRefs               `yaml:"source_refs" json:"source_refs"`
+	ProfileRequirements ProfileRequirements      `yaml:"profile_requirements" json:"profile_requirements"`
+	GUI                 GUIPolicy                `yaml:"gui,omitempty" json:"gui,omitempty"`
+	Mobile              MobilePolicy             `yaml:"mobile,omitempty" json:"mobile,omitempty"`
+	DesktopObservation  DesktopObservationPolicy `yaml:"desktop_observation,omitempty" json:"desktop_observation,omitempty"`
+	PassFailAuthority   string                   `yaml:"pass_fail_authority,omitempty" json:"pass_fail_authority,omitempty"`
+	InputSource         string                   `yaml:"source,omitempty" json:"input_source,omitempty"`
+	Source              string                   `yaml:"-" json:"source"`
 }
 
 type AdapterRef struct {
@@ -83,6 +84,20 @@ type MobilePolicy struct {
 	DeviceTarget      string   `yaml:"device_target,omitempty" json:"device_target,omitempty"`
 	AppArtifactDigest string   `yaml:"app_artifact_digest,omitempty" json:"app_artifact_digest,omitempty"`
 	ForbiddenActions  []string `yaml:"forbidden_actions,omitempty" json:"forbidden_actions,omitempty"`
+}
+
+type DesktopObservationPolicy struct {
+	Platform          string                       `yaml:"platform" json:"platform"`
+	Operations        []string                     `yaml:"operations" json:"operations"`
+	AppRef            string                       `yaml:"app_ref" json:"app_ref"`
+	WindowRef         string                       `yaml:"window_ref" json:"window_ref"`
+	RequiredLandmarks []DesktopObservationLandmark `yaml:"required_landmarks" json:"required_landmarks"`
+}
+
+type DesktopObservationLandmark struct {
+	Role          string `yaml:"role" json:"role"`
+	Name          string `yaml:"name" json:"name"`
+	RequiredState string `yaml:"required_state" json:"required_state"`
 }
 
 type ValidationError struct {

--- a/pkg/qa/journey/validate.go
+++ b/pkg/qa/journey/validate.go
@@ -30,6 +30,9 @@ func Validate(pack Pack, projectDir string) error {
 	if err := validateMobilePolicy(pack, projectDir); err != nil {
 		return err
 	}
+	if err := validateDesktopObservationPolicy(pack); err != nil {
+		return err
+	}
 	return ValidateCommand(pack.Adapter.ID, pack.Command, pack.Artifacts, projectDir, "qa_journey")
 }
 

--- a/pkg/qa/release/desktop_observation_release_test.go
+++ b/pkg/qa/release/desktop_observation_release_test.go
@@ -1,0 +1,124 @@
+package release
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+func TestDesktopObservationRelease_ReleaseLanesExactBytesAndOrderUnchanged(t *testing.T) {
+	t.Parallel()
+
+	body, err := json.Marshal(ReleaseLanes())
+	require.NoError(t, err)
+	assert.Equal(t,
+		`["fast","browser-staging","desktop-native","gui-explore","mobile-readiness","canary-explicit","evidence-dashboard"]`,
+		string(body),
+	)
+}
+
+func TestDesktopObservationRelease_CommandFreeNativePackIsExecutable(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeDesktopObservationReleaseJourney(t, dir)
+	plan, err := BuildPlan(Options{
+		ProjectDir:      dir,
+		Profile:         "prelaunch",
+		DryRun:          true,
+		RuntimeProvider: desktopobserve.RuntimeProviderLocal,
+	})
+	require.NoError(t, err)
+
+	row := findJourneyPackRow(t, plan.JourneyPacks, "desktop-native")
+	assert.Equal(t, "desktop-accessibility-observe", row.Adapter)
+	assert.False(t, row.CommandDeclared)
+	assert.True(t, row.Executable)
+	assertNoDesktopNativeGap(t, plan.SetupGaps)
+}
+
+func TestDesktopObservationRelease_RuntimeProviderMapsIntoRunOptions(t *testing.T) {
+	t.Parallel()
+
+	got := qarunOptionsForLane(Options{
+		ProjectDir:      "desktop",
+		Profile:         "prelaunch",
+		RunOutputRoot:   "runs",
+		RuntimeProvider: desktopobserve.RuntimeProviderOrca,
+	}, "desktop-native")
+	assert.Equal(t, desktopobserve.RuntimeProviderOrca, got.RuntimeProvider)
+	assert.Equal(t, "desktop-native", got.Lane)
+}
+
+func TestDesktopObservationRelease_NonPassStatesNeverPromote(t *testing.T) {
+	t.Parallel()
+
+	rows := []LaneRow{
+		{Lane: "desktop-native", LanePolicy: LanePolicyMust, Status: LaneStatusFailed, Severity: SeverityHigh},
+		{Lane: "desktop-native", LanePolicy: LanePolicyMust, Status: LaneStatusBlocked, Severity: SeverityHigh},
+		{Lane: "desktop-native", LanePolicy: LanePolicyMust, Status: LaneStatusSetupGap, SetupGapClass: SetupGapMissingJourneyPack, Severity: SeverityHigh},
+		{Lane: "desktop-native", LanePolicy: LanePolicyMust, Status: LaneStatus("quarantined"), Severity: SeverityHigh},
+	}
+	for _, row := range rows {
+		normalized := NormalizeLaneRow(row)
+		assert.NotEqual(t, LaneVerdictPass, normalized.LaneVerdict, row.Status)
+		assert.NotEqual(t, GateStatusPassed, AggregateGateStatus([]LaneRow{normalized}), row.Status)
+	}
+}
+
+func TestDesktopObservationRelease_PassedRunWithBlockedRedactionFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	row := runResultLaneRow(
+		ProfilePolicy{MustLanes: []string{"desktop-native"}},
+		"desktop-native",
+		LaneRunResult{Status: LaneStatusPassed, RedactionStatus: RedactionBlocked},
+		nil,
+	)
+	assert.Equal(t, LaneStatusBlocked, row.Status)
+	normalized := NormalizeLaneRow(row)
+	assert.Equal(t, LaneVerdictBlock, normalized.LaneVerdict)
+	assert.Equal(t, GateStatusBlocked, AggregateGateStatus([]LaneRow{normalized}))
+}
+
+func writeDesktopObservationReleaseJourney(t *testing.T, dir string) {
+	t.Helper()
+	journeyDir := filepath.Join(dir, ".autopus", "qa", "journeys")
+	require.NoError(t, os.MkdirAll(journeyDir, 0o755))
+	body := `id: desktop-accessibility-observe
+title: Desktop accessibility observation
+surface: desktop
+lanes: [desktop-native]
+adapter: {id: desktop-accessibility-observe}
+command: {}
+checks:
+  - {id: semantic-landmarks, type: desktop_accessibility_semantic}
+artifacts: []
+desktop_observation:
+  platform: macos
+  operations: [capabilities, permissions, list_apps, list_windows, get_state]
+  app_ref: autopus-desktop
+  window_ref: main-window
+  required_landmarks:
+    - {role: AXApplication, name: Autopus, required_state: enabled}
+    - {role: AXWindow, name: Autopus, required_state: focused}
+source_refs:
+  source_spec: SPEC-QAMESH-012
+  acceptance_refs: [AC-QAMESH12-016]
+pass_fail_authority: deterministic
+`
+	require.NoError(t, os.WriteFile(filepath.Join(journeyDir, "desktop-accessibility-observe.yaml"), []byte(body), 0o600))
+}
+
+func assertNoDesktopNativeGap(t *testing.T, gaps []SetupGapRow) {
+	t.Helper()
+	for _, gap := range gaps {
+		assert.NotEqual(t, "desktop-native", gap.Lane, gap)
+	}
+}

--- a/pkg/qa/release/execute.go
+++ b/pkg/qa/release/execute.go
@@ -97,13 +97,7 @@ const timeFormat = "2006-01-02T15:04:05.999999999Z07:00"
 
 // @AX:NOTE [AUTO] @AX:SPEC: SPEC-QAMESH-004: default release execution delegates lanes to QAMESH run and emits codex feedback bundle refs.
 func (defaultLaneRunner) RunLane(opts Options, lane string) (LaneRunResult, error) {
-	result, err := qarun.Execute(qarun.Options{
-		ProjectDir: opts.ProjectDir,
-		Profile:    opts.Profile,
-		Lane:       lane,
-		Output:     opts.RunOutputRoot,
-		FeedbackTo: "codex",
-	})
+	result, err := qarun.Execute(qarunOptionsForLane(opts, lane))
 	if result.RunID != "" {
 		_ = os.RemoveAll(filepath.Join(opts.RunOutputRoot, result.RunID, "_raw"))
 	}
@@ -117,6 +111,17 @@ func (defaultLaneRunner) RunLane(opts Options, lane string) (LaneRunResult, erro
 		FailureSummary:  failureSummary,
 		RedactionStatus: mapRunRedaction(result.RedactionStatus.Status),
 	}, err
+}
+
+func qarunOptionsForLane(opts Options, lane string) qarun.Options {
+	return qarun.Options{
+		ProjectDir:      opts.ProjectDir,
+		Profile:         opts.Profile,
+		Lane:            lane,
+		Output:          opts.RunOutputRoot,
+		FeedbackTo:      "codex",
+		RuntimeProvider: opts.RuntimeProvider,
+	}
 }
 
 func executionOutputPaths(opts Options, releaseID string) OutputPaths {
@@ -175,6 +180,9 @@ func runResultLaneRow(policy ProfilePolicy, lane string, result LaneRunResult, e
 	catalog := laneByID(lane)
 	status := result.Status
 	if status == "" {
+		status = LaneStatusBlocked
+	}
+	if result.RedactionStatus == RedactionBlocked {
 		status = LaneStatusBlocked
 	}
 	row := LaneRow{

--- a/pkg/qa/release/plan.go
+++ b/pkg/qa/release/plan.go
@@ -3,6 +3,7 @@ package release
 import (
 	"path/filepath"
 
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
 	"github.com/insajin/autopus-adk/pkg/qa/journey"
 	qaproject "github.com/insajin/autopus-adk/pkg/qa/project"
 )
@@ -17,6 +18,9 @@ func BuildPlan(opts Options) (Plan, error) {
 	policy, _ := profilePolicy(opts.Profile)
 	packs, err := journey.LoadDir(opts.ProjectDir)
 	if err != nil {
+		return Plan{}, err
+	}
+	if err := validateReleaseRuntimeProvider(opts.RuntimeProvider, packs); err != nil {
 		return Plan{}, err
 	}
 	journeyRows, redactionStatus := journeyPackRows(packs)
@@ -115,7 +119,7 @@ func journeyPackRows(packs []journey.Pack) ([]JourneyPackRow, RedactionState) {
 				CommandDeclared:        commandDeclared(pack.Command),
 				CommandPreview:         preview,
 				CommandPreviewRedacted: redacted,
-				Executable:             commandDeclared(pack.Command),
+				Executable:             executableReleasePack(pack),
 				SourceSpec:             sourceSpecForPack(pack, lane),
 				AcceptanceRefs:         nonNilStrings(pack.SourceRefs.AcceptanceRefs),
 				InventedCommand:        false,
@@ -135,7 +139,7 @@ func nonNilStrings(values []string) []string {
 func releaseSetupGaps(policy ProfilePolicy, journeyRows []JourneyPackRow) []SetupGapRow {
 	covered := map[string]bool{}
 	for _, row := range journeyRows {
-		if row.CommandDeclared && row.Executable {
+		if row.Executable {
 			covered[row.Lane] = true
 		}
 	}
@@ -201,6 +205,22 @@ func sourceLabel(value string) string {
 
 func commandDeclared(command journey.Command) bool {
 	return len(command.Argv) > 0 || command.Run != ""
+}
+
+func executableReleasePack(pack journey.Pack) bool {
+	return commandDeclared(pack.Command) || pack.Adapter.ID == "desktop-accessibility-observe"
+}
+
+func validateReleaseRuntimeProvider(provider desktopobserve.RuntimeProvider, packs []journey.Pack) error {
+	if provider != "" && provider != desktopobserve.RuntimeProviderLocal && provider != desktopobserve.RuntimeProviderOrca {
+		return desktopobserve.ErrRuntimeProviderInvalid
+	}
+	for _, pack := range packs {
+		if pack.Adapter.ID == "desktop-accessibility-observe" && provider == "" {
+			return desktopobserve.ErrRuntimeProviderRequired
+		}
+	}
+	return nil
 }
 
 func sourceSpecForPack(pack journey.Pack, lane string) string {

--- a/pkg/qa/release/types.go
+++ b/pkg/qa/release/types.go
@@ -3,6 +3,8 @@ package release
 import (
 	"errors"
 	"time"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
 )
 
 // @AX:NOTE [AUTO] @AX:SPEC: SPEC-QAMESH-004: schema version strings are persisted in release plan, index, roadmap, and blocker matrix JSON.
@@ -19,16 +21,17 @@ var (
 )
 
 type Options struct {
-	ProjectDir    string
-	Profile       string
-	Output        string
-	RunOutputRoot string
-	Command       string
-	DryRun        bool
-	Roadmap       bool
-	Runner        LaneRunner
-	Now           func() time.Time
-	NewID         func() string
+	ProjectDir      string
+	Profile         string
+	Output          string
+	RunOutputRoot   string
+	Command         string
+	DryRun          bool
+	Roadmap         bool
+	RuntimeProvider desktopobserve.RuntimeProvider
+	Runner          LaneRunner
+	Now             func() time.Time
+	NewID           func() string
 }
 
 type LaneRunner interface {

--- a/pkg/qa/releasereadiness/desktop_observation_dispatch_test.go
+++ b/pkg/qa/releasereadiness/desktop_observation_dispatch_test.go
@@ -1,0 +1,218 @@
+package releasereadiness
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+	"github.com/insajin/autopus-adk/pkg/qa/journey"
+	"github.com/insajin/autopus-adk/pkg/qa/release"
+	qarun "github.com/insajin/autopus-adk/pkg/qa/run"
+)
+
+func TestDesktopObservationDispatch_CommandFreePackPropagatesRuntimeProvider(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	desktopSignals(t, root)
+	pack := readinessDesktopObservationPack()
+	var captured qarun.Options
+	row := dispatchLane(Options{
+		ProjectDir: root, Approve: true, RuntimeProvider: desktopobserve.RuntimeProviderOrca,
+	}, pack, []string{"desktop"}, func(options qarun.Options) (qarun.Result, error) {
+		captured = options
+		return successfulReadinessDesktopObservationResult(t, options.RuntimeProvider), nil
+	})
+
+	assert.Equal(t, string(release.LaneStatusPassed), row.Status)
+	assert.Equal(t, "desktop-native", captured.Lane)
+	assert.Equal(t, "desktop-accessibility-observe", captured.AdapterID)
+	assert.Equal(t, desktopobserve.RuntimeProviderOrca, captured.RuntimeProvider)
+}
+
+func TestDesktopObservationDispatch_ConfiguredPackIsAdditiveAndDispatchedOnce(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	desktopSignals(t, root)
+	pack := readinessDesktopObservationPack()
+	writePack(t, root, pack)
+	adapters := []string{}
+	providers := []desktopobserve.RuntimeProvider{}
+
+	payload, err := orchestrateWith(Options{
+		ProjectDir: root, Approve: true, RuntimeProvider: desktopobserve.RuntimeProviderLocal,
+	}, func(options qarun.Options) (qarun.Result, error) {
+		adapters = append(adapters, options.AdapterID)
+		providers = append(providers, options.RuntimeProvider)
+		return successfulReadinessDesktopObservationResult(t, options.RuntimeProvider), nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, string(PhaseExecuted), payload.Phase)
+	assert.Equal(t, 1, countString(adapters, "desktop-accessibility-observe"))
+	for index, adapterID := range adapters {
+		if adapterID == "desktop-accessibility-observe" {
+			assert.Equal(t, desktopobserve.RuntimeProviderLocal, providers[index])
+		}
+	}
+}
+
+func TestDesktopObservationDispatch_NonPassStatusesNeverPromote(t *testing.T) {
+	t.Parallel()
+
+	statuses := []string{
+		string(release.LaneStatusFailed),
+		string(release.LaneStatusBlocked),
+		string(release.LaneStatusSetupGap),
+		"quarantined",
+	}
+	for _, status := range statuses {
+		status := status
+		t.Run(status, func(t *testing.T) {
+			t.Parallel()
+			verdict := aggregateVerdict([]LaneRow{{
+				Lane: "desktop-native", Status: status, DeterministicAuthority: true,
+			}})
+			assert.NotEqual(t, string(release.GateStatusPassed), verdict.Status)
+			assert.True(t, verdict.DeterministicAuthority)
+		})
+	}
+}
+
+func TestDesktopObservationDispatch_PassedOverallCannotLaunderObservationFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		result qarun.Result
+	}{
+		{name: "bare passed result", result: qarun.Result{Status: "passed"}},
+		{name: "adapter blocked", result: qarun.Result{
+			Status: "passed", AdapterResults: []qarun.AdapterResult{{
+				Adapter: "desktop-accessibility-observe", Status: "blocked",
+			}},
+		}},
+		{name: "adapter setup gap", result: qarun.Result{
+			Status: "passed", AdapterResults: []qarun.AdapterResult{{
+				Adapter: "desktop-accessibility-observe", Status: "setup_gap",
+				SetupGap: &qarun.SetupGap{Adapter: "desktop-accessibility-observe", Reason: "provider unavailable"},
+			}},
+		}},
+		{name: "deterministic check blocked", result: qarun.Result{
+			Status: "passed", Checks: []qarun.IndexCheck{{
+				ID: "desktop-semantic-landmarks", Adapter: "desktop-accessibility-observe", Status: "blocked",
+			}},
+		}},
+		{name: "redaction blocked", result: qarun.Result{
+			Status: "passed", RedactionStatus: qarun.RedactionStatus{Status: "blocked"},
+		}},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			row := laneRowFromRun(LaneRow{
+				Lane: "desktop-native", DeterministicAuthority: true,
+			}, test.result, nil)
+			assert.Equal(t, string(release.LaneStatusBlocked), row.Status)
+			verdict := aggregateVerdict([]LaneRow{row})
+			assert.Equal(t, string(release.GateStatusBlocked), verdict.Status)
+		})
+	}
+}
+
+func successfulReadinessDesktopObservationResult(t *testing.T, provider desktopobserve.RuntimeProvider) qarun.Result {
+	t.Helper()
+	enabled, focused := true, true
+	providerName, providerRef := "autopus-desktop-local", "provider-local"
+	if provider == desktopobserve.RuntimeProviderOrca {
+		providerName, providerRef = "orca-computer-use-macos", "provider-orca"
+	}
+	projection, err := desktopobserve.NormalizeProjection(desktopobserve.SemanticProjection{
+		SchemaVersion: desktopobserve.SemanticProjectionSchemaVersion,
+		ProviderRef:   providerRef,
+		AppRef:        "autopus-desktop",
+		WindowRef:     "main-window",
+		StateRef:      "state-readiness",
+		Root: desktopobserve.SemanticNode{
+			Role:          desktopobserve.RoleApplication,
+			Name:          "Autopus",
+			SemanticState: desktopobserve.SemanticState{Enabled: &enabled},
+			Children: []desktopobserve.SemanticNode{{
+				Role:          desktopobserve.RoleWindow,
+				Name:          "Autopus",
+				SemanticState: desktopobserve.SemanticState{Focused: &focused},
+			}},
+		},
+	}, func(value string) (string, error) { return value, nil })
+	require.NoError(t, err)
+	capabilities := make([]desktopobserve.CapabilityStatus, 0, len(desktopobserve.ReadOnlyOperations()))
+	for _, operation := range desktopobserve.ReadOnlyOperations() {
+		capabilities = append(capabilities, desktopobserve.CapabilityStatus{
+			Name: operation, Status: desktopobserve.CapabilitySupported,
+		})
+	}
+	observation := desktopobserve.ObservationEvidence{
+		SemanticProjection: &projection,
+		DeterministicChecks: []desktopobserve.DeterministicCheck{{
+			ID: "desktop-semantic-landmarks", Status: desktopobserve.CheckPassed,
+		}},
+		RuntimeReceipt: desktopobserve.RuntimeReceipt{
+			SchemaVersion: desktopobserve.RuntimeReceiptSchemaVersion,
+			Provider: desktopobserve.ProviderIdentity{
+				Name: providerName, Version: "1.0.0", ProtocolVersion: desktopobserve.ProtocolVersion,
+			},
+			Scope:             desktopobserve.ReceiptScope{Kind: desktopobserve.ScopeWindow, PublicRef: "main-window"},
+			CapabilitySummary: capabilities,
+			Redaction:         desktopobserve.RedactionReceipt{Status: desktopobserve.RedactionApplied},
+			Quarantine:        desktopobserve.QuarantineReceipt{Status: desktopobserve.QuarantineCleared},
+		},
+	}
+	require.NoError(t, observation.RuntimeReceipt.Validate())
+	return qarun.Result{
+		Status: "passed",
+		AdapterResults: []qarun.AdapterResult{{
+			Adapter: "desktop-accessibility-observe", JourneyID: "desktop-accessibility-observe", Status: "passed",
+			DesktopObservation: &observation,
+		}},
+		Checks: []qarun.IndexCheck{{
+			ID: "desktop-semantic-landmarks", JourneyID: "desktop-accessibility-observe",
+			Adapter: "desktop-accessibility-observe", Status: "passed",
+		}},
+		RedactionStatus: qarun.RedactionStatus{Status: "passed"},
+	}
+}
+
+func readinessDesktopObservationPack() journey.Pack {
+	return journey.Pack{
+		ID: "desktop-accessibility-observe", Title: "Desktop accessibility observation",
+		Surface: "desktop", Lanes: []string{"desktop-native"},
+		Adapter: journey.AdapterRef{ID: "desktop-accessibility-observe"},
+		Checks:  []journey.Check{{ID: "semantic-landmarks", Type: "desktop_accessibility_semantic"}},
+		DesktopObservation: journey.DesktopObservationPolicy{
+			Platform: "macos", Operations: []string{"capabilities", "permissions", "list_apps", "list_windows", "get_state"},
+			AppRef: "autopus-desktop", WindowRef: "main-window",
+			RequiredLandmarks: []journey.DesktopObservationLandmark{
+				{Role: "AXApplication", Name: "Autopus", RequiredState: "enabled"},
+				{Role: "AXWindow", Name: "Autopus", RequiredState: "focused"},
+			},
+		},
+		SourceRefs: journey.SourceRefs{
+			SourceSpec: "SPEC-QAMESH-012", AcceptanceRefs: []string{"AC-QAMESH12-016"},
+		},
+		PassFailAuthority: "deterministic",
+	}
+}
+
+func countString(values []string, target string) int {
+	count := 0
+	for _, value := range values {
+		if value == target {
+			count++
+		}
+	}
+	return count
+}

--- a/pkg/qa/releasereadiness/dispatch.go
+++ b/pkg/qa/releasereadiness/dispatch.go
@@ -87,7 +87,7 @@ func missingBinary(adapterID string) (string, bool) {
 // exec.LookPath); qarun setup-gap free text is never parsed for reason codes.
 func dispatchLane(opts Options, pack journey.Pack, present []string, runFn runFunc) LaneRow {
 	lane := laneForPack(pack)
-	row := LaneRow{Lane: lane, DeterministicAuthority: true}
+	row := LaneRow{Lane: lane, DeterministicAuthority: true, adapterID: pack.Adapter.ID}
 
 	if !surfacePresent(pack.Surface, present) {
 		row.Status = statusSetupGap
@@ -102,11 +102,12 @@ func dispatchLane(opts Options, pack journey.Pack, present []string, runFn runFu
 	}
 
 	result, err := runFn(qarun.Options{
-		ProjectDir: opts.ProjectDir,
-		Lane:       lane,
-		JourneyID:  pack.ID,
-		AdapterID:  pack.Adapter.ID,
-		Output:     runOutputDir(opts.ProjectDir),
+		ProjectDir:      opts.ProjectDir,
+		Lane:            lane,
+		JourneyID:       pack.ID,
+		AdapterID:       pack.Adapter.ID,
+		Output:          runOutputDir(opts.ProjectDir),
+		RuntimeProvider: opts.RuntimeProvider,
 	})
 	return laneRowFromRun(row, result, err)
 }

--- a/pkg/qa/releasereadiness/execute.go
+++ b/pkg/qa/releasereadiness/execute.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"path/filepath"
 
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
 	qaevidence "github.com/insajin/autopus-adk/pkg/qa/evidence"
 	"github.com/insajin/autopus-adk/pkg/qa/release"
 	qarun "github.com/insajin/autopus-adk/pkg/qa/run"
@@ -39,11 +40,67 @@ func laneRowFromRun(row LaneRow, result qarun.Result, err error) LaneRow {
 	if err != nil && status != release.LaneStatusFailed && status != release.LaneStatusBlocked {
 		status = release.LaneStatusBlocked
 	}
+	if status == release.LaneStatusPassed && desktopObservationDispatch(row, result) &&
+		!validPassingDesktopObservation(result) {
+		status = release.LaneStatusBlocked
+	}
 	row.Status = string(status)
 	if fs := firstFailureSummary(result); fs != "" {
 		row.FailureSummary = fs
 	}
 	return row
+}
+
+func desktopObservationDispatch(row LaneRow, result qarun.Result) bool {
+	if row.adapterID != "" {
+		return row.adapterID == "desktop-accessibility-observe"
+	}
+	for _, adapterResult := range result.AdapterResults {
+		if adapterResult.Adapter == "desktop-accessibility-observe" {
+			return true
+		}
+	}
+	for _, check := range result.Checks {
+		if check.Adapter == "desktop-accessibility-observe" || check.ID == "desktop-semantic-landmarks" {
+			return true
+		}
+	}
+	return row.Lane == "desktop-native"
+}
+
+func validPassingDesktopObservation(result qarun.Result) bool {
+	if result.RedactionStatus.Status != "passed" {
+		return false
+	}
+	adapterPassed := false
+	for _, adapterResult := range result.AdapterResults {
+		if adapterResult.Adapter != "desktop-accessibility-observe" {
+			continue
+		}
+		if adapterResult.Status != "passed" || adapterResult.SetupGap != nil ||
+			adapterResult.DesktopObservation == nil || adapterResult.DesktopObservation.RuntimeReceipt.Validate() != nil {
+			return false
+		}
+		body, err := json.Marshal(adapterResult.DesktopObservation)
+		if err != nil {
+			return false
+		}
+		if _, err := desktopobserve.DecodeObservationEvidence(body); err != nil {
+			return false
+		}
+		adapterPassed = true
+	}
+	checkPassed := false
+	for _, check := range result.Checks {
+		if check.Adapter != "desktop-accessibility-observe" && check.ID != "desktop-semantic-landmarks" {
+			continue
+		}
+		if check.Status != "passed" {
+			return false
+		}
+		checkPassed = true
+	}
+	return adapterPassed && checkPassed
 }
 
 func firstFailureSummary(result qarun.Result) string {

--- a/pkg/qa/releasereadiness/orchestrate.go
+++ b/pkg/qa/releasereadiness/orchestrate.go
@@ -1,6 +1,9 @@
 package releasereadiness
 
 import (
+	"sort"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
 	"github.com/insajin/autopus-adk/pkg/qa/journey"
 	"github.com/insajin/autopus-adk/pkg/qa/regen"
 	"github.com/insajin/autopus-adk/pkg/qa/release"
@@ -14,8 +17,8 @@ import (
 // build payload. When approval is not granted (or is declined) it returns the
 // redacted diff with files_written=0 and lanes_executed=0 and performs no write
 // or execution. When approved it persists the accepted packs via
-// regen.ApplyPacks, dispatches each persisted pack's lane, aggregates a
-// deterministic verdict, and attaches a sanitized v2 evidence summary.
+// regen.ApplyPacks, dispatches each eligible synthesized or configured pack's
+// lane, aggregates a deterministic verdict, and attaches a sanitized v2 evidence summary.
 func Orchestrate(opts Options) (Payload, error) {
 	return orchestrateWith(opts, func(o qarun.Options) (qarun.Result, error) {
 		return qarun.Execute(o)
@@ -63,13 +66,20 @@ func orchestrateWith(opts Options, runFn runFunc) (Payload, error) {
 
 	// Approved path: persist accepted packs, then dispatch their lanes.
 	accepted := result.AcceptedPacks()
+	dispatchPacks, err := readinessDispatchPacks(opts.ProjectDir, accepted)
+	if err != nil {
+		return Payload{}, err
+	}
+	if err := validateReadinessRuntimeProvider(opts.RuntimeProvider, dispatchPacks); err != nil {
+		return Payload{}, err
+	}
 	applied, err := regen.ApplyPacks(opts.ProjectDir, accepted)
 	if err != nil {
 		return Payload{}, err
 	}
 	payload.FilesWritten = len(applied.Written)
 
-	rows := dispatchAccepted(opts, accepted, surfaces, runFn)
+	rows := dispatchAccepted(opts, dispatchPacks, surfaces, runFn)
 	payload.LaneRows = rows
 	payload.LanesExecuted = len(rows)
 	payload.Verdict = aggregateVerdict(rows)
@@ -83,9 +93,50 @@ func orchestrateWith(opts Options, runFn runFunc) (Payload, error) {
 	return payload, nil
 }
 
-// dispatchAccepted resolves a LaneRow for every accepted pack. Each pack maps to
-// exactly one lane; ApplyPacks already excluded invalid/AI-authority packs, so
-// only persisted-eligible packs are dispatched (AC-012).
+func readinessDispatchPacks(projectDir string, accepted []journey.Pack) ([]journey.Pack, error) {
+	existing, err := regen.LoadExistingPacks(projectDir)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]bool, len(accepted))
+	packs := append([]journey.Pack(nil), accepted...)
+	for _, pack := range accepted {
+		seen[pack.ID] = true
+	}
+	ids := make([]string, 0, len(existing))
+	for id := range existing {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		pack := existing[id]
+		if seen[id] || pack.Adapter.ID != "desktop-accessibility-observe" {
+			continue
+		}
+		if evaluated := regen.EvaluatePack(projectDir, pack.Surface, pack); evaluated.Excluded {
+			continue
+		}
+		packs = append(packs, pack)
+		seen[id] = true
+	}
+	return packs, nil
+}
+
+func validateReadinessRuntimeProvider(provider desktopobserve.RuntimeProvider, packs []journey.Pack) error {
+	if provider != "" && provider != desktopobserve.RuntimeProviderLocal && provider != desktopobserve.RuntimeProviderOrca {
+		return desktopobserve.ErrRuntimeProviderInvalid
+	}
+	for _, pack := range packs {
+		if pack.Adapter.ID == "desktop-accessibility-observe" && provider == "" {
+			return desktopobserve.ErrRuntimeProviderRequired
+		}
+	}
+	return nil
+}
+
+// dispatchAccepted resolves a LaneRow for every eligible pack. Each pack maps to
+// exactly one lane; callers provide accepted synthesis results plus validated
+// additive desktop observation packs (AC-012).
 func dispatchAccepted(opts Options, packs []journey.Pack, present []string, runFn runFunc) []LaneRow {
 	rows := make([]LaneRow, 0, len(packs))
 	for _, pack := range packs {

--- a/pkg/qa/releasereadiness/types.go
+++ b/pkg/qa/releasereadiness/types.go
@@ -10,7 +10,10 @@
 // deliberately no init() or background trigger here (AC-006).
 package releasereadiness
 
-import "github.com/insajin/autopus-adk/pkg/qa/regen"
+import (
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+	"github.com/insajin/autopus-adk/pkg/qa/regen"
+)
 
 // @AX:NOTE [AUTO] @AX:SPEC: SPEC-QAMESH-011: SchemaVersion is the published payload envelope discriminator — bumping it is a breaking change for any consumer parsing the JSON output.
 // SchemaVersion is the release-readiness payload envelope version.
@@ -39,9 +42,10 @@ const (
 // exclusive operator signals; Decline takes precedence when both are set so a
 // decline never produces side effects.
 type Options struct {
-	ProjectDir string `json:"project_dir"`
-	Approve    bool   `json:"approve"`
-	Decline    bool   `json:"decline"`
+	ProjectDir      string                         `json:"project_dir"`
+	Approve         bool                           `json:"approve"`
+	Decline         bool                           `json:"decline"`
+	RuntimeProvider desktopobserve.RuntimeProvider `json:"runtime_provider,omitempty"`
 }
 
 // LaneRow is the release-readiness view of one dispatched (or gap) lane. Status
@@ -54,6 +58,7 @@ type LaneRow struct {
 	ReasonCode             string `json:"reason_code,omitempty"`
 	FailureSummary         string `json:"failure_summary,omitempty"`
 	DeterministicAuthority bool   `json:"deterministic_authority"`
+	adapterID              string
 }
 
 // Verdict is the aggregated deterministic gate decision over all lane rows.

--- a/pkg/qa/run/desktop_observe_contract.go
+++ b/pkg/qa/run/desktop_observe_contract.go
@@ -1,0 +1,174 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+const maxDesktopObservationDuration = 2 * time.Second
+
+type desktopProviderClient interface {
+	Handshake(context.Context) (desktopobserve.ProviderIdentity, error)
+	Capabilities(context.Context) ([]desktopobserve.Operation, error)
+	Permissions(context.Context) (desktopobserve.PermissionResult, error)
+	ListApps(context.Context) ([]desktopobserve.AppSummary, error)
+	ListWindows(context.Context, string) ([]desktopobserve.WindowSummary, error)
+	GetState(context.Context, string, string) (desktopobserve.SemanticProjection, error)
+}
+
+type desktopProviderResolver interface {
+	ResolveLocal(context.Context) (desktopProviderClient, error)
+	LookPath(context.Context, string) (string, error)
+	ResolveOrca(context.Context, string) (string, error)
+	NewOrcaClient(context.Context, string) (desktopProviderClient, error)
+}
+
+type DesktopObservationRunRequest struct {
+	RuntimeProvider desktopobserve.RuntimeProvider
+	Operations      []desktopobserve.Operation
+	AppRef          string
+	WindowRef       string
+	Policy          desktopobserve.OraclePolicy
+	Redactor        desktopobserve.Redactor
+}
+
+type desktopObservationRunner struct {
+	local    desktopProviderClient
+	orca     desktopProviderClient
+	resolver desktopProviderResolver
+	ledgers  map[desktopobserve.RuntimeProvider]*desktopobserve.StateLedger
+	timeout  time.Duration
+}
+
+func newDesktopObservationRunner(local, orca desktopProviderClient) *desktopObservationRunner {
+	return &desktopObservationRunner{
+		local:   local,
+		orca:    orca,
+		timeout: maxDesktopObservationDuration,
+		ledgers: map[desktopobserve.RuntimeProvider]*desktopobserve.StateLedger{
+			desktopobserve.RuntimeProviderLocal: desktopobserve.NewStateLedger(),
+			desktopobserve.RuntimeProviderOrca:  desktopobserve.NewStateLedger(),
+		},
+	}
+}
+
+func (runner *desktopObservationRunner) operationContext(parent context.Context) (context.Context, context.CancelFunc) {
+	timeout := maxDesktopObservationDuration
+	if runner != nil && runner.timeout > 0 && runner.timeout < timeout {
+		timeout = runner.timeout
+	}
+	return context.WithTimeout(parent, timeout)
+}
+
+func desktopBoundedError(ctx context.Context, err error) error {
+	if contextErr := ctx.Err(); contextErr != nil {
+		return contextErr
+	}
+	return err
+}
+
+func newDesktopObservationRunnerWithResolver(resolver desktopProviderResolver) *desktopObservationRunner {
+	runner := newDesktopObservationRunner(nil, nil)
+	runner.resolver = resolver
+	return runner
+}
+
+func (runner *desktopObservationRunner) resolveClient(
+	ctx context.Context,
+	provider desktopobserve.RuntimeProvider,
+) (desktopProviderClient, error) {
+	if runner == nil {
+		return nil, errors.New("desktop observation runner is unavailable")
+	}
+	if runner.resolver == nil {
+		if provider == desktopobserve.RuntimeProviderLocal {
+			return runner.local, nil
+		}
+		return runner.orca, nil
+	}
+	if provider == desktopobserve.RuntimeProviderLocal {
+		return runner.resolver.ResolveLocal(ctx)
+	}
+	path, err := runner.resolver.LookPath(ctx, "orca")
+	if err != nil {
+		return nil, err
+	}
+	resolved, err := runner.resolver.ResolveOrca(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	return runner.resolver.NewOrcaClient(ctx, resolved)
+}
+
+func desktopExecutionOperations() []desktopobserve.Operation {
+	return []desktopobserve.Operation{
+		desktopobserve.OperationCapabilities,
+		desktopobserve.OperationPermissions,
+		desktopobserve.OperationListApps,
+		desktopobserve.OperationListWindows,
+		desktopobserve.OperationGetState,
+	}
+}
+
+func validDesktopProvider(provider desktopobserve.RuntimeProvider) error {
+	switch provider {
+	case "":
+		return desktopobserve.ErrRuntimeProviderRequired
+	case desktopobserve.RuntimeProviderLocal, desktopobserve.RuntimeProviderOrca:
+		return nil
+	default:
+		return desktopobserve.ErrRuntimeProviderInvalid
+	}
+}
+
+func validDesktopOperations(operations []desktopobserve.Operation) bool {
+	expected := desktopExecutionOperations()
+	if len(operations) != len(expected) {
+		return false
+	}
+	for index := range expected {
+		if operations[index] != expected[index] || !desktopobserve.IsReadOnlyOperation(operations[index]) {
+			return false
+		}
+	}
+	return true
+}
+
+func expectedDesktopIdentity(provider desktopobserve.RuntimeProvider) desktopobserve.ProviderIdentity {
+	name := "autopus-desktop-local"
+	if provider == desktopobserve.RuntimeProviderOrca {
+		name = "orca-computer-use-macos"
+	}
+	return desktopobserve.ProviderIdentity{
+		Name: name, Version: "0.0.0", ProtocolVersion: desktopobserve.ProtocolVersion,
+	}
+}
+
+func validDesktopIdentity(identity desktopobserve.ProviderIdentity, provider desktopobserve.RuntimeProvider) bool {
+	if identity.Name != expectedDesktopIdentity(provider).Name ||
+		identity.ProtocolVersion != desktopobserve.ProtocolVersion {
+		return false
+	}
+	receipt := desktopSuccessReceipt(identity, desktopProviderScope(identity), desktopSupportedCapabilities())
+	receipt.Redaction.Status = desktopobserve.RedactionNotRequired
+	receipt.Quarantine.Status = desktopobserve.QuarantineEmpty
+	return receipt.Validate() == nil
+}
+
+func desktopProviderScope(identity desktopobserve.ProviderIdentity) desktopobserve.ReceiptScope {
+	return desktopobserve.ReceiptScope{Kind: desktopobserve.ScopeProvider, PublicRef: identity.Name}
+}
+
+func desktopWindowScope(windowRef string) desktopobserve.ReceiptScope {
+	return desktopobserve.ReceiptScope{Kind: desktopobserve.ScopeWindow, PublicRef: windowRef}
+}
+
+func desktopProviderPublicRef(provider desktopobserve.RuntimeProvider) string {
+	if provider == desktopobserve.RuntimeProviderOrca {
+		return "provider-orca"
+	}
+	return "provider-local"
+}

--- a/pkg/qa/run/desktop_observe_failure.go
+++ b/pkg/qa/run/desktop_observe_failure.go
@@ -1,0 +1,187 @@
+package run
+
+import (
+	"errors"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+type desktopProviderFailure struct {
+	condition desktopobserve.FailureCondition
+	operation desktopobserve.Operation
+	receipt   desktopobserve.RuntimeReceipt
+	validated bool
+}
+
+func (failure desktopProviderFailure) Error() string {
+	return "desktop provider returned a normalized failure"
+}
+
+func desktopFailureOutcome(
+	condition desktopobserve.FailureCondition,
+	provider desktopobserve.ProviderIdentity,
+	scope desktopobserve.ReceiptScope,
+	capabilities []desktopobserve.CapabilityStatus,
+	operation desktopobserve.Operation,
+) (desktopobserve.OracleOutcome, error) {
+	if condition == desktopobserve.FailureOperationMissing {
+		if !desktopobserve.IsReadOnlyOperation(operation) {
+			operation = desktopobserve.OperationCapabilities
+		}
+		capabilities = desktopMarkUnsupported(capabilities, operation)
+	}
+	return desktopobserve.NormalizeFailure(desktopobserve.FailureSignal{
+		Condition:          condition,
+		Provider:           provider,
+		Scope:              scope,
+		CapabilitySummary:  capabilities,
+		RequestedOperation: operation,
+	})
+}
+
+func desktopFailureFromError(
+	err error,
+	provider desktopobserve.ProviderIdentity,
+	scope desktopobserve.ReceiptScope,
+	capabilities []desktopobserve.CapabilityStatus,
+) (desktopobserve.OracleOutcome, error) {
+	var providerFailure desktopProviderFailure
+	if errors.As(err, &providerFailure) && providerFailure.validated && providerFailure.receipt.Validate() == nil {
+		return desktopFailureOutcome(
+			providerFailure.condition,
+			providerFailure.receipt.Provider,
+			providerFailure.receipt.Scope,
+			providerFailure.receipt.CapabilitySummary,
+			providerFailure.operation,
+		)
+	}
+	condition, operation := desktopFailureCondition(err)
+	return desktopFailureOutcome(condition, provider, scope, capabilities, operation)
+}
+
+func desktopFailureCondition(err error) (desktopobserve.FailureCondition, desktopobserve.Operation) {
+	var providerFailure desktopProviderFailure
+	if errors.As(err, &providerFailure) {
+		return providerFailure.condition, providerFailure.operation
+	}
+	switch {
+	case errors.Is(err, desktopobserve.ErrRawOnlyEvidence):
+		return desktopobserve.FailureRawOnlyQuarantine, ""
+	case errors.Is(err, desktopobserve.ErrRedactionFailed):
+		return desktopobserve.FailureRedaction, ""
+	case desktopProtocolError(err):
+		return desktopobserve.FailureProtocolVersion, ""
+	default:
+		return desktopobserve.FailureProviderStart, ""
+	}
+}
+
+func desktopProtocolError(err error) bool {
+	return errors.Is(err, desktopobserve.ErrDuplicateKey) ||
+		errors.Is(err, desktopobserve.ErrEnvelopeTooLarge) ||
+		errors.Is(err, desktopobserve.ErrInvalidStatus) ||
+		errors.Is(err, desktopobserve.ErrMalformedEnvelope) ||
+		errors.Is(err, desktopobserve.ErrMissingField) ||
+		errors.Is(err, desktopobserve.ErrProtocolMismatch) ||
+		errors.Is(err, desktopobserve.ErrRequestIDMismatch) ||
+		errors.Is(err, desktopobserve.ErrScopeMismatch) ||
+		errors.Is(err, desktopobserve.ErrUnknownField) ||
+		errors.Is(err, desktopobserve.ErrUnsupportedOperation)
+}
+
+func desktopFailureForReason(
+	reason desktopobserve.ReasonCode,
+	operation desktopobserve.Operation,
+	receipt desktopobserve.RuntimeReceipt,
+) desktopProviderFailure {
+	condition, _ := desktopFailureConditionForReason(reason)
+	return desktopProviderFailure{
+		condition: condition, operation: operation, receipt: receipt, validated: true,
+	}
+}
+
+func desktopFailureConditionForReason(
+	reason desktopobserve.ReasonCode,
+) (desktopobserve.FailureCondition, bool) {
+	condition, ok := map[desktopobserve.ReasonCode]desktopobserve.FailureCondition{
+		desktopobserve.ReasonProviderUnavailable:            desktopobserve.FailureProviderStart,
+		desktopobserve.ReasonCapabilityUnsupported:          desktopobserve.FailureOperationMissing,
+		desktopobserve.ReasonAccessibilityPermissionMissing: desktopobserve.FailureAccessibilityDenied,
+		desktopobserve.ReasonTargetAppNotFound:              desktopobserve.FailureAppAliasUnmatched,
+		desktopobserve.ReasonTargetWindowNotFound:           desktopobserve.FailureWindowAliasUnmatched,
+		desktopobserve.ReasonStaleState:                     desktopobserve.FailureStateRefRejected,
+		desktopobserve.ReasonSemanticProjectionUnavailable:  desktopobserve.FailureLandmarksInsufficient,
+		desktopobserve.ReasonRedactionFailed:                desktopobserve.FailureRedaction,
+		desktopobserve.ReasonEvidenceQuarantined:            desktopobserve.FailureRawOnlyQuarantine,
+		desktopobserve.ReasonProviderProtocolMismatch:       desktopobserve.FailureProtocolVersion,
+	}[reason]
+	return condition, ok
+}
+
+func desktopCapabilitySummary(operations []desktopobserve.Operation) []desktopobserve.CapabilityStatus {
+	supported := make(map[desktopobserve.Operation]bool, len(operations))
+	for _, operation := range operations {
+		if desktopobserve.IsReadOnlyOperation(operation) {
+			supported[operation] = true
+		}
+	}
+	result := make([]desktopobserve.CapabilityStatus, 0, len(desktopobserve.ReadOnlyOperations()))
+	for _, operation := range desktopobserve.ReadOnlyOperations() {
+		status := desktopobserve.CapabilityUnsupported
+		if supported[operation] {
+			status = desktopobserve.CapabilitySupported
+		}
+		result = append(result, desktopobserve.CapabilityStatus{Name: operation, Status: status})
+	}
+	return result
+}
+
+func desktopSupportedCapabilities() []desktopobserve.CapabilityStatus {
+	return desktopCapabilitySummary(desktopobserve.ReadOnlyOperations())
+}
+
+func desktopUnsupportedCapabilities() []desktopobserve.CapabilityStatus {
+	return desktopCapabilitySummary(nil)
+}
+
+func desktopMarkUnsupported(
+	capabilities []desktopobserve.CapabilityStatus,
+	operation desktopobserve.Operation,
+) []desktopobserve.CapabilityStatus {
+	copy := append([]desktopobserve.CapabilityStatus(nil), capabilities...)
+	if len(copy) != len(desktopobserve.ReadOnlyOperations()) {
+		copy = desktopSupportedCapabilities()
+	}
+	for index := range copy {
+		if copy[index].Name == operation {
+			copy[index].Status = desktopobserve.CapabilityUnsupported
+		}
+	}
+	return copy
+}
+
+func desktopFirstMissingCapability(capabilities []desktopobserve.CapabilityStatus) desktopobserve.Operation {
+	for _, requested := range desktopExecutionOperations() {
+		for _, capability := range capabilities {
+			if capability.Name == requested && capability.Status == desktopobserve.CapabilityUnsupported {
+				return requested
+			}
+		}
+	}
+	return ""
+}
+
+func desktopSuccessReceipt(
+	provider desktopobserve.ProviderIdentity,
+	scope desktopobserve.ReceiptScope,
+	capabilities []desktopobserve.CapabilityStatus,
+) desktopobserve.RuntimeReceipt {
+	return desktopobserve.RuntimeReceipt{
+		SchemaVersion:     desktopobserve.RuntimeReceiptSchemaVersion,
+		Provider:          provider,
+		Scope:             scope,
+		CapabilitySummary: append([]desktopobserve.CapabilityStatus(nil), capabilities...),
+		Redaction:         desktopobserve.RedactionReceipt{Status: desktopobserve.RedactionApplied},
+		Quarantine:        desktopobserve.QuarantineReceipt{Status: desktopobserve.QuarantineCleared},
+	}
+}

--- a/pkg/qa/run/desktop_observe_failure_mapping_test.go
+++ b/pkg/qa/run/desktop_observe_failure_mapping_test.go
@@ -1,0 +1,104 @@
+package run
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+func TestFailureNormalizer_ActualRunnerTriggersMapToExactSafeReasons(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		condition desktopobserve.FailureCondition
+		reason    desktopobserve.ReasonCode
+		attempts  int
+		leak      string
+		configure func(*fakeDesktopClient, *DesktopObservationRunRequest)
+	}{
+		{name: "provider start", condition: desktopobserve.FailureProviderStart, reason: desktopobserve.ReasonProviderUnavailable, leak: "private provider /Users/alice/helper", configure: func(client *fakeDesktopClient, _ *DesktopObservationRunRequest) {
+			client.handshakeErr = errors.New("private provider /Users/alice/helper")
+		}},
+		{name: "capability missing", condition: desktopobserve.FailureOperationMissing, reason: desktopobserve.ReasonCapabilityUnsupported, configure: func(client *fakeDesktopClient, _ *DesktopObservationRunRequest) {
+			client.capabilities = []desktopobserve.Operation{desktopobserve.OperationCapabilities, desktopobserve.OperationListApps, desktopobserve.OperationListWindows, desktopobserve.OperationPermissions}
+		}},
+		{name: "accessibility denied", condition: desktopobserve.FailureAccessibilityDenied, reason: desktopobserve.ReasonAccessibilityPermissionMissing, configure: func(client *fakeDesktopClient, _ *DesktopObservationRunRequest) {
+			client.accessibilityGranted = false
+		}},
+		{name: "app alias unmatched", condition: desktopobserve.FailureAppAliasUnmatched, reason: desktopobserve.ReasonTargetAppNotFound, leak: "raw-private-app-title", configure: func(client *fakeDesktopClient, _ *DesktopObservationRunRequest) {
+			client.apps = []desktopobserve.AppSummary{{AppRef: "raw-private-app-title"}}
+		}},
+		{name: "window alias unmatched", condition: desktopobserve.FailureWindowAliasUnmatched, reason: desktopobserve.ReasonTargetWindowNotFound, leak: "raw-private-window-title", configure: func(client *fakeDesktopClient, _ *DesktopObservationRunRequest) {
+			client.windows = []desktopobserve.WindowSummary{{WindowRef: "raw-private-window-title"}}
+		}},
+		{name: "consumed state", condition: desktopobserve.FailureStateRefRejected, reason: desktopobserve.ReasonStaleState, attempts: 2, configure: func(_ *fakeDesktopClient, _ *DesktopObservationRunRequest) {}},
+		{name: "minimum landmarks", condition: desktopobserve.FailureLandmarksInsufficient, reason: desktopobserve.ReasonSemanticProjectionUnavailable, configure: func(client *fakeDesktopClient, _ *DesktopObservationRunRequest) {
+			projection := runnerSemanticFixture("provider-local", "state-canvas")
+			projection.Root = desktopobserve.SemanticNode{Role: desktopobserve.RoleCanvas}
+			client.projection = &projection
+		}},
+		{name: "redactor error", condition: desktopobserve.FailureRedaction, reason: desktopobserve.ReasonRedactionFailed, leak: "private redactor secret /tmp/raw", configure: func(_ *fakeDesktopClient, request *DesktopObservationRunRequest) {
+			request.Redactor = func(string) (string, error) { return "", errors.New("private redactor secret /tmp/raw") }
+		}},
+		{name: "raw only quarantine", condition: desktopobserve.FailureRawOnlyQuarantine, reason: desktopobserve.ReasonEvidenceQuarantined, leak: "raw tree handle=0x42 /private/var/raw", configure: func(client *fakeDesktopClient, _ *DesktopObservationRunRequest) {
+			client.getStateErr = fmt.Errorf("raw tree handle=0x42 /private/var/raw: %w", desktopobserve.ErrRawOnlyEvidence)
+		}},
+		{name: "protocol version", condition: desktopobserve.FailureProtocolVersion, reason: desktopobserve.ReasonProviderProtocolMismatch, configure: func(client *fakeDesktopClient, _ *DesktopObservationRunRequest) {
+			client.protocolVersion = desktopobserve.ProtocolVersion + 1
+		}},
+	}
+
+	emitted := make([]desktopobserve.ReasonCode, 0, len(tests))
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			local := newFakeDesktopClient(desktopobserve.RuntimeProviderLocal)
+			alternate := newFakeDesktopClient(desktopobserve.RuntimeProviderOrca)
+			request := desktopRunRequest(desktopobserve.RuntimeProviderLocal)
+			test.configure(local, &request)
+			runner := newDesktopObservationRunner(local, alternate)
+			attempts := test.attempts
+			if attempts == 0 {
+				attempts = 1
+			}
+			var outcome desktopobserve.OracleOutcome
+			for attempt := 0; attempt < attempts; attempt++ {
+				var err error
+				outcome, err = runner.Run(context.Background(), request)
+				require.NoError(t, err)
+				if attempt+1 < attempts {
+					assert.Equal(t, desktopobserve.VerdictPassed, outcome.Verdict)
+				}
+			}
+
+			assert.Equal(t, test.condition, outcome.FailureCondition)
+			require.NotNil(t, outcome.ReasonCode)
+			assert.Equal(t, test.reason, *outcome.ReasonCode)
+			emitted = append(emitted, *outcome.ReasonCode)
+			assert.NotEqual(t, desktopobserve.VerdictPassed, outcome.Verdict)
+			assert.Nil(t, outcome.SemanticProjection)
+			assert.Zero(t, passedDesktopCheckCount(outcome.DeterministicChecks))
+			assert.Empty(t, alternate.calls)
+			require.NoError(t, outcome.RuntimeReceipt.Validate())
+			body, err := json.Marshal(outcome)
+			require.NoError(t, err)
+			assert.False(t, unsafeActualFailureOutput.Match(body), string(body))
+			if test.leak != "" {
+				assert.NotContains(t, string(body), test.leak)
+			}
+			assert.NotContains(t, string(body), "failure_condition")
+		})
+	}
+	assert.Equal(t, desktopobserve.ReasonCodes(), emitted)
+}
+
+var unsafeActualFailureOutput = regexp.MustCompile(`(?i)(raw[_ -]?tree|0x[0-9a-f]+|/Users/|/tmp/|/private/var/|handle[=:]|provider error|redactor secret)`)

--- a/pkg/qa/run/desktop_observe_forbidden_test.go
+++ b/pkg/qa/run/desktop_observe_forbidden_test.go
@@ -1,0 +1,75 @@
+package run
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+func TestReadOnlyOperationAllowlist_DispatchRejectsForbiddenOperationsBeforeProviderCalls(t *testing.T) {
+	t.Parallel()
+
+	providers := []desktopobserve.RuntimeProvider{
+		desktopobserve.RuntimeProviderLocal,
+		desktopobserve.RuntimeProviderOrca,
+	}
+	forbidden := []desktopobserve.Operation{
+		"click",
+		"type",
+		"paste",
+		"drag",
+		"scroll",
+		"screenshot",
+		"raw_tree",
+		"shell",
+		"file",
+		"lifecycle_mutation",
+	}
+
+	for _, provider := range providers {
+		provider := provider
+		for _, operation := range forbidden {
+			operation := operation
+			t.Run(string(provider)+"/"+string(operation), func(t *testing.T) {
+				t.Parallel()
+				local := newFakeDesktopClient(desktopobserve.RuntimeProviderLocal)
+				orca := newFakeDesktopClient(desktopobserve.RuntimeProviderOrca)
+				request := desktopRunRequest(provider)
+				request.Operations = []desktopobserve.Operation{operation}
+
+				outcome, err := newDesktopObservationRunner(local, orca).Run(context.Background(), request)
+				require.NoError(t, err)
+				require.NotNil(t, outcome.ReasonCode)
+				assert.Equal(t, desktopobserve.ReasonCapabilityUnsupported, *outcome.ReasonCode)
+				assert.NotEqual(t, desktopobserve.VerdictPassed, outcome.Verdict)
+				assert.Nil(t, outcome.SemanticProjection)
+				assert.Zero(t, passedDesktopCheckCount(outcome.DeterministicChecks))
+				assert.Equal(t, desktopobserve.ReadOnlyOperations(), capabilityNames(outcome.RuntimeReceipt))
+				assertDesktopClientCallCountsZero(t, local)
+				assertDesktopClientCallCountsZero(t, orca)
+			})
+		}
+	}
+}
+
+func assertDesktopClientCallCountsZero(t *testing.T, client *fakeDesktopClient) {
+	t.Helper()
+	assert.Empty(t, client.calls)
+	assert.Zero(t, client.rawIndexCalls)
+	assert.Zero(t, client.actionCalls)
+	assert.Zero(t, client.screenshotCalls)
+}
+
+func passedDesktopCheckCount(checks []desktopobserve.DeterministicCheck) int {
+	count := 0
+	for _, check := range checks {
+		if check.Status == desktopobserve.CheckPassed {
+			count++
+		}
+	}
+	return count
+}

--- a/pkg/qa/run/desktop_observe_orca.go
+++ b/pkg/qa/run/desktop_observe_orca.go
@@ -1,0 +1,146 @@
+package run
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"io"
+	"os"
+	"os/exec"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+const (
+	orcaExecutableName = "orca"
+	orcaAppBundleID    = "co.autopus.desktop"
+	orcaAppName        = "Autopus Desktop"
+	orcaWindowTitle    = "Autopus"
+	orcaMaxOutputBytes = 64 * 1024
+)
+
+type orcaCommandExecutor interface {
+	Run(context.Context, string, []string) ([]byte, error)
+}
+
+type processOrcaCommandExecutor struct {
+	executableInfo os.FileInfo
+}
+
+func (executor *processOrcaCommandExecutor) Run(
+	ctx context.Context,
+	path string,
+	arguments []string,
+) ([]byte, error) {
+	if executor == nil || executor.executableInfo == nil {
+		return nil, errDesktopProviderUnavailable
+	}
+	info, err := os.Stat(path)
+	if err != nil || !os.SameFile(executor.executableInfo, info) || !desktopExecutableFile(path) {
+		return nil, errDesktopProviderUnavailable
+	}
+	command := exec.CommandContext(ctx, path, arguments...)
+	command.Env = orcaProviderEnvironment()
+	command.WaitDelay = 250 * time.Millisecond
+	stdout := &boundedOrcaOutput{}
+	stderr := &boundedOrcaOutput{}
+	command.Stdout = stdout
+	command.Stderr = stderr
+	runErr := command.Run()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if stdout.overflow || stderr.overflow {
+		return nil, desktopobserve.ErrEnvelopeTooLarge
+	}
+	if stderr.buffer.Len() != 0 || runErr != nil || stdout.buffer.Len() == 0 {
+		return nil, errDesktopProviderUnavailable
+	}
+	return append([]byte(nil), stdout.buffer.Bytes()...), nil
+}
+
+type boundedOrcaOutput struct {
+	buffer   bytes.Buffer
+	overflow bool
+}
+
+func (output *boundedOrcaOutput) Write(value []byte) (int, error) {
+	remaining := orcaMaxOutputBytes - output.buffer.Len()
+	if remaining > 0 {
+		if remaining > len(value) {
+			remaining = len(value)
+		}
+		_, _ = output.buffer.Write(value[:remaining])
+	}
+	if remaining < len(value) {
+		output.overflow = true
+	}
+	return len(value), nil
+}
+
+func orcaProviderEnvironment() []string {
+	values := make(map[string]string)
+	for _, key := range []string{"HOME", "LANG", "LC_ALL", "LOGNAME", "PATH", "SHELL", "TMPDIR", "USER"} {
+		if value, ok := os.LookupEnv(key); ok {
+			values[key] = value
+		}
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	environment := make([]string, 0, len(keys))
+	for _, key := range keys {
+		environment = append(environment, key+"="+values[key])
+	}
+	return environment
+}
+
+type orcaWindowBinding struct {
+	id     int
+	index  int
+	pid    int
+	x      int
+	y      int
+	width  int
+	height int
+}
+
+type orcaDesktopClient struct {
+	mu           sync.Mutex
+	path         string
+	executor     orcaCommandExecutor
+	random       io.Reader
+	runtimeID    string
+	identity     desktopobserve.ProviderIdentity
+	capabilities []desktopobserve.Operation
+	targetPID    int
+	window       orcaWindowBinding
+}
+
+func newOrcaDesktopClient(path string) (desktopProviderClient, error) {
+	info, err := os.Stat(path)
+	if err != nil || !desktopExecutableFile(path) {
+		return nil, errDesktopProviderUnavailable
+	}
+	return newOrcaDesktopClientWith(
+		path,
+		&processOrcaCommandExecutor{executableInfo: info},
+		rand.Reader,
+	)
+}
+
+func newOrcaDesktopClientWith(
+	path string,
+	executor orcaCommandExecutor,
+	random io.Reader,
+) (*orcaDesktopClient, error) {
+	if path == "" || executor == nil || random == nil {
+		return nil, errDesktopProviderUnavailable
+	}
+	return &orcaDesktopClient{path: path, executor: executor, random: random}, nil
+}

--- a/pkg/qa/run/desktop_observe_orca_adversarial_test.go
+++ b/pkg/qa/run/desktop_observe_orca_adversarial_test.go
@@ -1,0 +1,164 @@
+package run
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+func TestOrcaDecoder_RejectsMalformedMissingUnknownDuplicateAndOversized(t *testing.T) {
+	valid := orcaCapabilitiesFixture()
+	tests := []struct {
+		name string
+		raw  []byte
+	}{
+		{name: "malformed", raw: []byte(`{"id":`)},
+		{name: "missing", raw: mutateOrcaJSON(valid, func(value map[string]any) {
+			delete(value["result"].(map[string]any), "provider")
+		})},
+		{name: "unknown", raw: mutateOrcaJSON(valid, func(value map[string]any) {
+			value["private_path"] = "/Users/private/secret"
+		})},
+		{name: "provider mismatch", raw: mutateOrcaJSON(valid, func(value map[string]any) {
+			value["result"].(map[string]any)["provider"] = "other-provider"
+		})},
+		{name: "protocol mismatch", raw: mutateOrcaJSON(valid, func(value map[string]any) {
+			value["result"].(map[string]any)["protocolVersion"] = 2
+		})},
+		{name: "nested missing", raw: mutateOrcaJSON(valid, func(value map[string]any) {
+			supports := value["result"].(map[string]any)["supports"].(map[string]any)
+			delete(supports["observation"].(map[string]any), "screenshot")
+		})},
+		{name: "duplicate", raw: bytes.Replace(valid, []byte(`"ok":true`),
+			[]byte(`"ok":true,"ok":true`), 1)},
+		{name: "oversized", raw: bytes.Repeat([]byte("x"), orcaMaxOutputBytes+1)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			identity, runtimeID, err := decodeOrcaCapabilities(test.raw)
+			assert.Error(t, err)
+			assert.Empty(t, identity)
+			assert.Empty(t, runtimeID)
+			assert.NotContains(t, err.Error(), "/Users/private/secret")
+		})
+	}
+}
+
+func TestOrcaDecoder_PreservesStrictDuplicateUnknownAndSizeTaxonomy(t *testing.T) {
+	valid := orcaCapabilitiesFixture()
+	duplicate := bytes.Replace(valid, []byte(`"ok":true`), []byte(`"ok":true,"ok":true`), 1)
+	assert.ErrorIs(t, decodeOrcaObject(duplicate, &orcaEnvelope{}, "id", "ok", "result", "_meta"),
+		desktopobserve.ErrDuplicateKey)
+	unknown := mutateOrcaJSON(valid, func(value map[string]any) { value["unknown"] = true })
+	assert.ErrorIs(t, decodeOrcaObject(unknown, &orcaEnvelope{}, "id", "ok", "result", "_meta"),
+		desktopobserve.ErrUnknownField)
+	assert.ErrorIs(t, decodeOrcaObject(bytes.Repeat([]byte("x"), orcaMaxOutputBytes+1),
+		&orcaEnvelope{}, "id", "ok", "result", "_meta"), desktopobserve.ErrEnvelopeTooLarge)
+}
+
+func TestOrcaStateDecoder_RejectsScreenshotTruncationUnsafeTreeAndTargetDrift(t *testing.T) {
+	binding := orcaWindowBinding{
+		id: orcaTestWindowID, index: 0, pid: orcaTestPID, x: 100, y: 50, width: 1460, height: 980,
+	}
+	tests := []struct {
+		name   string
+		mutate func(map[string]any)
+	}{
+		{name: "screenshot present", mutate: func(value map[string]any) {
+			result := value["result"].(map[string]any)
+			result["screenshot"] = map[string]any{"path": "/private/screenshot.png"}
+		}},
+		{name: "truncated", mutate: func(value map[string]any) {
+			snapshot(value)["truncation"].(map[string]any)["truncated"] = true
+		}},
+		{name: "unsafe tree path", mutate: func(value map[string]any) {
+			snapshot(value)["treeText"] = strings.Replace(
+				orcaFixtureTree(false), "Ready", "/Users/private/token", 1)
+		}},
+		{name: "unsafe action", mutate: func(value map[string]any) {
+			snapshot(value)["treeText"] = strings.Replace(
+				orcaFixtureTree(false), "Autopus disclosure", "Autopus disclosure, click", 1)
+		}},
+		{name: "unknown snapshot field", mutate: func(value map[string]any) {
+			snapshot(value)["rawTree"] = "private"
+		}},
+		{name: "missing tree", mutate: func(value map[string]any) {
+			delete(snapshot(value), "treeText")
+		}},
+		{name: "element count drift", mutate: func(value map[string]any) {
+			snapshot(value)["elementCount"] = 10
+		}},
+		{name: "pid drift", mutate: func(value map[string]any) {
+			snapshot(value)["app"].(map[string]any)["pid"] = orcaTestPID + 1
+		}},
+		{name: "window drift", mutate: func(value map[string]any) {
+			snapshot(value)["window"].(map[string]any)["id"] = orcaTestWindowID + 1
+		}},
+		{name: "runtime drift", mutate: func(value map[string]any) {
+			value["_meta"].(map[string]any)["runtimeId"] = "d0deb450-f449-4050-9e86-ff6e5c58b4a6"
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			raw := mutateOrcaJSON(orcaStateFixture(false), test.mutate)
+			projection, err := decodeOrcaState(
+				raw, orcaTestRuntimeID, binding, &countingOrcaReader{},
+			)
+			assert.Error(t, err)
+			assert.Empty(t, projection)
+			assert.NotContains(t, err.Error(), "/Users/private")
+			assert.NotContains(t, err.Error(), "token")
+		})
+	}
+}
+
+func TestOrcaTargets_AmbiguousAppAndWindowFailClosed(t *testing.T) {
+	_, matches, err := decodeOrcaApps(orcaAppsFixture(2), orcaTestRuntimeID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, matches)
+
+	_, matches, err = decodeOrcaWindows(orcaWindowsFixture(2), orcaTestRuntimeID, orcaTestPID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, matches)
+
+	wrongWindow := mutateOrcaJSON(orcaWindowsFixture(1), func(value map[string]any) {
+		result := value["result"].(map[string]any)
+		result["windows"].([]any)[0].(map[string]any)["title"] = "Other"
+	})
+	_, matches, err = decodeOrcaWindows(wrongWindow, orcaTestRuntimeID, orcaTestPID)
+	require.NoError(t, err)
+	assert.Zero(t, matches)
+
+	wrongPID := mutateOrcaJSON(orcaWindowsFixture(1), func(value map[string]any) {
+		result := value["result"].(map[string]any)
+		result["windows"].([]any)[0].(map[string]any)["app"].(map[string]any)["pid"] =
+			orcaTestPID + 1
+	})
+	_, _, err = decodeOrcaWindows(wrongPID, orcaTestRuntimeID, orcaTestPID)
+	assert.Error(t, err)
+}
+
+func TestOrcaDesktopClient_ContextTimeoutIsBoundedAndSanitized(t *testing.T) {
+	executor := &fakeOrcaCommandExecutor{block: true}
+	client, err := newOrcaDesktopClientWith("/private/provider/orca", executor, &countingOrcaReader{})
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	_, err = client.Handshake(ctx)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded))
+	assert.Less(t, time.Since(started), 500*time.Millisecond)
+	assert.NotContains(t, err.Error(), "/private/provider/orca")
+}
+
+func snapshot(value map[string]any) map[string]any {
+	return value["result"].(map[string]any)["snapshot"].(map[string]any)
+}

--- a/pkg/qa/run/desktop_observe_orca_client.go
+++ b/pkg/qa/run/desktop_observe_orca_client.go
@@ -1,0 +1,156 @@
+package run
+
+import (
+	"context"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+func (client *orcaDesktopClient) Handshake(
+	ctx context.Context,
+) (desktopobserve.ProviderIdentity, error) {
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if client.identity.Name != "" {
+		return client.identity, nil
+	}
+	raw, err := client.runLocked(ctx, "computer", "capabilities", "--json")
+	if err != nil {
+		return desktopobserve.ProviderIdentity{}, err
+	}
+	identity, runtimeID, err := decodeOrcaCapabilities(raw)
+	if err != nil {
+		return desktopobserve.ProviderIdentity{}, err
+	}
+	client.identity = identity
+	client.runtimeID = runtimeID
+	client.capabilities = desktopobserve.ReadOnlyOperations()
+	return client.identity, nil
+}
+
+func (client *orcaDesktopClient) Capabilities(
+	ctx context.Context,
+) ([]desktopobserve.Operation, error) {
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if err := client.requireHandshakeLocked(ctx); err != nil {
+		return nil, err
+	}
+	return append([]desktopobserve.Operation(nil), client.capabilities...), nil
+}
+
+func (client *orcaDesktopClient) Permissions(
+	ctx context.Context,
+) (desktopobserve.PermissionResult, error) {
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if err := client.requireHandshakeLocked(ctx); err != nil {
+		return desktopobserve.PermissionResult{}, err
+	}
+	raw, err := client.runLocked(ctx, "computer", "permissions", "--json")
+	if err != nil {
+		return desktopobserve.PermissionResult{}, err
+	}
+	granted, err := decodeOrcaPermissions(raw, client.runtimeID)
+	return desktopobserve.PermissionResult{AccessibilityGranted: granted}, err
+}
+
+func (client *orcaDesktopClient) ListApps(
+	ctx context.Context,
+) ([]desktopobserve.AppSummary, error) {
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if err := client.requireHandshakeLocked(ctx); err != nil {
+		return nil, err
+	}
+	raw, err := client.runLocked(ctx, "computer", "list-apps", "--json")
+	if err != nil {
+		return nil, err
+	}
+	pid, matches, err := decodeOrcaApps(raw, client.runtimeID)
+	if err != nil {
+		return nil, err
+	}
+	client.targetPID = 0
+	if matches != 1 {
+		apps := make([]desktopobserve.AppSummary, matches)
+		for index := range apps {
+			apps[index] = desktopobserve.AppSummary{AppRef: "autopus-desktop"}
+		}
+		return apps, nil
+	}
+	client.targetPID = pid
+	return []desktopobserve.AppSummary{{AppRef: "autopus-desktop"}}, nil
+}
+
+func (client *orcaDesktopClient) ListWindows(
+	ctx context.Context,
+	appRef string,
+) ([]desktopobserve.WindowSummary, error) {
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if appRef != "autopus-desktop" || client.targetPID <= 1 {
+		return nil, desktopobserve.ErrMalformedEnvelope
+	}
+	raw, err := client.runLocked(
+		ctx, "computer", "list-windows", "--app", orcaAppBundleID, "--json",
+	)
+	if err != nil {
+		return nil, err
+	}
+	binding, matches, err := decodeOrcaWindows(raw, client.runtimeID, client.targetPID)
+	if err != nil {
+		return nil, err
+	}
+	client.window = orcaWindowBinding{}
+	if matches != 1 {
+		windows := make([]desktopobserve.WindowSummary, matches)
+		for index := range windows {
+			windows[index] = desktopobserve.WindowSummary{WindowRef: "main-window"}
+		}
+		return windows, nil
+	}
+	client.window = binding
+	return []desktopobserve.WindowSummary{{WindowRef: "main-window"}}, nil
+}
+
+func (client *orcaDesktopClient) GetState(
+	ctx context.Context,
+	appRef string,
+	windowRef string,
+) (desktopobserve.SemanticProjection, error) {
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if appRef != "autopus-desktop" || windowRef != "main-window" ||
+		client.window.pid <= 1 || client.window.id <= 0 {
+		return desktopobserve.SemanticProjection{}, desktopobserve.ErrMalformedEnvelope
+	}
+	raw, err := client.runLocked(
+		ctx,
+		"computer", "get-app-state", "--app", orcaAppBundleID, "--no-screenshot", "--json",
+	)
+	if err != nil {
+		return desktopobserve.SemanticProjection{}, err
+	}
+	return decodeOrcaState(raw, client.runtimeID, client.window, client.random)
+}
+
+func (client *orcaDesktopClient) requireHandshakeLocked(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if client.identity.Name == "" || client.runtimeID == "" || len(client.capabilities) == 0 {
+		return errDesktopProviderUnavailable
+	}
+	return nil
+}
+
+func (client *orcaDesktopClient) runLocked(
+	ctx context.Context,
+	arguments ...string,
+) ([]byte, error) {
+	if client == nil || client.executor == nil || client.path == "" {
+		return nil, errDesktopProviderUnavailable
+	}
+	return client.executor.Run(ctx, client.path, append([]string(nil), arguments...))
+}

--- a/pkg/qa/run/desktop_observe_orca_client_test.go
+++ b/pkg/qa/run/desktop_observe_orca_client_test.go
@@ -1,0 +1,173 @@
+package run
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+func TestOrcaDesktopClient_ExactFiveReadOnlyCommandsNormalizePublicEvidence(t *testing.T) {
+	client, executor := newHermeticOrcaClient(t)
+	runner := newDesktopObservationRunner(nil, client)
+	request := desktopRunRequest(desktopobserve.RuntimeProviderOrca)
+	request.Policy.AllowedNames = append(request.Policy.AllowedNames, "Disclosure")
+
+	outcome, err := runner.Run(context.Background(), request)
+	require.NoError(t, err)
+	require.Equal(t, desktopobserve.VerdictPassed, outcome.Verdict)
+	require.NotNil(t, outcome.SemanticProjection)
+	assert.Equal(t, "orca-computer-use-macos", outcome.RuntimeReceipt.Provider.Name)
+	assert.Equal(t, []string{
+		"computer capabilities --json",
+		"computer permissions --json",
+		"computer list-apps --json",
+		"computer list-windows --app co.autopus.desktop --json",
+		"computer get-app-state --app co.autopus.desktop --no-screenshot --json",
+	}, executor.recordedCalls())
+
+	projection := outcome.SemanticProjection
+	require.Len(t, projection.Root.Children, 1)
+	require.Len(t, projection.Root.Children[0].Children, 1)
+	disclosure := projection.Root.Children[0].Children[0]
+	assert.Equal(t, desktopobserve.Role("AXButton"), disclosure.Role)
+	assert.Equal(t, "Disclosure", disclosure.Name)
+	assert.Equal(t, []desktopobserve.Action{desktopobserve.ActionPress}, disclosure.AdvertisedActions)
+	require.NotNil(t, disclosure.SemanticState.Enabled)
+	require.NotNil(t, disclosure.SemanticState.Expanded)
+	assert.True(t, *disclosure.SemanticState.Enabled)
+	assert.False(t, *disclosure.SemanticState.Expanded)
+
+	public, err := json.Marshal(outcome)
+	require.NoError(t, err)
+	for _, forbidden := range []string{
+		"treeText", "snapshot", "elementCount", "focusedElementId", "windowId",
+		"pid", "/private/", "Autopus fixture status", "Ready", "zoom the window",
+	} {
+		assert.NotContains(t, string(public), forbidden)
+	}
+}
+
+func TestOrcaDesktopClient_CanonicalDigestMatchesLocalForSameFixture(t *testing.T) {
+	client, _ := newHermeticOrcaClient(t)
+	runner := newDesktopObservationRunner(nil, client)
+	request := desktopRunRequest(desktopobserve.RuntimeProviderOrca)
+	request.Policy.AllowedNames = append(request.Policy.AllowedNames, "Disclosure")
+	orca, err := runner.Run(context.Background(), request)
+	require.NoError(t, err)
+	require.NotNil(t, orca.SemanticProjection)
+
+	local, err := desktopobserve.NormalizeProjection(
+		localOrcaParityFixture(),
+		func(value string) (string, error) { return value, nil },
+	)
+	require.NoError(t, err)
+	assert.Equal(t, local.Digest, orca.SemanticProjection.Digest)
+	assert.Equal(t, local.CanonicalJSON, orca.SemanticProjection.CanonicalJSON)
+	assert.Equal(t, local.SchemaVersion, orca.SemanticProjection.SchemaVersion)
+	assert.Equal(t, local.AppRef, orca.SemanticProjection.AppRef)
+	assert.Equal(t, local.WindowRef, orca.SemanticProjection.WindowRef)
+}
+
+func TestOrcaDesktopClient_FreshCSPRNGStateAndNodeRefs(t *testing.T) {
+	client, _ := newHermeticOrcaClient(t)
+	ctx := context.Background()
+	_, err := client.Handshake(ctx)
+	require.NoError(t, err)
+	_, err = client.Permissions(ctx)
+	require.NoError(t, err)
+	_, err = client.ListApps(ctx)
+	require.NoError(t, err)
+	_, err = client.ListWindows(ctx, "autopus-desktop")
+	require.NoError(t, err)
+
+	first, err := client.GetState(ctx, "autopus-desktop", "main-window")
+	require.NoError(t, err)
+	second, err := client.GetState(ctx, "autopus-desktop", "main-window")
+	require.NoError(t, err)
+	assert.NotEqual(t, first.StateRef, second.StateRef)
+	assert.Regexp(t, `^state-[0-9a-f]{64}$`, first.StateRef)
+	assert.Regexp(t, `^state-[0-9a-f]{64}$`, second.StateRef)
+	firstRefs, secondRefs := collectOrcaNodeRefs(first.Root), collectOrcaNodeRefs(second.Root)
+	require.Len(t, firstRefs, 3)
+	require.Len(t, secondRefs, 3)
+	for _, ref := range append(firstRefs, secondRefs...) {
+		assert.Regexp(t, `^node-[0-9a-f]{64}$`, ref)
+	}
+	for _, firstRef := range firstRefs {
+		assert.NotContains(t, secondRefs, firstRef)
+	}
+}
+
+func TestOrcaDesktopClient_ExpandedStateChangesAndBaselineRecoversDigest(t *testing.T) {
+	run := func(expanded bool) desktopobserve.SemanticProjection {
+		executor := &fakeOrcaCommandExecutor{responses: orcaTestResponses(expanded)}
+		client, err := newOrcaDesktopClientWith("/private/test/orca", executor, &countingOrcaReader{})
+		require.NoError(t, err)
+		runner := newDesktopObservationRunner(nil, client)
+		request := desktopRunRequest(desktopobserve.RuntimeProviderOrca)
+		request.Policy.AllowedNames = append(request.Policy.AllowedNames, "Disclosure")
+		outcome, err := runner.Run(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, outcome.SemanticProjection)
+		return *outcome.SemanticProjection
+	}
+	baseline := run(false)
+	expanded := run(true)
+	recovered := run(false)
+	assert.NotEqual(t, baseline.Digest, expanded.Digest)
+	assert.Equal(t, baseline.Digest, recovered.Digest)
+	assert.Equal(t, baseline.CanonicalJSON, recovered.CanonicalJSON)
+}
+
+func TestOrcaDesktopClient_DeniedAccessibilityStopsBeforeTargetEnumeration(t *testing.T) {
+	client, executor := newHermeticOrcaClient(t)
+	executor.responses["computer permissions --json"] = orcaPermissionsFixture("denied")
+	runner := newDesktopObservationRunner(nil, client)
+	request := desktopRunRequest(desktopobserve.RuntimeProviderOrca)
+	request.Policy.AllowedNames = append(request.Policy.AllowedNames, "Disclosure")
+	outcome, err := runner.Run(context.Background(), request)
+	require.NoError(t, err)
+	require.NotNil(t, outcome.ReasonCode)
+	assert.Equal(t, desktopobserve.ReasonAccessibilityPermissionMissing, *outcome.ReasonCode)
+	assert.Equal(t, []string{
+		"computer capabilities --json", "computer permissions --json",
+	}, executor.recordedCalls())
+	body, err := json.Marshal(outcome)
+	require.NoError(t, err)
+	assert.NotContains(t, string(body), "/private/provider/helper.app")
+}
+
+func localOrcaParityFixture() desktopobserve.SemanticProjection {
+	enabled, focused, expanded := true, true, false
+	return desktopobserve.SemanticProjection{
+		SchemaVersion: desktopobserve.SemanticProjectionSchemaVersion,
+		ProviderRef:   "provider-local", AppRef: "autopus-desktop",
+		WindowRef: "main-window", StateRef: "state-local-parity",
+		Root: desktopobserve.SemanticNode{
+			Role: desktopobserve.RoleApplication, Name: "Autopus",
+			SemanticState: desktopobserve.SemanticState{Enabled: &enabled},
+			Children: []desktopobserve.SemanticNode{{
+				Role: desktopobserve.RoleWindow, Name: "Autopus",
+				SemanticState: desktopobserve.SemanticState{Focused: &focused},
+				Children: []desktopobserve.SemanticNode{{
+					Role: desktopobserve.Role("AXButton"), Name: "Disclosure",
+					SemanticState:     desktopobserve.SemanticState{Enabled: &enabled, Expanded: &expanded},
+					AdvertisedActions: []desktopobserve.Action{desktopobserve.ActionPress},
+				}},
+			}},
+		},
+	}
+}
+
+func collectOrcaNodeRefs(root desktopobserve.SemanticNode) []string {
+	refs := []string{root.NodeRef}
+	for _, child := range root.Children {
+		refs = append(refs, collectOrcaNodeRefs(child)...)
+	}
+	return refs
+}

--- a/pkg/qa/run/desktop_observe_orca_decode.go
+++ b/pkg/qa/run/desktop_observe_orca_decode.go
@@ -1,0 +1,210 @@
+package run
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+var (
+	orcaUUIDPattern    = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+	orcaVersionPattern = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$`)
+)
+
+type orcaEnvelope struct {
+	ID     string          `json:"id"`
+	OK     *bool           `json:"ok"`
+	Result json.RawMessage `json:"result"`
+	Meta   orcaMeta        `json:"_meta"`
+}
+
+type orcaMeta struct {
+	RuntimeID string `json:"runtimeId"`
+}
+
+type orcaCapabilitiesResult struct {
+	Platform        string       `json:"platform"`
+	Provider        string       `json:"provider"`
+	Supports        orcaSupports `json:"supports"`
+	ProtocolVersion *int         `json:"protocolVersion"`
+	ProviderVersion string       `json:"providerVersion"`
+}
+
+type orcaSupports struct {
+	Apps        orcaAppSupports         `json:"apps"`
+	Observation orcaObservationSupports `json:"observation"`
+	Windows     orcaWindowSupports      `json:"windows"`
+	Actions     orcaActionSupports      `json:"actions"`
+	Surfaces    orcaSurfaceSupports     `json:"surfaces"`
+}
+
+type orcaAppSupports struct {
+	List      *bool `json:"list"`
+	PIDs      *bool `json:"pids"`
+	BundleIDs *bool `json:"bundleIds"`
+}
+
+type orcaObservationSupports struct {
+	OCR                 *bool `json:"ocr"`
+	AnnotatedScreenshot *bool `json:"annotatedScreenshot"`
+	ElementFrames       *bool `json:"elementFrames"`
+	Screenshot          *bool `json:"screenshot"`
+}
+
+type orcaWindowSupports struct {
+	List          *bool `json:"list"`
+	MoveResize    *bool `json:"moveResize"`
+	Focus         *bool `json:"focus"`
+	TargetByIndex *bool `json:"targetByIndex"`
+	TargetByID    *bool `json:"targetById"`
+}
+
+type orcaActionSupports struct {
+	PressKey      *bool `json:"pressKey"`
+	Hotkey        *bool `json:"hotkey"`
+	TypeText      *bool `json:"typeText"`
+	Click         *bool `json:"click"`
+	PasteText     *bool `json:"pasteText"`
+	Scroll        *bool `json:"scroll"`
+	SetValue      *bool `json:"setValue"`
+	Drag          *bool `json:"drag"`
+	PerformAction *bool `json:"performAction"`
+}
+
+type orcaSurfaceSupports struct {
+	Dialogs *bool `json:"dialogs"`
+	Menus   *bool `json:"menus"`
+	Menubar *bool `json:"menubar"`
+	Dock    *bool `json:"dock"`
+}
+
+func decodeOrcaCapabilities(raw []byte) (desktopobserve.ProviderIdentity, string, error) {
+	var result orcaCapabilitiesResult
+	runtimeID, err := decodeOrcaSuccess(raw, &result,
+		"platform", "provider", "supports", "protocolVersion", "providerVersion")
+	if err != nil || !validOrcaCapabilities(result) {
+		return desktopobserve.ProviderIdentity{}, "", desktopobserve.ErrMalformedEnvelope
+	}
+	return desktopobserve.ProviderIdentity{
+		Name: result.Provider, Version: result.ProviderVersion,
+		ProtocolVersion: *result.ProtocolVersion,
+	}, runtimeID, nil
+}
+
+func validOrcaCapabilities(result orcaCapabilitiesResult) bool {
+	if result.Platform != "darwin" || result.Provider != "orca-computer-use-macos" ||
+		result.ProtocolVersion == nil || *result.ProtocolVersion != desktopobserve.ProtocolVersion ||
+		!orcaVersionPattern.MatchString(result.ProviderVersion) {
+		return false
+	}
+	values := []*bool{
+		result.Supports.Apps.List, result.Supports.Apps.PIDs, result.Supports.Apps.BundleIDs,
+		result.Supports.Observation.OCR, result.Supports.Observation.AnnotatedScreenshot,
+		result.Supports.Observation.ElementFrames, result.Supports.Observation.Screenshot,
+		result.Supports.Windows.List, result.Supports.Windows.MoveResize, result.Supports.Windows.Focus,
+		result.Supports.Windows.TargetByIndex, result.Supports.Windows.TargetByID,
+		result.Supports.Actions.PressKey, result.Supports.Actions.Hotkey, result.Supports.Actions.TypeText,
+		result.Supports.Actions.Click, result.Supports.Actions.PasteText, result.Supports.Actions.Scroll,
+		result.Supports.Actions.SetValue, result.Supports.Actions.Drag, result.Supports.Actions.PerformAction,
+		result.Supports.Surfaces.Dialogs, result.Supports.Surfaces.Menus,
+		result.Supports.Surfaces.Menubar, result.Supports.Surfaces.Dock,
+	}
+	for _, value := range values {
+		if value == nil {
+			return false
+		}
+	}
+	return *result.Supports.Apps.List && *result.Supports.Apps.BundleIDs &&
+		*result.Supports.Windows.List && *result.Supports.Windows.TargetByIndex &&
+		*result.Supports.Observation.ElementFrames
+}
+
+type orcaPermissionsResult struct {
+	Platform       string           `json:"platform"`
+	HelperAppPath  string           `json:"helperAppPath"`
+	OpenedSettings *bool            `json:"openedSettings"`
+	LaunchedHelper *bool            `json:"launchedHelper"`
+	Permissions    []orcaPermission `json:"permissions"`
+	NextStep       json.RawMessage  `json:"nextStep"`
+}
+
+type orcaPermission struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+}
+
+func decodeOrcaPermissions(raw []byte, expectedRuntime string) (bool, error) {
+	var result orcaPermissionsResult
+	runtimeID, err := decodeOrcaSuccess(raw, &result,
+		"platform", "helperAppPath", "openedSettings", "launchedHelper", "permissions", "nextStep")
+	if err != nil || runtimeID != expectedRuntime || result.Platform != "darwin" ||
+		result.HelperAppPath == "" || result.OpenedSettings == nil || *result.OpenedSettings ||
+		result.LaunchedHelper == nil || *result.LaunchedHelper || len(result.Permissions) != 2 ||
+		len(result.NextStep) == 0 {
+		return false, desktopobserve.ErrMalformedEnvelope
+	}
+	statuses := make(map[string]string, 2)
+	for _, permission := range result.Permissions {
+		if (permission.ID != "accessibility" && permission.ID != "screenshots") ||
+			(permission.Status != "granted" && permission.Status != "denied" &&
+				permission.Status != "not_determined") || statuses[permission.ID] != "" {
+			return false, desktopobserve.ErrMalformedEnvelope
+		}
+		statuses[permission.ID] = permission.Status
+	}
+	return statuses["accessibility"] == "granted", nil
+}
+
+func decodeOrcaSuccess(raw []byte, target any, resultKeys ...string) (string, error) {
+	var envelope orcaEnvelope
+	if err := decodeOrcaObject(raw, &envelope, "id", "ok", "result", "_meta"); err != nil ||
+		envelope.OK == nil || !*envelope.OK || !orcaUUIDPattern.MatchString(envelope.ID) ||
+		!orcaUUIDPattern.MatchString(envelope.Meta.RuntimeID) || len(envelope.Result) == 0 ||
+		bytes.Equal(bytes.TrimSpace(envelope.Result), []byte("null")) {
+		return "", desktopobserve.ErrMalformedEnvelope
+	}
+	if err := decodeOrcaObject(envelope.Result, target, resultKeys...); err != nil {
+		return "", err
+	}
+	return envelope.Meta.RuntimeID, nil
+}
+
+func decodeOrcaObject(raw []byte, target any, keys ...string) error {
+	if len(raw) == 0 || len(raw) > orcaMaxOutputBytes || !utf8.Valid(raw) {
+		if len(raw) > orcaMaxOutputBytes {
+			return desktopobserve.ErrEnvelopeTooLarge
+		}
+		return desktopobserve.ErrMalformedEnvelope
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := rejectDesktopV2DuplicateKeys(decoder); err != nil {
+		return err
+	}
+	decoder = json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		if strings.Contains(err.Error(), "unknown field") {
+			return fmt.Errorf("%w: orca result", desktopobserve.ErrUnknownField)
+		}
+		return desktopobserve.ErrMalformedEnvelope
+	}
+	if err := desktopV2JSONEOF(decoder); err != nil {
+		return err
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &object); err != nil || object == nil || len(object) != len(keys) {
+		return desktopobserve.ErrMissingField
+	}
+	for _, key := range keys {
+		if _, ok := object[key]; !ok {
+			return desktopobserve.ErrMissingField
+		}
+	}
+	return nil
+}

--- a/pkg/qa/run/desktop_observe_orca_process_test.go
+++ b/pkg/qa/run/desktop_observe_orca_process_test.go
@@ -1,0 +1,159 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+func TestOrcaProductionResolver_ExplicitSelectionInvokesInstalledCLIOnly(t *testing.T) {
+	directory := t.TempDir()
+	callPath := filepath.Join(directory, "calls")
+	executable := filepath.Join(directory, orcaExecutableName)
+	require.NoError(t, os.WriteFile(executable, []byte(orcaProviderScript(t, callPath)), 0o700))
+	t.Setenv("PATH", directory)
+
+	runner := newProductionDesktopObservationRunner(Options{})
+	request := desktopRunRequest(desktopobserve.RuntimeProviderOrca)
+	request.Policy.AllowedNames = append(request.Policy.AllowedNames, "Disclosure")
+	outcome, err := runner.Run(context.Background(), request)
+	require.NoError(t, err)
+	assert.Equal(t, desktopobserve.VerdictPassed, outcome.Verdict)
+	calls, err := os.ReadFile(callPath)
+	require.NoError(t, err)
+	assert.Equal(t, strings.Join([]string{
+		"computer capabilities --json",
+		"computer permissions --json",
+		"computer list-apps --json",
+		"computer list-windows --app co.autopus.desktop --json",
+		"computer get-app-state --app co.autopus.desktop --no-screenshot --json",
+	}, "\n")+"\n", string(calls))
+}
+
+func TestProcessOrcaCommandExecutor_BoundsOutputTimeoutIdentityAndErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		source     string
+		mutate     bool
+		timeout    time.Duration
+		want       error
+		maxElapsed time.Duration
+	}{
+		{name: "stderr", source: "#!/bin/sh\nprintf private-secret >&2\n", want: errDesktopProviderUnavailable},
+		{name: "overflow", source: "#!/bin/sh\ni=0; while [ $i -lt 65537 ]; do printf x; i=$((i+1)); done\n",
+			want: desktopobserve.ErrEnvelopeTooLarge},
+		{name: "timeout", source: "#!/bin/sh\n/bin/sleep 5\n", timeout: 20 * time.Millisecond,
+			want: context.DeadlineExceeded, maxElapsed: time.Second},
+		{name: "identity drift", source: "#!/bin/sh\nprintf '{}\n'\n", mutate: true,
+			want: errDesktopProviderUnavailable},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			directory := t.TempDir()
+			path := filepath.Join(directory, "orca")
+			require.NoError(t, os.WriteFile(path, []byte(test.source), 0o700))
+			info, err := os.Stat(path)
+			require.NoError(t, err)
+			executor := &processOrcaCommandExecutor{executableInfo: info}
+			if test.mutate {
+				require.NoError(t, os.Rename(path, path+".old"))
+				require.NoError(t, os.WriteFile(path, []byte(test.source), 0o700))
+			}
+			ctx := context.Background()
+			cancel := func() {}
+			if test.timeout > 0 {
+				ctx, cancel = context.WithTimeout(ctx, test.timeout)
+			}
+			defer cancel()
+			started := time.Now()
+			body, err := executor.Run(ctx, path, []string{"computer", "capabilities", "--json"})
+			assert.ErrorIs(t, err, test.want)
+			assert.Empty(t, body)
+			assert.NotContains(t, err.Error(), "private-secret")
+			if test.maxElapsed > 0 {
+				assert.Less(t, time.Since(started), test.maxElapsed)
+			}
+		})
+	}
+}
+
+func TestOrcaProcessHelpers_RejectInvalidConstructionAndProjectEnvironment(t *testing.T) {
+	_, err := newOrcaDesktopClient("")
+	assert.ErrorIs(t, err, errDesktopProviderUnavailable)
+	_, err = newOrcaDesktopClientWith("", &fakeOrcaCommandExecutor{}, &countingOrcaReader{})
+	assert.ErrorIs(t, err, errDesktopProviderUnavailable)
+	_, err = newOrcaDesktopClientWith("orca", nil, &countingOrcaReader{})
+	assert.ErrorIs(t, err, errDesktopProviderUnavailable)
+	_, err = newOrcaDesktopClientWith("orca", &fakeOrcaCommandExecutor{}, nil)
+	assert.ErrorIs(t, err, errDesktopProviderUnavailable)
+
+	t.Setenv("Q12_PRIVATE_SECRET", "do-not-project")
+	environment := orcaProviderEnvironment()
+	assert.NotContains(t, strings.Join(environment, "\n"), "Q12_PRIVATE_SECRET")
+	assert.IsNonDecreasing(t, environment)
+
+	output := &boundedOrcaOutput{}
+	value := make([]byte, orcaMaxOutputBytes+1)
+	n, err := output.Write(value)
+	require.NoError(t, err)
+	assert.Equal(t, len(value), n)
+	assert.True(t, output.overflow)
+	assert.Len(t, output.buffer.Bytes(), orcaMaxOutputBytes)
+}
+
+func TestOrcaDesktopClient_MethodOrderAliasesAndRandomFailureFailClosed(t *testing.T) {
+	client, _ := newHermeticOrcaClient(t)
+	_, err := client.Capabilities(context.Background())
+	assert.ErrorIs(t, err, errDesktopProviderUnavailable)
+	_, err = client.ListWindows(context.Background(), "other-app")
+	assert.ErrorIs(t, err, desktopobserve.ErrMalformedEnvelope)
+	_, err = client.GetState(context.Background(), "other-app", "other-window")
+	assert.ErrorIs(t, err, desktopobserve.ErrMalformedEnvelope)
+
+	client, _ = newHermeticOrcaClient(t)
+	client.random = errorOrcaReader{}
+	ctx := context.Background()
+	_, err = client.Handshake(ctx)
+	require.NoError(t, err)
+	_, err = client.Permissions(ctx)
+	require.NoError(t, err)
+	_, err = client.ListApps(ctx)
+	require.NoError(t, err)
+	_, err = client.ListWindows(ctx, "autopus-desktop")
+	require.NoError(t, err)
+	projection, err := client.GetState(ctx, "autopus-desktop", "main-window")
+	assert.ErrorIs(t, err, desktopobserve.ErrMalformedEnvelope)
+	assert.Empty(t, projection)
+}
+
+type errorOrcaReader struct{}
+
+func (errorOrcaReader) Read([]byte) (int, error) {
+	return 0, errors.New("private random source failure")
+}
+
+func orcaProviderScript(t *testing.T, callPath string) string {
+	t.Helper()
+	responses := orcaTestResponses(false)
+	var cases strings.Builder
+	for arguments, response := range responses {
+		require.NotContains(t, string(response), "'")
+		fmt.Fprintf(&cases, "  '%s') printf '%%s\\n' '%s' ;;\n", arguments, response)
+	}
+	return fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$*" >> '%s'
+case "$*" in
+%s  *) exit 64 ;;
+esac
+`, callPath, cases.String())
+}

--- a/pkg/qa/run/desktop_observe_orca_state.go
+++ b/pkg/qa/run/desktop_observe_orca_state.go
@@ -1,0 +1,176 @@
+package run
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+type orcaStateResult struct {
+	Snapshot         orcaSnapshot         `json:"snapshot"`
+	Screenshot       json.RawMessage      `json:"screenshot"`
+	ScreenshotStatus orcaScreenshotStatus `json:"screenshotStatus"`
+}
+
+type orcaSnapshot struct {
+	TreeText        *string            `json:"treeText"`
+	Window          orcaSnapshotWindow `json:"window"`
+	App             orcaSnapshotApp    `json:"app"`
+	FocusedElement  *int               `json:"focusedElementId"`
+	ElementCount    *int               `json:"elementCount"`
+	CoordinateSpace *string            `json:"coordinateSpace"`
+	ID              *string            `json:"id"`
+	Truncation      orcaTruncation     `json:"truncation"`
+}
+
+type orcaSnapshotWindow struct {
+	ID          *int                 `json:"id"`
+	Index       *int                 `json:"index,omitempty"`
+	Title       *string              `json:"title"`
+	Width       *int                 `json:"width"`
+	Height      *int                 `json:"height"`
+	X           *int                 `json:"x"`
+	Y           *int                 `json:"y"`
+	IsMinimized *bool                `json:"isMinimized"`
+	IsOffscreen *bool                `json:"isOffscreen"`
+	ScreenIndex *int                 `json:"screenIndex"`
+	Platform    orcaSnapshotPlatform `json:"platform"`
+}
+
+type orcaSnapshotPlatform struct {
+	Layer *int `json:"layer"`
+}
+
+type orcaTruncation struct {
+	Truncated       *bool `json:"truncated"`
+	MaxDepth        *int  `json:"maxDepth"`
+	MaxNodes        *int  `json:"maxNodes"`
+	MaxDepthReached *bool `json:"maxDepthReached"`
+}
+
+type orcaScreenshotStatus struct {
+	Reason *string `json:"reason"`
+	State  *string `json:"state"`
+}
+
+func decodeOrcaState(
+	raw []byte,
+	expectedRuntime string,
+	binding orcaWindowBinding,
+	random io.Reader,
+) (desktopobserve.SemanticProjection, error) {
+	var result orcaStateResult
+	runtimeID, err := decodeOrcaSuccess(raw, &result, "snapshot", "screenshot", "screenshotStatus")
+	if err != nil || runtimeID != expectedRuntime || !validOrcaSnapshot(result, binding) {
+		return desktopobserve.SemanticProjection{}, desktopobserve.ErrMalformedEnvelope
+	}
+	expanded, err := parseOrcaFixtureTree(*result.Snapshot.TreeText, binding.pid)
+	if err != nil {
+		return desktopobserve.SemanticProjection{}, err
+	}
+	stateRef, err := orcaFreshRef(random, "state-")
+	if err != nil {
+		return desktopobserve.SemanticProjection{}, desktopobserve.ErrMalformedEnvelope
+	}
+	appNodeRef, err := orcaFreshRef(random, "node-")
+	if err != nil {
+		return desktopobserve.SemanticProjection{}, desktopobserve.ErrMalformedEnvelope
+	}
+	windowNodeRef, err := orcaFreshRef(random, "node-")
+	if err != nil {
+		return desktopobserve.SemanticProjection{}, desktopobserve.ErrMalformedEnvelope
+	}
+	disclosureNodeRef, err := orcaFreshRef(random, "node-")
+	if err != nil {
+		return desktopobserve.SemanticProjection{}, desktopobserve.ErrMalformedEnvelope
+	}
+	enabled, focused := true, true
+	return desktopobserve.SemanticProjection{
+		SchemaVersion: desktopobserve.SemanticProjectionSchemaVersion,
+		ProviderRef:   "provider-orca",
+		AppRef:        "autopus-desktop",
+		WindowRef:     "main-window",
+		StateRef:      stateRef,
+		Root: desktopobserve.SemanticNode{
+			NodeRef: appNodeRef, Role: desktopobserve.RoleApplication, Name: "Autopus",
+			SemanticState: desktopobserve.SemanticState{Enabled: &enabled},
+			Children: []desktopobserve.SemanticNode{{
+				NodeRef: windowNodeRef, Role: desktopobserve.RoleWindow, Name: "Autopus",
+				SemanticState: desktopobserve.SemanticState{Focused: &focused},
+				Children: []desktopobserve.SemanticNode{{
+					NodeRef: disclosureNodeRef, Role: desktopobserve.Role("AXButton"), Name: "Disclosure",
+					SemanticState:     desktopobserve.SemanticState{Enabled: &enabled, Expanded: &expanded},
+					AdvertisedActions: []desktopobserve.Action{desktopobserve.ActionPress},
+				}},
+			}},
+		},
+	}, nil
+}
+
+func validOrcaSnapshot(result orcaStateResult, binding orcaWindowBinding) bool {
+	snapshot := result.Snapshot
+	window := snapshot.Window
+	if len(result.Screenshot) == 0 || !bytes.Equal(bytes.TrimSpace(result.Screenshot), []byte("null")) ||
+		result.ScreenshotStatus.Reason == nil || *result.ScreenshotStatus.Reason != "no_screenshot_flag" ||
+		result.ScreenshotStatus.State == nil || *result.ScreenshotStatus.State != "skipped" ||
+		snapshot.TreeText == nil || len(*snapshot.TreeText) == 0 || len(*snapshot.TreeText) > 2_048 ||
+		snapshot.FocusedElement == nil || *snapshot.FocusedElement != 2 ||
+		snapshot.ElementCount == nil || *snapshot.ElementCount != 9 ||
+		snapshot.CoordinateSpace == nil || *snapshot.CoordinateSpace != "window" ||
+		snapshot.ID == nil || !orcaUUIDPattern.MatchString(*snapshot.ID) ||
+		!validOrcaSnapshotApp(snapshot.App, binding.pid) {
+		return false
+	}
+	if window.ID == nil || *window.ID != binding.id || window.Title == nil || *window.Title != orcaWindowTitle ||
+		window.Width == nil || *window.Width != binding.width || window.Height == nil || *window.Height != binding.height ||
+		window.X == nil || *window.X != binding.x || window.Y == nil || *window.Y != binding.y ||
+		window.IsMinimized == nil || *window.IsMinimized || window.IsOffscreen == nil || *window.IsOffscreen ||
+		window.ScreenIndex == nil || *window.ScreenIndex < 0 || window.Platform.Layer == nil || *window.Platform.Layer != 0 ||
+		(window.Index != nil && *window.Index != binding.index) {
+		return false
+	}
+	truncation := snapshot.Truncation
+	return truncation.Truncated != nil && !*truncation.Truncated &&
+		truncation.MaxDepth != nil && *truncation.MaxDepth == 64 &&
+		truncation.MaxNodes != nil && *truncation.MaxNodes == 1_200 &&
+		truncation.MaxDepthReached != nil && !*truncation.MaxDepthReached
+}
+
+func parseOrcaFixtureTree(tree string, pid int) (bool, error) {
+	if strings.ContainsAny(tree, "\r\x00") {
+		return false, desktopobserve.ErrMalformedEnvelope
+	}
+	lines := strings.Split(tree, "\n")
+	if len(lines) != 14 || lines[0] != fmt.Sprintf("App=%s (pid %d)", orcaAppBundleID, pid) ||
+		lines[1] != `Window: "Autopus", App: Autopus Desktop.` || lines[2] != "" ||
+		lines[3] != "0 standard window Autopus" || lines[4] != "\t1 scroll area" ||
+		lines[5] != "\t\t2 HTML content Autopus" ||
+		lines[7] != "\t\t\t4 container Autopus fixture status" ||
+		lines[8] != "\t\t\t\t5 text Ready" || lines[9] != "\t6 close button" ||
+		lines[10] != "\t7 full screen button, Secondary Actions: zoom the window" ||
+		lines[11] != "\t8 minimize button" || lines[12] != "" ||
+		lines[13] != "The focused UI element is 2 HTML content Autopus." {
+		return false, desktopobserve.ErrMalformedEnvelope
+	}
+	switch lines[6] {
+	case "\t\t\t3 button Autopus disclosure":
+		return false, nil
+	case "\t\t\t3 button (expanded) Autopus disclosure":
+		return true, nil
+	default:
+		return false, desktopobserve.ErrMalformedEnvelope
+	}
+}
+
+func orcaFreshRef(random io.Reader, prefix string) (string, error) {
+	value := make([]byte, 32)
+	if _, err := io.ReadFull(random, value); err != nil {
+		return "", err
+	}
+	return prefix + hex.EncodeToString(value), nil
+}

--- a/pkg/qa/run/desktop_observe_orca_targets.go
+++ b/pkg/qa/run/desktop_observe_orca_targets.go
@@ -1,0 +1,140 @@
+package run
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+type orcaAppsResult struct {
+	Apps []orcaAppRecord `json:"apps"`
+}
+
+type orcaAppRecord struct {
+	Name       *string         `json:"name"`
+	BundleID   *string         `json:"bundleId"`
+	IsRunning  *bool           `json:"isRunning"`
+	PID        *int            `json:"pid"`
+	LastUsedAt json.RawMessage `json:"lastUsedAt"`
+	UseCount   json.RawMessage `json:"useCount"`
+}
+
+func decodeOrcaApps(raw []byte, expectedRuntime string) (int, int, error) {
+	var result orcaAppsResult
+	runtimeID, err := decodeOrcaSuccess(raw, &result, "apps")
+	if err != nil || runtimeID != expectedRuntime || result.Apps == nil {
+		return 0, 0, desktopobserve.ErrMalformedEnvelope
+	}
+	pid, matches := 0, 0
+	for _, app := range result.Apps {
+		if !validOrcaAppRecord(app) {
+			return 0, 0, desktopobserve.ErrMalformedEnvelope
+		}
+		if *app.BundleID != orcaAppBundleID {
+			continue
+		}
+		if *app.Name != orcaAppName || !*app.IsRunning || *app.PID <= 1 {
+			return 0, 0, desktopobserve.ErrMalformedEnvelope
+		}
+		pid = *app.PID
+		matches++
+	}
+	return pid, matches, nil
+}
+
+func validOrcaAppRecord(app orcaAppRecord) bool {
+	return app.Name != nil && app.BundleID != nil && app.IsRunning != nil && app.PID != nil &&
+		len(app.LastUsedAt) != 0 && len(app.UseCount) != 0 &&
+		bytes.Equal(bytes.TrimSpace(app.LastUsedAt), []byte("null")) &&
+		bytes.Equal(bytes.TrimSpace(app.UseCount), []byte("null"))
+}
+
+type orcaWindowsResult struct {
+	App     orcaAppRecord `json:"app"`
+	Windows []orcaWindow  `json:"windows"`
+}
+
+type orcaSnapshotApp struct {
+	Name     *string `json:"name"`
+	BundleID *string `json:"bundleId"`
+	PID      *int    `json:"pid"`
+}
+
+type orcaWindow struct {
+	Title       *string            `json:"title"`
+	App         orcaSnapshotApp    `json:"app"`
+	Index       *int               `json:"index"`
+	Height      *int               `json:"height"`
+	ScreenIndex *int               `json:"screenIndex"`
+	Width       *int               `json:"width"`
+	Y           *int               `json:"y"`
+	IsMinimized *bool              `json:"isMinimized"`
+	IsOffscreen *bool              `json:"isOffscreen"`
+	IsMain      json.RawMessage    `json:"isMain"`
+	Platform    orcaWindowPlatform `json:"platform"`
+	ID          *int               `json:"id"`
+	X           *int               `json:"x"`
+}
+
+type orcaWindowPlatform struct {
+	Layer *int     `json:"layer"`
+	Alpha *float64 `json:"alpha"`
+}
+
+func decodeOrcaWindows(
+	raw []byte,
+	expectedRuntime string,
+	expectedPID int,
+) (orcaWindowBinding, int, error) {
+	var result orcaWindowsResult
+	runtimeID, err := decodeOrcaSuccess(raw, &result, "app", "windows")
+	if err != nil || runtimeID != expectedRuntime || !validOrcaAppRecord(result.App) ||
+		*result.App.Name != orcaAppName || *result.App.BundleID != orcaAppBundleID ||
+		!*result.App.IsRunning || *result.App.PID != expectedPID || result.Windows == nil {
+		return orcaWindowBinding{}, 0, desktopobserve.ErrMalformedEnvelope
+	}
+	for _, window := range result.Windows {
+		if !validOrcaWindowSchema(window) {
+			return orcaWindowBinding{}, 0, desktopobserve.ErrMalformedEnvelope
+		}
+	}
+	if len(result.Windows) != 1 {
+		return orcaWindowBinding{}, len(result.Windows), nil
+	}
+	window := result.Windows[0]
+	if *window.Title != orcaWindowTitle {
+		return orcaWindowBinding{}, 0, nil
+	}
+	if !validOrcaSnapshotApp(window.App, expectedPID) || *window.IsMinimized || *window.IsOffscreen ||
+		*window.Index < 0 || *window.ID <= 0 || *window.ScreenIndex < 0 ||
+		*window.Width <= 0 || *window.Height <= 0 || *window.Width > 100_000 || *window.Height > 100_000 ||
+		*window.X < -100_000 || *window.X > 100_000 || *window.Y < -100_000 || *window.Y > 100_000 ||
+		*window.Platform.Layer != 0 || *window.Platform.Alpha != 1 {
+		return orcaWindowBinding{}, 0, desktopobserve.ErrMalformedEnvelope
+	}
+	return orcaWindowBinding{
+		id: *window.ID, index: *window.Index, pid: expectedPID,
+		x: *window.X, y: *window.Y, width: *window.Width, height: *window.Height,
+	}, 1, nil
+}
+
+func validOrcaWindowSchema(window orcaWindow) bool {
+	return window.Title != nil && window.App.Name != nil && window.App.BundleID != nil &&
+		window.App.PID != nil && window.Index != nil && window.Height != nil &&
+		window.ScreenIndex != nil && window.Width != nil && window.Y != nil &&
+		window.IsMinimized != nil && window.IsOffscreen != nil && len(window.IsMain) != 0 &&
+		validNullableOrcaBool(window.IsMain) && window.Platform.Layer != nil &&
+		window.Platform.Alpha != nil && window.ID != nil && window.X != nil
+}
+
+func validOrcaSnapshotApp(app orcaSnapshotApp, expectedPID int) bool {
+	return app.Name != nil && *app.Name == orcaAppName && app.BundleID != nil &&
+		*app.BundleID == orcaAppBundleID && app.PID != nil && *app.PID == expectedPID
+}
+
+func validNullableOrcaBool(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	return bytes.Equal(trimmed, []byte("null")) || bytes.Equal(trimmed, []byte("true")) ||
+		bytes.Equal(trimmed, []byte("false"))
+}

--- a/pkg/qa/run/desktop_observe_orca_test_helpers_test.go
+++ b/pkg/qa/run/desktop_observe_orca_test_helpers_test.go
@@ -1,0 +1,209 @@
+package run
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	orcaTestRuntimeID  = "6285a71f-f14e-4654-ab19-13d7a73283a7"
+	orcaTestResponseID = "d0deb450-f449-4050-9e86-ff6e5c58b4a6"
+	orcaTestSnapshotID = "ED35443E-FB01-4601-A04A-01353D1417A6"
+	orcaTestPID        = 17673
+	orcaTestWindowID   = 52
+)
+
+type fakeOrcaCommandExecutor struct {
+	mu        sync.Mutex
+	responses map[string][]byte
+	calls     []string
+	err       error
+	block     bool
+}
+
+func (executor *fakeOrcaCommandExecutor) Run(
+	ctx context.Context,
+	_ string,
+	arguments []string,
+) ([]byte, error) {
+	executor.mu.Lock()
+	executor.calls = append(executor.calls, strings.Join(arguments, " "))
+	response := append([]byte(nil), executor.responses[strings.Join(arguments, " ")]...)
+	err, block := executor.err, executor.block
+	executor.mu.Unlock()
+	if block {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	return response, err
+}
+
+func (executor *fakeOrcaCommandExecutor) recordedCalls() []string {
+	executor.mu.Lock()
+	defer executor.mu.Unlock()
+	return append([]string(nil), executor.calls...)
+}
+
+type countingOrcaReader struct {
+	value byte
+}
+
+func (reader *countingOrcaReader) Read(value []byte) (int, error) {
+	for index := range value {
+		reader.value++
+		value[index] = reader.value
+	}
+	return len(value), nil
+}
+
+func newHermeticOrcaClient(t *testing.T) (*orcaDesktopClient, *fakeOrcaCommandExecutor) {
+	t.Helper()
+	executor := &fakeOrcaCommandExecutor{responses: orcaTestResponses(false)}
+	client, err := newOrcaDesktopClientWith("/private/test/orca", executor, &countingOrcaReader{})
+	require.NoError(t, err)
+	return client, executor
+}
+
+func orcaTestResponses(expanded bool) map[string][]byte {
+	return map[string][]byte{
+		"computer capabilities --json":                                           orcaCapabilitiesFixture(),
+		"computer permissions --json":                                            orcaPermissionsFixture("granted"),
+		"computer list-apps --json":                                              orcaAppsFixture(1),
+		"computer list-windows --app co.autopus.desktop --json":                  orcaWindowsFixture(1),
+		"computer get-app-state --app co.autopus.desktop --no-screenshot --json": orcaStateFixture(expanded),
+	}
+}
+
+func orcaEnvelopeFixture(result any) []byte {
+	return mustOrcaJSON(map[string]any{
+		"id": orcaTestResponseID, "ok": true, "result": result,
+		"_meta": map[string]any{"runtimeId": orcaTestRuntimeID},
+	})
+}
+
+func orcaCapabilitiesFixture() []byte {
+	return orcaEnvelopeFixture(map[string]any{
+		"platform": "darwin", "provider": "orca-computer-use-macos",
+		"protocolVersion": 1, "providerVersion": "1.0.0",
+		"supports": map[string]any{
+			"apps": map[string]any{"list": true, "pids": true, "bundleIds": true},
+			"observation": map[string]any{
+				"ocr": false, "annotatedScreenshot": false, "elementFrames": true, "screenshot": true,
+			},
+			"windows": map[string]any{
+				"list": true, "moveResize": false, "focus": false, "targetByIndex": true, "targetById": true,
+			},
+			"actions": map[string]any{
+				"pressKey": true, "hotkey": true, "typeText": true, "click": true, "pasteText": true,
+				"scroll": true, "setValue": true, "drag": true, "performAction": true,
+			},
+			"surfaces": map[string]any{"dialogs": false, "menus": false, "menubar": false, "dock": false},
+		},
+	})
+}
+
+func orcaPermissionsFixture(accessibility string) []byte {
+	return orcaEnvelopeFixture(map[string]any{
+		"platform": "darwin", "helperAppPath": "/private/provider/helper.app",
+		"openedSettings": false, "launchedHelper": false, "nextStep": nil,
+		"permissions": []any{
+			map[string]any{"id": "accessibility", "status": accessibility},
+			map[string]any{"id": "screenshots", "status": "granted"},
+		},
+	})
+}
+
+func orcaAppFixture() map[string]any {
+	return map[string]any{
+		"name": orcaAppName, "bundleId": orcaAppBundleID, "isRunning": true,
+		"pid": orcaTestPID, "lastUsedAt": nil, "useCount": nil,
+	}
+}
+
+func orcaAppsFixture(matches int) []byte {
+	apps := []any{map[string]any{
+		"name": "Other", "bundleId": "com.example.other", "isRunning": true,
+		"pid": 123, "lastUsedAt": nil, "useCount": nil,
+	}}
+	for range matches {
+		apps = append(apps, orcaAppFixture())
+	}
+	return orcaEnvelopeFixture(map[string]any{"apps": apps})
+}
+
+func orcaWindowFixture() map[string]any {
+	return map[string]any{
+		"title": orcaWindowTitle,
+		"app":   map[string]any{"name": orcaAppName, "bundleId": orcaAppBundleID, "pid": orcaTestPID},
+		"index": 0, "height": 980, "screenIndex": 0, "width": 1460, "y": 50,
+		"isMinimized": false, "isOffscreen": false, "isMain": nil,
+		"platform": map[string]any{"layer": 0, "alpha": 1}, "id": orcaTestWindowID, "x": 100,
+	}
+}
+
+func orcaWindowsFixture(matches int) []byte {
+	windows := make([]any, 0, matches)
+	for range matches {
+		windows = append(windows, orcaWindowFixture())
+	}
+	return orcaEnvelopeFixture(map[string]any{"app": orcaAppFixture(), "windows": windows})
+}
+
+func orcaFixtureTree(expanded bool) string {
+	button := "\t\t\t3 button Autopus disclosure"
+	if expanded {
+		button = "\t\t\t3 button (expanded) Autopus disclosure"
+	}
+	return strings.Join([]string{
+		fmt.Sprintf("App=%s (pid %d)", orcaAppBundleID, orcaTestPID),
+		`Window: "Autopus", App: Autopus Desktop.`, "", "0 standard window Autopus",
+		"\t1 scroll area", "\t\t2 HTML content Autopus", button,
+		"\t\t\t4 container Autopus fixture status", "\t\t\t\t5 text Ready",
+		"\t6 close button", "\t7 full screen button, Secondary Actions: zoom the window",
+		"\t8 minimize button", "", "The focused UI element is 2 HTML content Autopus.",
+	}, "\n")
+}
+
+func orcaStateFixture(expanded bool) []byte {
+	return orcaEnvelopeFixture(map[string]any{
+		"snapshot": map[string]any{
+			"treeText": orcaFixtureTree(expanded),
+			"window": map[string]any{
+				"id": orcaTestWindowID, "title": orcaWindowTitle, "width": 1460, "height": 980,
+				"x": 100, "y": 50, "isMinimized": false, "isOffscreen": false,
+				"screenIndex": 0, "platform": map[string]any{"layer": 0},
+			},
+			"app":              map[string]any{"name": orcaAppName, "bundleId": orcaAppBundleID, "pid": orcaTestPID},
+			"focusedElementId": 2, "elementCount": 9, "coordinateSpace": "window",
+			"id": orcaTestSnapshotID,
+			"truncation": map[string]any{
+				"truncated": false, "maxDepth": 64, "maxNodes": 1200, "maxDepthReached": false,
+			},
+		},
+		"screenshot":       nil,
+		"screenshotStatus": map[string]any{"reason": "no_screenshot_flag", "state": "skipped"},
+	})
+}
+
+func mustOrcaJSON(value any) []byte {
+	body, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return body
+}
+
+func mutateOrcaJSON(raw []byte, mutate func(map[string]any)) []byte {
+	var value map[string]any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		panic(err)
+	}
+	mutate(value)
+	return mustOrcaJSON(value)
+}

--- a/pkg/qa/run/desktop_observe_pack.go
+++ b/pkg/qa/run/desktop_observe_pack.go
@@ -1,0 +1,226 @@
+package run
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+	qaevidence "github.com/insajin/autopus-adk/pkg/qa/evidence"
+	"github.com/insajin/autopus-adk/pkg/qa/journey"
+)
+
+func executeDesktopObservationPack(
+	opts Options,
+	pack journey.Pack,
+	runDir string,
+) (AdapterResult, string, []IndexCheck) {
+	started := time.Now().UTC()
+	runner := opts.desktopRunner
+	if runner == nil {
+		runner = newProductionDesktopObservationRunner(opts)
+	}
+	outcome, err := runner.Run(context.Background(), desktopRequestFromPack(opts, pack))
+	ended := time.Now().UTC()
+	if err != nil {
+		return desktopObservationContractFailure(pack), "", []IndexCheck{desktopObservationErrorCheck(pack)}
+	}
+
+	status := "blocked"
+	actual := string(outcome.Verdict)
+	failureSummary := ""
+	if outcome.Verdict == desktopobserve.VerdictPassed {
+		status = "passed"
+	} else if outcome.ReasonCode != nil {
+		failureSummary = string(*outcome.ReasonCode)
+		actual = failureSummary
+	}
+	check := IndexCheck{
+		ID: desktopobserve.DeterministicCheckSemanticLandmarks, JourneyID: pack.ID, Adapter: pack.Adapter.ID,
+		Status: status, Expected: "verdict=passed", Actual: actual, FailureSummary: failureSummary,
+	}
+	result := commandResult{
+		Status: status, FailureSummary: failureSummary, StartedAt: started, EndedAt: ended,
+		DurationMS: ended.Sub(started).Milliseconds(),
+	}
+	manifest := buildManifest(opts, pack, result, []IndexCheck{check})
+	evidence := desktopObservationEvidence(outcome)
+	manifest.OracleResults.DesktopObservation = &evidence
+	if !applyDesktopObservationManifestProfile(&manifest, evidence) {
+		return desktopObservationContractFailure(pack), "", []IndexCheck{desktopObservationErrorCheck(pack)}
+	}
+	artifactPath, cleanup, err := writeDesktopObservationArtifact(evidence)
+	if err != nil {
+		return desktopObservationContractFailure(pack), "", []IndexCheck{desktopObservationErrorCheck(pack)}
+	}
+	defer cleanup()
+	manifest.Artifacts = []qaevidence.ArtifactRef{{
+		Kind: "desktop_observation", Path: artifactPath, Publishable: true,
+		Redaction: "typed_allowlist_and_scanned",
+	}}
+	manifestPath, err := qaevidence.WriteFinalManifest(manifest, manifestOutputDir(runDir, pack.ID))
+	if err != nil {
+		check.Status = "blocked"
+		check.FailureSummary = "desktop observation publication failed"
+		return AdapterResult{
+			Adapter: pack.Adapter.ID, JourneyID: pack.ID, Status: "blocked",
+			FailureSummary: check.FailureSummary,
+		}, "", []IndexCheck{check}
+	}
+	return AdapterResult{
+		Adapter: pack.Adapter.ID, JourneyID: pack.ID, Status: status,
+		QAMESHManifestPath: manifestPath, RepairPromptAvailable: status != "passed",
+		FailureSummary: failureSummary, DesktopObservation: &evidence,
+	}, manifestPath, []IndexCheck{check}
+}
+
+func applyDesktopObservationManifestProfile(
+	manifest *qaevidence.Manifest,
+	evidence desktopobserve.ObservationEvidence,
+) bool {
+	if manifest == nil || len(evidence.DeterministicChecks) != 1 {
+		return false
+	}
+	typedCheck := evidence.DeterministicChecks[0]
+	failureSummary := ""
+	if typedCheck.Status == desktopobserve.CheckBlocked {
+		failureSummary = "desktop observation blocked"
+	}
+	manifest.Runner = qaevidence.Runner{Name: "desktop-accessibility-observe"}
+	manifest.OracleResults.Checks = []qaevidence.CheckResult{{
+		ID: typedCheck.ID, Type: "desktop_accessibility_semantic",
+		Status: string(typedCheck.Status), FailureSummary: failureSummary,
+	}}
+	manifest.SourceRefs.OwnedPaths = nil
+	manifest.SourceRefs.DoNotModifyPaths = nil
+	manifest.SourceRefs.OracleThresholds = nil
+	manifest.SourceRefs.Mobile = nil
+	manifest.RepairPromptRef = ""
+	manifest.ReproductionCommand = ""
+	return true
+}
+
+func desktopRequestFromPack(opts Options, pack journey.Pack) DesktopObservationRunRequest {
+	policy := desktopobserve.OraclePolicy{}
+	seenNames := make(map[string]bool)
+	for _, landmark := range pack.DesktopObservation.RequiredLandmarks {
+		policy.MinimumLandmarks = append(policy.MinimumLandmarks, desktopobserve.LandmarkRequirement{
+			Role: desktopobserve.Role(landmark.Role), Name: landmark.Name,
+			RequiredState: desktopobserve.SemanticStateKey(landmark.RequiredState),
+		})
+		if !seenNames[landmark.Name] {
+			seenNames[landmark.Name] = true
+			policy.AllowedNames = append(policy.AllowedNames, landmark.Name)
+		}
+	}
+	for _, safeName := range []string{"Disclosure", "Status"} {
+		if !seenNames[safeName] {
+			seenNames[safeName] = true
+			policy.AllowedNames = append(policy.AllowedNames, safeName)
+		}
+	}
+	operations := make([]desktopobserve.Operation, 0, len(pack.DesktopObservation.Operations))
+	for _, operation := range pack.DesktopObservation.Operations {
+		operations = append(operations, desktopobserve.Operation(operation))
+	}
+	return DesktopObservationRunRequest{
+		RuntimeProvider: opts.RuntimeProvider,
+		Operations:      operations,
+		AppRef:          pack.DesktopObservation.AppRef,
+		WindowRef:       pack.DesktopObservation.WindowRef,
+		Policy:          policy,
+		Redactor: func(value string) (string, error) {
+			return value, nil
+		},
+	}
+}
+
+func desktopObservationEvidence(outcome desktopobserve.OracleOutcome) desktopobserve.ObservationEvidence {
+	evidence := desktopobserve.ObservationEvidence{
+		DeterministicChecks: append([]desktopobserve.DeterministicCheck(nil), outcome.DeterministicChecks...),
+		RuntimeReceipt:      outcome.RuntimeReceipt,
+	}
+	evidence.RuntimeReceipt.CapabilitySummary = append(
+		[]desktopobserve.CapabilityStatus(nil), outcome.RuntimeReceipt.CapabilitySummary...,
+	)
+	if outcome.RuntimeReceipt.ReasonCode != nil {
+		reason := *outcome.RuntimeReceipt.ReasonCode
+		evidence.RuntimeReceipt.ReasonCode = &reason
+	}
+	if outcome.RuntimeReceipt.NextStep != nil {
+		nextStep := *outcome.RuntimeReceipt.NextStep
+		evidence.RuntimeReceipt.NextStep = &nextStep
+	}
+	if outcome.SemanticProjection == nil {
+		return evidence
+	}
+	projection := *outcome.SemanticProjection
+	projection.Root = desktopObservationPublicationNode(outcome.SemanticProjection.Root)
+	projection.CanonicalJSON = append([]byte(nil), outcome.SemanticProjection.CanonicalJSON...)
+	evidence.SemanticProjection = &projection
+	return evidence
+}
+
+func desktopObservationPublicationNode(source desktopobserve.SemanticNode) desktopobserve.SemanticNode {
+	published := source
+	published.SemanticState = desktopobserve.SemanticState{
+		Enabled:  copyDesktopObservationBool(source.SemanticState.Enabled),
+		Expanded: copyDesktopObservationBool(source.SemanticState.Expanded),
+		Focused:  copyDesktopObservationBool(source.SemanticState.Focused),
+		Selected: copyDesktopObservationBool(source.SemanticState.Selected),
+	}
+	published.Frame = nil
+	published.AdvertisedActions = append([]desktopobserve.Action(nil), source.AdvertisedActions...)
+	published.Children = make([]desktopobserve.SemanticNode, len(source.Children))
+	for index := range source.Children {
+		published.Children[index] = desktopObservationPublicationNode(source.Children[index])
+	}
+	return published
+}
+
+func copyDesktopObservationBool(source *bool) *bool {
+	if source == nil {
+		return nil
+	}
+	value := *source
+	return &value
+}
+
+func writeDesktopObservationArtifact(evidence desktopobserve.ObservationEvidence) (string, func(), error) {
+	body, err := json.Marshal(evidence)
+	if err != nil {
+		return "", func() {}, err
+	}
+	file, err := os.CreateTemp("", "qamesh-desktop-observation-*.json")
+	if err != nil {
+		return "", func() {}, err
+	}
+	path := file.Name()
+	cleanup := func() { _ = os.Remove(path) }
+	if _, err := file.Write(append(body, '\n')); err != nil {
+		_ = file.Close()
+		cleanup()
+		return "", func() {}, err
+	}
+	if err := file.Close(); err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+	return path, cleanup, nil
+}
+
+func desktopObservationContractFailure(pack journey.Pack) AdapterResult {
+	return AdapterResult{
+		Adapter: pack.Adapter.ID, JourneyID: pack.ID, Status: "blocked",
+		FailureSummary: "desktop observation contract failed",
+	}
+}
+
+func desktopObservationErrorCheck(pack journey.Pack) IndexCheck {
+	return IndexCheck{
+		ID: desktopobserve.DeterministicCheckSemanticLandmarks, JourneyID: pack.ID, Adapter: pack.Adapter.ID,
+		Status: "blocked", Expected: "verdict=passed", Actual: "contract_error",
+		FailureSummary: "desktop observation contract failed",
+	}
+}

--- a/pkg/qa/run/desktop_observe_parity_test.go
+++ b/pkg/qa/run/desktop_observe_parity_test.go
@@ -1,0 +1,84 @@
+package run
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+func TestLocalOrcaOracleParity_FullTypedEvidenceDiffIsExplicitlyBounded(t *testing.T) {
+	t.Parallel()
+
+	local := newFakeDesktopClient(desktopobserve.RuntimeProviderLocal)
+	orca := newFakeDesktopClient(desktopobserve.RuntimeProviderOrca)
+	localProjection := runnerSemanticFixture("provider-local", "state-shared")
+	localProjection.Root.Frame = &desktopobserve.Frame{X: 1, Y: 2, Width: 1200, Height: 800}
+	localProjection.Root.Children[0].Frame = &desktopobserve.Frame{X: 10, Y: 20, Width: 1180, Height: 760}
+	local.projection = &localProjection
+	runner := newDesktopObservationRunner(local, orca)
+	localOutcome, err := runner.Run(context.Background(), desktopRunRequest(desktopobserve.RuntimeProviderLocal))
+	require.NoError(t, err)
+	orcaOutcome, err := runner.Run(context.Background(), desktopRunRequest(desktopobserve.RuntimeProviderOrca))
+	require.NoError(t, err)
+
+	assert.Equal(t, localOutcome.RuntimeReceipt.Provider.Version, orcaOutcome.RuntimeReceipt.Provider.Version)
+	assert.Equal(t, localOutcome.RuntimeReceipt.Provider.ProtocolVersion, orcaOutcome.RuntimeReceipt.Provider.ProtocolVersion)
+	require.NotNil(t, localOutcome.SemanticProjection)
+	require.NotNil(t, orcaOutcome.SemanticProjection)
+	assert.NotEqual(t, localOutcome.SemanticProjection.ProviderRef, orcaOutcome.SemanticProjection.ProviderRef)
+	assert.Equal(t, localOutcome.SemanticProjection.AppRef, orcaOutcome.SemanticProjection.AppRef)
+	assert.Equal(t, localOutcome.SemanticProjection.WindowRef, orcaOutcome.SemanticProjection.WindowRef)
+	assert.Equal(t, localOutcome.RuntimeReceipt.Scope, orcaOutcome.RuntimeReceipt.Scope)
+	assert.Equal(t, localOutcome.Verdict, orcaOutcome.Verdict)
+	assert.Equal(t, localOutcome.SemanticProjection.Digest, orcaOutcome.SemanticProjection.Digest)
+	assert.Equal(t, localOutcome.DeterministicChecks, orcaOutcome.DeterministicChecks)
+
+	localEvidence := desktopObservationEvidence(localOutcome)
+	require.NotNil(t, localEvidence.SemanticProjection)
+	assert.Nil(t, localEvidence.SemanticProjection.Root.Frame)
+	assert.Nil(t, localEvidence.SemanticProjection.Root.Children[0].Frame)
+	assert.NotNil(t, localOutcome.SemanticProjection.Root.Frame)
+	assert.NotNil(t, localOutcome.SemanticProjection.Root.Children[0].Frame)
+	assert.Equal(t, normalizedObservationBytes(t, localOutcome), normalizedObservationBytes(t, orcaOutcome))
+	assertDesktopClientUnsafeCallsZero(t, local)
+	assertDesktopClientUnsafeCallsZero(t, orca)
+}
+
+func normalizedObservationBytes(t *testing.T, outcome desktopobserve.OracleOutcome) []byte {
+	t.Helper()
+	value := desktopObservationEvidence(outcome)
+	body, err := json.Marshal(value)
+	require.NoError(t, err)
+	var clone desktopobserve.ObservationEvidence
+	require.NoError(t, json.Unmarshal(body, &clone))
+	require.NotNil(t, clone.SemanticProjection)
+	clone.SemanticProjection.ProviderRef = "<provider-public-ref>"
+	clone.SemanticProjection.StateRef = "<state-public-ref>"
+	placeholderNodeRefs(&clone.SemanticProjection.Root, 0)
+	clone.RuntimeReceipt.Provider.Name = "<provider-public-name>"
+	body, err = json.Marshal(clone)
+	require.NoError(t, err)
+	return body
+}
+
+func placeholderNodeRefs(node *desktopobserve.SemanticNode, index int) int {
+	node.NodeRef = fmt.Sprintf("<node-public-ref-%d>", index)
+	index++
+	for child := range node.Children {
+		index = placeholderNodeRefs(&node.Children[child], index)
+	}
+	return index
+}
+
+func assertDesktopClientUnsafeCallsZero(t *testing.T, client *fakeDesktopClient) {
+	t.Helper()
+	assert.Zero(t, client.rawIndexCalls)
+	assert.Zero(t, client.actionCalls)
+	assert.Zero(t, client.screenshotCalls)
+}

--- a/pkg/qa/run/desktop_observe_process.go
+++ b/pkg/qa/run/desktop_observe_process.go
@@ -1,0 +1,236 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+const (
+	desktopSignedArtifactEnvironment = "AUTOPUS_RELEASE_SIGNED_ARTIFACT_PATH"
+	desktopProviderExecutableName    = "autopus-desktop"
+	desktopProvenanceMarker          = "autopus.desktop-observe.candidate.release.v2"
+	desktopSupervisorRecipe          = "autopus.desktop-observe.supervisor-recipe.v2"
+)
+
+var errDesktopProviderUnavailable = errors.New("selected desktop observation provider is unavailable")
+
+type processDesktopProviderResolver struct {
+	artifactPath string
+	verifier     desktopArtifactVerifier
+}
+
+func newProductionDesktopObservationRunner(opts Options) *desktopObservationRunner {
+	return newDesktopObservationRunnerWithResolver(&processDesktopProviderResolver{
+		artifactPath: opts.desktopArtifactPath,
+		verifier:     opts.desktopArtifactVerifier,
+	})
+}
+
+func (resolver *processDesktopProviderResolver) ResolveLocal(
+	ctx context.Context,
+) (desktopProviderClient, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	artifactPath := resolver.artifactPath
+	if artifactPath == "" {
+		artifactPath = os.Getenv(desktopSignedArtifactEnvironment)
+	}
+	executable, err := desktopLocalProviderExecutable(artifactPath)
+	if err != nil {
+		return nil, errDesktopProviderUnavailable
+	}
+	resolvedArtifact, err := filepath.EvalSymlinks(artifactPath)
+	if err != nil {
+		return nil, errDesktopProviderUnavailable
+	}
+	resolvedExecutable, err := filepath.EvalSymlinks(executable)
+	if err != nil || resolvedExecutable != filepath.Join(
+		resolvedArtifact, "Contents", "MacOS", desktopProviderExecutableName,
+	) {
+		return nil, errDesktopProviderUnavailable
+	}
+	artifactPath, executable = resolvedArtifact, resolvedExecutable
+	verifier := resolver.verifier
+	if verifier == nil {
+		verifier = verifyDesktopReleaseArtifact
+	}
+	if err := verifier(ctx, artifactPath); err != nil {
+		return nil, errDesktopProviderUnavailable
+	}
+	executableInfo, executableDigest, codeIdentity, err := snapshotDesktopExecutable(ctx, executable, -1)
+	if err != nil {
+		return nil, errDesktopProviderUnavailable
+	}
+	fileIdentity, err := desktopExecutableFileIdentity(executableInfo)
+	if err != nil || !secureDesktopSpawnSupported() {
+		return nil, errDesktopProviderUnavailable
+	}
+	transport := &processDesktopEnvelopeTransport{
+		command:          executable,
+		artifactPath:     artifactPath,
+		executableInfo:   executableInfo,
+		executableDigest: executableDigest,
+		codeIdentity:     codeIdentity,
+		fileIdentity:     fileIdentity,
+		arguments: []string{
+			"--desktop-observe-spike-provider", "--protocol-version", "2",
+		},
+		environment: desktopProviderEnvironment(artifactPath),
+	}
+	client := newEnvelopeDesktopClient(
+		expectedDesktopIdentity(desktopobserve.RuntimeProviderLocal),
+		transport,
+		desktopobserve.DecodeExchange,
+	)
+	client.handshakeViaCapabilities = true
+	return client, nil
+}
+
+func (*processDesktopProviderResolver) LookPath(ctx context.Context, name string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	path, err := exec.LookPath(name)
+	if err != nil {
+		return "", errDesktopProviderUnavailable
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func (*processDesktopProviderResolver) ResolveOrca(ctx context.Context, path string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil || !filepath.IsAbs(resolved) || !desktopExecutableFile(resolved) {
+		return "", errDesktopProviderUnavailable
+	}
+	return resolved, nil
+}
+
+func (*processDesktopProviderResolver) NewOrcaClient(
+	ctx context.Context,
+	path string,
+) (desktopProviderClient, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return newOrcaDesktopClient(path)
+}
+
+func desktopLocalProviderExecutable(artifactPath string) (string, error) {
+	if artifactPath == "" || !filepath.IsAbs(artifactPath) || filepath.Ext(artifactPath) != ".app" {
+		return "", errDesktopProviderUnavailable
+	}
+	for _, path := range []string{
+		artifactPath,
+		filepath.Join(artifactPath, "Contents"),
+		filepath.Join(artifactPath, "Contents", "MacOS"),
+	} {
+		info, err := os.Lstat(path)
+		if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return "", errDesktopProviderUnavailable
+		}
+	}
+	executable := filepath.Join(artifactPath, "Contents", "MacOS", desktopProviderExecutableName)
+	info, err := os.Lstat(executable)
+	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
+		return "", errDesktopProviderUnavailable
+	}
+	return executable, nil
+}
+
+func desktopExecutableFile(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular() && info.Mode().Perm()&0o111 != 0
+}
+
+type processDesktopEnvelopeTransport struct {
+	command          string
+	artifactPath     string
+	arguments        []string
+	environment      []string
+	executableInfo   os.FileInfo
+	executableDigest desktopExecutableDigest
+	codeIdentity     desktopCodeIdentity
+	fileIdentity     desktopFileIdentity
+}
+
+func (transport *processDesktopEnvelopeTransport) RoundTrip(
+	ctx context.Context,
+	requestRaw []byte,
+) ([]byte, error) {
+	if transport == nil || transport.verifyIdentity(ctx) != nil {
+		return nil, errDesktopProviderUnavailable
+	}
+	privateRequestRaw, binding, err := encodeDesktopV2Request(requestRaw)
+	if err != nil {
+		return nil, err
+	}
+	result, runErr := runSecureDesktopCommand(ctx, secureDesktopSpawnSpec{
+		command:      transport.command,
+		arguments:    append([]string(nil), transport.arguments...),
+		environment:  append([]string(nil), transport.environment...),
+		codeIdentity: transport.codeIdentity,
+		fileIdentity: transport.fileIdentity,
+	}, privateRequestRaw)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if runErr != nil {
+		return nil, runErr
+	}
+	if len(result.stderr) != 0 {
+		return nil, desktopobserve.ErrMalformedEnvelope
+	}
+	privateResultRaw := append([]byte(nil), result.stdout...)
+	if len(privateResultRaw) == 0 {
+		return nil, errDesktopProviderUnavailable
+	}
+	resultRaw, privateStatus, decodeErr := translateDesktopV2Result(binding, privateResultRaw)
+	if decodeErr != nil {
+		return nil, decodeErr
+	}
+	if privateStatus == desktopV2StatusOK {
+		if result.exitCode != 0 {
+			return nil, desktopobserve.ErrMalformedEnvelope
+		}
+	} else if result.exitCode != 1 {
+		return nil, desktopobserve.ErrMalformedEnvelope
+	}
+	return resultRaw, nil
+}
+
+func desktopProviderEnvironment(artifactPath string) []string {
+	values := map[string]string{
+		"AUTOPUS_Q12_PROVENANCE_MARKER":    desktopProvenanceMarker,
+		"AUTOPUS_Q12_SIGNED_ARTIFACT_PATH": artifactPath,
+		"AUTOPUS_Q12_SPIKE_CANDIDATE_ID":   "rust-go",
+		"AUTOPUS_Q12_SUPERVISOR_RECIPE":    desktopSupervisorRecipe,
+	}
+	for _, key := range []string{"HOME", "LANG", "LC_ALL", "LOGNAME", "PATH", "SHELL", "TMPDIR", "USER"} {
+		if value, ok := os.LookupEnv(key); ok {
+			values[key] = value
+		}
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	environment := make([]string, 0, len(keys))
+	for _, key := range keys {
+		environment = append(environment, key+"="+values[key])
+	}
+	return environment
+}

--- a/pkg/qa/run/desktop_observe_process_identity.go
+++ b/pkg/qa/run/desktop_observe_process_identity.go
@@ -1,0 +1,100 @@
+package run
+
+import (
+	"context"
+	"crypto/sha256"
+	"io"
+	"os"
+)
+
+const maxDesktopProviderExecutableBytes = int64(256 << 20)
+
+type desktopExecutableDigest [sha256.Size]byte
+
+func (transport *processDesktopEnvelopeTransport) verifyIdentity(ctx context.Context) error {
+	if transport.command == "" || transport.artifactPath == "" || transport.executableInfo == nil {
+		return errDesktopProviderUnavailable
+	}
+	executable, err := desktopLocalProviderExecutable(transport.artifactPath)
+	if err != nil || executable != transport.command {
+		return errDesktopProviderUnavailable
+	}
+	before, err := os.Lstat(executable)
+	if err != nil || !sameDesktopExecutableInfo(transport.executableInfo, before) {
+		return errDesktopProviderUnavailable
+	}
+	info, digest, codeIdentity, err := snapshotDesktopExecutable(
+		ctx, executable, transport.executableInfo.Size(),
+	)
+	if err != nil || !sameDesktopExecutableInfo(transport.executableInfo, info) ||
+		digest != transport.executableDigest || codeIdentity != transport.codeIdentity {
+		return errDesktopProviderUnavailable
+	}
+	return nil
+}
+
+func snapshotDesktopExecutable(
+	ctx context.Context,
+	path string,
+	expectedSize int64,
+) (os.FileInfo, desktopExecutableDigest, desktopCodeIdentity, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, desktopExecutableDigest{}, desktopCodeIdentity{}, err
+	}
+	before, err := os.Lstat(path)
+	if err != nil || before.Mode()&os.ModeSymlink != 0 || !before.Mode().IsRegular() {
+		return nil, desktopExecutableDigest{}, desktopCodeIdentity{}, errDesktopProviderUnavailable
+	}
+	if expectedSize < 0 {
+		expectedSize = before.Size()
+	}
+	if expectedSize < 0 || expectedSize > maxDesktopProviderExecutableBytes || before.Size() != expectedSize {
+		return nil, desktopExecutableDigest{}, desktopCodeIdentity{}, errDesktopProviderUnavailable
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, desktopExecutableDigest{}, desktopCodeIdentity{}, errDesktopProviderUnavailable
+	}
+	openedInfo, err := file.Stat()
+	if err != nil || !sameDesktopExecutableInfo(before, openedInfo) {
+		_ = file.Close()
+		return nil, desktopExecutableDigest{}, desktopCodeIdentity{}, errDesktopProviderUnavailable
+	}
+	hash := sha256.New()
+	reader := io.LimitReader(desktopContextReader{ctx: ctx, reader: file}, expectedSize+1)
+	copied, copyErr := io.Copy(hash, reader)
+	codeIdentity, identityErr := readDesktopCodeIdentity(file, expectedSize)
+	closeErr := file.Close()
+	if copyErr != nil || identityErr != nil || closeErr != nil || ctx.Err() != nil || copied != expectedSize {
+		return nil, desktopExecutableDigest{}, desktopCodeIdentity{}, errDesktopProviderUnavailable
+	}
+	after, err := os.Lstat(path)
+	if err != nil || !sameDesktopExecutableInfo(before, after) {
+		return nil, desktopExecutableDigest{}, desktopCodeIdentity{}, errDesktopProviderUnavailable
+	}
+	var digest desktopExecutableDigest
+	copy(digest[:], hash.Sum(nil))
+	return after, digest, codeIdentity, nil
+}
+
+type desktopContextReader struct {
+	ctx    context.Context
+	reader io.Reader
+}
+
+func (reader desktopContextReader) Read(value []byte) (int, error) {
+	if err := reader.ctx.Err(); err != nil {
+		return 0, err
+	}
+	count, err := reader.reader.Read(value)
+	if contextErr := reader.ctx.Err(); contextErr != nil {
+		return count, contextErr
+	}
+	return count, err
+}
+
+func sameDesktopExecutableInfo(expected, actual os.FileInfo) bool {
+	return expected != nil && actual != nil && os.SameFile(expected, actual) &&
+		expected.Mode() == actual.Mode() && expected.Size() == actual.Size() &&
+		expected.ModTime().Equal(actual.ModTime())
+}

--- a/pkg/qa/run/desktop_observe_race_disabled_test.go
+++ b/pkg/qa/run/desktop_observe_race_disabled_test.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package run
+
+const desktopRaceEnabled = false

--- a/pkg/qa/run/desktop_observe_race_enabled_test.go
+++ b/pkg/qa/run/desktop_observe_race_enabled_test.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package run
+
+const desktopRaceEnabled = true

--- a/pkg/qa/run/desktop_observe_resolver_test.go
+++ b/pkg/qa/run/desktop_observe_resolver_test.go
@@ -1,0 +1,258 @@
+package run
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+func TestDesktopObservationRunner_LocalWithoutOrcaSkipsLookupResolveConstructorAndSubprocess(t *testing.T) {
+	dir := t.TempDir()
+	binDir := filepath.Join(dir, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	counterPath := filepath.Join(dir, "orca-subprocess-count")
+	sentinel := []byte("#!/bin/sh\nprintf x >> \"$ORCA_SENTINEL_COUNTER\"\nexit 1\n")
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "orca"), sentinel, 0o700))
+	t.Setenv("PATH", binDir)
+	t.Setenv("ORCA_SENTINEL_COUNTER", counterPath)
+
+	resolver := &fakeDesktopProviderResolver{
+		local: newFakeDesktopClient(desktopobserve.RuntimeProviderLocal),
+		orca:  newFakeDesktopClient(desktopobserve.RuntimeProviderOrca),
+	}
+	runner := newDesktopObservationRunnerWithResolver(resolver)
+	outcome, err := runner.Run(context.Background(), desktopRunRequest(desktopobserve.RuntimeProviderLocal))
+	require.NoError(t, err)
+	assert.Equal(t, desktopobserve.VerdictPassed, outcome.Verdict)
+	assert.Equal(t, "autopus-desktop-local", outcome.RuntimeReceipt.Provider.Name)
+	assert.Equal(t, 1, resolver.localResolveCalls)
+	assert.Equal(t, []string{"handshake", "capabilities", "permissions", "list_apps", "list_windows", "get_state"}, resolver.local.calls)
+	assert.Zero(t, resolver.orcaLookupCalls)
+	assert.Zero(t, resolver.orcaResolveCalls)
+	assert.Zero(t, resolver.orcaConstructorCalls)
+	assert.Empty(t, resolver.orca.calls)
+	assert.NoFileExists(t, counterPath)
+}
+
+func TestDesktopObservationRunner_ProviderResolutionIsBoundedWithoutFallback(t *testing.T) {
+	t.Parallel()
+	resolver := &blockingDesktopProviderResolver{}
+	runner := newDesktopObservationRunnerWithResolver(resolver)
+	runner.timeout = 10 * time.Millisecond
+	started := time.Now()
+	outcome, err := runner.Run(
+		context.Background(), desktopRunRequest(desktopobserve.RuntimeProviderLocal),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, outcome.ReasonCode)
+	assert.Equal(t, desktopobserve.ReasonProviderUnavailable, *outcome.ReasonCode)
+	assert.Less(t, time.Since(started), 500*time.Millisecond)
+	assert.Equal(t, 1, resolver.localResolveCalls)
+	assert.Zero(t, resolver.orcaLookupCalls)
+}
+
+func TestExecuteDesktopObservation_ProductionConstructorRunsControlledProviderProcess(t *testing.T) {
+	if !secureDesktopSpawnSupported() {
+		t.Skip("production process execution requires secure Darwin cgo spawn")
+	}
+	if desktopRaceEnabled {
+		t.Skip("race instrumentation distorts the strict two-second subprocess integration clock")
+	}
+	dir := t.TempDir()
+	journeyDir := filepath.Join(dir, ".autopus", "qa", "journeys")
+	require.NoError(t, os.MkdirAll(journeyDir, 0o755))
+	packBody, err := json.Marshal(desktopObservationPack())
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(journeyDir, "desktop-observe.yaml"), packBody, 0o644))
+	artifactPath, callsPath := writeControlledDesktopProvider(t, dir)
+
+	output := filepath.Join(dir, ".autopus", "qa", "runs")
+	result, err := Execute(Options{
+		ProjectDir: dir, Lane: "desktop-native", JourneyID: "desktop-accessibility-observe",
+		AdapterID: "desktop-accessibility-observe", RuntimeProvider: desktopobserve.RuntimeProviderLocal,
+		Output: output, desktopArtifactPath: artifactPath,
+		desktopArtifactVerifier: func(context.Context, string) error { return nil },
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "passed", result.Status)
+	require.Len(t, result.AdapterResults, 1)
+	require.NotNil(t, result.AdapterResults[0].DesktopObservation)
+	assert.NoDirExists(t, filepath.Join(output, result.RunID, "_raw"))
+	calls, err := os.ReadFile(callsPath)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"capabilities", "permissions", "list_apps", "list_windows", "get_state",
+	}, strings.Fields(string(calls)))
+}
+
+func writeControlledDesktopProvider(t *testing.T, root string) (string, string) {
+	t.Helper()
+	artifactPath := filepath.Join(root, "Autopus Desktop.app")
+	executableDir := filepath.Join(artifactPath, "Contents", "MacOS")
+	require.NoError(t, os.MkdirAll(executableDir, 0o755))
+	projectionBody := controlledDesktopV2Projection(t)
+	if secureDesktopSpawnSupported() {
+		source := strings.Replace(controlledDesktopProviderSource,
+			"__PROJECTION__", string(projectionBody), 1)
+		sourcePath := filepath.Join(executableDir, "provider.go")
+		require.NoError(t, os.WriteFile(sourcePath, []byte(source), 0o600))
+		executable := filepath.Join(executableDir, desktopProviderExecutableName)
+		command := exec.Command("go", "build", "-o", executable, sourcePath)
+		output, err := command.CombinedOutput()
+		require.NoError(t, err, string(output))
+		return artifactPath, filepath.Join(executableDir, "provider-calls")
+	}
+
+	script := strings.NewReplacer(
+		"__PROJECTION__", string(projectionBody),
+	).Replace(`#!/bin/sh
+if [ "$#" -ne 3 ] || [ "$1" != "--desktop-observe-spike-provider" ] || [ "$2" != "--protocol-version" ] || [ "$3" != "2" ]; then
+  exit 64
+fi
+if [ "$AUTOPUS_Q12_PROVENANCE_MARKER" != "autopus.desktop-observe.candidate.release.v2" ] || [ "$AUTOPUS_Q12_SUPERVISOR_RECIPE" != "autopus.desktop-observe.supervisor-recipe.v2" ]; then
+  exit 78
+fi
+IFS= read -r request || exit 65
+value=${request#*\"request_id\":\"}
+request_id=${value%%\"*}
+value=${request#*\"operation\":\"}
+operation=${value%%\"*}
+log=${0%/*}/provider-calls
+printf '%s\n' "$operation" >> "$log"
+case "$operation" in
+  capabilities) payload='{"capabilities":["capabilities","get_state","list_apps","list_windows","permissions"]}' ;;
+  permissions) payload='{"accessibility":"granted","next_step":null}' ;;
+  list_apps) payload='{"app_refs":["autopus-desktop"]}' ;;
+  list_windows) payload='{"window_refs":["main-window"]}' ;;
+  get_state) payload='{"semantic_projection":__PROJECTION__}' ;;
+  *) exit 65 ;;
+esac
+case "$operation" in
+  list_windows) scope='{"kind":"application","public_ref":"autopus-desktop"}' ;;
+  get_state) scope='{"kind":"window","public_ref":"main-window"}' ;;
+  *) scope='{"kind":"provider","public_ref":"provider_selected"}' ;;
+esac
+redaction=not_required
+if [ "$operation" = "get_state" ]; then redaction=applied; fi
+capabilities='[{"name":"capabilities","status":"supported"},{"name":"get_state","status":"supported"},{"name":"list_apps","status":"supported"},{"name":"list_windows","status":"supported"},{"name":"permissions","status":"supported"}]'
+printf '{"protocol_version":2,"request_id":"%s","status":"ok","runtime_receipt":{"schema_version":"qamesh.runtime_receipt.v1","provider":{"name":"rust-go","version":"0.0.1","protocol_version":2},"scope":%s,"capability_summary":%s,"reason_code":null,"next_step":null,"redaction":{"status":"%s"},"quarantine":{"status":"empty"}},"payload":%s}\n' "$request_id" "$scope" "$capabilities" "$redaction" "$payload"
+`)
+	executable := filepath.Join(executableDir, desktopProviderExecutableName)
+	require.NoError(t, os.WriteFile(executable, []byte(script), 0o700))
+	return artifactPath, filepath.Join(executableDir, "provider-calls")
+}
+
+const controlledDesktopProviderSource = `package main
+import ("encoding/json"; "os"; "path/filepath")
+type request struct { RequestID string ` + "`json:\"request_id\"`" + `; Operation string ` + "`json:\"operation\"`" + ` }
+func main() {
+  if len(os.Args) != 4 || os.Args[1] != "--desktop-observe-spike-provider" ||
+    os.Args[2] != "--protocol-version" || os.Args[3] != "2" ||
+    os.Getenv("AUTOPUS_Q12_PROVENANCE_MARKER") != "autopus.desktop-observe.candidate.release.v2" ||
+    os.Getenv("AUTOPUS_Q12_SUPERVISOR_RECIPE") != "autopus.desktop-observe.supervisor-recipe.v2" { os.Exit(64) }
+  var input request
+  if json.NewDecoder(os.Stdin).Decode(&input) != nil { os.Exit(65) }
+  executable, _ := os.Executable()
+  logPath := filepath.Join(filepath.Dir(executable), "provider-calls")
+  log, _ := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+  if log != nil { _, _ = log.WriteString(input.Operation+"\n"); _ = log.Close() }
+  payloads := map[string]json.RawMessage{
+    "capabilities": json.RawMessage(` + "`{\"capabilities\":[\"capabilities\",\"get_state\",\"list_apps\",\"list_windows\",\"permissions\"]}`" + `),
+    "permissions": json.RawMessage(` + "`{\"accessibility\":\"granted\",\"next_step\":null}`" + `),
+    "list_apps": json.RawMessage(` + "`{\"app_refs\":[\"autopus-desktop\"]}`" + `),
+    "list_windows": json.RawMessage(` + "`{\"window_refs\":[\"main-window\"]}`" + `),
+    "get_state": json.RawMessage(` + "`{\"semantic_projection\":__PROJECTION__}`" + `),
+  }
+  payload, ok := payloads[input.Operation]; if !ok { os.Exit(65) }
+  scopeKind, scopeRef, redaction := "provider", "provider_selected", "not_required"
+  if input.Operation == "list_windows" { scopeKind, scopeRef = "application", "autopus-desktop" }
+  if input.Operation == "get_state" { scopeKind, scopeRef, redaction = "window", "main-window", "applied" }
+  capabilities := []map[string]string{{"name":"capabilities","status":"supported"},
+    {"name":"get_state","status":"supported"},{"name":"list_apps","status":"supported"},
+    {"name":"list_windows","status":"supported"},{"name":"permissions","status":"supported"}}
+  output := map[string]any{"protocol_version":2,"request_id":input.RequestID,"status":"ok","payload":payload,
+    "runtime_receipt":map[string]any{"schema_version":"qamesh.runtime_receipt.v1",
+      "provider":map[string]any{"name":"rust-go","version":"0.0.1","protocol_version":2},
+      "scope":map[string]string{"kind":scopeKind,"public_ref":scopeRef},"capability_summary":capabilities,
+      "reason_code":nil,"next_step":nil,"redaction":map[string]string{"status":redaction},
+      "quarantine":map[string]string{"status":"empty"}}}
+  if json.NewEncoder(os.Stdout).Encode(output) != nil { os.Exit(66) }
+}
+`
+
+func controlledDesktopV2Projection(t *testing.T) []byte {
+	t.Helper()
+	body := []byte(`{"schema_version":"autopus.desktop-observe.semantic-projection.v2","provider_ref":"provider_rust_go","app_ref":"autopus-desktop","window_ref":"main-window","state_ref":"state_v2_0000000000000000000000000000000000000000000000000000000000000000","digest":"0000000000000000000000000000000000000000000000000000000000000000","nodes":[{"advertised_actions":[],"children":[{"advertised_actions":[],"children":[{"advertised_actions":["AXPress"],"children":[],"name":"Disclosure","node_ref":"disclosure_controlled_00","occurrence":0,"parent_node_ref":"window_controlled_00","role":"AXButton","semantic_state":{"enabled":true,"expanded":false}}],"name":"Autopus","node_ref":"window_controlled_00","occurrence":0,"parent_node_ref":"application_controlled_00","role":"AXWindow","semantic_state":{"focused":true}}],"name":"Autopus","node_ref":"application_controlled_00","occurrence":0,"parent_node_ref":null,"role":"AXApplication","semantic_state":{"enabled":true}}]}`)
+	projection, err := decodeDesktopV2Projection(body)
+	require.NoError(t, err)
+	canonical, err := desktopV2CanonicalBytes(projection)
+	require.NoError(t, err)
+	digest := fmt.Sprintf("%x", sha256.Sum256(canonical))
+	return []byte(strings.Replace(string(body), strings.Repeat("0", 64)+`","nodes`, digest+`","nodes`, 1))
+}
+
+type blockingDesktopProviderResolver struct {
+	localResolveCalls int
+	orcaLookupCalls   int
+}
+
+func (resolver *blockingDesktopProviderResolver) ResolveLocal(ctx context.Context) (desktopProviderClient, error) {
+	resolver.localResolveCalls++
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (resolver *blockingDesktopProviderResolver) LookPath(context.Context, string) (string, error) {
+	resolver.orcaLookupCalls++
+	return "", context.Canceled
+}
+
+func (*blockingDesktopProviderResolver) ResolveOrca(context.Context, string) (string, error) {
+	return "", context.Canceled
+}
+
+func (*blockingDesktopProviderResolver) NewOrcaClient(context.Context, string) (desktopProviderClient, error) {
+	return nil, context.Canceled
+}
+
+type fakeDesktopProviderResolver struct {
+	local *fakeDesktopClient
+	orca  *fakeDesktopClient
+
+	localResolveCalls    int
+	orcaLookupCalls      int
+	orcaResolveCalls     int
+	orcaConstructorCalls int
+}
+
+func (resolver *fakeDesktopProviderResolver) ResolveLocal(context.Context) (desktopProviderClient, error) {
+	resolver.localResolveCalls++
+	return resolver.local, nil
+}
+
+func (resolver *fakeDesktopProviderResolver) LookPath(context.Context, string) (string, error) {
+	resolver.orcaLookupCalls++
+	return "orca", nil
+}
+
+func (resolver *fakeDesktopProviderResolver) ResolveOrca(context.Context, string) (string, error) {
+	resolver.orcaResolveCalls++
+	return "orca://resolved", nil
+}
+
+func (resolver *fakeDesktopProviderResolver) NewOrcaClient(context.Context, string) (desktopProviderClient, error) {
+	resolver.orcaConstructorCalls++
+	return resolver.orca, nil
+}

--- a/pkg/qa/run/desktop_observe_runner.go
+++ b/pkg/qa/run/desktop_observe_runner.go
@@ -1,0 +1,278 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+func (runner *desktopObservationRunner) Run(
+	ctx context.Context,
+	request DesktopObservationRunRequest,
+) (desktopobserve.OracleOutcome, error) {
+	if err := validDesktopProvider(request.RuntimeProvider); err != nil {
+		return desktopobserve.OracleOutcome{}, err
+	}
+	expectedIdentity := expectedDesktopIdentity(request.RuntimeProvider)
+	if !validDesktopOperations(request.Operations) {
+		return desktopFailureOutcome(
+			desktopobserve.FailureOperationMissing,
+			expectedIdentity,
+			desktopProviderScope(expectedIdentity),
+			desktopUnsupportedCapabilities(),
+			desktopobserve.OperationCapabilities,
+		)
+	}
+	ctx, cancel := runner.operationContext(ctx)
+	defer cancel()
+
+	client, err := runner.resolveClient(ctx, request.RuntimeProvider)
+	err = desktopBoundedError(ctx, err)
+	if err != nil || client == nil {
+		return desktopFailureOutcome(
+			desktopobserve.FailureProviderStart,
+			expectedIdentity,
+			desktopProviderScope(expectedIdentity),
+			desktopUnsupportedCapabilities(),
+			"",
+		)
+	}
+	identity, err := client.Handshake(ctx)
+	err = desktopBoundedError(ctx, err)
+	if err != nil {
+		return desktopFailureFromError(
+			err, expectedIdentity, desktopProviderScope(expectedIdentity), desktopUnsupportedCapabilities(),
+		)
+	}
+	if !validDesktopIdentity(identity, request.RuntimeProvider) {
+		return desktopFailureOutcome(
+			desktopobserve.FailureProtocolVersion,
+			expectedIdentity,
+			desktopProviderScope(expectedIdentity),
+			desktopUnsupportedCapabilities(),
+			"",
+		)
+	}
+
+	operations, err := client.Capabilities(ctx)
+	err = desktopBoundedError(ctx, err)
+	if err != nil {
+		return desktopFailureFromError(
+			err, identity, desktopProviderScope(identity), desktopUnsupportedCapabilities(),
+		)
+	}
+	capabilities := desktopCapabilitySummary(operations)
+	if missing := desktopFirstMissingCapability(capabilities); missing != "" {
+		return desktopFailureOutcome(
+			desktopobserve.FailureOperationMissing,
+			identity,
+			desktopProviderScope(identity),
+			capabilities,
+			missing,
+		)
+	}
+
+	permission, err := client.Permissions(ctx)
+	err = desktopBoundedError(ctx, err)
+	if err != nil {
+		return desktopFailureFromError(err, identity, desktopProviderScope(identity), capabilities)
+	}
+	if !permission.AccessibilityGranted {
+		return desktopFailureOutcome(
+			desktopobserve.FailureAccessibilityDenied,
+			identity,
+			desktopProviderScope(identity),
+			capabilities,
+			"",
+		)
+	}
+
+	apps, err := client.ListApps(ctx)
+	err = desktopBoundedError(ctx, err)
+	if err != nil {
+		return desktopFailureFromError(err, identity, desktopProviderScope(identity), capabilities)
+	}
+	appMatched, multipleApps := desktopSingleAppMatches(apps, request.AppRef)
+	if multipleApps {
+		return desktopFailureOutcome(
+			desktopobserve.FailureProtocolVersion,
+			identity,
+			desktopobserve.ReceiptScope{Kind: desktopobserve.ScopeApplication, PublicRef: "autopus-desktop"},
+			capabilities,
+			"",
+		)
+	}
+	if !appMatched {
+		return desktopFailureOutcome(
+			desktopobserve.FailureAppAliasUnmatched,
+			identity,
+			desktopobserve.ReceiptScope{Kind: desktopobserve.ScopeApplication, PublicRef: "autopus-desktop"},
+			capabilities,
+			"",
+		)
+	}
+
+	windows, err := client.ListWindows(ctx, request.AppRef)
+	err = desktopBoundedError(ctx, err)
+	if err != nil {
+		return desktopFailureFromError(
+			err,
+			identity,
+			desktopobserve.ReceiptScope{Kind: desktopobserve.ScopeApplication, PublicRef: "autopus-desktop"},
+			capabilities,
+		)
+	}
+	windowMatched, multipleWindows := desktopSingleWindowMatches(windows, request.WindowRef)
+	if multipleWindows {
+		return desktopFailureOutcome(
+			desktopobserve.FailureProtocolVersion,
+			identity,
+			desktopWindowScope("main-window"),
+			capabilities,
+			"",
+		)
+	}
+	if !windowMatched {
+		return desktopFailureOutcome(
+			desktopobserve.FailureWindowAliasUnmatched,
+			identity,
+			desktopWindowScope("main-window"),
+			capabilities,
+			"",
+		)
+	}
+
+	projection, err := client.GetState(ctx, request.AppRef, request.WindowRef)
+	err = desktopBoundedError(ctx, err)
+	if err != nil {
+		return desktopFailureFromError(err, identity, desktopWindowScope("main-window"), capabilities)
+	}
+	if !desktopProjectionMatchesRequest(projection, request) {
+		return desktopFailureOutcome(
+			desktopobserve.FailureProtocolVersion,
+			identity,
+			desktopWindowScope("main-window"),
+			capabilities,
+			"",
+		)
+	}
+	projection, err = desktopobserve.NormalizeProjection(projection, request.Redactor)
+	if err != nil {
+		return desktopFailureFromError(err, identity, desktopWindowScope("main-window"), capabilities)
+	}
+	return runner.evaluateProjection(request, identity, capabilities, projection)
+}
+
+func (runner *desktopObservationRunner) evaluateProjection(
+	request DesktopObservationRunRequest,
+	identity desktopobserve.ProviderIdentity,
+	capabilities []desktopobserve.CapabilityStatus,
+	projection desktopobserve.SemanticProjection,
+) (desktopobserve.OracleOutcome, error) {
+	binding := desktopobserve.StateBinding{
+		StateRef: projection.StateRef, ProviderRef: projection.ProviderRef,
+		AppRef: projection.AppRef, WindowRef: projection.WindowRef, Digest: projection.Digest,
+	}
+	ledger := runner.ledgers[request.RuntimeProvider]
+	if ledger == nil {
+		return desktopobserve.OracleOutcome{}, errors.New("desktop observation ledger is unavailable")
+	}
+	if err := ledger.Register(binding); err != nil {
+		return desktopFailureOutcome(
+			desktopobserve.FailureStateRefRejected,
+			identity,
+			desktopWindowScope("main-window"),
+			capabilities,
+			"",
+		)
+	}
+	if !desktopHasStructuralLandmarks(projection.Root, request.Policy.MinimumLandmarks) {
+		_ = ledger.Consume(binding)
+		return desktopFailureOutcome(
+			desktopobserve.FailureLandmarksInsufficient,
+			identity,
+			desktopWindowScope("main-window"),
+			capabilities,
+			"",
+		)
+	}
+	receipt := desktopSuccessReceipt(identity, desktopWindowScope("main-window"), capabilities)
+	return desktopobserve.EvaluateOracle(desktopobserve.OracleInput{
+		Projection: projection,
+		Ledger:     ledger,
+		Policy:     request.Policy,
+		Receipt:    receipt,
+	})
+}
+
+func desktopHasStructuralLandmarks(
+	root desktopobserve.SemanticNode,
+	requirements []desktopobserve.LandmarkRequirement,
+) bool {
+	if len(requirements) == 0 {
+		return true
+	}
+	for _, requirement := range requirements {
+		if !desktopContainsStructuralLandmark(root, requirement) {
+			return false
+		}
+	}
+	return true
+}
+
+func desktopContainsStructuralLandmark(
+	node desktopobserve.SemanticNode,
+	requirement desktopobserve.LandmarkRequirement,
+) bool {
+	if node.Role == requirement.Role && desktopStateIsTrue(node.SemanticState, requirement.RequiredState) {
+		return true
+	}
+	for _, child := range node.Children {
+		if desktopContainsStructuralLandmark(child, requirement) {
+			return true
+		}
+	}
+	return false
+}
+
+func desktopStateIsTrue(state desktopobserve.SemanticState, key desktopobserve.SemanticStateKey) bool {
+	var value *bool
+	switch key {
+	case desktopobserve.StateEnabled:
+		value = state.Enabled
+	case desktopobserve.StateFocused:
+		value = state.Focused
+	case desktopobserve.StateSelected:
+		value = state.Selected
+	case desktopobserve.StateExpanded:
+		value = state.Expanded
+	default:
+		return false
+	}
+	return value != nil && *value
+}
+
+func desktopProjectionMatchesRequest(
+	projection desktopobserve.SemanticProjection,
+	request DesktopObservationRunRequest,
+) bool {
+	return projection.ProviderRef == desktopProviderPublicRef(request.RuntimeProvider) &&
+		projection.AppRef == request.AppRef && projection.WindowRef == request.WindowRef &&
+		strings.HasPrefix(projection.StateRef, "state-")
+}
+
+func desktopSingleAppMatches(apps []desktopobserve.AppSummary, appRef string) (bool, bool) {
+	if len(apps) > 1 {
+		return false, true
+	}
+	return len(apps) == 1 && apps[0].AppRef == appRef, false
+}
+
+func desktopSingleWindowMatches(windows []desktopobserve.WindowSummary, windowRef string) (bool, bool) {
+	if len(windows) > 1 {
+		return false, true
+	}
+	return len(windows) == 1 && windows[0].WindowRef == windowRef, false
+}

--- a/pkg/qa/run/desktop_observe_runner_test.go
+++ b/pkg/qa/run/desktop_observe_runner_test.go
@@ -1,0 +1,282 @@
+package run
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+	qaevidence "github.com/insajin/autopus-adk/pkg/qa/evidence"
+)
+
+func TestDesktopObservationRunner_SelectedProviderOnlyAndExactOperationOrder(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		selected desktopobserve.RuntimeProvider
+	}{
+		{name: "local", selected: desktopobserve.RuntimeProviderLocal},
+		{name: "orca", selected: desktopobserve.RuntimeProviderOrca},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			local := newFakeDesktopClient(desktopobserve.RuntimeProviderLocal)
+			orca := newFakeDesktopClient(desktopobserve.RuntimeProviderOrca)
+			runner := newDesktopObservationRunner(local, orca)
+			outcome, err := runner.Run(context.Background(), desktopRunRequest(test.selected))
+			require.NoError(t, err)
+			assert.Equal(t, desktopobserve.VerdictPassed, outcome.Verdict)
+			selected := local
+			alternate := orca
+			if test.selected == desktopobserve.RuntimeProviderOrca {
+				selected, alternate = orca, local
+			}
+			assert.Equal(t, []string{"handshake", "capabilities", "permissions", "list_apps", "list_windows", "get_state"}, selected.calls)
+			assert.Empty(t, alternate.calls)
+			assert.Equal(t, desktopobserve.ReadOnlyOperations(), capabilityNames(outcome.RuntimeReceipt))
+		})
+	}
+}
+
+func TestDesktopProviderProtocolMismatch_BlocksBeforeOperationsWithoutFallback(t *testing.T) {
+	t.Parallel()
+	local := newFakeDesktopClient(desktopobserve.RuntimeProviderLocal)
+	local.protocolVersion = desktopobserve.ProtocolVersion + 1
+	orca := newFakeDesktopClient(desktopobserve.RuntimeProviderOrca)
+	runner := newDesktopObservationRunner(local, orca)
+	outcome, err := runner.Run(context.Background(), desktopRunRequest(desktopobserve.RuntimeProviderLocal))
+	require.NoError(t, err)
+	require.NotNil(t, outcome.ReasonCode)
+	assert.Equal(t, desktopobserve.ReasonProviderProtocolMismatch, *outcome.ReasonCode)
+	assert.NotEqual(t, desktopobserve.VerdictPassed, outcome.Verdict)
+	assert.Nil(t, outcome.SemanticProjection)
+	assert.Equal(t, []string{"handshake"}, local.calls)
+	assert.Empty(t, orca.calls)
+}
+
+func TestDesktopObservationRunner_UnavailableSelectedProviderDoesNotFallback(t *testing.T) {
+	t.Parallel()
+	local := newFakeDesktopClient(desktopobserve.RuntimeProviderLocal)
+	local.handshakeErr = errors.New("private provider path failed")
+	orca := newFakeDesktopClient(desktopobserve.RuntimeProviderOrca)
+	runner := newDesktopObservationRunner(local, orca)
+	outcome, err := runner.Run(context.Background(), desktopRunRequest(desktopobserve.RuntimeProviderLocal))
+	require.NoError(t, err)
+	require.NotNil(t, outcome.ReasonCode)
+	assert.Equal(t, desktopobserve.ReasonProviderUnavailable, *outcome.ReasonCode)
+	assert.Nil(t, outcome.SemanticProjection)
+	assert.Equal(t, []string{"handshake"}, local.calls)
+	assert.Empty(t, orca.calls)
+	body, marshalErr := json.Marshal(outcome.RuntimeReceipt)
+	require.NoError(t, marshalErr)
+	assert.NotContains(t, string(body), "private provider path failed")
+}
+
+func TestDesktopObservationRunner_AccessibilityDeniedStopsBeforeTargetCalls(t *testing.T) {
+	t.Parallel()
+	local := newFakeDesktopClient(desktopobserve.RuntimeProviderLocal)
+	local.accessibilityGranted = false
+	orca := newFakeDesktopClient(desktopobserve.RuntimeProviderOrca)
+	outcome, err := newDesktopObservationRunner(local, orca).Run(
+		context.Background(), desktopRunRequest(desktopobserve.RuntimeProviderLocal),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, outcome.ReasonCode)
+	assert.Equal(t, desktopobserve.ReasonAccessibilityPermissionMissing, *outcome.ReasonCode)
+	assert.Nil(t, outcome.SemanticProjection)
+	assert.Equal(t, []string{"handshake", "capabilities", "permissions"}, local.calls)
+	assert.Empty(t, orca.calls)
+	assert.Equal(t, desktopobserve.RedactionNotRequired, outcome.RuntimeReceipt.Redaction.Status)
+	require.NotNil(t, outcome.RuntimeReceipt.NextStep)
+	assert.NotEmpty(t, *outcome.RuntimeReceipt.NextStep)
+}
+func TestDesktopObservationRunner_MissingOrInvalidProviderCallsNeitherClient(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		provider desktopobserve.RuntimeProvider
+		want     error
+	}{
+		{name: "missing", provider: "", want: desktopobserve.ErrRuntimeProviderRequired},
+		{name: "invalid", provider: "automatic", want: desktopobserve.ErrRuntimeProviderInvalid},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			local := newFakeDesktopClient(desktopobserve.RuntimeProviderLocal)
+			orca := newFakeDesktopClient(desktopobserve.RuntimeProviderOrca)
+			runner := newDesktopObservationRunner(local, orca)
+			request := desktopRunRequest(test.provider)
+
+			_, err := runner.Run(context.Background(), request)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, test.want)
+			assert.Empty(t, local.calls)
+			assert.Empty(t, orca.calls)
+		})
+	}
+}
+
+func TestDesktopObservationRunner_RequiresExactlyOneExactAppAndWindow(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		configure func(*fakeDesktopClient)
+		reason    desktopobserve.ReasonCode
+		calls     []string
+	}{
+		{name: "zero apps", configure: func(client *fakeDesktopClient) { client.apps = []desktopobserve.AppSummary{} }, reason: desktopobserve.ReasonTargetAppNotFound, calls: []string{"handshake", "capabilities", "permissions", "list_apps"}},
+		{name: "one wrong app", configure: func(client *fakeDesktopClient) { client.apps = []desktopobserve.AppSummary{{AppRef: "other-app"}} }, reason: desktopobserve.ReasonTargetAppNotFound, calls: []string{"handshake", "capabilities", "permissions", "list_apps"}},
+		{name: "duplicate app", configure: func(client *fakeDesktopClient) {
+			client.apps = []desktopobserve.AppSummary{{AppRef: "autopus-desktop"}, {AppRef: "autopus-desktop"}}
+		}, reason: desktopobserve.ReasonProviderProtocolMismatch, calls: []string{"handshake", "capabilities", "permissions", "list_apps"}},
+		{name: "extra app", configure: func(client *fakeDesktopClient) {
+			client.apps = []desktopobserve.AppSummary{{AppRef: "autopus-desktop"}, {AppRef: "other-app"}}
+		}, reason: desktopobserve.ReasonProviderProtocolMismatch, calls: []string{"handshake", "capabilities", "permissions", "list_apps"}},
+		{name: "zero windows", configure: func(client *fakeDesktopClient) { client.windows = []desktopobserve.WindowSummary{} }, reason: desktopobserve.ReasonTargetWindowNotFound, calls: []string{"handshake", "capabilities", "permissions", "list_apps", "list_windows"}},
+		{name: "one wrong window", configure: func(client *fakeDesktopClient) {
+			client.windows = []desktopobserve.WindowSummary{{WindowRef: "other-window"}}
+		}, reason: desktopobserve.ReasonTargetWindowNotFound, calls: []string{"handshake", "capabilities", "permissions", "list_apps", "list_windows"}},
+		{name: "duplicate window", configure: func(client *fakeDesktopClient) {
+			client.windows = []desktopobserve.WindowSummary{{WindowRef: "main-window"}, {WindowRef: "main-window"}}
+		}, reason: desktopobserve.ReasonProviderProtocolMismatch, calls: []string{"handshake", "capabilities", "permissions", "list_apps", "list_windows"}},
+		{name: "extra window", configure: func(client *fakeDesktopClient) {
+			client.windows = []desktopobserve.WindowSummary{{WindowRef: "main-window"}, {WindowRef: "other-window"}}
+		}, reason: desktopobserve.ReasonProviderProtocolMismatch, calls: []string{"handshake", "capabilities", "permissions", "list_apps", "list_windows"}},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			local := newFakeDesktopClient(desktopobserve.RuntimeProviderLocal)
+			alternate := newFakeDesktopClient(desktopobserve.RuntimeProviderOrca)
+			test.configure(local)
+			outcome, err := newDesktopObservationRunner(local, alternate).Run(
+				context.Background(), desktopRunRequest(desktopobserve.RuntimeProviderLocal),
+			)
+			require.NoError(t, err)
+			require.NotNil(t, outcome.ReasonCode)
+			assert.Equal(t, test.reason, *outcome.ReasonCode)
+			assert.Nil(t, outcome.SemanticProjection)
+			assert.Equal(t, test.calls, local.calls)
+			assert.Empty(t, alternate.calls)
+		})
+	}
+}
+
+func TestLocalOrcaOracleParity_ProviderIdentityIsOnlyReceiptDifference(t *testing.T) {
+	t.Parallel()
+	local := newFakeDesktopClient(desktopobserve.RuntimeProviderLocal)
+	orca := newFakeDesktopClient(desktopobserve.RuntimeProviderOrca)
+	runner := newDesktopObservationRunner(local, orca)
+	localOutcome, err := runner.Run(context.Background(), desktopRunRequest(desktopobserve.RuntimeProviderLocal))
+	require.NoError(t, err)
+	orcaOutcome, err := runner.Run(context.Background(), desktopRunRequest(desktopobserve.RuntimeProviderOrca))
+	require.NoError(t, err)
+	assert.Equal(t, normalizedObservationBytes(t, localOutcome), normalizedObservationBytes(t, orcaOutcome))
+	assert.NotEqual(t, localOutcome.RuntimeReceipt.Provider.Name, orcaOutcome.RuntimeReceipt.Provider.Name)
+	require.NotNil(t, orcaOutcome.SemanticProjection)
+	assert.Equal(t, []desktopobserve.Action{
+		desktopobserve.ActionPress,
+		desktopobserve.ActionShowMenu,
+	}, orcaOutcome.SemanticProjection.Root.AdvertisedActions)
+	assert.Zero(t, orca.rawIndexCalls)
+	assert.Zero(t, orca.actionCalls)
+	assert.Zero(t, orca.screenshotCalls)
+}
+
+func TestDesktopObservationExecutePack_BypassesGenericRawCommandPath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	runDir := filepath.Join(dir, "run")
+	rawRoot := filepath.Join(runDir, "_raw")
+	local := newFakeDesktopClient(desktopobserve.RuntimeProviderLocal)
+	runner := newDesktopObservationRunner(local, newFakeDesktopClient(desktopobserve.RuntimeProviderOrca))
+	pack := desktopObservationPack()
+	result, manifestPath, checks := executePack(Options{
+		ProjectDir:      dir,
+		Lane:            "desktop-native",
+		RuntimeProvider: desktopobserve.RuntimeProviderLocal,
+		desktopRunner:   runner,
+	}, pack, rawRoot, runDir)
+	assert.Equal(t, "passed", result.Status)
+	assert.NotEmpty(t, manifestPath)
+	assert.NotEmpty(t, checks)
+	assert.NoDirExists(t, rawRoot)
+	require.NotNil(t, result.DesktopObservation)
+
+	manifest, err := qaevidence.LoadManifest(manifestPath)
+	require.NoError(t, err)
+	require.NotNil(t, manifest.OracleResults.DesktopObservation)
+	assert.Equal(t, qaevidence.Runner{Name: "desktop-accessibility-observe"}, manifest.Runner)
+	assert.Equal(t, "desktop-accessibility-observe", manifest.ScenarioRef)
+	assert.Equal(t, "desktop-accessibility-observe", manifest.SourceRefs.JourneyID)
+	assert.Equal(t, "step-1", manifest.SourceRefs.StepID)
+	assert.Empty(t, manifest.SourceRefs.OwnedPaths)
+	assert.Empty(t, manifest.SourceRefs.DoNotModifyPaths)
+	assert.Empty(t, manifest.SourceRefs.OracleThresholds)
+	assert.Nil(t, manifest.SourceRefs.Mobile)
+	assert.Empty(t, manifest.ReproductionCommand)
+	assert.Empty(t, manifest.RepairPromptRef)
+	require.Len(t, manifest.OracleResults.Checks, 1)
+	manifestCheck := manifest.OracleResults.Checks[0]
+	assert.Equal(t, desktopobserve.DeterministicCheckSemanticLandmarks, manifestCheck.ID)
+	assert.Equal(t, "desktop_accessibility_semantic", manifestCheck.Type)
+	assert.Equal(t, "passed", manifestCheck.Status)
+	assert.Empty(t, manifestCheck.Expected)
+	assert.Empty(t, manifestCheck.Actual)
+	assert.Empty(t, manifestCheck.ArtifactRefs)
+	assert.Empty(t, manifestCheck.FailureSummary)
+	resultBody, err := json.Marshal(result.DesktopObservation)
+	require.NoError(t, err)
+	manifestBody, err := json.Marshal(manifest.OracleResults.DesktopObservation)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(resultBody, manifestBody))
+	require.Len(t, manifest.Artifacts, 1)
+	artifactBody, err := os.ReadFile(filepath.Join(filepath.Dir(manifestPath), manifest.Artifacts[0].Path))
+	require.NoError(t, err)
+	artifact, err := desktopobserve.DecodeObservationEvidence(artifactBody)
+	require.NoError(t, err)
+	inlineBody, err := json.Marshal(manifest.OracleResults.DesktopObservation)
+	require.NoError(t, err)
+	decodedArtifactBody, err := json.Marshal(artifact)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(inlineBody, decodedArtifactBody))
+}
+
+func TestDesktopObservationExecutePack_BlockedManifestUsesTypedFailureProfile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	local := newFakeDesktopClient(desktopobserve.RuntimeProviderLocal)
+	local.accessibilityGranted = false
+	pack := desktopObservationPack()
+	result, manifestPath, checks := executePack(Options{
+		ProjectDir: dir, Lane: "desktop-native", RuntimeProvider: desktopobserve.RuntimeProviderLocal,
+		desktopRunner: newDesktopObservationRunner(
+			local, newFakeDesktopClient(desktopobserve.RuntimeProviderOrca),
+		),
+	}, pack, filepath.Join(dir, "run", "_raw"), filepath.Join(dir, "run"))
+	assert.Equal(t, "blocked", result.Status)
+	assert.Equal(t, string(desktopobserve.ReasonAccessibilityPermissionMissing), result.FailureSummary)
+	require.NotNil(t, result.DesktopObservation)
+	require.NotEmpty(t, manifestPath)
+	require.Len(t, checks, 1)
+	manifest, err := qaevidence.LoadManifest(manifestPath)
+	require.NoError(t, err)
+	require.Len(t, manifest.OracleResults.Checks, 1)
+	assert.Equal(t, "blocked", manifest.OracleResults.Checks[0].Status)
+	assert.Equal(t, "desktop observation blocked", manifest.OracleResults.Checks[0].FailureSummary)
+	assert.Empty(t, manifest.OracleResults.Checks[0].Expected)
+	assert.Empty(t, manifest.OracleResults.Checks[0].Actual)
+	assert.Empty(t, manifest.OracleResults.Checks[0].ArtifactRefs)
+}

--- a/pkg/qa/run/desktop_observe_secure_spawn.go
+++ b/pkg/qa/run/desktop_observe_secure_spawn.go
@@ -8,12 +8,6 @@ import (
 	"sync"
 )
 
-type desktopFileIdentity struct {
-	device uint64
-	inode  uint64
-	links  uint64
-}
-
 type secureDesktopSpawnSpec struct {
 	command      string
 	arguments    []string

--- a/pkg/qa/run/desktop_observe_secure_spawn.go
+++ b/pkg/qa/run/desktop_observe_secure_spawn.go
@@ -1,0 +1,154 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"sync"
+)
+
+type desktopFileIdentity struct {
+	device uint64
+	inode  uint64
+	links  uint64
+}
+
+type secureDesktopSpawnSpec struct {
+	command      string
+	arguments    []string
+	environment  []string
+	codeIdentity desktopCodeIdentity
+	fileIdentity desktopFileIdentity
+}
+
+type secureDesktopProcess struct {
+	pid    int
+	stdin  *os.File
+	stdout *os.File
+	stderr *os.File
+	wait   func() (*os.ProcessState, error)
+}
+
+type secureDesktopCommandResult struct {
+	exitCode int
+	stderr   []byte
+	stdout   []byte
+}
+
+func runSecureDesktopCommand(
+	ctx context.Context,
+	spec secureDesktopSpawnSpec,
+	input []byte,
+) (secureDesktopCommandResult, error) {
+	if err := ctx.Err(); err != nil {
+		return secureDesktopCommandResult{}, err
+	}
+	child, err := startSecureDesktopProcess(spec)
+	if err != nil {
+		return secureDesktopCommandResult{}, errDesktopProviderUnavailable
+	}
+	stdout := newSecureDesktopOutput()
+	stderr := newSecureDesktopOutput()
+	readDone := make(chan error, 2)
+	go copySecureDesktopOutput(child.stdout, stdout, readDone)
+	go copySecureDesktopOutput(child.stderr, stderr, readDone)
+	writeDone := make(chan error, 1)
+	go func() {
+		_, writeErr := child.stdin.Write(input)
+		closeErr := child.stdin.Close()
+		writeDone <- errors.Join(writeErr, closeErr)
+	}()
+	waitDone := make(chan secureDesktopWaitResult, 1)
+	go func() {
+		state, waitErr := child.wait()
+		waitDone <- secureDesktopWaitResult{state: state, err: waitErr}
+	}()
+	var waited secureDesktopWaitResult
+	var terminalErr error
+	select {
+	case waited = <-waitDone:
+	case <-ctx.Done():
+		secureDesktopKillProcessGroup(child.pid)
+		waited = <-waitDone
+		terminalErr = ctx.Err()
+	case <-stdout.overflowed:
+		secureDesktopKillProcessGroup(child.pid)
+		waited = <-waitDone
+	case <-stderr.overflowed:
+		secureDesktopKillProcessGroup(child.pid)
+		waited = <-waitDone
+	}
+	groupErr := secureDesktopReapProcessGroup(child.pid)
+	writeErr := <-writeDone
+	readErr := errors.Join(<-readDone, <-readDone)
+	closeSecureDesktopFiles(child)
+	if terminalErr != nil {
+		return secureDesktopCommandResult{}, terminalErr
+	}
+	if waited.state == nil || (waited.err != nil && waited.state.ExitCode() < 0) ||
+		readErr != nil || groupErr != nil {
+		return secureDesktopCommandResult{}, errDesktopProviderUnavailable
+	}
+	if writeErr != nil && waited.state.Success() {
+		return secureDesktopCommandResult{}, errDesktopProviderUnavailable
+	}
+	if stdout.overflow || stderr.overflow {
+		return secureDesktopCommandResult{}, desktopobserveEnvelopeTooLarge()
+	}
+	return secureDesktopCommandResult{
+		exitCode: waited.state.ExitCode(),
+		stderr:   append([]byte(nil), stderr.buffer...),
+		stdout:   append([]byte(nil), stdout.buffer...),
+	}, nil
+}
+
+type secureDesktopWaitResult struct {
+	state *os.ProcessState
+	err   error
+}
+
+type secureDesktopOutput struct {
+	buffer     []byte
+	mu         sync.Mutex
+	once       sync.Once
+	overflow   bool
+	overflowed chan struct{}
+}
+
+func newSecureDesktopOutput() *secureDesktopOutput {
+	return &secureDesktopOutput{overflowed: make(chan struct{})}
+}
+
+func (output *secureDesktopOutput) Write(value []byte) (int, error) {
+	output.mu.Lock()
+	defer output.mu.Unlock()
+	remaining := desktopObservationEnvelopeLimit() - len(output.buffer)
+	if remaining > len(value) {
+		remaining = len(value)
+	}
+	if remaining > 0 {
+		output.buffer = append(output.buffer, value[:remaining]...)
+	}
+	if remaining < len(value) {
+		output.overflow = true
+		output.once.Do(func() { close(output.overflowed) })
+	}
+	return len(value), nil
+}
+
+func copySecureDesktopOutput(source *os.File, target io.Writer, done chan<- error) {
+	_, err := io.Copy(target, source)
+	done <- err
+}
+
+func closeSecureDesktopFiles(child *secureDesktopProcess) {
+	if child == nil {
+		return
+	}
+	for _, file := range []*os.File{child.stdin, child.stdout, child.stderr} {
+		if file != nil {
+			_ = file.Close()
+		}
+	}
+}

--- a/pkg/qa/run/desktop_observe_secure_spawn_darwin_cgo.go
+++ b/pkg/qa/run/desktop_observe_secure_spawn_darwin_cgo.go
@@ -1,0 +1,295 @@
+//go:build darwin && cgo
+
+package run
+
+/*
+#cgo LDFLAGS: -framework CoreFoundation -framework Security -lproc
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <libproc.h>
+#include <signal.h>
+#include <spawn.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+extern char **environ;
+
+typedef struct {
+  int pid;
+  int stdin_fd;
+  int stdout_fd;
+  int stderr_fd;
+} q12_spawn_result;
+
+static void q12_close(int *fd) {
+  if (*fd >= 0) { close(*fd); *fd = -1; }
+}
+
+static void q12_abort_child(pid_t pid) {
+  if (pid > 1) {
+    kill(-pid, SIGKILL);
+    kill(pid, SIGKILL);
+    while (waitpid(pid, NULL, 0) < 0 && errno == EINTR) {}
+  }
+}
+
+static char **q12_vector(char *first, char *blob, size_t length, int count) {
+  int extra = first == NULL ? 0 : 1;
+  char **result = calloc((size_t)count + (size_t)extra + 1, sizeof(char *));
+  if (result == NULL) return NULL;
+  if (first != NULL) result[0] = first;
+  size_t offset = 0;
+  for (int index = 0; index < count; index++) {
+    if (offset >= length) { free(result); return NULL; }
+    result[index + extra] = blob + offset;
+    size_t item = strnlen(blob + offset, length - offset);
+    if (item == length - offset) { free(result); return NULL; }
+    offset += item + 1;
+  }
+  if (offset != length) { free(result); return NULL; }
+  return result;
+}
+
+static int q12_hash_matches(CFDictionaryRef info, const uint8_t *expected, int count) {
+  CFArrayRef hashes = CFDictionaryGetValue(info, kSecCodeInfoCdHashes);
+  if (hashes == NULL || CFGetTypeID(hashes) != CFArrayGetTypeID()) return 0;
+  CFIndex total = CFArrayGetCount(hashes);
+  if (total < 1 || total > 64) return 0;
+  for (CFIndex index = 0; index < total; index++) {
+    CFDataRef value = (CFDataRef)CFArrayGetValueAtIndex(hashes, index);
+    if (value == NULL || CFGetTypeID(value) != CFDataGetTypeID() ||
+        CFDataGetLength(value) != 20) continue;
+    for (int expected_index = 0; expected_index < count; expected_index++) {
+      if (memcmp(CFDataGetBytePtr(value), expected + expected_index * 20, 20) == 0) return 1;
+    }
+  }
+  return 0;
+}
+
+static int q12_mapped_vnode_matches(pid_t pid, uint64_t device, uint64_t inode,
+                                    uint64_t links) {
+  uint64_t address = 0;
+  for (int index = 0; index < 4096; index++) {
+    struct proc_regionwithpathinfo region;
+    memset(&region, 0, sizeof(region));
+    if (proc_pidinfo(pid, PROC_PIDREGIONPATHINFO, address, &region, sizeof(region)) !=
+        (int)sizeof(region)) break;
+    struct vinfo_stat *stat_value = &region.prp_vip.vip_vi.vi_stat;
+    if ((uint64_t)stat_value->vst_dev == device && (uint64_t)stat_value->vst_ino == inode &&
+        (uint64_t)stat_value->vst_nlink == links) return 1;
+    uint64_t start = region.prp_prinfo.pri_address;
+    uint64_t length = region.prp_prinfo.pri_size;
+    if (length == 0 || start > UINT64_MAX - length || start + length <= address) break;
+    address = start + length;
+  }
+  return 0;
+}
+
+static int q12_validate_child(pid_t pid, const char *command, const uint8_t *expected,
+                              int hash_count, uint64_t device, uint64_t inode, uint64_t links) {
+  CFNumberRef pid_number = CFNumberCreate(NULL, kCFNumberIntType, &pid);
+  if (pid_number == NULL) return 101;
+  const void *keys[] = { kSecGuestAttributePid };
+  const void *values[] = { pid_number };
+  CFDictionaryRef attributes = CFDictionaryCreate(NULL, keys, values, 1,
+    &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+  SecCodeRef code = NULL;
+  OSStatus status = attributes == NULL ? errSecAllocate :
+    SecCodeCopyGuestWithAttributes(NULL, attributes, kSecCSDefaultFlags, &code);
+  if (attributes != NULL) CFRelease(attributes);
+  CFRelease(pid_number);
+  if (status != errSecSuccess || code == NULL) return 102;
+  status = SecCodeCheckValidity(code, kSecCSDefaultFlags, NULL);
+  if (status != errSecSuccess) { CFRelease(code); return 103; }
+  CFDictionaryRef info = NULL;
+  status = SecCodeCopySigningInformation(code,
+    kSecCSSigningInformation | kSecCSDynamicInformation, &info);
+  if (status != errSecSuccess || info == NULL) { CFRelease(code); return 104; }
+  int matched = q12_hash_matches(info, expected, hash_count);
+  if (info != NULL) CFRelease(info);
+  CFRelease(code);
+  if (!matched) return 105;
+
+  char process_path[PROC_PIDPATHINFO_MAXSIZE];
+  char expected_path[PATH_MAX];
+  char actual_path[PATH_MAX];
+  struct stat stat_value;
+  if (proc_pidpath(pid, process_path, sizeof(process_path)) <= 0 ||
+      realpath(command, expected_path) == NULL || realpath(process_path, actual_path) == NULL ||
+      strcmp(expected_path, actual_path) != 0 || lstat(command, &stat_value) != 0 ||
+      !S_ISREG(stat_value.st_mode) || S_ISLNK(stat_value.st_mode) ||
+      (uint64_t)stat_value.st_dev != device || (uint64_t)stat_value.st_ino != inode ||
+      (uint64_t)stat_value.st_nlink != links ||
+      !q12_mapped_vnode_matches(pid, device, inode, links)) return 106;
+  return 0;
+}
+
+static int q12_secure_spawn(const char *command, char *args_blob, size_t args_length,
+                            int args_count, char *env_blob, size_t env_length, int env_count,
+                            const uint8_t *hashes, int hash_count, uint64_t device,
+                            uint64_t inode, uint64_t links, q12_spawn_result *output) {
+  if (command == NULL || output == NULL || hash_count < 1 || hash_count > 7) return EINVAL;
+  output->pid = output->stdin_fd = output->stdout_fd = output->stderr_fd = -1;
+  char **argv = q12_vector((char *)command, args_blob, args_length, args_count);
+  char **envp = q12_vector(NULL, env_blob, env_length, env_count);
+  if (argv == NULL || envp == NULL) { free(argv); free(envp); return ENOMEM; }
+  int input[2] = {-1, -1}, stdout_pipe[2] = {-1, -1}, stderr_pipe[2] = {-1, -1};
+  if (pipe(input) || pipe(stdout_pipe) || pipe(stderr_pipe)) goto fail;
+  for (int index = 0; index < 2; index++) {
+    fcntl(input[index], F_SETFD, FD_CLOEXEC);
+    fcntl(stdout_pipe[index], F_SETFD, FD_CLOEXEC);
+    fcntl(stderr_pipe[index], F_SETFD, FD_CLOEXEC);
+  }
+  posix_spawn_file_actions_t actions;
+  posix_spawnattr_t attributes;
+  if (posix_spawn_file_actions_init(&actions) != 0) goto fail;
+  int actions_ready = 1, attributes_ready = 0;
+  if (posix_spawnattr_init(&attributes) != 0) goto spawn_fail;
+  attributes_ready = 1;
+  short flags = POSIX_SPAWN_START_SUSPENDED | POSIX_SPAWN_SETPGROUP |
+    POSIX_SPAWN_CLOEXEC_DEFAULT | POSIX_SPAWN_SETSIGMASK;
+  sigset_t mask;
+  sigemptyset(&mask);
+  if (posix_spawnattr_setflags(&attributes, flags) != 0 ||
+      posix_spawnattr_setpgroup(&attributes, 0) != 0 ||
+      posix_spawnattr_setsigmask(&attributes, &mask) != 0) goto spawn_fail;
+  if (posix_spawn_file_actions_adddup2(&actions, input[0], STDIN_FILENO) != 0 ||
+      posix_spawn_file_actions_adddup2(&actions, stdout_pipe[1], STDOUT_FILENO) != 0 ||
+      posix_spawn_file_actions_adddup2(&actions, stderr_pipe[1], STDERR_FILENO) != 0) goto spawn_fail;
+  for (int index = 0; index < 2; index++) {
+    if (posix_spawn_file_actions_addclose(&actions, input[index]) != 0 ||
+        posix_spawn_file_actions_addclose(&actions, stdout_pipe[index]) != 0 ||
+        posix_spawn_file_actions_addclose(&actions, stderr_pipe[index]) != 0) goto spawn_fail;
+  }
+  pid_t pid = -1;
+  int result = posix_spawn(&pid, command, &actions, &attributes, argv, envp);
+  posix_spawnattr_destroy(&attributes);
+  posix_spawn_file_actions_destroy(&actions);
+  free(argv); free(envp);
+  if (result != 0) goto fail_no_vectors;
+  q12_close(&input[0]); q12_close(&stdout_pipe[1]); q12_close(&stderr_pipe[1]);
+  if (getpgid(pid) != pid) {
+    q12_abort_child(pid);
+    goto fail_no_vectors;
+  }
+  result = q12_validate_child(pid, command, hashes, hash_count, device, inode, links);
+  if (result != 0 || kill(pid, SIGCONT) != 0) {
+    q12_abort_child(pid);
+    goto fail_no_vectors;
+  }
+  output->pid = pid;
+  output->stdin_fd = input[1]; output->stdout_fd = stdout_pipe[0]; output->stderr_fd = stderr_pipe[0];
+  return 0;
+
+spawn_fail:
+  if (attributes_ready) posix_spawnattr_destroy(&attributes);
+  if (actions_ready) posix_spawn_file_actions_destroy(&actions);
+fail:
+  free(argv); free(envp);
+fail_no_vectors:
+  q12_close(&input[0]); q12_close(&input[1]); q12_close(&stdout_pipe[0]); q12_close(&stdout_pipe[1]);
+  q12_close(&stderr_pipe[0]); q12_close(&stderr_pipe[1]);
+  return EACCES;
+}
+*/
+import "C"
+
+import (
+	"os"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+func secureDesktopSpawnSupported() bool { return true }
+
+func startSecureDesktopProcess(spec secureDesktopSpawnSpec) (*secureDesktopProcess, error) {
+	args, argsCount, err := packSecureDesktopStrings(spec.arguments)
+	if err != nil {
+		return nil, err
+	}
+	environment, environmentCount, err := packSecureDesktopStrings(spec.environment)
+	if err != nil {
+		return nil, err
+	}
+	command := C.CString(spec.command)
+	argsRaw := C.CBytes(args)
+	environmentRaw := C.CBytes(environment)
+	hashes := C.CBytes(spec.codeIdentity.bytes())
+	defer C.free(unsafe.Pointer(command))
+	defer C.free(argsRaw)
+	defer C.free(environmentRaw)
+	defer C.free(hashes)
+	var result C.q12_spawn_result
+	status := C.q12_secure_spawn(command, (*C.char)(argsRaw), C.size_t(len(args)), C.int(argsCount),
+		(*C.char)(environmentRaw), C.size_t(len(environment)), C.int(environmentCount),
+		(*C.uint8_t)(hashes), C.int(spec.codeIdentity.count), C.uint64_t(spec.fileIdentity.device),
+		C.uint64_t(spec.fileIdentity.inode), C.uint64_t(spec.fileIdentity.links), &result)
+	if status != 0 {
+		return nil, errDesktopProviderUnavailable
+	}
+	process, err := os.FindProcess(int(result.pid))
+	if err != nil {
+		secureDesktopKillProcessGroup(int(result.pid))
+		return nil, err
+	}
+	return &secureDesktopProcess{pid: int(result.pid), stdin: os.NewFile(uintptr(result.stdin_fd), "stdin"),
+		stdout: os.NewFile(uintptr(result.stdout_fd), "stdout"), stderr: os.NewFile(uintptr(result.stderr_fd), "stderr"),
+		wait: process.Wait}, nil
+}
+
+func secureDesktopKillProcessGroup(pid int) {
+	if pid > 1 {
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+		_ = syscall.Kill(pid, syscall.SIGKILL)
+	}
+}
+
+func secureDesktopReapProcessGroup(pid int) error {
+	if pid <= 1 {
+		return nil
+	}
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for {
+		err := syscall.Kill(-pid, 0)
+		if err == syscall.ESRCH {
+			return nil
+		}
+		if err != nil && err != syscall.EPERM {
+			return err
+		}
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+		if time.Now().After(deadline) {
+			return errDesktopProviderUnavailable
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func packSecureDesktopStrings(values []string) ([]byte, int, error) {
+	packed := make([]byte, 0)
+	for _, value := range values {
+		for index := range value {
+			if value[index] == 0 {
+				return nil, 0, errDesktopProviderUnavailable
+			}
+		}
+		packed = append(packed, value...)
+		packed = append(packed, 0)
+	}
+	return packed, len(values), nil
+}
+
+func (identity desktopCodeIdentity) bytes() []byte {
+	result := make([]byte, 0, int(identity.count)*len(desktopCodeDirectoryDigest{}))
+	for index := uint8(0); index < identity.count; index++ {
+		result = append(result, identity.digests[index][:]...)
+	}
+	return result
+}

--- a/pkg/qa/run/desktop_observe_secure_spawn_darwin_test.go
+++ b/pkg/qa/run/desktop_observe_secure_spawn_darwin_test.go
@@ -1,0 +1,122 @@
+//go:build darwin && cgo
+
+package run
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecureDesktopSpawn_ExecutesOnlyBoundCodeIdentity(t *testing.T) {
+	t.Parallel()
+	target := filepath.Join(t.TempDir(), "candidate")
+	buildSecureSpawnFixture(t, target, secureSpawnFixtureSource)
+	spec := secureSpawnFixtureSpec(t, target, []string{"echo"})
+
+	result, err := runSecureDesktopCommand(context.Background(), spec, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.exitCode)
+	assert.Equal(t, "bound\n", string(result.stdout))
+	assert.Empty(t, result.stderr)
+}
+
+func TestSecureDesktopSpawn_SubstitutedSentinelNeverRuns(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	target := filepath.Join(directory, "candidate")
+	marker := filepath.Join(directory, "sentinel-executed")
+	buildSecureSpawnFixture(t, target, secureSpawnFixtureSource)
+	spec := secureSpawnFixtureSpec(t, target, []string{marker})
+
+	require.NoError(t, os.Remove(target))
+	buildSecureSpawnFixture(t, target, secureSpawnSentinelSource)
+	_, err := runSecureDesktopCommand(context.Background(), spec, nil)
+	assert.ErrorIs(t, err, errDesktopProviderUnavailable)
+	assert.NoFileExists(t, marker)
+}
+
+func TestSecureDesktopSpawn_HardlinkedExecutableFailsIdentityAdmission(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	target := filepath.Join(directory, "candidate")
+	buildSecureSpawnFixture(t, target, secureSpawnFixtureSource)
+	require.NoError(t, os.Link(target, filepath.Join(directory, "candidate-alias")))
+	info, _, _, err := snapshotDesktopExecutable(context.Background(), target, -1)
+	require.NoError(t, err)
+	_, err = desktopExecutableFileIdentity(info)
+	assert.ErrorIs(t, err, errDesktopProviderUnavailable)
+}
+
+func TestSecureDesktopSpawn_PreservesStderrExitAndTimeoutCleanup(t *testing.T) {
+	t.Parallel()
+	shell := filepath.Join(t.TempDir(), "helper")
+	buildSecureSpawnFixture(t, shell, secureSpawnFixtureSource)
+	spec := secureSpawnFixtureSpec(t, shell, []string{"stderr"})
+	result, err := runSecureDesktopCommand(context.Background(), spec, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 7, result.exitCode)
+	assert.Equal(t, "bounded-error", string(result.stderr))
+
+	hanging := secureSpawnFixtureSpec(t, shell, []string{"hang"})
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	_, err = runSecureDesktopCommand(ctx, hanging, nil)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, time.Since(started), 2*time.Second)
+}
+
+func TestSecureDesktopSpawn_RejectsBoundedOutputOverflow(t *testing.T) {
+	t.Parallel()
+	shell := filepath.Join(t.TempDir(), "helper")
+	buildSecureSpawnFixture(t, shell, secureSpawnFixtureSource)
+	spec := secureSpawnFixtureSpec(t, shell, []string{"overflow"})
+	_, err := runSecureDesktopCommand(context.Background(), spec, nil)
+	assert.Error(t, err)
+}
+
+func secureSpawnFixtureSpec(t *testing.T, command string, arguments []string) secureDesktopSpawnSpec {
+	t.Helper()
+	info, _, codeIdentity, err := snapshotDesktopExecutable(context.Background(), command, -1)
+	require.NoError(t, err)
+	fileIdentity, err := desktopExecutableFileIdentity(info)
+	require.NoError(t, err)
+	return secureDesktopSpawnSpec{command: command, arguments: arguments,
+		environment: os.Environ(), codeIdentity: codeIdentity, fileIdentity: fileIdentity}
+}
+
+func buildSecureSpawnFixture(t *testing.T, target, source string) {
+	t.Helper()
+	sourcePath := filepath.Join(filepath.Dir(target), filepath.Base(target)+".go")
+	require.NoError(t, os.WriteFile(sourcePath, []byte(source), 0o600))
+	command := exec.Command("go", "build", "-o", target, sourcePath)
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, string(output))
+}
+
+const secureSpawnFixtureSource = `package main
+import ("bytes"; "os"; "os/exec"; "time")
+func main() {
+  if len(os.Args) != 2 { os.Exit(64) }
+  switch os.Args[1] {
+  case "echo": os.Stdout.Write([]byte("bound\n"))
+  case "stderr": os.Stderr.Write([]byte("bounded-error")); os.Exit(7)
+  case "overflow": os.Stdout.Write(bytes.Repeat([]byte("x"), 70000))
+  case "hang": command := exec.Command(os.Args[0], "child"); _ = command.Run()
+  case "child": time.Sleep(10 * time.Second)
+  default: os.Exit(65)
+  }
+}
+`
+
+const secureSpawnSentinelSource = `package main
+import "os"
+func main() { if len(os.Args) == 2 { _ = os.WriteFile(os.Args[1], []byte("executed"), 0600) } }
+`

--- a/pkg/qa/run/desktop_observe_secure_spawn_identity.go
+++ b/pkg/qa/run/desktop_observe_secure_spawn_identity.go
@@ -1,0 +1,159 @@
+package run
+
+import (
+	"crypto/sha1" // #nosec G505 -- CodeDirectory may advertise legacy SHA-1; it is only an identity comparator.
+	"crypto/sha256"
+	"crypto/sha512"
+	"debug/macho"
+	"encoding/binary"
+	"errors"
+	"io"
+	"runtime"
+)
+
+const (
+	desktopCodeSignatureCommand = uint32(0x1d)
+	desktopEmbeddedSignature    = uint32(0xfade0cc0)
+	desktopCodeDirectory        = uint32(0xfade0c02)
+	maxDesktopCodeDirectories   = 7
+	maxDesktopSignatureEntries  = uint32(64)
+	maxDesktopSignatureBytes    = uint32(16 << 20)
+)
+
+type desktopCodeDirectoryDigest [sha1.Size]byte
+
+type desktopCodeIdentity struct {
+	digests [maxDesktopCodeDirectories]desktopCodeDirectoryDigest
+	count   uint8
+}
+
+func readDesktopCodeIdentity(reader io.ReaderAt, size int64) (desktopCodeIdentity, error) {
+	if reader == nil || size <= 0 || size > maxDesktopProviderExecutableBytes {
+		return desktopCodeIdentity{}, errDesktopProviderUnavailable
+	}
+	file, base, err := currentDesktopMachO(reader)
+	if err != nil {
+		return desktopCodeIdentity{}, errDesktopProviderUnavailable
+	}
+	defer file.Close()
+	offset, length, err := desktopCodeSignatureRange(file)
+	if err != nil || length == 0 || length > maxDesktopSignatureBytes ||
+		base > uint64(size) || uint64(offset) > uint64(size)-base ||
+		uint64(length) > uint64(size)-base-uint64(offset) {
+		return desktopCodeIdentity{}, errDesktopProviderUnavailable
+	}
+	blob := make([]byte, length)
+	if _, err := reader.ReadAt(blob, int64(base)+int64(offset)); err != nil {
+		return desktopCodeIdentity{}, errDesktopProviderUnavailable
+	}
+	return parseDesktopEmbeddedSignature(blob)
+}
+
+func currentDesktopMachO(reader io.ReaderAt) (*macho.File, uint64, error) {
+	fat, err := macho.NewFatFile(reader)
+	if err == nil {
+		for index := range fat.Arches {
+			arch := &fat.Arches[index]
+			if arch.Cpu == currentDesktopCPU() {
+				return arch.File, uint64(arch.Offset), nil
+			}
+		}
+		_ = fat.Close()
+		return nil, 0, errDesktopProviderUnavailable
+	}
+	if !errors.Is(err, macho.ErrNotFat) {
+		return nil, 0, err
+	}
+	file, err := macho.NewFile(reader)
+	return file, 0, err
+}
+
+func currentDesktopCPU() macho.Cpu {
+	switch runtime.GOARCH {
+	case "amd64":
+		return macho.CpuAmd64
+	case "arm64":
+		return macho.CpuArm64
+	default:
+		return 0
+	}
+}
+
+func desktopCodeSignatureRange(file *macho.File) (uint32, uint32, error) {
+	for _, load := range file.Loads {
+		raw := load.Raw()
+		if len(raw) >= 16 && file.ByteOrder.Uint32(raw[:4]) == desktopCodeSignatureCommand {
+			return file.ByteOrder.Uint32(raw[8:12]), file.ByteOrder.Uint32(raw[12:16]), nil
+		}
+	}
+	return 0, 0, errDesktopProviderUnavailable
+}
+
+func parseDesktopEmbeddedSignature(blob []byte) (desktopCodeIdentity, error) {
+	if len(blob) < 12 || binary.BigEndian.Uint32(blob[:4]) != desktopEmbeddedSignature {
+		return desktopCodeIdentity{}, errDesktopProviderUnavailable
+	}
+	length := binary.BigEndian.Uint32(blob[4:8])
+	count := binary.BigEndian.Uint32(blob[8:12])
+	if length > uint32(len(blob)) || count > maxDesktopSignatureEntries || 12+count*8 > length {
+		return desktopCodeIdentity{}, errDesktopProviderUnavailable
+	}
+	var identity desktopCodeIdentity
+	for index := uint32(0); index < count; index++ {
+		entry := 12 + index*8
+		slot := binary.BigEndian.Uint32(blob[entry : entry+4])
+		if slot != 0 && (slot < 0x1000 || slot > 0x1005) {
+			continue
+		}
+		offset := binary.BigEndian.Uint32(blob[entry+4 : entry+8])
+		if offset > length-8 || binary.BigEndian.Uint32(blob[offset:offset+4]) != desktopCodeDirectory {
+			return desktopCodeIdentity{}, errDesktopProviderUnavailable
+		}
+		directoryLength := binary.BigEndian.Uint32(blob[offset+4 : offset+8])
+		if directoryLength < 44 || directoryLength > length-offset {
+			return desktopCodeIdentity{}, errDesktopProviderUnavailable
+		}
+		digest, ok := digestDesktopCodeDirectory(blob[offset : offset+directoryLength])
+		if !ok {
+			continue
+		}
+		if !identity.contains(digest) {
+			if identity.count >= maxDesktopCodeDirectories {
+				return desktopCodeIdentity{}, errDesktopProviderUnavailable
+			}
+			identity.digests[identity.count] = digest
+			identity.count++
+		}
+	}
+	if identity.count == 0 {
+		return desktopCodeIdentity{}, errDesktopProviderUnavailable
+	}
+	return identity, nil
+}
+
+func digestDesktopCodeDirectory(directory []byte) (desktopCodeDirectoryDigest, bool) {
+	var digest desktopCodeDirectoryDigest
+	switch directory[37] {
+	case 1:
+		value := sha1.Sum(directory) // #nosec G401 -- compared with Apple's signed CodeDirectory identity only.
+		copy(digest[:], value[:])
+	case 2, 3:
+		value := sha256.Sum256(directory)
+		copy(digest[:], value[:sha1.Size])
+	case 4:
+		value := sha512.Sum384(directory)
+		copy(digest[:], value[:sha1.Size])
+	default:
+		return desktopCodeDirectoryDigest{}, false
+	}
+	return digest, true
+}
+
+func (identity desktopCodeIdentity) contains(candidate desktopCodeDirectoryDigest) bool {
+	for index := uint8(0); index < identity.count; index++ {
+		if identity.digests[index] == candidate {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/qa/run/desktop_observe_secure_spawn_identity.go
+++ b/pkg/qa/run/desktop_observe_secure_spawn_identity.go
@@ -27,7 +27,10 @@ type desktopCodeIdentity struct {
 	count   uint8
 }
 
-func readDesktopCodeIdentity(reader io.ReaderAt, size int64) (desktopCodeIdentity, error) {
+func readDesktopCodeIdentity(
+	reader io.ReaderAt,
+	size int64,
+) (identity desktopCodeIdentity, resultErr error) {
 	if reader == nil || size <= 0 || size > maxDesktopProviderExecutableBytes {
 		return desktopCodeIdentity{}, errDesktopProviderUnavailable
 	}
@@ -35,7 +38,12 @@ func readDesktopCodeIdentity(reader io.ReaderAt, size int64) (desktopCodeIdentit
 	if err != nil {
 		return desktopCodeIdentity{}, errDesktopProviderUnavailable
 	}
-	defer file.Close()
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			identity = desktopCodeIdentity{}
+			resultErr = errDesktopProviderUnavailable
+		}
+	}()
 	offset, length, err := desktopCodeSignatureRange(file)
 	if err != nil || length == 0 || length > maxDesktopSignatureBytes ||
 		base > uint64(size) || uint64(offset) > uint64(size)-base ||

--- a/pkg/qa/run/desktop_observe_secure_spawn_identity_darwin.go
+++ b/pkg/qa/run/desktop_observe_secure_spawn_identity_darwin.go
@@ -7,6 +7,12 @@ import (
 	"syscall"
 )
 
+type desktopFileIdentity struct {
+	device uint64
+	inode  uint64
+	links  uint64
+}
+
 func desktopExecutableFileIdentity(info os.FileInfo) (desktopFileIdentity, error) {
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	if !ok || stat.Nlink != 1 {

--- a/pkg/qa/run/desktop_observe_secure_spawn_identity_darwin.go
+++ b/pkg/qa/run/desktop_observe_secure_spawn_identity_darwin.go
@@ -1,0 +1,20 @@
+//go:build darwin
+
+package run
+
+import (
+	"os"
+	"syscall"
+)
+
+func desktopExecutableFileIdentity(info os.FileInfo) (desktopFileIdentity, error) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || stat.Nlink != 1 {
+		return desktopFileIdentity{}, errDesktopProviderUnavailable
+	}
+	return desktopFileIdentity{
+		device: uint64(stat.Dev),
+		inode:  stat.Ino,
+		links:  uint64(stat.Nlink),
+	}, nil
+}

--- a/pkg/qa/run/desktop_observe_secure_spawn_identity_test.go
+++ b/pkg/qa/run/desktop_observe_secure_spawn_identity_test.go
@@ -1,0 +1,120 @@
+package run
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDesktopCodeIdentity_UsesExactEmbeddedCodeDirectoryBytes(t *testing.T) {
+	t.Parallel()
+	directory := make([]byte, 44)
+	binary.BigEndian.PutUint32(directory[0:4], desktopCodeDirectory)
+	binary.BigEndian.PutUint32(directory[4:8], uint32(len(directory)))
+	directory[37] = 2
+	blob := embeddedSignatureFixture(t, directory)
+
+	identity, err := parseDesktopEmbeddedSignature(blob)
+	require.NoError(t, err)
+	require.Equal(t, uint8(1), identity.count)
+	expected := sha256.Sum256(directory)
+	assert.Equal(t, expected[:20], identity.digests[0][:])
+
+	directory[43] = 1
+	changed, err := parseDesktopEmbeddedSignature(embeddedSignatureFixture(t, directory))
+	require.NoError(t, err)
+	assert.NotEqual(t, identity, changed)
+}
+
+func TestDesktopCodeIdentity_RejectsMalformedOrUnsupportedSignatures(t *testing.T) {
+	t.Parallel()
+	for name, blob := range map[string][]byte{
+		"empty":       nil,
+		"wrong magic": make([]byte, 20),
+		"truncated":   {0xfa, 0xde, 0x0c, 0xc0, 0, 0, 0, 20, 0, 0, 0, 1},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := parseDesktopEmbeddedSignature(blob)
+			assert.ErrorIs(t, err, errDesktopProviderUnavailable)
+		})
+	}
+	directory := make([]byte, 44)
+	binary.BigEndian.PutUint32(directory[0:4], desktopCodeDirectory)
+	binary.BigEndian.PutUint32(directory[4:8], uint32(len(directory)))
+	directory[37] = 99
+	_, err := parseDesktopEmbeddedSignature(embeddedSignatureFixture(t, directory))
+	assert.ErrorIs(t, err, errDesktopProviderUnavailable)
+}
+
+func TestDesktopCodeIdentity_BoundsCodeDirectoriesNotUnrelatedSignatureSlots(t *testing.T) {
+	t.Parallel()
+	directory := make([]byte, 44)
+	binary.BigEndian.PutUint32(directory[0:4], desktopCodeDirectory)
+	binary.BigEndian.PutUint32(directory[4:8], uint32(len(directory)))
+	directory[37] = 2
+	const count = 8
+	const directoryOffset = 12 + count*8
+	blob := make([]byte, directoryOffset+len(directory))
+	binary.BigEndian.PutUint32(blob[0:4], desktopEmbeddedSignature)
+	binary.BigEndian.PutUint32(blob[4:8], uint32(len(blob)))
+	binary.BigEndian.PutUint32(blob[8:12], count)
+	binary.BigEndian.PutUint32(blob[12:16], 0)
+	binary.BigEndian.PutUint32(blob[16:20], directoryOffset)
+	for index := 1; index < count; index++ {
+		binary.BigEndian.PutUint32(blob[12+index*8:16+index*8], uint32(index))
+	}
+	copy(blob[directoryOffset:], directory)
+
+	identity, err := parseDesktopEmbeddedSignature(blob)
+	require.NoError(t, err)
+	assert.Equal(t, uint8(1), identity.count)
+}
+
+func TestDesktopCodeIdentity_ConfiguredSignedArtifactMatchesCodesignStructure(t *testing.T) {
+	artifact := os.Getenv(desktopSignedArtifactEnvironment)
+	if artifact == "" {
+		t.Skip("release-signed artifact is not configured")
+	}
+	executable := filepath.Join(artifact, "Contents", "MacOS", desktopProviderExecutableName)
+	info, _, identity, err := snapshotDesktopExecutable(context.Background(), executable, -1)
+	require.NoError(t, err)
+	assert.Positive(t, info.Size())
+	assert.NotZero(t, identity.count)
+}
+
+func TestSecureDesktopSpawn_ConfiguredSignedArtifactRunsBoundImage(t *testing.T) {
+	artifact := os.Getenv(desktopSignedArtifactEnvironment)
+	if artifact == "" || !secureDesktopSpawnSupported() {
+		t.Skip("secure Darwin spawn and release-signed artifact are required")
+	}
+	resolver := &processDesktopProviderResolver{artifactPath: artifact}
+	client, err := resolver.ResolveLocal(context.Background())
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	identity, err := client.Handshake(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "autopus-desktop-local", identity.Name)
+	assert.Equal(t, 1, identity.ProtocolVersion)
+}
+
+func embeddedSignatureFixture(t *testing.T, directory []byte) []byte {
+	t.Helper()
+	const directoryOffset = 20
+	blob := bytes.Repeat([]byte{0}, directoryOffset+len(directory))
+	binary.BigEndian.PutUint32(blob[0:4], desktopEmbeddedSignature)
+	binary.BigEndian.PutUint32(blob[4:8], uint32(len(blob)))
+	binary.BigEndian.PutUint32(blob[8:12], 1)
+	binary.BigEndian.PutUint32(blob[12:16], 0)
+	binary.BigEndian.PutUint32(blob[16:20], directoryOffset)
+	copy(blob[directoryOffset:], directory)
+	return blob
+}

--- a/pkg/qa/run/desktop_observe_secure_spawn_identity_unsupported.go
+++ b/pkg/qa/run/desktop_observe_secure_spawn_identity_unsupported.go
@@ -1,0 +1,9 @@
+//go:build !darwin
+
+package run
+
+import "os"
+
+func desktopExecutableFileIdentity(os.FileInfo) (desktopFileIdentity, error) {
+	return desktopFileIdentity{}, errDesktopProviderUnavailable
+}

--- a/pkg/qa/run/desktop_observe_secure_spawn_identity_unsupported.go
+++ b/pkg/qa/run/desktop_observe_secure_spawn_identity_unsupported.go
@@ -4,6 +4,8 @@ package run
 
 import "os"
 
+type desktopFileIdentity struct{}
+
 func desktopExecutableFileIdentity(os.FileInfo) (desktopFileIdentity, error) {
 	return desktopFileIdentity{}, errDesktopProviderUnavailable
 }

--- a/pkg/qa/run/desktop_observe_secure_spawn_limits.go
+++ b/pkg/qa/run/desktop_observe_secure_spawn_limits.go
@@ -1,0 +1,11 @@
+package run
+
+import "github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+
+func desktopObservationEnvelopeLimit() int {
+	return desktopobserve.MaxEnvelopeBytes
+}
+
+func desktopobserveEnvelopeTooLarge() error {
+	return desktopobserve.ErrEnvelopeTooLarge
+}

--- a/pkg/qa/run/desktop_observe_secure_spawn_unsupported.go
+++ b/pkg/qa/run/desktop_observe_secure_spawn_unsupported.go
@@ -1,0 +1,13 @@
+//go:build !darwin || !cgo
+
+package run
+
+func secureDesktopSpawnSupported() bool { return false }
+
+func startSecureDesktopProcess(secureDesktopSpawnSpec) (*secureDesktopProcess, error) {
+	return nil, errDesktopProviderUnavailable
+}
+
+func secureDesktopKillProcessGroup(int) {}
+
+func secureDesktopReapProcessGroup(int) error { return errDesktopProviderUnavailable }

--- a/pkg/qa/run/desktop_observe_secure_spawn_unsupported_test.go
+++ b/pkg/qa/run/desktop_observe_secure_spawn_unsupported_test.go
@@ -1,0 +1,17 @@
+//go:build !darwin || !cgo
+
+package run
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSecureDesktopSpawn_UnsupportedBuildFailsClosed(t *testing.T) {
+	t.Parallel()
+	assert.False(t, secureDesktopSpawnSupported())
+	_, err := startSecureDesktopProcess(secureDesktopSpawnSpec{})
+	assert.ErrorIs(t, err, errDesktopProviderUnavailable)
+	assert.ErrorIs(t, secureDesktopReapProcessGroup(123), errDesktopProviderUnavailable)
+}

--- a/pkg/qa/run/desktop_observe_signature.go
+++ b/pkg/qa/run/desktop_observe_signature.go
@@ -1,0 +1,185 @@
+package run
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+const (
+	desktopReleaseBundleIdentifier = "co.autopus.desktop"
+	desktopReleaseTeamIdentifier   = "GP2PFA2PUV"
+	desktopCodesignOutputLimit     = 65_536
+)
+
+var desktopCodeDirectoryRuntime = regexp.MustCompile(
+	`flags=0x[0-9a-f]+\([^)]*\bruntime\b[^)]*\)`,
+)
+
+type desktopArtifactVerifier func(context.Context, string) error
+
+type desktopCodesignRunner func(context.Context, ...string) (string, error)
+
+func verifyDesktopReleaseArtifact(ctx context.Context, artifactPath string) error {
+	return verifyDesktopReleaseArtifactIdentity(
+		ctx, artifactPath, desktopReleaseBundleIdentifier, desktopReleaseTeamIdentifier,
+	)
+}
+
+func verifyDesktopReleaseArtifactIdentity(
+	ctx context.Context,
+	artifactPath string,
+	bundleIdentifier string,
+	teamIdentifier string,
+) error {
+	return verifyDesktopReleaseArtifactIdentityWithRunner(
+		ctx, artifactPath, bundleIdentifier, teamIdentifier, runDesktopCodesign,
+	)
+}
+
+func verifyDesktopReleaseArtifactIdentityWithRunner(
+	ctx context.Context,
+	artifactPath string,
+	bundleIdentifier string,
+	teamIdentifier string,
+	runner desktopCodesignRunner,
+) error {
+	requirement := desktopReleaseCodeRequirement(bundleIdentifier, teamIdentifier)
+	if _, err := runner(ctx,
+		"--verify", "--deep", "--strict", "--all-architectures",
+		"-R="+requirement, artifactPath,
+	); err != nil {
+		return fmt.Errorf("verify desktop release signature: %w", err)
+	}
+	metadata, err := runner(ctx,
+		"--display", "--verbose=4", "--all-architectures", artifactPath,
+	)
+	if err != nil {
+		return fmt.Errorf("inspect desktop release signature: %w", err)
+	}
+	if err := verifyDesktopCodesignMetadata(metadata, bundleIdentifier, teamIdentifier); err != nil {
+		return fmt.Errorf("verify desktop release metadata: %w", err)
+	}
+	return nil
+}
+
+func desktopReleaseCodeRequirement(bundleIdentifier string, teamIdentifier string) string {
+	return `anchor apple generic and identifier "` + bundleIdentifier +
+		`" and certificate leaf[subject.OU] = "` + teamIdentifier +
+		`" and certificate 1[field.1.2.840.113635.100.6.2.6] exists` +
+		` and certificate leaf[field.1.2.840.113635.100.6.1.13] exists`
+}
+
+func runDesktopCodesign(ctx context.Context, arguments ...string) (string, error) {
+	command := exec.CommandContext(ctx, "/usr/bin/codesign", arguments...)
+	output := &desktopBoundedBuffer{limit: desktopCodesignOutputLimit}
+	command.Stdout = output
+	command.Stderr = output
+	if err := command.Run(); err != nil {
+		return "", err
+	}
+	if output.overflow {
+		return "", errors.New("codesign output exceeds bound")
+	}
+	return output.String(), nil
+}
+
+type desktopBoundedBuffer struct {
+	bytes.Buffer
+	limit    int
+	overflow bool
+}
+
+func (buffer *desktopBoundedBuffer) Write(data []byte) (int, error) {
+	written := len(data)
+	remaining := buffer.limit - buffer.Len()
+	if remaining <= 0 {
+		buffer.overflow = true
+		return written, nil
+	}
+	if len(data) > remaining {
+		buffer.overflow = true
+		data = data[:remaining]
+	}
+	_, _ = buffer.Buffer.Write(data)
+	return written, nil
+}
+
+func verifyDesktopCodesignMetadata(metadata string, bundleIdentifier string, teamIdentifier string) error {
+	if len(metadata) == 0 || len(metadata) > desktopCodesignOutputLimit || strings.ContainsRune(metadata, '\x00') {
+		return errors.New("invalid codesign metadata")
+	}
+	lines := strings.Split(strings.ReplaceAll(metadata, "\r\n", "\n"), "\n")
+	identifiers := desktopMetadataValues(lines, "Identifier=")
+	teams := desktopMetadataValues(lines, "TeamIdentifier=")
+	authorities := desktopMetadataValues(lines, "Authority=")
+	codeDirectories := desktopMetadataLines(lines, "CodeDirectory ")
+	if !desktopAllExact(identifiers, bundleIdentifier) || !desktopAllExact(teams, teamIdentifier) {
+		return errors.New("codesign identifier or team mismatch")
+	}
+	for _, line := range codeDirectories {
+		if !desktopCodeDirectoryRuntime.MatchString(line) {
+			return errors.New("hardened runtime is required")
+		}
+	}
+	if len(codeDirectories) == 0 || !desktopAuthorityChainValid(authorities, teamIdentifier) {
+		return errors.New("Developer ID authority metadata mismatch")
+	}
+	return nil
+}
+
+func desktopMetadataValues(lines []string, prefix string) []string {
+	values := make([]string, 0)
+	for _, line := range lines {
+		if strings.HasPrefix(line, prefix) {
+			values = append(values, strings.TrimPrefix(line, prefix))
+		}
+	}
+	return values
+}
+
+func desktopMetadataLines(lines []string, prefix string) []string {
+	values := make([]string, 0)
+	for _, line := range lines {
+		if strings.HasPrefix(line, prefix) {
+			values = append(values, line)
+		}
+	}
+	return values
+}
+
+func desktopAllExact(values []string, expected string) bool {
+	if len(values) == 0 {
+		return false
+	}
+	for _, value := range values {
+		if value != expected {
+			return false
+		}
+	}
+	return true
+}
+
+func desktopAuthorityChainValid(authorities []string, teamIdentifier string) bool {
+	leafCount := 0
+	intermediate := false
+	root := false
+	for _, authority := range authorities {
+		switch {
+		case strings.HasPrefix(authority, "Developer ID Application:"):
+			if !strings.HasSuffix(authority, "("+teamIdentifier+")") {
+				return false
+			}
+			leafCount++
+		case authority == "Developer ID Certification Authority":
+			intermediate = true
+		case authority == "Apple Root CA":
+			root = true
+		}
+	}
+	return leafCount > 0 && intermediate && root
+}

--- a/pkg/qa/run/desktop_observe_signature_test.go
+++ b/pkg/qa/run/desktop_observe_signature_test.go
@@ -1,0 +1,243 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDesktopReleaseIdentity_RequiresPinnedDeveloperIDChainRuntimeAndArchitectures(t *testing.T) {
+	t.Parallel()
+	calls := make([][]string, 0, 2)
+	runner := func(_ context.Context, arguments ...string) (string, error) {
+		calls = append(calls, append([]string(nil), arguments...))
+		if arguments[0] == "--verify" {
+			return "", nil
+		}
+		return desktopCodesignFixtureMetadata(), nil
+	}
+	require.NoError(t, verifyDesktopReleaseArtifactIdentityWithRunner(
+		context.Background(), "/release/Autopus Desktop.app",
+		desktopReleaseBundleIdentifier, desktopReleaseTeamIdentifier, runner,
+	))
+	require.Len(t, calls, 2)
+	assert.Equal(t, []string{"--verify", "--deep", "--strict", "--all-architectures"},
+		calls[0][:4])
+	require.Len(t, calls[0], 6)
+	requirement := strings.TrimPrefix(calls[0][4], "-R=")
+	assert.Contains(t, requirement, "anchor apple generic")
+	assert.Contains(t, requirement, `identifier "co.autopus.desktop"`)
+	assert.Contains(t, requirement, `certificate leaf[subject.OU] = "GP2PFA2PUV"`)
+	assert.Contains(t, requirement, "1.2.840.113635.100.6.2.6")
+	assert.Contains(t, requirement, "1.2.840.113635.100.6.1.13")
+	assert.Equal(t, []string{"--display", "--verbose=4", "--all-architectures",
+		"/release/Autopus Desktop.app"}, calls[1])
+}
+
+func TestDesktopReleaseIdentity_RejectsWeakMetadataAfterCodesignRunnerSuccess(t *testing.T) {
+	t.Parallel()
+	variants := map[string]string{
+		"self-signed-style": strings.ReplaceAll(desktopCodesignFixtureMetadata(),
+			"Developer ID Application: Autopus, Inc. (GP2PFA2PUV)",
+			"Self Signed Developer: Attacker (GP2PFA2PUV)"),
+		"wrong-intermediate": strings.ReplaceAll(desktopCodesignFixtureMetadata(),
+			"Developer ID Certification Authority", "Attacker Certification Authority"),
+		"no-runtime": strings.ReplaceAll(desktopCodesignFixtureMetadata(),
+			"0x10000(runtime)", "0x0(none)"),
+		"wrong-identifier": strings.ReplaceAll(desktopCodesignFixtureMetadata(),
+			"co.autopus.desktop", "co.attacker.desktop"),
+		"wrong-team": strings.ReplaceAll(desktopCodesignFixtureMetadata(),
+			"GP2PFA2PUV", "EVILTEAM00"),
+	}
+	for name, metadata := range variants {
+		metadata := metadata
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			runner := func(_ context.Context, arguments ...string) (string, error) {
+				if arguments[0] == "--verify" {
+					return "", nil
+				}
+				return metadata, nil
+			}
+			assert.Error(t, verifyDesktopReleaseArtifactIdentityWithRunner(
+				context.Background(), "/release/Autopus Desktop.app",
+				desktopReleaseBundleIdentifier, desktopReleaseTeamIdentifier, runner,
+			))
+		})
+	}
+}
+
+func TestDesktopReleaseIdentity_RejectsCodesignFailureOrOversizedMetadata(t *testing.T) {
+	t.Parallel()
+	for _, failurePhase := range []string{"verify", "display"} {
+		failurePhase := failurePhase
+		t.Run(failurePhase, func(t *testing.T) {
+			t.Parallel()
+			failing := func(_ context.Context, arguments ...string) (string, error) {
+				if arguments[0] == "--verify" && failurePhase == "display" {
+					return "", nil
+				}
+				return "", errors.New("codesign rejected artifact")
+			}
+			assert.Error(t, verifyDesktopReleaseArtifactIdentityWithRunner(
+				context.Background(), "/release/Autopus Desktop.app",
+				desktopReleaseBundleIdentifier, desktopReleaseTeamIdentifier, failing,
+			))
+		})
+	}
+	oversized := func(_ context.Context, arguments ...string) (string, error) {
+		if arguments[0] == "--verify" {
+			return "", nil
+		}
+		return strings.Repeat("x", desktopCodesignOutputLimit+1), nil
+	}
+	assert.Error(t, verifyDesktopReleaseArtifactIdentityWithRunner(
+		context.Background(), "/release/Autopus Desktop.app",
+		desktopReleaseBundleIdentifier, desktopReleaseTeamIdentifier, oversized,
+	))
+}
+
+func TestDesktopCodesignOutput_WithOverflow_TruncatesAndFailsClosed(t *testing.T) {
+	t.Parallel()
+	buffer := &desktopBoundedBuffer{limit: 4}
+	written, err := buffer.Write([]byte("abcdef"))
+	require.NoError(t, err)
+	assert.Equal(t, 6, written)
+	assert.Equal(t, "abcd", buffer.String())
+	assert.True(t, buffer.overflow)
+	written, err = buffer.Write([]byte("next"))
+	require.NoError(t, err)
+	assert.Equal(t, 4, written)
+	assert.Equal(t, "abcd", buffer.String())
+}
+
+func TestDesktopReleaseIdentity_RejectsUnsignedBundleBeforeProviderExecution(t *testing.T) {
+	t.Parallel()
+	artifactPath, callsPath := writeControlledDesktopProvider(t, t.TempDir())
+	resolver := &processDesktopProviderResolver{artifactPath: artifactPath}
+	client, err := resolver.ResolveLocal(context.Background())
+	assert.ErrorIs(t, err, errDesktopProviderUnavailable)
+	assert.Nil(t, client)
+	assert.NoFileExists(t, callsPath)
+}
+
+func TestDesktopReleaseIdentity_RejectsSymlinkedBundleAndExecutable(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	realBundle, _ := writeControlledDesktopProvider(t, filepath.Join(root, "real"))
+	symlinkBundle := filepath.Join(root, "Linked.app")
+	require.NoError(t, os.Symlink(realBundle, symlinkBundle))
+	_, err := desktopLocalProviderExecutable(symlinkBundle)
+	assert.ErrorIs(t, err, errDesktopProviderUnavailable)
+
+	linkedExecutableBundle := filepath.Join(root, "Executable Link.app")
+	executableDir := filepath.Join(linkedExecutableBundle, "Contents", "MacOS")
+	require.NoError(t, os.MkdirAll(executableDir, 0o755))
+	require.NoError(t, os.Symlink(
+		filepath.Join(realBundle, "Contents", "MacOS", desktopProviderExecutableName),
+		filepath.Join(executableDir, desktopProviderExecutableName),
+	))
+	_, err = desktopLocalProviderExecutable(linkedExecutableBundle)
+	assert.ErrorIs(t, err, errDesktopProviderUnavailable)
+}
+
+func TestDesktopReleaseIdentity_VerificationUsesOperationContext(t *testing.T) {
+	t.Parallel()
+	artifactPath, _ := writeControlledDesktopProvider(t, t.TempDir())
+	resolver := &processDesktopProviderResolver{
+		artifactPath: artifactPath,
+		verifier: func(ctx context.Context, _ string) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	client, err := resolver.ResolveLocal(ctx)
+	assert.ErrorIs(t, err, errDesktopProviderUnavailable)
+	assert.Nil(t, client)
+}
+
+func TestDesktopReleaseIdentity_RejectsPostResolutionExecutableSwapBeforeExecution(t *testing.T) {
+	if !secureDesktopSpawnSupported() {
+		t.Skip("post-resolution execution identity requires secure Darwin cgo spawn")
+	}
+	t.Parallel()
+	for _, replacement := range []string{"regular", "symlink", "in_place", "large"} {
+		t.Run(replacement, func(t *testing.T) {
+			artifactPath, _ := writeControlledDesktopProvider(t, t.TempDir())
+			verificationCalls := 0
+			resolver := &processDesktopProviderResolver{
+				artifactPath: artifactPath,
+				verifier: func(context.Context, string) error {
+					verificationCalls++
+					return nil
+				},
+			}
+			client, err := resolver.ResolveLocal(context.Background())
+			require.NoError(t, err)
+			executable := filepath.Join(artifactPath, "Contents", "MacOS", desktopProviderExecutableName)
+			verifiedCopy := executable + ".verified"
+			sentinel := filepath.Join(t.TempDir(), "executed")
+			script := fmt.Sprintf("#!/bin/sh\nprintf x > '%s'\nexit 0\n", sentinel)
+			if replacement == "in_place" {
+				require.NoError(t, os.WriteFile(executable, []byte(script), 0o700))
+			} else {
+				require.NoError(t, os.Rename(executable, verifiedCopy))
+			}
+			if replacement == "symlink" {
+				require.NoError(t, os.Symlink(verifiedCopy, executable))
+			} else if replacement == "regular" || replacement == "large" {
+				require.NoError(t, os.WriteFile(executable, []byte(script), 0o700))
+				if replacement == "large" {
+					require.NoError(t, os.Truncate(executable, maxDesktopProviderExecutableBytes+1))
+				}
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+			defer cancel()
+			started := time.Now()
+			_, err = client.Handshake(ctx)
+			assert.Error(t, err)
+			assert.Less(t, time.Since(started), 500*time.Millisecond)
+			assert.NoFileExists(t, sentinel)
+			assert.Equal(t, 1, verificationCalls)
+		})
+	}
+}
+
+func TestDesktopReleaseIdentity_ConfiguredSignedArtifact(t *testing.T) {
+	artifactPath := os.Getenv(desktopSignedArtifactEnvironment)
+	if artifactPath == "" {
+		t.Skip("release-signed artifact is not configured")
+	}
+	require.NoError(t, verifyDesktopReleaseArtifact(context.Background(), artifactPath))
+	assert.Error(t, verifyDesktopReleaseArtifactIdentity(
+		context.Background(), artifactPath, "co.autopus.wrong", desktopReleaseTeamIdentifier,
+	))
+	assert.Error(t, verifyDesktopReleaseArtifactIdentity(
+		context.Background(), artifactPath, desktopReleaseBundleIdentifier, "WRONGTEAM00",
+	))
+	_, err := desktopLocalProviderExecutable(artifactPath)
+	require.NoError(t, err)
+}
+
+func desktopCodesignFixtureMetadata() string {
+	return strings.Join([]string{
+		"Executable=/release/Autopus Desktop.app/Contents/MacOS/autopus-desktop",
+		"Identifier=co.autopus.desktop",
+		"CodeDirectory v=20500 size=2048 flags=0x10000(runtime) hashes=32+7 location=embedded",
+		"Authority=Developer ID Application: Autopus, Inc. (GP2PFA2PUV)",
+		"Authority=Developer ID Certification Authority",
+		"Authority=Apple Root CA",
+		"TeamIdentifier=GP2PFA2PUV",
+		"Runtime Version=14.0.0",
+	}, "\n")
+}

--- a/pkg/qa/run/desktop_observe_test_helpers_test.go
+++ b/pkg/qa/run/desktop_observe_test_helpers_test.go
@@ -1,0 +1,173 @@
+package run
+
+import (
+	"context"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+	"github.com/insajin/autopus-adk/pkg/qa/journey"
+)
+
+type fakeDesktopClient struct {
+	provider             desktopobserve.RuntimeProvider
+	protocolVersion      int
+	handshakeErr         error
+	accessibilityGranted bool
+	capabilities         []desktopobserve.Operation
+	apps                 []desktopobserve.AppSummary
+	windows              []desktopobserve.WindowSummary
+	projection           *desktopobserve.SemanticProjection
+	getStateErr          error
+	calls                []string
+	rawIndexCalls        int
+	actionCalls          int
+	screenshotCalls      int
+}
+
+func newFakeDesktopClient(provider desktopobserve.RuntimeProvider) *fakeDesktopClient {
+	return &fakeDesktopClient{
+		provider: provider, protocolVersion: desktopobserve.ProtocolVersion, accessibilityGranted: true,
+	}
+}
+
+func (client *fakeDesktopClient) Handshake(context.Context) (desktopobserve.ProviderIdentity, error) {
+	client.calls = append(client.calls, "handshake")
+	name := "autopus-desktop-local"
+	if client.provider == desktopobserve.RuntimeProviderOrca {
+		name = "orca-computer-use-macos"
+	}
+	return desktopobserve.ProviderIdentity{
+		Name: name, Version: "1.0.0", ProtocolVersion: client.protocolVersion,
+	}, client.handshakeErr
+}
+
+func (client *fakeDesktopClient) Capabilities(context.Context) ([]desktopobserve.Operation, error) {
+	client.calls = append(client.calls, "capabilities")
+	if client.capabilities != nil {
+		return append([]desktopobserve.Operation{}, client.capabilities...), nil
+	}
+	return append(desktopobserve.ReadOnlyOperations(), desktopobserve.Operation("screenshot")), nil
+}
+
+func (client *fakeDesktopClient) Permissions(context.Context) (desktopobserve.PermissionResult, error) {
+	client.calls = append(client.calls, "permissions")
+	return desktopobserve.PermissionResult{AccessibilityGranted: client.accessibilityGranted}, nil
+}
+
+func (client *fakeDesktopClient) ListApps(context.Context) ([]desktopobserve.AppSummary, error) {
+	client.calls = append(client.calls, "list_apps")
+	if client.apps != nil {
+		return append([]desktopobserve.AppSummary{}, client.apps...), nil
+	}
+	return []desktopobserve.AppSummary{{AppRef: "autopus-desktop"}}, nil
+}
+
+func (client *fakeDesktopClient) ListWindows(context.Context, string) ([]desktopobserve.WindowSummary, error) {
+	client.calls = append(client.calls, "list_windows")
+	if client.windows != nil {
+		return append([]desktopobserve.WindowSummary{}, client.windows...), nil
+	}
+	return []desktopobserve.WindowSummary{{WindowRef: "main-window"}}, nil
+}
+
+func (client *fakeDesktopClient) GetState(context.Context, string, string) (desktopobserve.SemanticProjection, error) {
+	client.calls = append(client.calls, "get_state")
+	if client.getStateErr != nil {
+		return desktopobserve.SemanticProjection{}, client.getStateErr
+	}
+	if client.projection != nil {
+		return *client.projection, nil
+	}
+	providerRef := "provider-local"
+	if client.provider == desktopobserve.RuntimeProviderOrca {
+		providerRef = "provider-orca"
+	}
+	return runnerSemanticFixture(providerRef, "state-shared"), nil
+}
+
+func (client *fakeDesktopClient) ResolveRawIndex(context.Context, int) error {
+	client.rawIndexCalls++
+	return nil
+}
+
+func (client *fakeDesktopClient) InvokeAction(context.Context, string) error {
+	client.actionCalls++
+	return nil
+}
+
+func (client *fakeDesktopClient) Screenshot(context.Context) error {
+	client.screenshotCalls++
+	return nil
+}
+
+func desktopRunRequest(provider desktopobserve.RuntimeProvider) DesktopObservationRunRequest {
+	return DesktopObservationRunRequest{
+		RuntimeProvider: provider,
+		Operations: []desktopobserve.Operation{
+			desktopobserve.OperationCapabilities,
+			desktopobserve.OperationPermissions,
+			desktopobserve.OperationListApps,
+			desktopobserve.OperationListWindows,
+			desktopobserve.OperationGetState,
+		},
+		AppRef:    "autopus-desktop",
+		WindowRef: "main-window",
+		Policy: desktopobserve.OraclePolicy{
+			AllowedNames: []string{"Autopus"},
+			MinimumLandmarks: []desktopobserve.LandmarkRequirement{
+				{Role: desktopobserve.RoleApplication, Name: "Autopus", RequiredState: desktopobserve.StateEnabled},
+				{Role: desktopobserve.RoleWindow, Name: "Autopus", RequiredState: desktopobserve.StateFocused},
+			},
+		},
+		Redactor: func(value string) (string, error) { return value, nil },
+	}
+}
+
+func runnerSemanticFixture(providerRef, stateRef string) desktopobserve.SemanticProjection {
+	enabled, focused := true, true
+	return desktopobserve.SemanticProjection{
+		SchemaVersion: desktopobserve.SemanticProjectionSchemaVersion,
+		ProviderRef:   providerRef,
+		AppRef:        "autopus-desktop",
+		WindowRef:     "main-window",
+		StateRef:      stateRef,
+		Root: desktopobserve.SemanticNode{
+			Role:              desktopobserve.RoleApplication,
+			Name:              "Autopus",
+			SemanticState:     desktopobserve.SemanticState{Enabled: &enabled},
+			AdvertisedActions: []desktopobserve.Action{desktopobserve.ActionShowMenu, desktopobserve.ActionPress},
+			Children: []desktopobserve.SemanticNode{{
+				Role:          desktopobserve.RoleWindow,
+				Name:          "Autopus",
+				SemanticState: desktopobserve.SemanticState{Focused: &focused},
+			}},
+		},
+	}
+}
+
+func desktopObservationPack() journey.Pack {
+	return journey.Pack{
+		ID: "desktop-accessibility-observe", Surface: "desktop", Lanes: []string{"desktop-native"},
+		Adapter: journey.AdapterRef{ID: "desktop-accessibility-observe"},
+		Checks:  []journey.Check{{ID: "semantic-landmarks", Type: "desktop_accessibility_semantic"}},
+		DesktopObservation: journey.DesktopObservationPolicy{
+			Platform: "macos", Operations: []string{"capabilities", "permissions", "list_apps", "list_windows", "get_state"},
+			AppRef: "autopus-desktop", WindowRef: "main-window",
+			RequiredLandmarks: []journey.DesktopObservationLandmark{
+				{Role: "AXApplication", Name: "Autopus", RequiredState: "enabled"},
+				{Role: "AXWindow", Name: "Autopus", RequiredState: "focused"},
+			},
+		},
+		SourceRefs: journey.SourceRefs{
+			SourceSpec: "SPEC-QAMESH-012", AcceptanceRefs: []string{"AC-QAMESH12-011"},
+		},
+		PassFailAuthority: "deterministic",
+	}
+}
+
+func capabilityNames(receipt desktopobserve.RuntimeReceipt) []desktopobserve.Operation {
+	out := make([]desktopobserve.Operation, 0, len(receipt.CapabilitySummary))
+	for _, capability := range receipt.CapabilitySummary {
+		out = append(out, capability.Name)
+	}
+	return out
+}

--- a/pkg/qa/run/desktop_observe_transport.go
+++ b/pkg/qa/run/desktop_observe_transport.go
@@ -1,0 +1,248 @@
+package run
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+type desktopEnvelopeTransport interface {
+	RoundTrip(context.Context, []byte) ([]byte, error)
+}
+
+type desktopExchangeDecoder func([]byte, []byte) (desktopobserve.Exchange, error)
+
+type envelopeDesktopClient struct {
+	identity                 desktopobserve.ProviderIdentity
+	transport                desktopEnvelopeTransport
+	decode                   desktopExchangeDecoder
+	sequence                 atomic.Uint64
+	handshakeViaCapabilities bool
+	handshakeDone            bool
+	cachedCapabilities       []desktopobserve.Operation
+}
+
+func newEnvelopeDesktopClient(
+	identity desktopobserve.ProviderIdentity,
+	transport desktopEnvelopeTransport,
+	decode desktopExchangeDecoder,
+) *envelopeDesktopClient {
+	return &envelopeDesktopClient{identity: identity, transport: transport, decode: decode}
+}
+
+func (client *envelopeDesktopClient) Handshake(ctx context.Context) (desktopobserve.ProviderIdentity, error) {
+	if client.handshakeViaCapabilities && !client.handshakeDone {
+		exchange, err := client.exchange(
+			ctx, desktopobserve.OperationCapabilities, desktopProviderScope(client.identity),
+		)
+		if err != nil {
+			return desktopobserve.ProviderIdentity{}, err
+		}
+		operations, err := desktopCapabilitiesFromExchange(exchange)
+		if err != nil {
+			return desktopobserve.ProviderIdentity{}, err
+		}
+		client.identity = exchange.Result.RuntimeReceipt.Provider
+		client.cachedCapabilities = operations
+		client.handshakeDone = true
+	}
+	return client.identity, nil
+}
+
+func (client *envelopeDesktopClient) Capabilities(ctx context.Context) ([]desktopobserve.Operation, error) {
+	if client.handshakeViaCapabilities && client.handshakeDone {
+		return append([]desktopobserve.Operation(nil), client.cachedCapabilities...), nil
+	}
+	exchange, err := client.exchange(ctx, desktopobserve.OperationCapabilities, desktopProviderScope(client.identity))
+	if err != nil {
+		return nil, err
+	}
+	return desktopCapabilitiesFromExchange(exchange)
+}
+
+func desktopCapabilitiesFromExchange(exchange desktopobserve.Exchange) ([]desktopobserve.Operation, error) {
+	var payload struct {
+		Capabilities []desktopobserve.CapabilityStatus `json:"capabilities"`
+	}
+	if err := json.Unmarshal(exchange.Result.Payload, &payload); err != nil {
+		return nil, desktopobserve.ErrMalformedEnvelope
+	}
+	operations := make([]desktopobserve.Operation, 0, len(payload.Capabilities))
+	for _, capability := range payload.Capabilities {
+		if capability.Status == desktopobserve.CapabilitySupported {
+			operations = append(operations, capability.Name)
+		}
+	}
+	return operations, nil
+}
+
+func (client *envelopeDesktopClient) Permissions(ctx context.Context) (desktopobserve.PermissionResult, error) {
+	exchange, err := client.exchange(ctx, desktopobserve.OperationPermissions, desktopProviderScope(client.identity))
+	if err != nil {
+		return desktopobserve.PermissionResult{}, err
+	}
+	var payload desktopobserve.PermissionResult
+	if err := json.Unmarshal(exchange.Result.Payload, &payload); err != nil {
+		return desktopobserve.PermissionResult{}, desktopobserve.ErrMalformedEnvelope
+	}
+	return payload, nil
+}
+
+func (client *envelopeDesktopClient) ListApps(ctx context.Context) ([]desktopobserve.AppSummary, error) {
+	exchange, err := client.exchange(ctx, desktopobserve.OperationListApps, desktopProviderScope(client.identity))
+	if err != nil {
+		return nil, err
+	}
+	var payload struct {
+		Apps []desktopobserve.AppSummary `json:"apps"`
+	}
+	if err := json.Unmarshal(exchange.Result.Payload, &payload); err != nil {
+		return nil, desktopobserve.ErrMalformedEnvelope
+	}
+	return payload.Apps, nil
+}
+
+func (client *envelopeDesktopClient) ListWindows(
+	ctx context.Context,
+	appRef string,
+) ([]desktopobserve.WindowSummary, error) {
+	exchange, err := client.exchange(ctx, desktopobserve.OperationListWindows, desktopobserve.ReceiptScope{
+		Kind: desktopobserve.ScopeApplication, PublicRef: appRef,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var payload struct {
+		Windows []desktopobserve.WindowSummary `json:"windows"`
+	}
+	if err := json.Unmarshal(exchange.Result.Payload, &payload); err != nil {
+		return nil, desktopobserve.ErrMalformedEnvelope
+	}
+	return payload.Windows, nil
+}
+
+func (client *envelopeDesktopClient) GetState(
+	ctx context.Context,
+	_ string,
+	windowRef string,
+) (desktopobserve.SemanticProjection, error) {
+	exchange, err := client.exchange(ctx, desktopobserve.OperationGetState, desktopWindowScope(windowRef))
+	if err != nil {
+		return desktopobserve.SemanticProjection{}, err
+	}
+	var payload struct {
+		SemanticProjection desktopobserve.SemanticProjection `json:"semantic_projection"`
+	}
+	if err := json.Unmarshal(exchange.Result.Payload, &payload); err != nil {
+		return desktopobserve.SemanticProjection{}, desktopobserve.ErrMalformedEnvelope
+	}
+	return payload.SemanticProjection, nil
+}
+
+func (client *envelopeDesktopClient) exchange(
+	ctx context.Context,
+	operation desktopobserve.Operation,
+	scope desktopobserve.ReceiptScope,
+) (desktopobserve.Exchange, error) {
+	if client == nil || client.transport == nil || client.decode == nil {
+		return desktopobserve.Exchange{}, errors.New("desktop envelope client is unavailable")
+	}
+	request := desktopobserve.Request{
+		ProtocolVersion: desktopobserve.ProtocolVersion,
+		RequestID:       fmt.Sprintf("desktop-observe-%d", client.sequence.Add(1)),
+		Operation:       operation,
+		Scope:           scope,
+	}
+	requestRaw, err := json.Marshal(request)
+	if err != nil {
+		return desktopobserve.Exchange{}, desktopobserve.ErrMalformedEnvelope
+	}
+	requestRaw = append(requestRaw, '\n')
+	if len(requestRaw) > desktopobserve.MaxEnvelopeBytes {
+		return desktopobserve.Exchange{}, desktopobserve.ErrEnvelopeTooLarge
+	}
+	resultRaw, err := client.transport.RoundTrip(ctx, requestRaw)
+	if err != nil {
+		return desktopobserve.Exchange{}, err
+	}
+	exchange, err := client.decode(requestRaw, resultRaw)
+	if err != nil {
+		return desktopobserve.Exchange{}, err
+	}
+	if exchange.Result.Status == desktopobserve.ResultFailed {
+		if exchange.Result.RuntimeReceipt.ReasonCode == nil {
+			return desktopobserve.Exchange{}, desktopobserve.ErrMalformedEnvelope
+		}
+		allowProviderVersion := client.handshakeViaCapabilities && !client.handshakeDone
+		if !validFailedDesktopReceipt(
+			client.identity, request, exchange.Result.RuntimeReceipt, allowProviderVersion,
+		) {
+			return desktopobserve.Exchange{}, desktopobserve.ErrMalformedEnvelope
+		}
+		return desktopobserve.Exchange{}, desktopFailureForReason(
+			*exchange.Result.RuntimeReceipt.ReasonCode,
+			operation,
+			exchange.Result.RuntimeReceipt,
+		)
+	}
+	return exchange, nil
+}
+
+func validFailedDesktopReceipt(
+	identity desktopobserve.ProviderIdentity,
+	request desktopobserve.Request,
+	receipt desktopobserve.RuntimeReceipt,
+	allowProviderVersion bool,
+) bool {
+	providerMatches := receipt.Provider == identity
+	if allowProviderVersion {
+		providerMatches = receipt.Provider.Name == identity.Name &&
+			receipt.Provider.ProtocolVersion == identity.ProtocolVersion
+	}
+	if !providerMatches || receipt.Scope != request.Scope || receipt.ReasonCode == nil {
+		return false
+	}
+	condition, ok := desktopFailureConditionForReason(*receipt.ReasonCode)
+	if !ok || !desktopFailureReasonAllowed(*receipt.ReasonCode, request.Operation) {
+		return false
+	}
+	if condition != desktopobserve.FailureOperationMissing {
+		return true
+	}
+	for _, capability := range receipt.CapabilitySummary {
+		if capability.Name == request.Operation {
+			return capability.Status == desktopobserve.CapabilityUnsupported
+		}
+	}
+	return false
+}
+
+func desktopFailureReasonAllowed(
+	reason desktopobserve.ReasonCode,
+	operation desktopobserve.Operation,
+) bool {
+	switch reason {
+	case desktopobserve.ReasonProviderUnavailable,
+		desktopobserve.ReasonCapabilityUnsupported,
+		desktopobserve.ReasonProviderProtocolMismatch,
+		desktopobserve.ReasonRedactionFailed:
+		return desktopobserve.IsReadOnlyOperation(operation)
+	case desktopobserve.ReasonAccessibilityPermissionMissing:
+		return operation != desktopobserve.OperationCapabilities
+	case desktopobserve.ReasonTargetAppNotFound:
+		return operation == desktopobserve.OperationListApps ||
+			operation == desktopobserve.OperationListWindows || operation == desktopobserve.OperationGetState
+	case desktopobserve.ReasonTargetWindowNotFound:
+		return operation == desktopobserve.OperationListWindows || operation == desktopobserve.OperationGetState
+	case desktopobserve.ReasonStaleState,
+		desktopobserve.ReasonSemanticProjectionUnavailable,
+		desktopobserve.ReasonEvidenceQuarantined:
+		return operation == desktopobserve.OperationGetState
+	default:
+		return false
+	}
+}

--- a/pkg/qa/run/desktop_observe_transport_test.go
+++ b/pkg/qa/run/desktop_observe_transport_test.go
@@ -1,0 +1,264 @@
+package run
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+func TestDesktopEnvelopeTransport_SuccessfulRunnerChainDecodesEveryRawExchange(t *testing.T) {
+	t.Parallel()
+
+	transport := newFakeDesktopEnvelopeTransport(t)
+	decoder := &countingDesktopExchangeDecoder{}
+	client := newEnvelopeDesktopClient(localEnvelopeIdentity(), transport, decoder.Decode)
+	outcome, err := newDesktopObservationRunner(
+		client, newFakeDesktopClient(desktopobserve.RuntimeProviderOrca),
+	).Run(context.Background(), desktopRunRequest(desktopobserve.RuntimeProviderLocal))
+	require.NoError(t, err)
+	assert.Equal(t, desktopobserve.VerdictPassed, outcome.Verdict)
+	assert.Equal(t, 5, transport.calls)
+	assert.Equal(t, 5, decoder.calls)
+	assert.NoError(t, decoder.lastErr)
+	assert.Equal(t, []desktopobserve.Operation{
+		desktopobserve.OperationCapabilities,
+		desktopobserve.OperationPermissions,
+		desktopobserve.OperationListApps,
+		desktopobserve.OperationListWindows,
+		desktopobserve.OperationGetState,
+	}, transport.operations)
+}
+
+func TestDesktopEnvelopeTransport_MalformedResultIsRejectedByDecoderBeforeLaterOperations(t *testing.T) {
+	t.Parallel()
+
+	transport := newFakeDesktopEnvelopeTransport(t)
+	transport.malformedOperation = desktopobserve.OperationPermissions
+	decoder := &countingDesktopExchangeDecoder{}
+	client := newEnvelopeDesktopClient(localEnvelopeIdentity(), transport, decoder.Decode)
+	outcome, err := newDesktopObservationRunner(
+		client, newFakeDesktopClient(desktopobserve.RuntimeProviderOrca),
+	).Run(context.Background(), desktopRunRequest(desktopobserve.RuntimeProviderLocal))
+	require.NoError(t, err)
+	assert.NotEqual(t, desktopobserve.VerdictPassed, outcome.Verdict)
+	assert.Nil(t, outcome.SemanticProjection)
+	require.NotNil(t, outcome.ReasonCode)
+	assert.Equal(t, 2, transport.calls)
+	assert.Equal(t, 2, decoder.calls)
+	assert.ErrorIs(t, decoder.lastErr, desktopobserve.ErrMalformedEnvelope)
+	assert.Equal(t, []desktopobserve.Operation{
+		desktopobserve.OperationCapabilities,
+		desktopobserve.OperationPermissions,
+	}, transport.operations)
+}
+
+func TestDesktopEnvelopeTransport_FailedReceiptPreservesCurrentCapabilitySummary(t *testing.T) {
+	t.Parallel()
+
+	transport := newFakeDesktopEnvelopeTransport(t)
+	transport.failedOperation = desktopobserve.OperationGetState
+	client := newEnvelopeDesktopClient(localEnvelopeIdentity(), transport, desktopobserve.DecodeExchange)
+	alternate := newFakeDesktopClient(desktopobserve.RuntimeProviderOrca)
+	outcome, err := newDesktopObservationRunner(client, alternate).Run(
+		context.Background(), desktopRunRequest(desktopobserve.RuntimeProviderLocal),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, outcome.ReasonCode)
+	assert.Equal(t, desktopobserve.ReasonCapabilityUnsupported, *outcome.ReasonCode)
+	assert.Equal(t, 5, transport.calls)
+	assert.Equal(t, desktopobserve.CapabilityUnsupported, capabilityStatus(
+		outcome.RuntimeReceipt, desktopobserve.OperationGetState,
+	))
+	for _, operation := range desktopobserve.ReadOnlyOperations() {
+		if operation != desktopobserve.OperationGetState {
+			assert.Equal(t, desktopobserve.CapabilitySupported, capabilityStatus(outcome.RuntimeReceipt, operation))
+		}
+	}
+	assert.Empty(t, alternate.calls)
+}
+
+func TestDesktopEnvelopeTransport_ContradictoryFailedReceiptIsProtocolMismatch(t *testing.T) {
+	t.Parallel()
+
+	transport := newFakeDesktopEnvelopeTransport(t)
+	transport.failedOperation = desktopobserve.OperationGetState
+	transport.keepFailedCapabilitySupported = true
+	client := newEnvelopeDesktopClient(localEnvelopeIdentity(), transport, desktopobserve.DecodeExchange)
+	alternate := newFakeDesktopClient(desktopobserve.RuntimeProviderOrca)
+	outcome, err := newDesktopObservationRunner(client, alternate).Run(
+		context.Background(), desktopRunRequest(desktopobserve.RuntimeProviderLocal),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, outcome.ReasonCode)
+	assert.Equal(t, desktopobserve.ReasonProviderProtocolMismatch, *outcome.ReasonCode)
+	assert.Equal(t, 5, transport.calls)
+	assert.Empty(t, alternate.calls)
+}
+
+func TestDesktopEnvelopeTransport_RoundTripUsesWholeOperationDeadline(t *testing.T) {
+	t.Parallel()
+
+	transport := &blockingDesktopEnvelopeTransport{}
+	client := newEnvelopeDesktopClient(localEnvelopeIdentity(), transport, desktopobserve.DecodeExchange)
+	alternate := newFakeDesktopClient(desktopobserve.RuntimeProviderOrca)
+	runner := newDesktopObservationRunner(client, alternate)
+	runner.timeout = 10 * time.Millisecond
+	started := time.Now()
+	outcome, err := runner.Run(context.Background(), desktopRunRequest(desktopobserve.RuntimeProviderLocal))
+	require.NoError(t, err)
+	require.NotNil(t, outcome.ReasonCode)
+	assert.Equal(t, desktopobserve.ReasonProviderUnavailable, *outcome.ReasonCode)
+	assert.Less(t, time.Since(started), 500*time.Millisecond)
+	assert.Equal(t, 1, transport.calls)
+	assert.Empty(t, alternate.calls)
+}
+
+type blockingDesktopEnvelopeTransport struct {
+	calls int
+}
+
+func (transport *blockingDesktopEnvelopeTransport) RoundTrip(ctx context.Context, _ []byte) ([]byte, error) {
+	transport.calls++
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+type countingDesktopExchangeDecoder struct {
+	calls   int
+	lastErr error
+}
+
+func (decoder *countingDesktopExchangeDecoder) Decode(requestRaw, resultRaw []byte) (desktopobserve.Exchange, error) {
+	decoder.calls++
+	exchange, err := desktopobserve.DecodeExchange(requestRaw, resultRaw)
+	decoder.lastErr = err
+	return exchange, err
+}
+
+type fakeDesktopEnvelopeTransport struct {
+	projection                    desktopobserve.SemanticProjection
+	malformedOperation            desktopobserve.Operation
+	failedOperation               desktopobserve.Operation
+	keepFailedCapabilitySupported bool
+	calls                         int
+	operations                    []desktopobserve.Operation
+}
+
+func newFakeDesktopEnvelopeTransport(t *testing.T) *fakeDesktopEnvelopeTransport {
+	t.Helper()
+	projection, err := desktopobserve.NormalizeProjection(
+		runnerSemanticFixture("provider-local", "state-envelope"),
+		func(value string) (string, error) { return value, nil },
+	)
+	require.NoError(t, err)
+	return &fakeDesktopEnvelopeTransport{projection: projection}
+}
+
+func (transport *fakeDesktopEnvelopeTransport) RoundTrip(_ context.Context, requestRaw []byte) ([]byte, error) {
+	var request struct {
+		ProtocolVersion int                         `json:"protocol_version"`
+		RequestID       string                      `json:"request_id"`
+		Operation       desktopobserve.Operation    `json:"operation"`
+		Scope           desktopobserve.ReceiptScope `json:"scope"`
+	}
+	if err := json.Unmarshal(requestRaw, &request); err != nil {
+		return nil, err
+	}
+	transport.calls++
+	transport.operations = append(transport.operations, request.Operation)
+	if request.Operation == transport.malformedOperation {
+		return []byte(`{"protocol_version":`), nil
+	}
+	if request.Operation == transport.failedOperation {
+		receipt := envelopeReceipt(request.Scope)
+		reason := desktopobserve.ReasonCapabilityUnsupported
+		nextStep := desktopobserve.NextStep(reason)
+		receipt.ReasonCode = &reason
+		receipt.NextStep = &nextStep
+		receipt.Redaction.Status = desktopobserve.RedactionNotRequired
+		receipt.Quarantine.Status = desktopobserve.QuarantineEmpty
+		if !transport.keepFailedCapabilitySupported {
+			for index := range receipt.CapabilitySummary {
+				if receipt.CapabilitySummary[index].Name == request.Operation {
+					receipt.CapabilitySummary[index].Status = desktopobserve.CapabilityUnsupported
+				}
+			}
+		}
+		return json.Marshal(map[string]any{
+			"protocol_version": desktopobserve.ProtocolVersion,
+			"request_id":       request.RequestID,
+			"status":           "failed",
+			"runtime_receipt":  receipt,
+		})
+	}
+	payload := transport.payload(request.Operation)
+	return json.Marshal(map[string]any{
+		"protocol_version": desktopobserve.ProtocolVersion,
+		"request_id":       request.RequestID,
+		"status":           "passed",
+		"payload":          payload,
+		"runtime_receipt":  envelopeReceipt(request.Scope),
+	})
+}
+
+func (transport *fakeDesktopEnvelopeTransport) payload(operation desktopobserve.Operation) any {
+	switch operation {
+	case desktopobserve.OperationCapabilities:
+		return map[string]any{"capabilities": envelopeCapabilities()}
+	case desktopobserve.OperationPermissions:
+		return map[string]any{"accessibility_granted": true}
+	case desktopobserve.OperationListApps:
+		return map[string]any{"apps": []desktopobserve.AppSummary{{AppRef: "autopus-desktop"}}}
+	case desktopobserve.OperationListWindows:
+		return map[string]any{"windows": []desktopobserve.WindowSummary{{WindowRef: "main-window"}}}
+	case desktopobserve.OperationGetState:
+		return map[string]any{"semantic_projection": transport.projection}
+	default:
+		return map[string]any{}
+	}
+}
+
+func localEnvelopeIdentity() desktopobserve.ProviderIdentity {
+	return desktopobserve.ProviderIdentity{
+		Name: "autopus-desktop-local", Version: "1.0.0", ProtocolVersion: desktopobserve.ProtocolVersion,
+	}
+}
+
+func envelopeCapabilities() []desktopobserve.CapabilityStatus {
+	capabilities := make([]desktopobserve.CapabilityStatus, 0, len(desktopobserve.ReadOnlyOperations()))
+	for _, operation := range desktopobserve.ReadOnlyOperations() {
+		capabilities = append(capabilities, desktopobserve.CapabilityStatus{
+			Name: operation, Status: desktopobserve.CapabilitySupported,
+		})
+	}
+	return capabilities
+}
+
+func envelopeReceipt(scope desktopobserve.ReceiptScope) desktopobserve.RuntimeReceipt {
+	return desktopobserve.RuntimeReceipt{
+		SchemaVersion:     desktopobserve.RuntimeReceiptSchemaVersion,
+		Provider:          localEnvelopeIdentity(),
+		Scope:             scope,
+		CapabilitySummary: envelopeCapabilities(),
+		Redaction:         desktopobserve.RedactionReceipt{Status: desktopobserve.RedactionApplied},
+		Quarantine:        desktopobserve.QuarantineReceipt{Status: desktopobserve.QuarantineCleared},
+	}
+}
+
+func capabilityStatus(
+	receipt desktopobserve.RuntimeReceipt,
+	operation desktopobserve.Operation,
+) desktopobserve.CapabilityState {
+	for _, capability := range receipt.CapabilitySummary {
+		if capability.Name == operation {
+			return capability.Status
+		}
+	}
+	return ""
+}

--- a/pkg/qa/run/desktop_observe_v2_contract.go
+++ b/pkg/qa/run/desktop_observe_v2_contract.go
@@ -1,0 +1,149 @@
+package run
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+const (
+	desktopV2Protocol    = 2
+	desktopV2StatusOK    = "ok"
+	desktopV2StatusError = "error"
+)
+
+var desktopV2Operations = []string{
+	"capabilities", "get_state", "list_apps", "list_windows", "permissions",
+}
+
+type desktopV2Scope struct {
+	Kind      string `json:"kind"`
+	PublicRef string `json:"public_ref"`
+}
+
+type desktopV2Request struct {
+	ProtocolVersion  int            `json:"protocol_version"`
+	RequestID        string         `json:"request_id"`
+	Operation        string         `json:"operation"`
+	Scope            desktopV2Scope `json:"scope"`
+	ExpectedStateRef string         `json:"expected_state_ref,omitempty"`
+}
+
+type desktopV2Binding struct {
+	publicRequest    desktopobserve.Request
+	publicRequestRaw []byte
+	privateRequest   desktopV2Request
+}
+
+type desktopV2ResultWire struct {
+	ProtocolVersion int             `json:"protocol_version"`
+	RequestID       string          `json:"request_id"`
+	Status          string          `json:"status"`
+	RuntimeReceipt  json.RawMessage `json:"runtime_receipt"`
+	Payload         json.RawMessage `json:"payload,omitempty"`
+}
+
+func encodeDesktopV2Request(publicRaw []byte) ([]byte, desktopV2Binding, error) {
+	body, err := desktopV2MessageBody(publicRaw)
+	if err != nil {
+		return nil, desktopV2Binding{}, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	if err := rejectDesktopV2DuplicateKeys(decoder); err != nil {
+		return nil, desktopV2Binding{}, err
+	}
+	request, err := desktopobserve.DecodeRequest(publicRaw)
+	if err != nil {
+		return nil, desktopV2Binding{}, err
+	}
+	privateScope := desktopV2Scope{Kind: "provider", PublicRef: "provider_selected"}
+	switch request.Operation {
+	case desktopobserve.OperationListWindows:
+		privateScope = desktopV2Scope{Kind: "application", PublicRef: "autopus-desktop"}
+	case desktopobserve.OperationGetState:
+		privateScope = desktopV2Scope{Kind: "window", PublicRef: "main-window"}
+	}
+	idDigest := sha256.Sum256([]byte(request.RequestID))
+	privateRequest := desktopV2Request{
+		ProtocolVersion: desktopV2Protocol,
+		RequestID:       "req_adk_" + hex.EncodeToString(idDigest[:]),
+		Operation:       string(request.Operation),
+		Scope:           privateScope,
+	}
+	if request.ExpectedStateRef != "" {
+		suffix := request.ExpectedStateRef[len("state-"):]
+		if !desktopV2DigestPattern.MatchString(suffix) {
+			return nil, desktopV2Binding{}, desktopobserve.ErrMalformedEnvelope
+		}
+		privateRequest.ExpectedStateRef = "state_v2_" + suffix
+	}
+	encoded, err := json.Marshal(privateRequest)
+	if err != nil {
+		return nil, desktopV2Binding{}, desktopobserve.ErrMalformedEnvelope
+	}
+	encoded = append(encoded, '\n')
+	if len(encoded) > desktopobserve.MaxEnvelopeBytes {
+		return nil, desktopV2Binding{}, desktopobserve.ErrEnvelopeTooLarge
+	}
+	return encoded, desktopV2Binding{
+		publicRequest: request, publicRequestRaw: append([]byte(nil), publicRaw...),
+		privateRequest: privateRequest,
+	}, nil
+}
+
+func translateDesktopV2Result(
+	binding desktopV2Binding,
+	privateRaw []byte,
+) ([]byte, string, error) {
+	body, err := desktopV2MessageBody(privateRaw)
+	if err != nil {
+		return nil, "", err
+	}
+	var wire desktopV2ResultWire
+	errWithPayload := decodeDesktopV2Object(
+		body, &wire, "protocol_version", "request_id", "status", "runtime_receipt", "payload",
+	)
+	if errWithPayload != nil {
+		if err := decodeDesktopV2Object(
+			body, &wire, "protocol_version", "request_id", "status", "runtime_receipt",
+		); err != nil {
+			return nil, "", errWithPayload
+		}
+	}
+	if wire.ProtocolVersion != desktopV2Protocol {
+		return nil, "", desktopobserve.ErrProtocolMismatch
+	}
+	if wire.RequestID != binding.privateRequest.RequestID {
+		return nil, "", desktopobserve.ErrRequestIDMismatch
+	}
+	if wire.Status != desktopV2StatusOK && wire.Status != desktopV2StatusError {
+		return nil, "", desktopobserve.ErrInvalidStatus
+	}
+	if (wire.Status == desktopV2StatusOK) != (len(wire.Payload) != 0) ||
+		bytes.Equal(bytes.TrimSpace(wire.Payload), []byte("null")) {
+		return nil, "", desktopobserve.ErrMalformedEnvelope
+	}
+	receipt, err := decodeDesktopV2Receipt(wire.RuntimeReceipt, binding, wire.Status)
+	if err != nil {
+		return nil, "", err
+	}
+	publicResult, err := mapDesktopV2Result(binding, wire, receipt)
+	if err != nil {
+		return nil, "", err
+	}
+	publicRaw, err := json.Marshal(publicResult)
+	if err != nil {
+		return nil, "", desktopobserve.ErrMalformedEnvelope
+	}
+	publicRaw = append(publicRaw, '\n')
+	if len(publicRaw) > desktopobserve.MaxEnvelopeBytes {
+		return nil, "", desktopobserve.ErrEnvelopeTooLarge
+	}
+	if _, err := desktopobserve.DecodeExchange(binding.publicRequestRaw, publicRaw); err != nil {
+		return nil, "", err
+	}
+	return publicRaw, wire.Status, nil
+}

--- a/pkg/qa/run/desktop_observe_v2_contract_test.go
+++ b/pkg/qa/run/desktop_observe_v2_contract_test.go
@@ -1,0 +1,185 @@
+package run
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+func TestDesktopV2RequestAdapter_MapsExactIDsScopesAndOperations(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		operation desktopobserve.Operation
+		scope     desktopV2Scope
+	}{
+		{desktopobserve.OperationCapabilities, desktopV2Scope{"provider", "provider_selected"}},
+		{desktopobserve.OperationPermissions, desktopV2Scope{"provider", "provider_selected"}},
+		{desktopobserve.OperationListApps, desktopV2Scope{"provider", "provider_selected"}},
+		{desktopobserve.OperationListWindows, desktopV2Scope{"application", "autopus-desktop"}},
+		{desktopobserve.OperationGetState, desktopV2Scope{"window", "main-window"}},
+	}
+	for _, test := range tests {
+		t.Run(string(test.operation), func(t *testing.T) {
+			publicRaw, _ := desktopV2PublicRequest(t, test.operation)
+			privateRaw, binding, err := encodeDesktopV2Request(publicRaw)
+			require.NoError(t, err)
+			assert.Equal(t, 2, binding.privateRequest.ProtocolVersion)
+			assert.Equal(t, string(test.operation), binding.privateRequest.Operation)
+			assert.Equal(t, test.scope, binding.privateRequest.Scope)
+			assert.Regexp(t, `^req_adk_[0-9a-f]{64}$`, binding.privateRequest.RequestID)
+			assert.LessOrEqual(t, len(privateRaw), desktopobserve.MaxEnvelopeBytes)
+			assert.Equal(t, byte('\n'), privateRaw[len(privateRaw)-1])
+		})
+	}
+}
+
+func TestDesktopV2RequestAdapter_MapsOnlyExactPrivateStateTokens(t *testing.T) {
+	t.Parallel()
+	request := desktopobserve.Request{
+		ProtocolVersion: 1, RequestID: "desktop-observe-state", Operation: desktopobserve.OperationGetState,
+		Scope:            desktopobserve.ReceiptScope{Kind: desktopobserve.ScopeWindow, PublicRef: "main-window"},
+		ExpectedStateRef: "state-" + repeatDesktopV2Zero(),
+	}
+	raw, err := json.Marshal(request)
+	require.NoError(t, err)
+	privateRaw, binding, err := encodeDesktopV2Request(append(raw, '\n'))
+	require.NoError(t, err)
+	assert.Equal(t, "state_v2_"+repeatDesktopV2Zero(), binding.privateRequest.ExpectedStateRef)
+	assert.Contains(t, string(privateRaw), `"expected_state_ref":"state_v2_`)
+
+	request.ExpectedStateRef = "state-" + strings.Repeat("z", 64)
+	raw, err = json.Marshal(request)
+	require.NoError(t, err)
+	privateRaw, _, err = encodeDesktopV2Request(append(raw, '\n'))
+	assert.Error(t, err)
+	assert.Nil(t, privateRaw)
+}
+
+func TestDesktopV2ResultAdapter_GoldenCapabilitiesAndGetState(t *testing.T) {
+	t.Parallel()
+	t.Run("capabilities", func(t *testing.T) {
+		publicRaw, binding := desktopV2PublicRequest(t, desktopobserve.OperationCapabilities)
+		privateRaw := desktopV2SuccessResult(t, binding, map[string]any{
+			"capabilities": desktopV2Operations,
+		})
+		resultRaw, status, err := translateDesktopV2Result(binding, privateRaw)
+		require.NoError(t, err)
+		assert.Equal(t, desktopV2StatusOK, status)
+		exchange, err := desktopobserve.DecodeExchange(publicRaw, resultRaw)
+		require.NoError(t, err)
+		assert.Equal(t, "autopus-desktop-local", exchange.Result.RuntimeReceipt.Provider.Name)
+		assert.Equal(t, "0.0.1", exchange.Result.RuntimeReceipt.Provider.Version)
+		assert.NotContains(t, string(resultRaw), "rust-go")
+	})
+
+	t.Run("recursive get state", func(t *testing.T) {
+		publicRaw, binding := desktopV2PublicRequest(t, desktopobserve.OperationGetState)
+		privateProjection := desktopV2ProjectionResult(t, desktopV2RecursiveRoot(false))
+		privateRaw := desktopV2SuccessResult(t, binding, map[string]any{
+			"semantic_projection": privateProjection,
+		})
+		resultRaw, _, err := translateDesktopV2Result(binding, privateRaw)
+		require.NoError(t, err)
+		exchange, err := desktopobserve.DecodeExchange(publicRaw, resultRaw)
+		require.NoError(t, err)
+		var payload struct {
+			Projection desktopobserve.SemanticProjection `json:"semantic_projection"`
+		}
+		require.NoError(t, json.Unmarshal(exchange.Result.Payload, &payload))
+		assert.Equal(t, "provider-local", payload.Projection.ProviderRef)
+		assert.Equal(t, "state-"+repeatDesktopV2Zero(), payload.Projection.StateRef)
+		assert.Regexp(t, `^[0-9a-f]{64}$`, payload.Projection.Digest)
+		assert.Regexp(t, `^n_[0-9a-f]{64}$`, payload.Projection.Root.NodeRef)
+		assert.Equal(t, 3, countPublicDesktopNodesByName(payload.Projection.Root, "Disclosure"))
+		assert.False(t, strings.Contains(string(resultRaw), "fixture_00"))
+	})
+}
+
+func TestDesktopV2ResultAdapter_RejectsMalformedBoundaries(t *testing.T) {
+	t.Parallel()
+	_, binding := desktopV2PublicRequest(t, desktopobserve.OperationCapabilities)
+	valid := desktopV2SuccessResult(t, binding, map[string]any{"capabilities": desktopV2Operations})
+	tests := []struct {
+		name string
+		raw  []byte
+	}{
+		{"duplicate top key", bytes.Replace(valid, []byte(`"status":"ok"`), []byte(`"status":"ok","status":"ok"`), 1)},
+		{"duplicate nested key", bytes.Replace(valid, []byte(`"name":"rust-go"`), []byte(`"name":"rust-go","name":"rust-go"`), 1)},
+		{"unknown secret field", bytes.Replace(valid, []byte(`,"payload":`), []byte(`,"socket_handle":"private.sock","payload":`), 1)},
+		{"tampered provider", bytes.Replace(valid, []byte(`"name":"rust-go"`), []byte(`"name":"evil-go"`), 1)},
+		{"tampered team-facing version", bytes.Replace(valid, []byte(`"version":"0.0.1"`), []byte(`"version":"0.0.2"`), 1)},
+		{"wrong scope", bytes.Replace(valid, []byte(`"public_ref":"provider_selected"`), []byte(`"public_ref":"other"`), 1)},
+		{"wrong capability order", bytes.Replace(valid, []byte(`"capabilities","status":"supported"},{"name":"get_state"`), []byte(`"get_state","status":"supported"},{"name":"capabilities"`), 1)},
+		{"missing newline", bytes.TrimSuffix(valid, []byte{'\n'})},
+		{"embedded carriage return", append(bytes.TrimSuffix(valid, []byte{'\n'}), '\r', '\n')},
+		{"oversize", append(bytes.Repeat([]byte{'x'}, desktopobserve.MaxEnvelopeBytes), '\n')},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, _, err := translateDesktopV2Result(binding, test.raw)
+			assert.Error(t, err)
+			assert.Nil(t, result)
+			assert.NotContains(t, err.Error(), "private.sock")
+		})
+	}
+}
+
+func TestDesktopV2ResultAdapter_MapsExactTenReasonReceipts(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		reason    desktopobserve.ReasonCode
+		operation desktopobserve.Operation
+	}{
+		{desktopobserve.ReasonProviderUnavailable, desktopobserve.OperationCapabilities},
+		{desktopobserve.ReasonCapabilityUnsupported, desktopobserve.OperationCapabilities},
+		{desktopobserve.ReasonAccessibilityPermissionMissing, desktopobserve.OperationPermissions},
+		{desktopobserve.ReasonTargetAppNotFound, desktopobserve.OperationListApps},
+		{desktopobserve.ReasonTargetWindowNotFound, desktopobserve.OperationListWindows},
+		{desktopobserve.ReasonStaleState, desktopobserve.OperationGetState},
+		{desktopobserve.ReasonSemanticProjectionUnavailable, desktopobserve.OperationGetState},
+		{desktopobserve.ReasonRedactionFailed, desktopobserve.OperationCapabilities},
+		{desktopobserve.ReasonEvidenceQuarantined, desktopobserve.OperationGetState},
+		{desktopobserve.ReasonProviderProtocolMismatch, desktopobserve.OperationCapabilities},
+	}
+	for _, test := range tests {
+		t.Run(string(test.reason), func(t *testing.T) {
+			publicRaw, binding := desktopV2PublicRequest(t, test.operation)
+			privateRaw := desktopV2FailureResult(t, binding, test.reason)
+			resultRaw, status, err := translateDesktopV2Result(binding, privateRaw)
+			require.NoError(t, err)
+			assert.Equal(t, desktopV2StatusError, status)
+			exchange, err := desktopobserve.DecodeExchange(publicRaw, resultRaw)
+			require.NoError(t, err)
+			require.NotNil(t, exchange.Result.RuntimeReceipt.ReasonCode)
+			assert.Equal(t, test.reason, *exchange.Result.RuntimeReceipt.ReasonCode)
+			assert.Equal(t, desktopobserve.NextStep(test.reason), *exchange.Result.RuntimeReceipt.NextStep)
+		})
+	}
+
+	_, binding := desktopV2PublicRequest(t, desktopobserve.OperationPermissions)
+	tampered := bytes.Replace(
+		desktopV2FailureResult(t, binding, desktopobserve.ReasonAccessibilityPermissionMissing),
+		[]byte("Grant Accessibility access to the signed app and retry explicitly."),
+		[]byte("Run an unsafe fallback."), 1,
+	)
+	result, _, err := translateDesktopV2Result(binding, tampered)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func countPublicDesktopNodesByName(node desktopobserve.SemanticNode, name string) int {
+	count := 0
+	if node.Name == name {
+		count++
+	}
+	for _, child := range node.Children {
+		count += countPublicDesktopNodesByName(child, name)
+	}
+	return count
+}

--- a/pkg/qa/run/desktop_observe_v2_digest.go
+++ b/pkg/qa/run/desktop_observe_v2_digest.go
@@ -1,0 +1,127 @@
+package run
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"slices"
+	"sort"
+	"strings"
+	"unicode/utf16"
+
+	"golang.org/x/text/unicode/norm"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+type desktopV2CanonicalContent struct {
+	Nodes         []desktopV2CanonicalNode `json:"nodes"`
+	SchemaVersion string                   `json:"schema_version"`
+}
+
+type desktopV2CanonicalNode struct {
+	AdvertisedActions []string                 `json:"advertised_actions"`
+	Children          []desktopV2CanonicalNode `json:"children"`
+	Name              string                   `json:"name"`
+	Occurrence        uint64                   `json:"occurrence"`
+	Role              string                   `json:"role"`
+	SemanticState     map[string]any           `json:"semantic_state"`
+}
+
+type desktopV2CanonicalBase struct {
+	AdvertisedActions []string                 `json:"advertised_actions"`
+	Children          []desktopV2CanonicalNode `json:"children"`
+	Name              string                   `json:"name"`
+	Role              string                   `json:"role"`
+	SemanticState     map[string]any           `json:"semantic_state"`
+}
+
+type desktopV2PreparedCanonical struct {
+	base    desktopV2CanonicalBase
+	primary string
+	sortKey string
+}
+
+func validateDesktopV2Digest(projection desktopV2Projection) error {
+	canonical, err := desktopV2CanonicalBytes(projection)
+	if err != nil {
+		return err
+	}
+	digest := sha256.Sum256(canonical)
+	if hex.EncodeToString(digest[:]) != projection.Digest {
+		return desktopobserve.ErrMalformedEnvelope
+	}
+	return nil
+}
+
+func desktopV2CanonicalBytes(projection desktopV2Projection) ([]byte, error) {
+	nodes, err := canonicalizeDesktopV2Siblings(projection.Nodes)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(desktopV2CanonicalContent{
+		Nodes: nodes, SchemaVersion: "autopus.desktop-observe.canonical.v2",
+	})
+}
+
+func canonicalizeDesktopV2Siblings(nodes []desktopV2Node) ([]desktopV2CanonicalNode, error) {
+	prepared := make([]desktopV2PreparedCanonical, 0, len(nodes))
+	for _, node := range nodes {
+		actions := make([]string, 0, len(node.AdvertisedActions))
+		for _, action := range node.AdvertisedActions {
+			actions = append(actions, normalizeDesktopV2Text(action))
+		}
+		sort.Slice(actions, func(i, j int) bool { return compareDesktopV2Text(actions[i], actions[j]) < 0 })
+		actions = slices.Compact(actions)
+		children, err := canonicalizeDesktopV2Siblings(node.Children)
+		if err != nil {
+			return nil, err
+		}
+		state := make(map[string]any, len(node.SemanticState))
+		for key, value := range node.SemanticState {
+			state[normalizeDesktopV2Text(key)] = value
+		}
+		base := desktopV2CanonicalBase{
+			AdvertisedActions: actions, Children: children, Name: normalizeDesktopV2Text(node.Name),
+			Role: normalizeDesktopV2Text(node.Role), SemanticState: state,
+		}
+		primaryRaw, err := json.Marshal([]any{base.Role, base.Name, base.SemanticState, base.AdvertisedActions})
+		if err != nil {
+			return nil, desktopobserve.ErrMalformedEnvelope
+		}
+		sortRaw, err := json.Marshal(base)
+		if err != nil {
+			return nil, desktopobserve.ErrMalformedEnvelope
+		}
+		prepared = append(prepared, desktopV2PreparedCanonical{
+			base: base, primary: string(primaryRaw), sortKey: string(sortRaw),
+		})
+	}
+	sort.SliceStable(prepared, func(i, j int) bool {
+		if comparison := compareDesktopV2Text(prepared[i].primary, prepared[j].primary); comparison != 0 {
+			return comparison < 0
+		}
+		return compareDesktopV2Text(prepared[i].sortKey, prepared[j].sortKey) < 0
+	})
+	occurrences := make(map[string]uint64)
+	canonical := make([]desktopV2CanonicalNode, 0, len(prepared))
+	for _, item := range prepared {
+		canonical = append(canonical, desktopV2CanonicalNode{
+			AdvertisedActions: item.base.AdvertisedActions, Children: item.base.Children,
+			Name: item.base.Name, Occurrence: occurrences[item.primary], Role: item.base.Role,
+			SemanticState: item.base.SemanticState,
+		})
+		occurrences[item.primary]++
+	}
+	return canonical, nil
+}
+
+func normalizeDesktopV2Text(value string) string {
+	value = strings.ReplaceAll(value, "\r\n", "\n")
+	value = strings.ReplaceAll(value, "\r", "\n")
+	return norm.NFC.String(value)
+}
+
+func compareDesktopV2Text(left, right string) int {
+	return slices.Compare(utf16.Encode([]rune(left)), utf16.Encode([]rune(right)))
+}

--- a/pkg/qa/run/desktop_observe_v2_json.go
+++ b/pkg/qa/run/desktop_observe_v2_json.go
@@ -1,0 +1,125 @@
+package run
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+func desktopV2MessageBody(raw []byte) ([]byte, error) {
+	if len(raw) == 0 || len(raw) > desktopobserve.MaxEnvelopeBytes {
+		if len(raw) > desktopobserve.MaxEnvelopeBytes {
+			return nil, desktopobserve.ErrEnvelopeTooLarge
+		}
+		return nil, desktopobserve.ErrMalformedEnvelope
+	}
+	if !utf8.Valid(raw) || raw[len(raw)-1] != '\n' {
+		return nil, desktopobserve.ErrMalformedEnvelope
+	}
+	body := raw[:len(raw)-1]
+	if len(body) == 0 || bytes.ContainsAny(body, "\r\n") {
+		return nil, desktopobserve.ErrMalformedEnvelope
+	}
+	return body, nil
+}
+
+func decodeDesktopV2Object(raw []byte, target any, keys ...string) error {
+	if len(raw) == 0 || len(raw) > desktopobserve.MaxEnvelopeBytes || !utf8.Valid(raw) {
+		if len(raw) > desktopobserve.MaxEnvelopeBytes {
+			return desktopobserve.ErrEnvelopeTooLarge
+		}
+		return desktopobserve.ErrMalformedEnvelope
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := rejectDesktopV2DuplicateKeys(decoder); err != nil {
+		return err
+	}
+	decoder = json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		if strings.Contains(err.Error(), "unknown field") {
+			return fmt.Errorf("%w: private result", desktopobserve.ErrUnknownField)
+		}
+		return desktopobserve.ErrMalformedEnvelope
+	}
+	if err := desktopV2JSONEOF(decoder); err != nil {
+		return err
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &object); err != nil || object == nil || len(object) != len(keys) {
+		return desktopobserve.ErrMissingField
+	}
+	for _, key := range keys {
+		if _, ok := object[key]; !ok {
+			return desktopobserve.ErrMissingField
+		}
+	}
+	return nil
+}
+
+func rejectDesktopV2DuplicateKeys(decoder *json.Decoder) error {
+	if err := consumeDesktopV2Value(decoder); err != nil {
+		return err
+	}
+	return desktopV2JSONEOF(decoder)
+}
+
+func consumeDesktopV2Value(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return desktopobserve.ErrMalformedEnvelope
+	}
+	delimiter, structured := token.(json.Delim)
+	if !structured {
+		return nil
+	}
+	switch delimiter {
+	case '{':
+		seen := make(map[string]bool)
+		for decoder.More() {
+			keyToken, keyErr := decoder.Token()
+			key, ok := keyToken.(string)
+			if keyErr != nil || !ok {
+				return desktopobserve.ErrMalformedEnvelope
+			}
+			if seen[key] {
+				return desktopobserve.ErrDuplicateKey
+			}
+			seen[key] = true
+			if err := consumeDesktopV2Value(decoder); err != nil {
+				return err
+			}
+		}
+		return consumeDesktopV2Closing(decoder, '}')
+	case '[':
+		for decoder.More() {
+			if err := consumeDesktopV2Value(decoder); err != nil {
+				return err
+			}
+		}
+		return consumeDesktopV2Closing(decoder, ']')
+	default:
+		return desktopobserve.ErrMalformedEnvelope
+	}
+}
+
+func consumeDesktopV2Closing(decoder *json.Decoder, expected json.Delim) error {
+	token, err := decoder.Token()
+	if err != nil || token != expected {
+		return desktopobserve.ErrMalformedEnvelope
+	}
+	return nil
+}
+
+func desktopV2JSONEOF(decoder *json.Decoder) error {
+	if _, err := decoder.Token(); err != io.EOF {
+		return desktopobserve.ErrMalformedEnvelope
+	}
+	return nil
+}

--- a/pkg/qa/run/desktop_observe_v2_payload.go
+++ b/pkg/qa/run/desktop_observe_v2_payload.go
@@ -1,0 +1,84 @@
+package run
+
+import (
+	"bytes"
+	"encoding/json"
+	"slices"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+func mapDesktopV2Payload(
+	operation desktopobserve.Operation,
+	raw json.RawMessage,
+) (json.RawMessage, error) {
+	var publicPayload any
+	switch operation {
+	case desktopobserve.OperationCapabilities:
+		var payload struct {
+			Capabilities []string `json:"capabilities"`
+		}
+		if err := decodeDesktopV2Object(raw, &payload, "capabilities"); err != nil ||
+			!slices.Equal(payload.Capabilities, desktopV2Operations) {
+			return nil, desktopobserve.ErrMalformedEnvelope
+		}
+		publicPayload = struct {
+			Capabilities []desktopobserve.CapabilityStatus `json:"capabilities"`
+		}{Capabilities: desktopSupportedCapabilities()}
+	case desktopobserve.OperationPermissions:
+		var payload struct {
+			Accessibility string  `json:"accessibility"`
+			NextStep      *string `json:"next_step"`
+		}
+		if err := decodeDesktopV2Object(raw, &payload, "accessibility", "next_step"); err != nil ||
+			payload.Accessibility != "granted" || payload.NextStep != nil {
+			return nil, desktopobserve.ErrMalformedEnvelope
+		}
+		publicPayload = desktopobserve.PermissionResult{AccessibilityGranted: true}
+	case desktopobserve.OperationListApps:
+		var payload struct {
+			AppRefs []string `json:"app_refs"`
+		}
+		if err := decodeDesktopV2Object(raw, &payload, "app_refs"); err != nil ||
+			!slices.Equal(payload.AppRefs, []string{"autopus-desktop"}) {
+			return nil, desktopobserve.ErrMalformedEnvelope
+		}
+		publicPayload = struct {
+			Apps []desktopobserve.AppSummary `json:"apps"`
+		}{Apps: []desktopobserve.AppSummary{{AppRef: "autopus-desktop"}}}
+	case desktopobserve.OperationListWindows:
+		var payload struct {
+			WindowRefs []string `json:"window_refs"`
+		}
+		if err := decodeDesktopV2Object(raw, &payload, "window_refs"); err != nil ||
+			!slices.Equal(payload.WindowRefs, []string{"main-window"}) {
+			return nil, desktopobserve.ErrMalformedEnvelope
+		}
+		publicPayload = struct {
+			Windows []desktopobserve.WindowSummary `json:"windows"`
+		}{Windows: []desktopobserve.WindowSummary{{WindowRef: "main-window"}}}
+	case desktopobserve.OperationGetState:
+		var payload struct {
+			SemanticProjection json.RawMessage `json:"semantic_projection"`
+		}
+		if err := decodeDesktopV2Object(raw, &payload, "semantic_projection"); err != nil ||
+			len(payload.SemanticProjection) == 0 ||
+			bytes.Equal(bytes.TrimSpace(payload.SemanticProjection), []byte("null")) {
+			return nil, desktopobserve.ErrMalformedEnvelope
+		}
+		projection, err := mapDesktopV2Projection(payload.SemanticProjection)
+		if err != nil {
+			return nil, err
+		}
+		publicPayload = struct {
+			SemanticProjection desktopobserve.SemanticProjection `json:"semantic_projection"`
+		}{SemanticProjection: projection}
+	default:
+		return nil, desktopobserve.ErrUnsupportedOperation
+	}
+	encoded, err := json.Marshal(publicPayload)
+	if err != nil || len(encoded) > desktopobserve.MaxEnvelopeBytes {
+		return nil, desktopobserve.ErrEnvelopeTooLarge
+	}
+	return encoded, nil
+}

--- a/pkg/qa/run/desktop_observe_v2_projection.go
+++ b/pkg/qa/run/desktop_observe_v2_projection.go
@@ -1,0 +1,235 @@
+package run
+
+import (
+	"bytes"
+	"encoding/json"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+const (
+	desktopV2ProjectionSchema = "autopus.desktop-observe.semantic-projection.v2"
+	desktopV2MaxNodes         = 256
+	desktopV2MaxDepth         = 32
+	desktopV2MaxSafeInteger   = uint64(9_007_199_254_740_991)
+)
+
+var (
+	desktopV2RolePattern   = regexp.MustCompile(`^AX[A-Za-z]+$`)
+	desktopV2DigestPattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
+	desktopV2RefPattern    = regexp.MustCompile(`^[a-z][a-z0-9_-]{2,95}$`)
+	desktopV2SafeNames     = []string{"Autopus", "Disclosure", "Status"}
+)
+
+type desktopV2Projection struct {
+	SchemaVersion string          `json:"schema_version"`
+	ProviderRef   string          `json:"provider_ref"`
+	AppRef        string          `json:"app_ref"`
+	WindowRef     string          `json:"window_ref"`
+	StateRef      string          `json:"state_ref"`
+	Digest        string          `json:"digest"`
+	Nodes         []desktopV2Node `json:"-"`
+}
+
+type desktopV2ProjectionWire struct {
+	SchemaVersion string            `json:"schema_version"`
+	ProviderRef   string            `json:"provider_ref"`
+	AppRef        string            `json:"app_ref"`
+	WindowRef     string            `json:"window_ref"`
+	StateRef      string            `json:"state_ref"`
+	Digest        string            `json:"digest"`
+	Nodes         []json.RawMessage `json:"nodes"`
+}
+
+type desktopV2Node struct {
+	AdvertisedActions []string
+	Children          []desktopV2Node
+	Frame             *desktopobserve.Frame
+	Name              string
+	NodeRef           string
+	Occurrence        uint64
+	ParentNodeRef     *string
+	Role              string
+	SemanticState     map[string]any
+}
+
+type desktopV2NodeWire struct {
+	AdvertisedActions []string                   `json:"advertised_actions"`
+	Children          []json.RawMessage          `json:"children"`
+	Frame             *desktopV2FrameWire        `json:"frame,omitempty"`
+	Name              string                     `json:"name"`
+	NodeRef           string                     `json:"node_ref"`
+	Occurrence        *uint64                    `json:"occurrence"`
+	ParentNodeRef     *string                    `json:"parent_node_ref"`
+	Role              string                     `json:"role"`
+	SemanticState     map[string]json.RawMessage `json:"semantic_state"`
+}
+
+type desktopV2FrameWire struct {
+	X      *int `json:"x"`
+	Y      *int `json:"y"`
+	Width  *int `json:"width"`
+	Height *int `json:"height"`
+}
+
+type desktopV2ProjectionContext struct {
+	count int
+	refs  map[string]bool
+}
+
+func mapDesktopV2Projection(raw []byte) (desktopobserve.SemanticProjection, error) {
+	projection, err := decodeDesktopV2Projection(raw)
+	if err != nil || validateDesktopV2Digest(projection) != nil {
+		return desktopobserve.SemanticProjection{}, desktopobserve.ErrMalformedEnvelope
+	}
+	if len(projection.Nodes) != 1 || !validDesktopV2Landmarks(projection.Nodes[0]) {
+		return desktopobserve.SemanticProjection{}, desktopobserve.ErrMalformedEnvelope
+	}
+	publicRoot := mapDesktopV2Node(projection.Nodes[0])
+	publicProjection := desktopobserve.SemanticProjection{
+		SchemaVersion: desktopobserve.SemanticProjectionSchemaVersion,
+		ProviderRef:   "provider-local",
+		AppRef:        projection.AppRef,
+		WindowRef:     projection.WindowRef,
+		StateRef:      "state-" + strings.TrimPrefix(projection.StateRef, "state_v2_"),
+		Root:          publicRoot,
+	}
+	return desktopobserve.NormalizeProjection(publicProjection, func(value string) (string, error) {
+		if slices.Contains(desktopV2SafeNames, value) {
+			return value, nil
+		}
+		return "", desktopobserve.ErrRedactionFailed
+	})
+}
+
+func decodeDesktopV2Projection(raw []byte) (desktopV2Projection, error) {
+	var wire desktopV2ProjectionWire
+	if err := decodeDesktopV2Object(
+		raw, &wire, "schema_version", "provider_ref", "app_ref", "window_ref",
+		"state_ref", "digest", "nodes",
+	); err != nil {
+		return desktopV2Projection{}, err
+	}
+	if wire.SchemaVersion != desktopV2ProjectionSchema || wire.ProviderRef != "provider_rust_go" ||
+		wire.AppRef != "autopus-desktop" || wire.WindowRef != "main-window" ||
+		!strings.HasPrefix(wire.StateRef, "state_v2_") ||
+		!desktopV2DigestPattern.MatchString(strings.TrimPrefix(wire.StateRef, "state_v2_")) ||
+		!desktopV2DigestPattern.MatchString(wire.Digest) || len(wire.Nodes) == 0 {
+		return desktopV2Projection{}, desktopobserve.ErrMalformedEnvelope
+	}
+	context := &desktopV2ProjectionContext{refs: make(map[string]bool)}
+	nodes := make([]desktopV2Node, 0, len(wire.Nodes))
+	for _, rawNode := range wire.Nodes {
+		node, err := decodeDesktopV2Node(rawNode, nil, 1, context)
+		if err != nil {
+			return desktopV2Projection{}, err
+		}
+		nodes = append(nodes, node)
+	}
+	return desktopV2Projection{
+		SchemaVersion: wire.SchemaVersion, ProviderRef: wire.ProviderRef, AppRef: wire.AppRef,
+		WindowRef: wire.WindowRef, StateRef: wire.StateRef, Digest: wire.Digest, Nodes: nodes,
+	}, nil
+}
+
+func decodeDesktopV2Node(
+	raw []byte,
+	parent *string,
+	depth int,
+	context *desktopV2ProjectionContext,
+) (desktopV2Node, error) {
+	var wire desktopV2NodeWire
+	withFrame := []string{"advertised_actions", "children", "frame", "name", "node_ref", "occurrence", "parent_node_ref", "role", "semantic_state"}
+	withoutFrame := []string{"advertised_actions", "children", "name", "node_ref", "occurrence", "parent_node_ref", "role", "semantic_state"}
+	if err := decodeDesktopV2Object(raw, &wire, withFrame...); err != nil {
+		if err := decodeDesktopV2Object(raw, &wire, withoutFrame...); err != nil {
+			return desktopV2Node{}, err
+		}
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil || wire.Children == nil || wire.Occurrence == nil ||
+		bytes.Equal(bytes.TrimSpace(fields["frame"]), []byte("null")) {
+		return desktopV2Node{}, desktopobserve.ErrMalformedEnvelope
+	}
+	context.count++
+	if depth > desktopV2MaxDepth || context.count > desktopV2MaxNodes ||
+		!desktopV2RefPattern.MatchString(wire.NodeRef) || context.refs[wire.NodeRef] ||
+		!sameDesktopV2Parent(wire.ParentNodeRef, parent) || *wire.Occurrence > desktopV2MaxSafeInteger ||
+		!desktopV2RolePattern.MatchString(wire.Role) || len(wire.Name) > 512 ||
+		!slices.Contains(desktopV2SafeNames, wire.Name) || !validDesktopV2Actions(wire.AdvertisedActions) ||
+		!validDesktopV2FrameWire(wire.Frame) {
+		return desktopV2Node{}, desktopobserve.ErrMalformedEnvelope
+	}
+	context.refs[wire.NodeRef] = true
+	state, err := decodeDesktopV2State(wire.SemanticState)
+	if err != nil {
+		return desktopV2Node{}, err
+	}
+	children := make([]desktopV2Node, 0, len(wire.Children))
+	for _, rawChild := range wire.Children {
+		child, err := decodeDesktopV2Node(rawChild, &wire.NodeRef, depth+1, context)
+		if err != nil {
+			return desktopV2Node{}, err
+		}
+		children = append(children, child)
+	}
+	return desktopV2Node{
+		AdvertisedActions: wire.AdvertisedActions, Children: children, Frame: mapDesktopV2Frame(wire.Frame),
+		Name: wire.Name, NodeRef: wire.NodeRef, Occurrence: *wire.Occurrence,
+		ParentNodeRef: wire.ParentNodeRef, Role: wire.Role, SemanticState: state,
+	}, nil
+}
+
+func decodeDesktopV2State(raw map[string]json.RawMessage) (map[string]any, error) {
+	if raw == nil {
+		return nil, desktopobserve.ErrMalformedEnvelope
+	}
+	state := make(map[string]any, len(raw))
+	for key, value := range raw {
+		if key == "checked" {
+			return nil, desktopobserve.ErrMalformedEnvelope
+		}
+		if !slices.Contains([]string{"enabled", "expanded", "focused", "selected", "visible"}, key) {
+			return nil, desktopobserve.ErrMalformedEnvelope
+		}
+		trimmed := bytes.TrimSpace(value)
+		if !bytes.Equal(trimmed, []byte("true")) && !bytes.Equal(trimmed, []byte("false")) {
+			return nil, desktopobserve.ErrMalformedEnvelope
+		}
+		boolean := bytes.Equal(trimmed, []byte("true"))
+		state[key] = boolean
+	}
+	return state, nil
+}
+
+func mapDesktopV2Node(node desktopV2Node) desktopobserve.SemanticNode {
+	state := desktopobserve.SemanticState{}
+	for key, raw := range node.SemanticState {
+		value := raw.(bool)
+		switch key {
+		case "enabled":
+			state.Enabled = &value
+		case "expanded":
+			state.Expanded = &value
+		case "focused":
+			state.Focused = &value
+		case "selected":
+			state.Selected = &value
+		}
+	}
+	children := make([]desktopobserve.SemanticNode, 0, len(node.Children))
+	for _, child := range node.Children {
+		children = append(children, mapDesktopV2Node(child))
+	}
+	actions := make([]desktopobserve.Action, 0, len(node.AdvertisedActions))
+	for _, action := range node.AdvertisedActions {
+		actions = append(actions, desktopobserve.Action(action))
+	}
+	return desktopobserve.SemanticNode{
+		Role: desktopobserve.Role(node.Role), Name: node.Name, SemanticState: state,
+		Frame: node.Frame, AdvertisedActions: actions, Children: children,
+	}
+}

--- a/pkg/qa/run/desktop_observe_v2_projection_test.go
+++ b/pkg/qa/run/desktop_observe_v2_projection_test.go
@@ -1,0 +1,112 @@
+package run
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+func TestDesktopV2CanonicalDigest_MatchesRustGoldenVector(t *testing.T) {
+	t.Parallel()
+	appRef := "application_fixture_00"
+	windowRef := "window_fixture_00"
+	projection := desktopV2Projection{Nodes: []desktopV2Node{{
+		AdvertisedActions: []string{}, Name: "Autopus", NodeRef: appRef, Role: "AXApplication",
+		SemanticState: map[string]any{"enabled": true},
+		Children: []desktopV2Node{{
+			AdvertisedActions: []string{}, Name: "Autopus", NodeRef: windowRef,
+			ParentNodeRef: &appRef, Role: "AXWindow", SemanticState: map[string]any{"focused": true},
+			Children: []desktopV2Node{
+				{AdvertisedActions: []string{}, Name: "Cafe\u0301\r\nReady", NodeRef: "text_fixture_00",
+					Occurrence: 7, ParentNodeRef: &windowRef, Role: "AXStaticText",
+					SemanticState: map[string]any{"visible": true}},
+				{AdvertisedActions: []string{"AXPress"}, Name: "Retry", NodeRef: "retry_fixture_01",
+					Occurrence: 9, ParentNodeRef: &windowRef, Role: "AXButton",
+					SemanticState: map[string]any{"enabled": true}},
+				{AdvertisedActions: []string{"AXPress"}, Name: "Retry", NodeRef: "retry_fixture_00",
+					Occurrence: 4, ParentNodeRef: &windowRef, Role: "AXButton",
+					SemanticState: map[string]any{"enabled": true}},
+			},
+		}},
+	}}}
+	canonical, err := desktopV2CanonicalBytes(projection)
+	require.NoError(t, err)
+	digest := sha256.Sum256(canonical)
+	assert.Equal(t, "8e7104e0c5dfe7f39ae3a2aa9282020b5cc1d6375f231d6a9ef1fb73cc6d2ce4", hex.EncodeToString(digest[:]))
+}
+
+func TestDesktopV2ProjectionAdapter_PreservesRecursiveMultiplicityAndSemanticChange(t *testing.T) {
+	t.Parallel()
+	beforeRaw := desktopV2ProjectionResult(t, desktopV2RecursiveRoot(false))
+	afterRaw := desktopV2ProjectionResult(t, desktopV2RecursiveRoot(true))
+	before, err := mapDesktopV2Projection(beforeRaw)
+	require.NoError(t, err)
+	after, err := mapDesktopV2Projection(afterRaw)
+	require.NoError(t, err)
+	assert.NotEqual(t, before.Digest, after.Digest)
+	assert.Equal(t, 3, countPublicDesktopNodesByName(before.Root, "Disclosure"))
+	refs := collectPublicDesktopRefs(before.Root, nil)
+	assert.Len(t, refs, 6)
+
+	visibleRoot := desktopV2RecursiveRoot(false)
+	visibleRoot.Children[0].Children[1].SemanticState["visible"] = false
+	visibleRaw := desktopV2ProjectionResult(t, visibleRoot)
+	visibleProjection, err := mapDesktopV2Projection(visibleRaw)
+	require.NoError(t, err)
+	assert.Equal(t, before.Digest, visibleProjection.Digest, "visible is the explicit safe private-only state")
+	assert.NotEqual(t, privateDesktopV2Digest(t, beforeRaw), privateDesktopV2Digest(t, visibleRaw))
+}
+
+func TestDesktopV2ProjectionAdapter_RejectsTamperingAndUnmappableTreeData(t *testing.T) {
+	t.Parallel()
+	valid := desktopV2ProjectionResult(t, desktopV2RecursiveRoot(false))
+	framedRoot := desktopV2RecursiveRoot(false)
+	framedRoot.Children[0].Frame = &desktopobserve.Frame{X: 4, Y: 8, Width: 800, Height: 600}
+	withFrame := desktopV2ProjectionResult(t, framedRoot)
+	tests := []struct {
+		name string
+		raw  []byte
+	}{
+		{"private digest tamper", bytes.Replace(valid, []byte(`"digest":"`), []byte(`"digest":"f`), 1)},
+		{"unknown safe name", bytes.Replace(valid, []byte(`"name":"Status"`), []byte(`"name":"Private User Title"`), 1)},
+		{"unmappable checked state", bytes.Replace(valid, []byte(`"visible":true`), []byte(`"checked":"mixed"`), 1)},
+		{"null boolean state", bytes.Replace(valid, []byte(`"expanded":false`), []byte(`"expanded":null`), 1)},
+		{"null occurrence", bytes.Replace(valid, []byte(`"occurrence":0`), []byte(`"occurrence":null`), 1)},
+		{"null frame coordinate", bytes.Replace(withFrame, []byte(`"x":4`), []byte(`"x":null`), 1)},
+		{"missing frame coordinate", bytes.Replace(withFrame, []byte(`"x":4,`), nil, 1)},
+		{"unknown action", bytes.Replace(valid, []byte(`"AXPress"`), []byte(`"AXDelete"`), 1)},
+		{"duplicate node ref", bytes.Replace(valid, []byte(`disclosure_fixture_01`), []byte(`disclosure_fixture_00`), 1)},
+		{"broken parent ref", bytes.Replace(valid, []byte(`"parent_node_ref":"group_fixture_00"`), []byte(`"parent_node_ref":"window_fixture_00"`), 1)},
+		{"unknown node field", bytes.Replace(valid, []byte(`"name":"Status"`), []byte(`"pid":4242,"name":"Status"`), 1)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			projection, err := mapDesktopV2Projection(test.raw)
+			assert.Error(t, err)
+			assert.Empty(t, projection.Digest)
+			assert.NotContains(t, err.Error(), "4242")
+		})
+	}
+}
+
+func privateDesktopV2Digest(t *testing.T, raw []byte) string {
+	t.Helper()
+	var wire desktopV2TestProjection
+	require.NoError(t, json.Unmarshal(raw, &wire))
+	return wire.Digest
+}
+
+func collectPublicDesktopRefs(node desktopobserve.SemanticNode, refs []string) []string {
+	refs = append(refs, node.NodeRef)
+	for _, child := range node.Children {
+		refs = collectPublicDesktopRefs(child, refs)
+	}
+	return refs
+}

--- a/pkg/qa/run/desktop_observe_v2_projection_validate.go
+++ b/pkg/qa/run/desktop_observe_v2_projection_validate.go
@@ -1,0 +1,85 @@
+package run
+
+import (
+	"slices"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+func sameDesktopV2Parent(actual, expected *string) bool {
+	if actual == nil || expected == nil {
+		return actual == nil && expected == nil
+	}
+	return *actual == *expected
+}
+
+func validDesktopV2Actions(actions []string) bool {
+	if actions == nil {
+		return false
+	}
+	allowed := []string{
+		string(desktopobserve.ActionPress),
+		string(desktopobserve.ActionRaise),
+		string(desktopobserve.ActionShowMenu),
+	}
+	for index, action := range actions {
+		if !slices.Contains(allowed, action) || (index > 0 && actions[index-1] >= action) {
+			return false
+		}
+	}
+	return true
+}
+
+func validDesktopV2FrameWire(frame *desktopV2FrameWire) bool {
+	if frame == nil {
+		return true
+	}
+	if frame.X == nil || frame.Y == nil || frame.Width == nil || frame.Height == nil {
+		return false
+	}
+	return *frame.X >= 0 && *frame.Y >= 0 && *frame.Width > 0 && *frame.Height > 0 &&
+		*frame.X <= 100_000 && *frame.Y <= 100_000 &&
+		*frame.Width <= 100_000 && *frame.Height <= 100_000
+}
+
+func mapDesktopV2Frame(frame *desktopV2FrameWire) *desktopobserve.Frame {
+	if frame == nil {
+		return nil
+	}
+	return &desktopobserve.Frame{
+		X: *frame.X, Y: *frame.Y, Width: *frame.Width, Height: *frame.Height,
+	}
+}
+
+func validDesktopV2Landmarks(root desktopV2Node) bool {
+	if root.Role != string(desktopobserve.RoleApplication) || root.Name != "Autopus" ||
+		root.ParentNodeRef != nil || !desktopV2StateTrue(root, "enabled") || len(root.Children) != 1 {
+		return false
+	}
+	window := root.Children[0]
+	if window.Role != string(desktopobserve.RoleWindow) || window.Name != "Autopus" ||
+		window.ParentNodeRef == nil || *window.ParentNodeRef != root.NodeRef ||
+		!desktopV2StateTrue(window, "focused") {
+		return false
+	}
+	return hasDesktopV2Disclosure(window.Children)
+}
+
+func desktopV2StateTrue(node desktopV2Node, key string) bool {
+	value, ok := node.SemanticState[key].(bool)
+	return ok && value
+}
+
+func hasDesktopV2Disclosure(nodes []desktopV2Node) bool {
+	for _, node := range nodes {
+		if node.Name == "Disclosure" && node.Role == "AXButton" {
+			if _, ok := node.SemanticState["expanded"].(bool); ok {
+				return true
+			}
+		}
+		if hasDesktopV2Disclosure(node.Children) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/qa/run/desktop_observe_v2_receipt.go
+++ b/pkg/qa/run/desktop_observe_v2_receipt.go
@@ -1,0 +1,150 @@
+package run
+
+import (
+	"bytes"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+type desktopV2Provider struct {
+	Name            string `json:"name"`
+	Version         string `json:"version"`
+	ProtocolVersion int    `json:"protocol_version"`
+}
+
+type desktopV2Capability struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+
+type desktopV2Status struct {
+	Status string `json:"status"`
+}
+
+type desktopV2Receipt struct {
+	SchemaVersion     string                `json:"schema_version"`
+	Provider          desktopV2Provider     `json:"provider"`
+	Scope             desktopV2Scope        `json:"scope"`
+	CapabilitySummary []desktopV2Capability `json:"capability_summary"`
+	ReasonCode        *string               `json:"reason_code"`
+	NextStep          *string               `json:"next_step"`
+	Redaction         desktopV2Status       `json:"redaction"`
+	Quarantine        desktopV2Status       `json:"quarantine"`
+}
+
+var desktopV2NextSteps = map[desktopobserve.ReasonCode]string{
+	desktopobserve.ReasonAccessibilityPermissionMissing: "Grant Accessibility access to the signed app and retry explicitly.",
+	desktopobserve.ReasonTargetAppNotFound:              "Launch exactly one signed Autopus Desktop target and retry.",
+	desktopobserve.ReasonTargetWindowNotFound:           "Open and focus the public main window, then retry.",
+	desktopobserve.ReasonStaleState:                     "Request a fresh state without reusing an earlier state reference.",
+	desktopobserve.ReasonSemanticProjectionUnavailable:  "Expose the required application and window landmarks, then retry.",
+	desktopobserve.ReasonCapabilityUnsupported:          "Use one of the five advertised read-only operations.",
+	desktopobserve.ReasonProviderUnavailable:            "Retry with the exact bounded provider contract.",
+	desktopobserve.ReasonRedactionFailed:                "Retry with the exact bounded provider contract.",
+	desktopobserve.ReasonEvidenceQuarantined:            "Retry with the exact bounded provider contract.",
+	desktopobserve.ReasonProviderProtocolMismatch:       "Retry with the exact bounded provider contract.",
+}
+
+func decodeDesktopV2Receipt(
+	raw []byte,
+	binding desktopV2Binding,
+	resultStatus string,
+) (desktopV2Receipt, error) {
+	if len(raw) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return desktopV2Receipt{}, desktopobserve.ErrMissingField
+	}
+	var receipt desktopV2Receipt
+	if err := decodeDesktopV2Object(
+		raw, &receipt, "schema_version", "provider", "scope", "capability_summary",
+		"reason_code", "next_step", "redaction", "quarantine",
+	); err != nil {
+		return desktopV2Receipt{}, err
+	}
+	if receipt.SchemaVersion != desktopobserve.RuntimeReceiptSchemaVersion ||
+		receipt.Provider != (desktopV2Provider{Name: "rust-go", Version: "0.0.1", ProtocolVersion: 2}) ||
+		receipt.Scope != binding.privateRequest.Scope || receipt.Quarantine.Status != "empty" ||
+		!validDesktopV2Capabilities(receipt.CapabilitySummary) {
+		return desktopV2Receipt{}, desktopobserve.ErrMalformedEnvelope
+	}
+	if resultStatus == desktopV2StatusOK {
+		expectedRedaction := "not_required"
+		if binding.publicRequest.Operation == desktopobserve.OperationGetState {
+			expectedRedaction = "applied"
+		}
+		if receipt.ReasonCode != nil || receipt.NextStep != nil || receipt.Redaction.Status != expectedRedaction {
+			return desktopV2Receipt{}, desktopobserve.ErrMalformedEnvelope
+		}
+		return receipt, nil
+	}
+	if receipt.ReasonCode == nil || receipt.NextStep == nil || receipt.Redaction.Status != "not_required" {
+		return desktopV2Receipt{}, desktopobserve.ErrMalformedEnvelope
+	}
+	reason := desktopobserve.ReasonCode(*receipt.ReasonCode)
+	if expected, ok := desktopV2NextSteps[reason]; !ok || *receipt.NextStep != expected ||
+		!desktopFailureReasonAllowed(reason, binding.publicRequest.Operation) {
+		return desktopV2Receipt{}, desktopobserve.ErrMalformedEnvelope
+	}
+	return receipt, nil
+}
+
+func validDesktopV2Capabilities(capabilities []desktopV2Capability) bool {
+	if len(capabilities) != len(desktopV2Operations) {
+		return false
+	}
+	for index, capability := range capabilities {
+		if capability.Name != desktopV2Operations[index] || capability.Status != "supported" {
+			return false
+		}
+	}
+	return true
+}
+
+func mapDesktopV2Result(
+	binding desktopV2Binding,
+	wire desktopV2ResultWire,
+	receipt desktopV2Receipt,
+) (desktopobserve.Result, error) {
+	publicReceipt := desktopSuccessReceipt(
+		desktopobserve.ProviderIdentity{Name: "autopus-desktop-local", Version: "0.0.1", ProtocolVersion: 1},
+		binding.publicRequest.Scope,
+		desktopSupportedCapabilities(),
+	)
+	publicReceipt.Redaction.Status = desktopobserve.RedactionNotRequired
+	publicReceipt.Quarantine.Status = desktopobserve.QuarantineEmpty
+	result := desktopobserve.Result{
+		ProtocolVersion: desktopobserve.ProtocolVersion,
+		RequestID:       binding.publicRequest.RequestID,
+		Status:          desktopobserve.ResultPassed,
+		RuntimeReceipt:  publicReceipt,
+	}
+	if wire.Status == desktopV2StatusOK {
+		payload, err := mapDesktopV2Payload(binding.publicRequest.Operation, wire.Payload)
+		if err != nil {
+			return desktopobserve.Result{}, err
+		}
+		result.Payload = payload
+		if binding.publicRequest.Operation == desktopobserve.OperationGetState {
+			result.RuntimeReceipt.Redaction.Status = desktopobserve.RedactionApplied
+			result.RuntimeReceipt.Quarantine.Status = desktopobserve.QuarantineCleared
+		}
+		return result, nil
+	}
+	reason := desktopobserve.ReasonCode(*receipt.ReasonCode)
+	nextStep := desktopobserve.NextStep(reason)
+	result.Status = desktopobserve.ResultFailed
+	result.RuntimeReceipt.ReasonCode = &reason
+	result.RuntimeReceipt.NextStep = &nextStep
+	if reason == desktopobserve.ReasonCapabilityUnsupported {
+		result.RuntimeReceipt.CapabilitySummary = desktopMarkUnsupported(
+			result.RuntimeReceipt.CapabilitySummary, binding.publicRequest.Operation,
+		)
+	}
+	if reason == desktopobserve.ReasonRedactionFailed {
+		result.RuntimeReceipt.Redaction.Status = desktopobserve.RedactionFailed
+		result.RuntimeReceipt.Quarantine.Status = desktopobserve.QuarantineBlocked
+	} else if reason == desktopobserve.ReasonEvidenceQuarantined {
+		result.RuntimeReceipt.Redaction.Status = desktopobserve.RedactionApplied
+		result.RuntimeReceipt.Quarantine.Status = desktopobserve.QuarantineBlocked
+	}
+	return result, nil
+}

--- a/pkg/qa/run/desktop_observe_v2_test_helpers_test.go
+++ b/pkg/qa/run/desktop_observe_v2_test_helpers_test.go
@@ -1,0 +1,176 @@
+package run
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
+)
+
+type desktopV2TestNode struct {
+	AdvertisedActions []string              `json:"advertised_actions"`
+	Children          []desktopV2TestNode   `json:"children"`
+	Frame             *desktopobserve.Frame `json:"frame,omitempty"`
+	Name              string                `json:"name"`
+	NodeRef           string                `json:"node_ref"`
+	Occurrence        uint64                `json:"occurrence"`
+	ParentNodeRef     *string               `json:"parent_node_ref"`
+	Role              string                `json:"role"`
+	SemanticState     map[string]any        `json:"semantic_state"`
+}
+
+type desktopV2TestProjection struct {
+	SchemaVersion string              `json:"schema_version"`
+	ProviderRef   string              `json:"provider_ref"`
+	AppRef        string              `json:"app_ref"`
+	WindowRef     string              `json:"window_ref"`
+	StateRef      string              `json:"state_ref"`
+	Digest        string              `json:"digest"`
+	Nodes         []desktopV2TestNode `json:"nodes"`
+}
+
+func desktopV2PublicRequest(
+	t *testing.T,
+	operation desktopobserve.Operation,
+) ([]byte, desktopV2Binding) {
+	t.Helper()
+	scope := desktopobserve.ReceiptScope{
+		Kind: desktopobserve.ScopeProvider, PublicRef: "autopus-desktop-local",
+	}
+	if operation == desktopobserve.OperationListWindows {
+		scope = desktopobserve.ReceiptScope{Kind: desktopobserve.ScopeApplication, PublicRef: "autopus-desktop"}
+	} else if operation == desktopobserve.OperationGetState {
+		scope = desktopobserve.ReceiptScope{Kind: desktopobserve.ScopeWindow, PublicRef: "main-window"}
+	}
+	request := desktopobserve.Request{
+		ProtocolVersion: 1, RequestID: "desktop-observe-golden", Operation: operation, Scope: scope,
+	}
+	raw, err := json.Marshal(request)
+	require.NoError(t, err)
+	raw = append(raw, '\n')
+	_, binding, err := encodeDesktopV2Request(raw)
+	require.NoError(t, err)
+	return raw, binding
+}
+
+func desktopV2SuccessResult(t *testing.T, binding desktopV2Binding, payload any) []byte {
+	t.Helper()
+	redaction := "not_required"
+	if binding.publicRequest.Operation == desktopobserve.OperationGetState {
+		redaction = "applied"
+	}
+	receipt := desktopV2Receipt{
+		SchemaVersion:     desktopobserve.RuntimeReceiptSchemaVersion,
+		Provider:          desktopV2Provider{Name: "rust-go", Version: "0.0.1", ProtocolVersion: 2},
+		Scope:             binding.privateRequest.Scope,
+		CapabilitySummary: desktopV2TestCapabilities(),
+		Redaction:         desktopV2Status{Status: redaction}, Quarantine: desktopV2Status{Status: "empty"},
+	}
+	result := struct {
+		ProtocolVersion int              `json:"protocol_version"`
+		RequestID       string           `json:"request_id"`
+		Status          string           `json:"status"`
+		RuntimeReceipt  desktopV2Receipt `json:"runtime_receipt"`
+		Payload         any              `json:"payload"`
+	}{2, binding.privateRequest.RequestID, desktopV2StatusOK, receipt, payload}
+	raw, err := json.Marshal(result)
+	require.NoError(t, err)
+	return append(raw, '\n')
+}
+
+func desktopV2FailureResult(
+	t *testing.T,
+	binding desktopV2Binding,
+	reason desktopobserve.ReasonCode,
+) []byte {
+	t.Helper()
+	reasonValue := string(reason)
+	nextStep := desktopV2NextSteps[reason]
+	receipt := desktopV2Receipt{
+		SchemaVersion: desktopobserve.RuntimeReceiptSchemaVersion,
+		Provider:      desktopV2Provider{Name: "rust-go", Version: "0.0.1", ProtocolVersion: 2},
+		Scope:         binding.privateRequest.Scope, CapabilitySummary: desktopV2TestCapabilities(),
+		ReasonCode: &reasonValue, NextStep: &nextStep,
+		Redaction: desktopV2Status{Status: "not_required"}, Quarantine: desktopV2Status{Status: "empty"},
+	}
+	result := struct {
+		ProtocolVersion int              `json:"protocol_version"`
+		RequestID       string           `json:"request_id"`
+		Status          string           `json:"status"`
+		RuntimeReceipt  desktopV2Receipt `json:"runtime_receipt"`
+	}{2, binding.privateRequest.RequestID, desktopV2StatusError, receipt}
+	raw, err := json.Marshal(result)
+	require.NoError(t, err)
+	return append(raw, '\n')
+}
+
+func desktopV2TestCapabilities() []desktopV2Capability {
+	result := make([]desktopV2Capability, 0, len(desktopV2Operations))
+	for _, operation := range desktopV2Operations {
+		result = append(result, desktopV2Capability{Name: operation, Status: "supported"})
+	}
+	return result
+}
+
+func desktopV2ProjectionResult(t *testing.T, root desktopV2TestNode) json.RawMessage {
+	t.Helper()
+	wire := desktopV2TestProjection{
+		SchemaVersion: desktopV2ProjectionSchema, ProviderRef: "provider_rust_go",
+		AppRef: "autopus-desktop", WindowRef: "main-window",
+		StateRef: "state_v2_" + repeatDesktopV2Zero(),
+		Digest:   repeatDesktopV2Zero(), Nodes: []desktopV2TestNode{root},
+	}
+	raw, err := json.Marshal(wire)
+	require.NoError(t, err)
+	projection, err := decodeDesktopV2Projection(raw)
+	require.NoError(t, err)
+	canonical, err := desktopV2CanonicalBytes(projection)
+	require.NoError(t, err)
+	digest := sha256.Sum256(canonical)
+	wire.Digest = hex.EncodeToString(digest[:])
+	raw, err = json.Marshal(wire)
+	require.NoError(t, err)
+	return raw
+}
+
+func repeatDesktopV2Zero() string {
+	return "0000000000000000000000000000000000000000000000000000000000000000"
+}
+
+func desktopV2RecursiveRoot(expanded bool) desktopV2TestNode {
+	applicationRef := "application_fixture_00"
+	windowRef := "window_fixture_00"
+	groupRef := "group_fixture_00"
+	disclosureOne := desktopV2TestNode{
+		AdvertisedActions: []string{"AXPress"}, Children: []desktopV2TestNode{}, Name: "Disclosure",
+		NodeRef: "disclosure_fixture_00", ParentNodeRef: &groupRef, Role: "AXButton",
+		SemanticState: map[string]any{"enabled": true, "expanded": expanded},
+	}
+	disclosureTwo := disclosureOne
+	disclosureTwo.NodeRef = "disclosure_fixture_01"
+	disclosureTwo.Occurrence = 1
+	group := desktopV2TestNode{
+		AdvertisedActions: []string{}, Children: []desktopV2TestNode{disclosureOne, disclosureTwo},
+		Name: "Disclosure", NodeRef: groupRef, ParentNodeRef: &windowRef, Role: "AXGroup",
+		SemanticState: map[string]any{"selected": false},
+	}
+	status := desktopV2TestNode{
+		AdvertisedActions: []string{}, Children: []desktopV2TestNode{}, Name: "Status",
+		NodeRef: "status_fixture_00", ParentNodeRef: &windowRef, Role: "AXStaticText",
+		SemanticState: map[string]any{"visible": true},
+	}
+	window := desktopV2TestNode{
+		AdvertisedActions: []string{}, Children: []desktopV2TestNode{group, status}, Name: "Autopus",
+		NodeRef: windowRef, ParentNodeRef: &applicationRef, Role: "AXWindow",
+		SemanticState: map[string]any{"focused": true},
+	}
+	return desktopV2TestNode{
+		AdvertisedActions: []string{}, Children: []desktopV2TestNode{window}, Name: "Autopus",
+		NodeRef: applicationRef, ParentNodeRef: nil, Role: "AXApplication",
+		SemanticState: map[string]any{"enabled": true},
+	}
+}

--- a/pkg/qa/run/runner.go
+++ b/pkg/qa/run/runner.go
@@ -173,6 +173,9 @@ func selectedPacks(opts Options) ([]journey.Pack, error) {
 
 func executePack(opts Options, pack journey.Pack, rawRoot, runDir string) (AdapterResult, string, []IndexCheck) {
 	check := IndexCheck{ID: firstCheckID(pack), JourneyID: pack.ID, Adapter: pack.Adapter.ID, Expected: "exit_code=0"}
+	if pack.Adapter.ID == "desktop-accessibility-observe" {
+		return executeDesktopObservationPack(opts, pack, runDir)
+	}
 	if gap := setupGapFor(opts, pack); gap != nil {
 		check.Status = "skipped"
 		return AdapterResult{Adapter: pack.Adapter.ID, JourneyID: pack.ID, Status: "skipped", SetupGap: gap}, "", []IndexCheck{check}

--- a/pkg/qa/run/types.go
+++ b/pkg/qa/run/types.go
@@ -2,24 +2,34 @@ package run
 
 import (
 	"github.com/insajin/autopus-adk/pkg/qa/adapter"
+	"github.com/insajin/autopus-adk/pkg/qa/desktopobserve"
 	"github.com/insajin/autopus-adk/pkg/qa/mobile"
 )
 
 const RunIndexSchemaVersion = "qamesh.run_index.v1"
 
 type Options struct {
-	ProjectDir    string
-	Profile       string
-	Lane          string
-	JourneyID     string
-	AdapterID     string
-	Output        string
-	DryRun        bool
-	FeedbackTo    string
-	ManagedDevice bool
+	ProjectDir      string
+	Profile         string
+	Lane            string
+	JourneyID       string
+	AdapterID       string
+	Output          string
+	DryRun          bool
+	FeedbackTo      string
+	ManagedDevice   bool
+	RuntimeProvider desktopobserve.RuntimeProvider
 	// deviceRunner is the injectable mobile device seam. It is unexported so the
 	// CLI cannot set it; nil resolves to realMobileDeviceRunner at execution.
 	deviceRunner MobileDeviceRunner
+	// desktopRunner is the injectable, provider-neutral native observation seam.
+	desktopRunner *desktopObservationRunner
+	// desktopArtifactPath injects the release-signed local provider artifact in tests.
+	// Production CLI execution resolves the same value from AUTOPUS_RELEASE_SIGNED_ARTIFACT_PATH.
+	desktopArtifactPath string
+	// desktopArtifactVerifier is the test-only seam for release identity verification.
+	// Production always uses the strict macOS code-signing verifier.
+	desktopArtifactVerifier desktopArtifactVerifier
 }
 
 type Plan struct {
@@ -85,13 +95,14 @@ type SetupGap struct {
 }
 
 type AdapterResult struct {
-	Adapter               string    `json:"adapter"`
-	JourneyID             string    `json:"journey_id"`
-	Status                string    `json:"status"`
-	QAMESHManifestPath    string    `json:"qamesh_manifest_path"`
-	RepairPromptAvailable bool      `json:"repair_prompt_available"`
-	SetupGap              *SetupGap `json:"setup_gap"`
-	FailureSummary        string    `json:"failure_summary"`
+	Adapter               string                              `json:"adapter"`
+	JourneyID             string                              `json:"journey_id"`
+	Status                string                              `json:"status"`
+	QAMESHManifestPath    string                              `json:"qamesh_manifest_path"`
+	RepairPromptAvailable bool                                `json:"repair_prompt_available"`
+	SetupGap              *SetupGap                           `json:"setup_gap"`
+	FailureSummary        string                              `json:"failure_summary"`
+	DesktopObservation    *desktopobserve.ObservationEvidence `json:"desktop_observation,omitempty"`
 }
 
 type WorkspaceRef struct {


### PR DESCRIPTION
## 변경 사항

- `desktop-accessibility-observe` 어댑터와 명시적 `--runtime-provider local|orca` 선택 경계를 추가합니다.
- canonical observation, state reference, runtime receipt, failure taxonomy와 공개 증거 계약을 구현합니다.
- QA run, release, release-readiness 경로에 데스크톱 관찰 결과를 fail-closed 방식으로 연결합니다.
- 서명된 로컬 provider 실행과 Orca parity를 검증하는 보안·race 회귀 테스트를 추가합니다.

## 배경

SPEC-QAMESH-012는 macOS Accessibility 관찰 결과를 QAMESH의 결정적이고 공개 가능한 증거로 연결해야 합니다. 이 PR은 Desktop Journey와 native provider가 소비하는 ADK 계약을 먼저 제공합니다.

## 영향

- 데스크톱 관찰 Journey는 runtime provider를 반드시 명시해야 합니다.
- raw AX 정보는 공개 manifest에 들어가지 않으며, redaction·quarantine·receipt 검증 실패는 통과로 승격되지 않습니다.
- 기존 모바일·브라우저·release lane의 동작은 유지합니다.

## 검증

- `go test -race -count=1 -p=1 ./pkg/qa/adapter ./pkg/qa/desktopobserve ./pkg/qa/evidence ./pkg/qa/journey ./pkg/qa/release ./pkg/qa/releasereadiness ./pkg/qa/run`
- `go test -race -count=1 ./internal/cli -run '^TestQARuntimeProvider_'`
- `go test -cover -count=1 ./pkg/qa/desktopobserve` — statements 87.5%
- `git diff --check origin/main...HEAD`
- Q12 변경 소스 파일 300줄 상한 확인

로컬 메타 workspace에서 전체 `internal/cli` 테스트를 실행하면 sibling `Autopus` checkout을 감지하는 기존 eval-regression 오라클 1개가 실패합니다. 같은 실패는 이 PR 변경이 없는 `origin/main`에서도 재현되며, 원격 main CI는 통과 상태입니다.

## 머지 순서

1. 이 ADK PR
2. 후속 `autopus-desktop` Q12 PR
3. 마지막 `autopus-co` SPEC 완료 문서 PR