### PR TITLE
fix(update): Codex preview와 적용 파일 집합을 일치시킨다

### DIFF
--- a/internal/cli/update_preview_test.go
+++ b/internal/cli/update_preview_test.go
@@ -214,6 +214,33 @@ func TestUpdateCmd_PlanKeepsFullCompatibleSharedSkillPathWithoutSplitOptIn(t *te
 	assert.NotContains(t, output, ".autopus/plugins/auto/skills/metrics/SKILL.md", "acceptance S2: default full mode must not route shared long-tail skills to split Codex plugin targets")
 }
 
+func TestUpdateCmd_PlanRetainsCodexWorkflowCompatibilitySkills(t *testing.T) {
+	dir := t.TempDir()
+	configurePreviewBinaries(t, "codex", "opencode")
+	initMixedPreviewHarness(t, dir)
+
+	applyCmd := newTestRootCmd()
+	applyCmd.SetArgs([]string{"update", "--dir", dir, "--yes"})
+	require.NoError(t, applyCmd.Execute())
+
+	var out bytes.Buffer
+	updateCmd := newTestRootCmd()
+	updateCmd.SetOut(&out)
+	updateCmd.SetErr(&out)
+	updateCmd.SetArgs([]string{"update", "--dir", dir, "--plan"})
+	require.NoError(t, updateCmd.Execute())
+
+	output := out.String()
+	for _, name := range []string{
+		"auto-dev", "auto-doctor", "auto-goal", "auto-map", "auto-secure",
+		"auto-status", "auto-test", "auto-update", "auto-verify", "auto-why",
+	} {
+		path := ".codex/skills/" + name + ".md"
+		assert.Contains(t, output, "retain "+path)
+		assert.NotContains(t, output, "prune "+path)
+	}
+}
+
 func selectManagedPreviewTargets(t *testing.T, dir, platform string) (string, string) {
 	t.Helper()
 

--- a/pkg/adapter/codex/codex_skills.go
+++ b/pkg/adapter/codex/codex_skills.go
@@ -4,67 +4,27 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/insajin/autopus-adk/pkg/adapter"
 	"github.com/insajin/autopus-adk/pkg/config"
-	"github.com/insajin/autopus-adk/templates"
 )
 
 // renderSkillTemplates reads Codex skill templates from embedded FS,
 // renders them, and writes to .codex/skills/.
 func (a *Adapter) renderSkillTemplates(cfg *config.HarnessConfig) ([]adapter.FileMapping, error) {
-	var files []adapter.FileMapping
-
-	entries, err := templates.FS.ReadDir("codex/skills")
+	files, err := a.prepareSkillTemplateMappings(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("코덱스 스킬 템플릿 디렉터리 읽기 실패: %w", err)
+		return nil, err
 	}
 
-	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".tmpl") {
-			continue
+	for _, file := range files {
+		targetPath := filepath.Join(a.root, file.TargetPath)
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+			return nil, fmt.Errorf("코덱스 스킬 디렉터리 생성 실패 %s: %w", filepath.Dir(targetPath), err)
 		}
-
-		name := entry.Name()
-		skillFile := strings.TrimSuffix(name, ".tmpl")
-		emit, err := shouldEmitCodexRepoSkillTemplate(skillFile, cfg)
-		if err != nil {
-			return nil, fmt.Errorf("코덱스 스킬 템플릿 대상 판정 실패 %s: %w", name, err)
-		}
-		if !emit {
-			continue
-		}
-
-		tmplContent, err := templates.FS.ReadFile("codex/skills/" + name)
-		if err != nil {
-			return nil, fmt.Errorf("코덱스 스킬 템플릿 읽기 실패 %s: %w", name, err)
-		}
-
-		rendered, err := a.engine.RenderString(string(tmplContent), cfg)
-		if err != nil {
-			if strings.HasPrefix(skillFile, "auto-") {
-				return nil, fmt.Errorf("코덱스 스킬 템플릿 렌더링 실패 %s: %w", name, err)
-			}
-			// Non-auto skill docs can legitimately contain raw `{{ ... }}` examples
-			// such as GitHub Actions expressions. Preserve the template verbatim.
-			rendered = string(tmplContent)
-		}
-		rendered = normalizeCodexInvocationBody(rendered)
-		rendered = normalizeCodexHelperPaths(rendered)
-		rendered = normalizeCodexToolingBody(rendered)
-
-		targetPath := filepath.Join(a.root, ".codex", "skills", skillFile)
-		if err := os.WriteFile(targetPath, []byte(rendered), 0644); err != nil {
+		if err := os.WriteFile(targetPath, file.Content, 0644); err != nil {
 			return nil, fmt.Errorf("코덱스 스킬 파일 쓰기 실패 %s: %w", targetPath, err)
 		}
-
-		files = append(files, adapter.FileMapping{
-			TargetPath:      filepath.Join(".codex", "skills", skillFile),
-			OverwritePolicy: adapter.OverwriteAlways,
-			Checksum:        checksum(rendered),
-			Content:         []byte(rendered),
-		})
 	}
 
 	// Extended skills from content/skills/ via transformer


### PR DESCRIPTION
## 변경 사항

- Codex `Generate`가 `Update`와 같은 `prepareSkillTemplateMappings` 결과를 사용하도록 생성 경로를 통합했습니다.
- mixed Codex+OpenCode 환경에서 실제 update를 적용한 뒤 preview가 workflow compatibility skill 10개를 모두 `retain`하고 `prune`하지 않는 회귀 테스트를 추가했습니다.

## 원인

preview는 `Generate`의 `renderSkillTemplates` 결과로 desired file set을 계산했지만, 실제 update는 `prepareSkillTemplateMappings`를 사용했습니다. 후자만 template이 없는 workflow의 compatibility skill을 추가해 적용 직후에도 preview가 10개 파일을 영구 prune 대상으로 오인했습니다.

## 영향

`auto update --plan`과 실제 update가 같은 Codex skill mapping을 사용합니다. 기존 compatibility skill 내용, update transaction, OpenCode shared surface 계약은 바꾸지 않습니다.

## 검증

- 회귀 테스트 red-green 확인
- `go test ./pkg/adapter/codex ./internal/cli -count=1`
- `go test -race ./pkg/adapter/codex ./internal/cli -count=1`
- `go test -cover ./pkg/adapter/codex ./internal/cli -count=1`
- `go vet ./...`
- GitHub CI 정상 clone 환경에서 `go test -race -count=1 -timeout=25m -tags integration -coverprofile=coverage.out ./...`
- 전체 coverage 84.4%로 기준 83% 통과
- build, cross-compile, E2E, lint, static contracts, macOS/Windows runtime, secret scan, dependency scan 통과

로컬 linked-worktree bind mount에서 발생한 `getwd` 실패는 absolute gitdir/common gitdir가 컨테이너 경로와 불일치한 검증 환경 문제입니다. 같은 HEAD의 정상 clone 전체 CI가 통과했으며 제품 코드 실패는 재현되지 않았습니다.

Fixes #83
