### PR TITLE
feat(review): 관리형 ReviewRun 준비 계약 추가

### DIFF
--- a/e2e/testdata/help_output.golden
+++ b/e2e/testdata/help_output.golden
@@ -36,6 +36,7 @@ Available Commands:
   qa                 Plan, initialize, run, and publish QAMESH QA evidence
   quality            Show or change quality mode and Codex supervisor ownership
   react              CI 실패 감지 및 자동 수정
+  review             Prepare managed typed review contracts
   search             Search the web using Exa API (requires EXA_API_KEY)
   setup              Generate and manage project documentation for AI agents
   skill              Autopus 빌트인 스킬 관리

--- a/internal/cli/review_prepare.go
+++ b/internal/cli/review_prepare.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/insajin/autopus-adk/pkg/orchestra"
+)
+
+type reviewPrepareOptions struct {
+	ContractStdin bool
+	JSONOut       bool
+}
+
+type reviewPrepareEnvelope struct {
+	SchemaVersion string            `json:"schema_version"`
+	Command       string            `json:"command"`
+	Status        string            `json:"status"`
+	GeneratedAt   time.Time         `json:"generated_at"`
+	Error         *jsonErrorPayload `json:"error,omitempty"`
+	Data          any               `json:"data"`
+}
+
+func newReviewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "review",
+		Short: "Prepare managed typed review contracts",
+		Args:  cobra.NoArgs,
+	}
+	cmd.AddCommand(newReviewPrepareCmd())
+	return cmd
+}
+
+func newReviewPrepareCmd() *cobra.Command {
+	var opts reviewPrepareOptions
+	cmd := &cobra.Command{
+		Use:          "prepare",
+		Short:        "Prepare bounded provider review prompts",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runReviewPrepare(cmd, opts)
+		},
+	}
+	cmd.Flags().BoolVar(&opts.ContractStdin, "contract-stdin", false, "Read one managed review contract from stdin")
+	cmd.Flags().BoolVar(&opts.JSONOut, "json", false, "Output as JSON")
+	return cmd
+}
+
+func runReviewPrepare(cmd *cobra.Command, opts reviewPrepareOptions) error {
+	if !opts.ContractStdin {
+		return finishReviewPrepareError(cmd, opts.JSONOut)
+	}
+	preparation, err := orchestra.ReadAndPrepareManagedReview(
+		cmd.InOrStdin(),
+		orchestra.ReviewPrepareMaximumBytes,
+	)
+	if err != nil {
+		return finishReviewPrepareError(cmd, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return writeReviewPrepareEnvelope(cmd, reviewPrepareEnvelope{
+			SchemaVersion: cliJSONSchemaVersion,
+			Command:       cmd.CommandPath(),
+			Status:        "success",
+			GeneratedAt:   time.Now().UTC(),
+			Data:          preparation,
+		})
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "review prepared providers=%d snapshot=%s\n",
+		len(preparation.ProviderContracts), preparation.SnapshotDigest)
+	return nil
+}
+
+func finishReviewPrepareError(cmd *cobra.Command, jsonOutput bool) error {
+	if !jsonOutput {
+		return orchestra.ErrReviewPrepareInvalid
+	}
+	envelope := reviewPrepareEnvelope{
+		SchemaVersion: cliJSONSchemaVersion,
+		Command:       cmd.CommandPath(),
+		Status:        "error",
+		GeneratedAt:   time.Now().UTC(),
+		Error: &jsonErrorPayload{
+			Code:    "review_prepare_invalid",
+			Message: "review_prepare_invalid",
+		},
+		Data: map[string]any{"schema_version": orchestra.ReviewPreparationSchemaV1},
+	}
+	if err := writeReviewPrepareEnvelope(cmd, envelope); err != nil {
+		return err
+	}
+	return &jsonFatalError{cause: orchestra.ErrReviewPrepareInvalid}
+}
+
+func writeReviewPrepareEnvelope(cmd *cobra.Command, envelope reviewPrepareEnvelope) error {
+	encoder := json.NewEncoder(cmd.OutOrStdout())
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(envelope)
+}

--- a/internal/cli/review_prepare_contract_test.go
+++ b/internal/cli/review_prepare_contract_test.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReviewPrepareCLI_ContractStdin_DoesNotSpawnProviderOrTerminalProcess(t *testing.T) {
+	marker := installReviewPrepareSpawnSentinels(t)
+	contract := reviewPrepareCLIContract(t)
+	root := &cobra.Command{Use: "auto", SilenceErrors: true, SilenceUsage: true}
+	root.AddCommand(newReviewCmd())
+	var stdout bytes.Buffer
+	root.SetIn(bytes.NewReader(contract))
+	root.SetOut(&stdout)
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"review", "prepare", "--contract-stdin", "--json"})
+
+	require.NoError(t, root.Execute())
+	_, err := os.Stat(marker)
+	assert.True(t, os.IsNotExist(err), "review prepare must not spawn a provider, pane, or terminal process")
+
+	var envelope map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, "success", envelope["status"])
+	data, ok := envelope["data"].(map[string]any)
+	require.True(t, ok)
+	providers, ok := data["provider_contracts"].([]any)
+	require.True(t, ok)
+	require.Len(t, providers, 3)
+	assertCLIReviewPrepareNoKeys(t, data,
+		"command", "cwd", "env", "terminal_handle", "next_state", "raw_response", "failure_preview",
+	)
+}
+
+func installReviewPrepareSpawnSentinels(t *testing.T) string {
+	t.Helper()
+	directory := t.TempDir()
+	marker := filepath.Join(directory, "spawned")
+	stub := []byte("#!/bin/sh\nprintf spawned > '" + marker + "'\nexit 97\n")
+	for _, name := range []string{"claude", "codex", "gemini", "cmux", "tmux", "open", "pane_runner"} {
+		require.NoError(t, os.WriteFile(filepath.Join(directory, name), stub, 0o755))
+	}
+	t.Setenv("PATH", directory+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return marker
+}
+
+func reviewPrepareCLIContract(t *testing.T) []byte {
+	t.Helper()
+	digest := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	payload := map[string]any{
+		"schema_version": "review.prepare.v1",
+		"request_id":     "req-review-1", "workspace_id": "ws-a",
+		"repo_scope_ref": "repo-scope-a", "work_item_id": "work-a",
+		"review_run_id": "review-1", "snapshot_digest": digest,
+		"role": "reviewer", "contract_digest": "sha256:" + digest,
+		"providers": []map[string]any{
+			{"adapter_id": "claude", "model": "claude-review", "role": "reviewer"},
+			{"adapter_id": "codex", "model": "codex-review", "role": "reviewer"},
+			{"adapter_id": "gemini", "model": "gemini-review", "role": "reviewer"},
+		},
+		"bounds": map[string]any{"max_result_bytes": 1 << 20, "max_findings": 200},
+	}
+	encoded, err := json.Marshal(payload)
+	require.NoError(t, err)
+	return encoded
+}
+
+func assertCLIReviewPrepareNoKeys(t *testing.T, value any, forbidden ...string) {
+	t.Helper()
+	blocked := make(map[string]bool, len(forbidden))
+	for _, key := range forbidden {
+		blocked[key] = true
+	}
+	var walk func(any)
+	walk = func(current any) {
+		switch typed := current.(type) {
+		case map[string]any:
+			for key, nested := range typed {
+				assert.Falsef(t, blocked[key], "forbidden CLI preparation key %q", key)
+				walk(nested)
+			}
+		case []any:
+			for _, nested := range typed {
+				walk(nested)
+			}
+		}
+	}
+	walk(value)
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -104,6 +104,7 @@ func NewRootCmd() *cobra.Command {
 	// @AX:NOTE [AUTO] @AX:SPEC: SPEC-CODEOPS-ADK-001: registers the public `auto delivery` namespace for supervised delivery contract checks.
 	// @AX:REASON: Backend/Desktop delivery gates and CLI tests depend on local dry-run planning and envelope validation staying reachable.
 	root.AddCommand(newDeliveryCmd())
+	root.AddCommand(newReviewCmd())
 	// @AX:ANCHOR [AUTO] @AX:SPEC: SPEC-AUTO-MEM-001: registers the public `auto mem` namespace for memory projection workflows.
 	// @AX:REASON: External CLI users and integration tests depend on rebuild/search/context/status subcommands staying reachable.
 	root.AddCommand(newMemCmd())

--- a/pkg/orchestra/review_contract_json.go
+++ b/pkg/orchestra/review_contract_json.go
@@ -1,0 +1,92 @@
+package orchestra
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"unicode/utf8"
+)
+
+func DecodeReviewPrepareContractStrict(payload []byte, maxBytes int) (ReviewPrepareContract, error) {
+	limit := maxBytes
+	if limit <= 0 || limit > ReviewPrepareMaximumBytes {
+		limit = ReviewPrepareMaximumBytes
+	}
+	if len(payload) == 0 || len(payload) > limit || !utf8.Valid(payload) || rejectReviewDuplicateKeys(payload) != nil {
+		return ReviewPrepareContract{}, ErrReviewPrepareInvalid
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	var contract ReviewPrepareContract
+	if err := decoder.Decode(&contract); err != nil {
+		return ReviewPrepareContract{}, ErrReviewPrepareInvalid
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return ReviewPrepareContract{}, ErrReviewPrepareInvalid
+	}
+	if validateReviewPrepareContract(contract) != nil {
+		return ReviewPrepareContract{}, ErrReviewPrepareInvalid
+	}
+	return contract, nil
+}
+
+func rejectReviewDuplicateKeys(payload []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	if err := consumeReviewJSONValue(decoder); err != nil {
+		return err
+	}
+	if _, err := decoder.Token(); err != io.EOF {
+		return ErrReviewPrepareInvalid
+	}
+	return nil
+}
+
+func consumeReviewJSONValue(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delimiter, structured := token.(json.Delim)
+	if !structured {
+		return nil
+	}
+	switch delimiter {
+	case '{':
+		seen := make(map[string]struct{})
+		for decoder.More() {
+			keyToken, keyErr := decoder.Token()
+			if keyErr != nil {
+				return keyErr
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return ErrReviewPrepareInvalid
+			}
+			if _, duplicate := seen[key]; duplicate {
+				return ErrReviewPrepareInvalid
+			}
+			seen[key] = struct{}{}
+			if err := consumeReviewJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		return consumeReviewClosingDelimiter(decoder, '}')
+	case '[':
+		for decoder.More() {
+			if err := consumeReviewJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		return consumeReviewClosingDelimiter(decoder, ']')
+	default:
+		return ErrReviewPrepareInvalid
+	}
+}
+
+func consumeReviewClosingDelimiter(decoder *json.Decoder, expected json.Delim) error {
+	token, err := decoder.Token()
+	if err != nil || token != expected {
+		return ErrReviewPrepareInvalid
+	}
+	return nil
+}

--- a/pkg/orchestra/review_contract_prepare.go
+++ b/pkg/orchestra/review_contract_prepare.go
@@ -1,0 +1,88 @@
+package orchestra
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"strconv"
+	"strings"
+)
+
+func PrepareManagedReview(contract ReviewPrepareContract) (ReviewPreparation, error) {
+	if validateReviewPrepareContract(contract) != nil {
+		return ReviewPreparation{}, ErrReviewPrepareInvalid
+	}
+	preparation := ReviewPreparation{
+		SchemaVersion:     ReviewPreparationSchemaV1,
+		RequestID:         contract.RequestID,
+		WorkspaceID:       contract.WorkspaceID,
+		RepoScopeRef:      contract.RepoScopeRef,
+		WorkItemID:        contract.WorkItemID,
+		ReviewRunID:       contract.ReviewRunID,
+		SnapshotDigest:    contract.SnapshotDigest,
+		ContractDigest:    contract.ContractDigest,
+		ProviderContracts: make([]ReviewProviderPreparation, 0, len(contract.Providers)),
+	}
+	for _, provider := range contract.Providers {
+		prompt := buildManagedReviewPrompt(contract, provider)
+		preparation.ProviderContracts = append(preparation.ProviderContracts, ReviewProviderPreparation{
+			AdapterID:      provider.AdapterID,
+			Model:          provider.Model,
+			Role:           provider.Role,
+			Prompt:         prompt,
+			PromptDigest:   reviewPromptDigest(prompt),
+			ResultSchema:   ReviewProviderResultSchema,
+			MaxResultBytes: contract.Bounds.MaxResultBytes,
+			MaxFindings:    contract.Bounds.MaxFindings,
+		})
+	}
+	return preparation, nil
+}
+
+func ReadAndPrepareManagedReview(reader io.Reader, maxBytes int) (ReviewPreparation, error) {
+	limit := maxBytes
+	if limit <= 0 || limit > ReviewPrepareMaximumBytes {
+		limit = ReviewPrepareMaximumBytes
+	}
+	payload, err := io.ReadAll(io.LimitReader(reader, int64(limit)+1))
+	if err != nil || len(payload) == 0 || len(payload) > limit {
+		return ReviewPreparation{}, ErrReviewPrepareInvalid
+	}
+	contract, err := DecodeReviewPrepareContractStrict(payload, limit)
+	if err != nil {
+		return ReviewPreparation{}, ErrReviewPrepareInvalid
+	}
+	return PrepareManagedReview(contract)
+}
+
+func buildManagedReviewPrompt(contract ReviewPrepareContract, provider ReviewProviderSpec) string {
+	var prompt strings.Builder
+	prompt.WriteString("Review exactly one sealed snapshot using typed evidence only.\n")
+	prompt.WriteString("Review run: ")
+	prompt.WriteString(contract.ReviewRunID)
+	prompt.WriteString("\nWork item: ")
+	prompt.WriteString(contract.WorkItemID)
+	prompt.WriteString("\nSnapshot SHA-256: ")
+	prompt.WriteString(contract.SnapshotDigest)
+	prompt.WriteString("\nAdapter: ")
+	prompt.WriteString(provider.AdapterID)
+	prompt.WriteString("\nModel: ")
+	prompt.WriteString(provider.Model)
+	prompt.WriteString("\nRole: ")
+	prompt.WriteString(provider.Role)
+	prompt.WriteString("\nReturn exactly one strict ")
+	prompt.WriteString(ReviewProviderResultSchema)
+	prompt.WriteString(" JSON object. Every finding must include severity, category, scope, typed evidence references, provider provenance, snapshot digest, and result digest. ")
+	prompt.WriteString("Set raw_terminal_omitted=true and never include transcript bytes. ")
+	prompt.WriteString("Use at most ")
+	prompt.WriteString(strconv.Itoa(contract.Bounds.MaxFindings))
+	prompt.WriteString(" findings and keep the encoded result at or below ")
+	prompt.WriteString(strconv.Itoa(contract.Bounds.MaxResultBytes))
+	prompt.WriteString(" bytes.")
+	return prompt.String()
+}
+
+func reviewPromptDigest(prompt string) string {
+	digest := sha256.Sum256([]byte(prompt))
+	return hex.EncodeToString(digest[:])
+}

--- a/pkg/orchestra/review_contract_test.go
+++ b/pkg/orchestra/review_contract_test.go
@@ -1,0 +1,116 @@
+package orchestra
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const managedReviewSnapshotDigest = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+func TestPrepareManagedReview_ThreeProviders_ReturnsPureBoundedContracts(t *testing.T) {
+	t.Parallel()
+
+	contractJSON := managedReviewContractJSON(t)
+	contract, err := DecodeReviewPrepareContractStrict(contractJSON, 256*1024)
+	require.NoError(t, err)
+	preparation, err := PrepareManagedReview(contract)
+	require.NoError(t, err)
+
+	encoded, err := json.Marshal(preparation)
+	require.NoError(t, err)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(encoded, &payload))
+	assert.Equal(t, "review.preparation.v1", payload["schema_version"])
+	assert.Equal(t, managedReviewSnapshotDigest, payload["snapshot_digest"])
+	providers, ok := payload["provider_contracts"].([]any)
+	require.True(t, ok)
+	require.Len(t, providers, 3)
+	for _, value := range providers {
+		provider, ok := value.(map[string]any)
+		require.True(t, ok)
+		assert.Contains(t, []string{"claude", "codex", "gemini"}, provider["adapter_id"])
+		assert.Regexp(t, `^[0-9a-f]{64}$`, provider["prompt_digest"])
+		assert.Equal(t, "review.provider_result.v1", provider["result_schema"])
+		assert.NotEmpty(t, provider["prompt"])
+		assert.EqualValues(t, 1<<20, provider["max_result_bytes"])
+		assert.EqualValues(t, 200, provider["max_findings"])
+	}
+	assertManagedReviewNoKeys(t, payload,
+		"command", "cwd", "env", "terminal_handle", "next_state",
+		"raw_response", "failure_preview", "provider_process",
+	)
+}
+
+func TestDecodeReviewPrepareContractStrict_UnknownField_FailsClosed(t *testing.T) {
+	t.Parallel()
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(managedReviewContractJSON(t), &payload))
+	payload["command"] = "codex review"
+	encoded, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	_, err = DecodeReviewPrepareContractStrict(encoded, 256*1024)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "review_prepare_invalid")
+}
+
+func TestPrepareManagedReview_AdapterIdentityMustBeCanonicalLowercase(t *testing.T) {
+	t.Parallel()
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(managedReviewContractJSON(t), &payload))
+	providers := payload["providers"].([]any)
+	providers[0].(map[string]any)["adapter_id"] = "Claude"
+	encoded, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	_, err = DecodeReviewPrepareContractStrict(encoded, ReviewPrepareMaximumBytes)
+	require.ErrorIs(t, err, ErrReviewPrepareInvalid)
+}
+
+func managedReviewContractJSON(t *testing.T) []byte {
+	t.Helper()
+	payload := map[string]any{
+		"schema_version": "review.prepare.v1",
+		"request_id":     "req-review-1", "workspace_id": "ws-a",
+		"repo_scope_ref": "repo-scope-a", "work_item_id": "work-a",
+		"review_run_id": "review-1", "snapshot_digest": managedReviewSnapshotDigest,
+		"role": "reviewer", "contract_digest": "sha256:" + managedReviewSnapshotDigest,
+		"providers": []map[string]any{
+			{"adapter_id": "claude", "model": "claude-review", "role": "reviewer"},
+			{"adapter_id": "codex", "model": "codex-review", "role": "reviewer"},
+			{"adapter_id": "gemini", "model": "gemini-review", "role": "reviewer"},
+		},
+		"bounds": map[string]any{"max_result_bytes": 1 << 20, "max_findings": 200},
+	}
+	encoded, err := json.Marshal(payload)
+	require.NoError(t, err)
+	return encoded
+}
+
+func assertManagedReviewNoKeys(t *testing.T, value any, forbidden ...string) {
+	t.Helper()
+	blocked := make(map[string]bool, len(forbidden))
+	for _, key := range forbidden {
+		blocked[key] = true
+	}
+	var walk func(any)
+	walk = func(current any) {
+		switch typed := current.(type) {
+		case map[string]any:
+			for key, nested := range typed {
+				assert.Falsef(t, blocked[key], "forbidden preparation key %q", key)
+				walk(nested)
+			}
+		case []any:
+			for _, nested := range typed {
+				walk(nested)
+			}
+		}
+	}
+	walk(value)
+}

