### PR TITLE
fix(canary): 보호된 metrics 응답을 정상으로 판정한다

### DIFF
--- a/internal/cli/canary_helpers.go
+++ b/internal/cli/canary_helpers.go
@@ -52,28 +52,52 @@ func runCanaryExternal(ctx context.Context, id, display, dir string, argv ...str
 
 func runCanaryEndpointChecks(ctx context.Context, baseURL string, result *canaryResult) string {
 	status := "PASS"
-	for _, path := range []string{"/health", "/metrics"} {
-		if !canaryHTTPCheck(ctx, strings.TrimRight(baseURL, "/")+path) {
-			status = "FAIL"
+	endpoints := []struct {
+		path               string
+		acceptUnauthorized bool
+	}{
+		{path: "/health"},
+		{path: "/metrics", acceptUnauthorized: true},
+	}
+	for _, endpoint := range endpoints {
+		code, err := canaryHTTPStatus(ctx, strings.TrimRight(baseURL, "/")+endpoint.path)
+		successResponse := code >= http.StatusOK && code < http.StatusBadRequest
+		protectedResponse := endpoint.acceptUnauthorized && code == http.StatusUnauthorized
+		passed := err == nil && (successResponse || protectedResponse)
+		targetStatus := "PASS"
+		detail := fmt.Sprintf("HTTP %d", code)
+		if protectedResponse {
+			detail += " (protected endpoint)"
 		}
-		result.Targets = append(result.Targets, canaryTargetResult{ID: "endpoint" + path, Status: status})
+		if err != nil {
+			detail = err.Error()
+		}
+		if !passed {
+			status = "FAIL"
+			targetStatus = "FAIL"
+		}
+		result.Targets = append(result.Targets, canaryTargetResult{
+			ID:     "endpoint" + endpoint.path,
+			Status: targetStatus,
+			Detail: detail,
+		})
 	}
 	return status
 }
 
-func canaryHTTPCheck(ctx context.Context, url string) bool {
+func canaryHTTPStatus(ctx context.Context, url string) (int, error) {
 	reqCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, url, nil)
 	if err != nil {
-		return false
+		return 0, err
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return false
+		return 0, err
 	}
 	defer resp.Body.Close()
-	return resp.StatusCode >= 200 && resp.StatusCode < 400
+	return resp.StatusCode, nil
 }
 
 func writeCanaryLatest(projectDir string, result canaryResult) error {

--- a/internal/cli/canary_helpers_extra_test.go
+++ b/internal/cli/canary_helpers_extra_test.go
@@ -3,6 +3,9 @@ package cli
 import (
 	"bytes"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -109,4 +112,133 @@ func TestRunCanaryExternal_EmptyCommand(t *testing.T) {
 	result := runCanaryExternal(ctx, "H-test", "empty command test", t.TempDir())
 	assert.Equal(t, "FAIL", result.Status)
 	assert.Contains(t, result.Detail, "empty command")
+}
+
+func TestRunCanaryEndpointChecks_AcceptsProtectedMetrics(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			w.WriteHeader(http.StatusOK)
+		case "/metrics":
+			w.WriteHeader(http.StatusUnauthorized)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	result := canaryResult{}
+	status := runCanaryEndpointChecks(t.Context(), server.URL, &result)
+
+	assert.Equal(t, "PASS", status)
+	require.Len(t, result.Targets, 2)
+	assert.Equal(t, "PASS", result.Targets[0].Status)
+	assert.Contains(t, result.Targets[0].Detail, "HTTP 200")
+	assert.Equal(t, "PASS", result.Targets[1].Status)
+	assert.Contains(t, result.Targets[1].Detail, "HTTP 401")
+	assert.Contains(t, result.Targets[1].Detail, "protected")
+}
+
+func TestRunCanaryEndpointChecks_ReportsIndependentFailures(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			w.WriteHeader(http.StatusInternalServerError)
+		case "/metrics":
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	result := canaryResult{}
+	status := runCanaryEndpointChecks(t.Context(), server.URL, &result)
+
+	assert.Equal(t, "FAIL", status)
+	require.Len(t, result.Targets, 2)
+	assert.Equal(t, "FAIL", result.Targets[0].Status)
+	assert.Contains(t, result.Targets[0].Detail, "HTTP 500")
+	assert.Equal(t, "PASS", result.Targets[1].Status)
+	assert.Contains(t, result.Targets[1].Detail, "HTTP 200")
+}
+
+func TestRunCanaryEndpointChecks_RejectsMetricsErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, code := range []int{http.StatusNotFound, http.StatusInternalServerError} {
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/health" {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				w.WriteHeader(code)
+			}))
+			t.Cleanup(server.Close)
+
+			result := canaryResult{}
+			status := runCanaryEndpointChecks(t.Context(), server.URL, &result)
+
+			assert.Equal(t, "FAIL", status)
+			require.Len(t, result.Targets, 2)
+			assert.Equal(t, "FAIL", result.Targets[1].Status)
+			assert.Contains(t, result.Targets[1].Detail, fmt.Sprintf("HTTP %d", code))
+		})
+	}
+}
+
+func TestRunCanaryEndpointChecks_LimitsUnauthorizedExceptionToMetrics(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		healthCode   int
+		metricsCode  int
+		failedTarget int
+	}{
+		{name: "health unauthorized", healthCode: http.StatusUnauthorized, metricsCode: http.StatusUnauthorized, failedTarget: 0},
+		{name: "metrics forbidden", healthCode: http.StatusOK, metricsCode: http.StatusForbidden, failedTarget: 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/health" {
+					w.WriteHeader(tc.healthCode)
+					return
+				}
+				w.WriteHeader(tc.metricsCode)
+			}))
+			t.Cleanup(server.Close)
+
+			result := canaryResult{}
+			status := runCanaryEndpointChecks(t.Context(), server.URL, &result)
+
+			assert.Equal(t, "FAIL", status)
+			require.Len(t, result.Targets, 2)
+			assert.Equal(t, "FAIL", result.Targets[tc.failedTarget].Status)
+		})
+	}
+}
+
+func TestRunCanaryEndpointChecks_RejectsTransportErrors(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	baseURL := server.URL
+	server.Close()
+
+	result := canaryResult{}
+	status := runCanaryEndpointChecks(t.Context(), baseURL, &result)
+
+	assert.Equal(t, "FAIL", status)
+	require.Len(t, result.Targets, 2)
+	for _, target := range result.Targets {
+		assert.Equal(t, "FAIL", target.Status)
+		assert.NotEmpty(t, target.Detail)
+	}
 }


### PR DESCRIPTION
## 요약

- 기본 스테이징에서 인증 보호된 `/metrics`의 401을 정상적인 보호 신호로 판정합니다.
- `/health` 401과 `/metrics` 403·404·500, transport 오류는 계속 실패합니다.
- endpoint별 상태와 HTTP/error detail을 독립적으로 기록합니다.

## 검증

- Linux Go 1.26.5 focused RED/GREEN
- `go test -count=1 -timeout=15m ./internal/cli`
- `go vet ./internal/cli`
- targeted race
- 실제 staging `/health` 200, `/metrics` 401
- 독립 TRUST 5 리뷰: HIGH/MEDIUM/LOW 0건

Closes #87