--- a/pkg/orchestra/review_contract_types.go
+++ b/pkg/orchestra/review_contract_types.go
@@ -1,0 +1,62 @@
+package orchestra
+
+import "errors"
+
+const (
+	ReviewPrepareSchemaV1      = "review.prepare.v1"
+	ReviewPreparationSchemaV1  = "review.preparation.v1"
+	ReviewProviderResultSchema = "review.provider_result.v1"
+	ReviewPrepareMaximumBytes  = 256 * 1024
+	ReviewResultMaximumBytes   = 1024 * 1024
+	ReviewFindingsMaximum      = 200
+)
+
+var ErrReviewPrepareInvalid = errors.New("review_prepare_invalid")
+
+type ReviewPrepareContract struct {
+	SchemaVersion  string               `json:"schema_version"`
+	RequestID      string               `json:"request_id"`
+	WorkspaceID    string               `json:"workspace_id"`
+	RepoScopeRef   string               `json:"repo_scope_ref"`
+	WorkItemID     string               `json:"work_item_id"`
+	ReviewRunID    string               `json:"review_run_id"`
+	SnapshotDigest string               `json:"snapshot_digest"`
+	Role           string               `json:"role"`
+	ContractDigest string               `json:"contract_digest"`
+	Providers      []ReviewProviderSpec `json:"providers"`
+	Bounds         ReviewPrepareBounds  `json:"bounds"`
+}
+
+type ReviewProviderSpec struct {
+	AdapterID string `json:"adapter_id"`
+	Model     string `json:"model"`
+	Role      string `json:"role"`
+}
+
+type ReviewPrepareBounds struct {
+	MaxResultBytes int `json:"max_result_bytes"`
+	MaxFindings    int `json:"max_findings"`
+}
+
+type ReviewPreparation struct {
+	SchemaVersion     string                      `json:"schema_version"`
+	RequestID         string                      `json:"request_id"`
+	WorkspaceID       string                      `json:"workspace_id"`
+	RepoScopeRef      string                      `json:"repo_scope_ref"`
+	WorkItemID        string                      `json:"work_item_id"`
+	ReviewRunID       string                      `json:"review_run_id"`
+	SnapshotDigest    string                      `json:"snapshot_digest"`
+	ContractDigest    string                      `json:"contract_digest"`
+	ProviderContracts []ReviewProviderPreparation `json:"provider_contracts"`
+}
+
+type ReviewProviderPreparation struct {
+	AdapterID      string `json:"adapter_id"`
+	Model          string `json:"model"`
+	Role           string `json:"role"`
+	Prompt         string `json:"prompt"`
+	PromptDigest   string `json:"prompt_digest"`
+	ResultSchema   string `json:"result_schema"`
+	MaxResultBytes int    `json:"max_result_bytes"`
+	MaxFindings    int    `json:"max_findings"`
+}

--- a/pkg/orchestra/review_contract_validation.go
+++ b/pkg/orchestra/review_contract_validation.go
@@ -1,0 +1,75 @@
+package orchestra
+
+import (
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+var (
+	reviewSnapshotDigestPattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
+	reviewContractDigestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	reviewAdapterPattern        = regexp.MustCompile(`^[a-z0-9][a-z0-9_.-]{0,63}$`)
+	reviewModelPattern          = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,255}$`)
+	reviewRolePattern           = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$`)
+)
+
+var managedReviewAdapters = map[string]struct{}{
+	"claude":   {},
+	"codex":    {},
+	"gemini":   {},
+	"opencode": {},
+}
+
+func validateReviewPrepareContract(contract ReviewPrepareContract) error {
+	if contract.SchemaVersion != ReviewPrepareSchemaV1 ||
+		!reviewSnapshotDigestPattern.MatchString(contract.SnapshotDigest) ||
+		!reviewContractDigestPattern.MatchString(contract.ContractDigest) ||
+		!validReviewOpaqueRef(contract.RequestID) ||
+		!validReviewOpaqueRef(contract.WorkspaceID) ||
+		!validReviewOpaqueRef(contract.RepoScopeRef) ||
+		!validReviewOpaqueRef(contract.WorkItemID) ||
+		!validReviewOpaqueRef(contract.ReviewRunID) ||
+		!reviewRolePattern.MatchString(contract.Role) ||
+		contract.Bounds.MaxResultBytes < 1 ||
+		contract.Bounds.MaxResultBytes > ReviewResultMaximumBytes ||
+		contract.Bounds.MaxFindings < 1 ||
+		contract.Bounds.MaxFindings > ReviewFindingsMaximum ||
+		len(contract.Providers) < 2 || len(contract.Providers) > 4 {
+		return ErrReviewPrepareInvalid
+	}
+	seen := make(map[string]struct{}, len(contract.Providers))
+	for _, provider := range contract.Providers {
+		if !reviewAdapterPattern.MatchString(provider.AdapterID) ||
+			reviewProviderAllowed(provider.AdapterID) == false ||
+			!reviewModelPattern.MatchString(provider.Model) ||
+			!reviewRolePattern.MatchString(provider.Role) {
+			return ErrReviewPrepareInvalid
+		}
+		if _, duplicate := seen[provider.AdapterID]; duplicate {
+			return ErrReviewPrepareInvalid
+		}
+		seen[provider.AdapterID] = struct{}{}
+	}
+	return nil
+}
+
+func reviewProviderAllowed(adapterID string) bool {
+	_, allowed := managedReviewAdapters[adapterID]
+	return allowed
+}
+
+func validReviewOpaqueRef(value string) bool {
+	if value == "" || len(value) > 256 || !utf8.ValidString(value) || strings.TrimSpace(value) != value {
+		return false
+	}
+	if strings.ContainsAny(value, `/\\`) || strings.Contains(value, "://") {
+		return false
+	}
+	for _, character := range value {
+		if character < 0x21 || character == 0x7f {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/orchestra/review_contract_validation.go
+++ b/pkg/orchestra/review_contract_validation.go
@@ -41,7 +41,7 @@ func validateReviewPrepareContract(contract ReviewPrepareContract) error {
 	seen := make(map[string]struct{}, len(contract.Providers))
 	for _, provider := range contract.Providers {
 		if !reviewAdapterPattern.MatchString(provider.AdapterID) ||
-			reviewProviderAllowed(provider.AdapterID) == false ||
+			!reviewProviderAllowed(provider.AdapterID) ||
 			!reviewModelPattern.MatchString(provider.Model) ||
 			!reviewRolePattern.MatchString(provider.Role) {
 			return ErrReviewPrepareInvalid


### PR DESCRIPTION
## 변경 사항

ADK에 strict JSON 기반 ReviewRun preparation contract, validation, prepare command와 contract tests를 추가합니다.

## 이유

provider prompt/materialization을 Backend에 노출하지 않고 Desktop/ADK 로컬 경계에서 준비하기 위한 canonical harness surface가 필요합니다.

## 검증

- 원본 `363d3e2`와 최신 main 기반 clean branch patch가 `git range-diff`에서 동일
- 최신 main과 merge-tree conflict 없음
- `git diff --check` 및 파일 크기 정책 통과
- 로컬 동적 Go 테스트는 host `_dyld_start` 정지로 재실행 PASS를 주장하지 않으며 GitHub runner 결과를 확인할 예정

## 병합 순서

Protocol 계약 이후, Backend/Desktop보다 먼저 병합합니다.