### PR TITLE
fix(release): v0.50.82 릴리스 부채를 해소한다

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,10 +67,30 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # @AX:REASON [AUTO]: Keep the bounded GoReleaser warm-up off the shared package scheduler so its 23-minute budget is deterministic.
+      - name: Test non-lineage integration packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          lineage_package="$(go list -tags integration ./pkg/companionmanifest)"
+          all_packages="$(go list -tags integration ./...)"
+          packages=()
+          lineage_matches=0
+          while IFS= read -r package; do
+            if [[ "$package" == "$lineage_package" ]]; then
+              lineage_matches=$((lineage_matches + 1))
+            else
+              packages+=("$package")
+            fi
+          done <<<"$all_packages"
+          ((lineage_matches == 1))
+          ((${#packages[@]} > 0))
+          go test -count=1 -timeout=15m -tags integration "${packages[@]}"
+
       - name: Test release lineage integration
         run: >-
-          go test -count=1 -timeout=35m -tags integration
-          ./...
+          go test -count=1 -timeout=23m -tags integration
+          ./pkg/companionmanifest
 
   e2e:
     name: e2e

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,9 +38,26 @@ jobs:
           GOOS=darwin GOARCH=arm64 go build ./...
           GOOS=linux GOARCH=arm64 go build ./...
 
+      # @AX:REASON [AUTO]: Keep the process-heavy Bash release fixture off the shared Go package scheduler while preserving its race gate.
+      - name: Test release hardening contract in isolation
+        shell: bash
+        run: |
+          set -euo pipefail
+          inventory="$(go test -list '^TestReleaseHardeningBashContract$' ./internal/companionmanifest)"
+          count="$(
+            printf '%s\n' "$inventory" |
+              awk '$0 == "TestReleaseHardeningBashContract" { found++ } END { print found + 0 }'
+          )"
+          [[ "$count" == 1 ]]
+          go test -race -count=1 -timeout=5m \
+            -run '^TestReleaseHardeningBashContract$' \
+            ./internal/companionmanifest
+
       - name: Test with Coverage
         run: |
-          go test -race -count=1 -timeout=20m -coverprofile=coverage.out ./...
+          go test -race -count=1 -timeout=20m \
+            -skip '^TestReleaseHardeningBashContract$' \
+            -coverprofile=coverage.out ./...
           COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | tr -d '%')
           echo "Total coverage: ${COVERAGE}%"
           THRESHOLD=${COVERAGE_THRESHOLD:-83}

--- a/internal/companionmanifest/release_ci_stability_test.go
+++ b/internal/companionmanifest/release_ci_stability_test.go
@@ -61,15 +61,28 @@ func TestCIWorkflow_StableChecksHaveBoundedTimeouts(t *testing.T) {
 	if strings.Contains(testRun, "-tags integration") {
 		t.Fatal("CI race coverage gate must not run executable release integration fixtures")
 	}
+	nonLineageRun := ciStepRun(t, workflow.Jobs["lineage-integration"], "Test non-lineage integration packages")
+	for _, required := range []string{
+		`lineage_package="$(go list -tags integration ./pkg/companionmanifest)"`,
+		`all_packages="$(go list -tags integration ./...)"`,
+		`[[ "$package" == "$lineage_package" ]]`, `done <<<"$all_packages"`,
+		"((lineage_matches == 1))", `"${packages[@]}"`,
+		"-timeout=15m", "-tags integration",
+	} {
+		if !strings.Contains(nonLineageRun, required) {
+			t.Fatalf("CI non-lineage integration contract missing %q", required)
+		}
+	}
 	lineageRun := ciStepRun(t, workflow.Jobs["lineage-integration"], "Test release lineage integration")
 	for _, required := range []string{
-		"-timeout=35m", "-tags integration", "./...",
+		"-timeout=23m", "-tags integration", "./pkg/companionmanifest",
 	} {
 		if !strings.Contains(lineageRun, required) {
 			t.Fatalf("CI release lineage integration contract missing %q", required)
 		}
 	}
-	if strings.Contains(lineageRun, "-race") || strings.Contains(lineageRun, "-coverprofile") {
+	if strings.Contains(nonLineageRun+lineageRun, "-race") ||
+		strings.Contains(nonLineageRun+lineageRun, "-coverprofile") {
 		t.Fatal("CI release lineage integration gate must be isolated from race coverage instrumentation")
 	}
 }

--- a/internal/companionmanifest/release_ci_stability_test.go
+++ b/internal/companionmanifest/release_ci_stability_test.go
@@ -48,12 +48,36 @@ func TestCIWorkflow_StableChecksHaveBoundedTimeouts(t *testing.T) {
 		linter.With["version"] != "v2.12.2" {
 		t.Fatalf("golangci-lint gate drifted: uses=%q version=%v", linter.Uses, linter.With["version"])
 	}
+	hardeningRun := ciStepRun(t, workflow.Jobs["test"], "Test release hardening contract in isolation")
+	for _, required := range []string{
+		"set -euo pipefail",
+		"go test -list '^TestReleaseHardeningBashContract$' ./internal/companionmanifest",
+		`awk '$0 == "TestReleaseHardeningBashContract" { found++ } END { print found + 0 }'`,
+		`[[ "$count" == 1 ]]`, "-race", "-count=1", "-timeout=5m",
+		"-run '^TestReleaseHardeningBashContract$'", "./internal/companionmanifest",
+	} {
+		if !strings.Contains(hardeningRun, required) {
+			t.Fatalf("CI release hardening isolation contract missing %q", required)
+		}
+	}
 	testRun := ciStepRun(t, workflow.Jobs["test"], "Test with Coverage")
-	for _, required := range []string{"-race", "-timeout=20m", "-coverprofile=coverage.out", "COVERAGE_THRESHOLD: \"83\""} {
+	for _, required := range []string{
+		"-race", "-timeout=20m", "-skip '^TestReleaseHardeningBashContract$'",
+		"-coverprofile=coverage.out", "COVERAGE_THRESHOLD: \"83\"",
+	} {
 		if !strings.Contains(readReleaseFile(t, ".github/workflows/ci.yaml"), required) &&
 			!strings.Contains(testRun, required) {
 			t.Fatalf("CI coverage contract missing %q", required)
 		}
+	}
+	if strings.Count(hardeningRun, "-run '^TestReleaseHardeningBashContract$'") != 1 ||
+		strings.Count(testRun, "-skip '^TestReleaseHardeningBashContract$'") != 1 ||
+		strings.Contains(hardeningRun, "-skip") || strings.Contains(testRun, "-run") {
+		t.Fatal("CI release hardening run/skip boundary is not exact")
+	}
+	if ciStepIndex(t, workflow.Jobs["test"], "Test release hardening contract in isolation") >=
+		ciStepIndex(t, workflow.Jobs["test"], "Test with Coverage") {
+		t.Fatal("CI release hardening contract must pass before shared race coverage")
 	}
 	if !strings.Contains(testRun, "./...") {
 		t.Fatal("CI race coverage gate must cover every Go package")
@@ -182,6 +206,17 @@ func readCIStabilityJob(t *testing.T, path, id string) string {
 func ciStepRun(t *testing.T, job ciStabilityJob, name string) string {
 	t.Helper()
 	return ciStep(t, job, name).Run
+}
+
+func ciStepIndex(t *testing.T, job ciStabilityJob, name string) int {
+	t.Helper()
+	for index, step := range job.Steps {
+		if step.Name == name {
+			return index
+		}
+	}
+	t.Fatalf("CI step %q is missing", name)
+	return -1
 }
 
 func ciStep(t *testing.T, job ciStabilityJob, name string) ciStabilityStep {

--- a/internal/companionmanifest/release_debt_contract_test.go
+++ b/internal/companionmanifest/release_debt_contract_test.go
@@ -1,0 +1,112 @@
+package companionmanifest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// @AX:NOTE [AUTO]: The 250-line ceiling preserves A12 expansion headroom below the 300-line source limit.
+const releaseDebtHeadroomLimit = 250
+
+func TestReleaseDebtSaturatedScriptsHaveExpansionHeadroom(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{
+		"scripts/companion-release/verify-public-key-lineage.sh",
+		"scripts/companion-release/publish-homebrew-formula-bridge.sh",
+		"scripts/companion-release/tests/release-hardening-test.sh",
+	} {
+		data, err := os.ReadFile(filepath.Join(repositoryRoot(t), path))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if lines := strings.Count(string(data), "\n") + 1; lines > releaseDebtHeadroomLimit {
+			t.Errorf("%s has %d lines, want <= %d for A12 headroom",
+				path, lines, releaseDebtHeadroomLimit)
+		}
+	}
+}
+
+func TestReleaseDebtLineageCoordinatesHaveDedicatedHelper(t *testing.T) {
+	t.Parallel()
+
+	lineage := readReleaseFile(t, "scripts/companion-release/verify-public-key-lineage.sh")
+	coordinates := readReleaseFile(t,
+		"scripts/companion-release/verify-public-key-lineage-coordinates.sh")
+	for _, required := range []string{
+		"verify-public-key-lineage-coordinates.sh",
+		`[[ -f "$coordinates_helper" && ! -L "$coordinates_helper" ]]`,
+		`source "$coordinates_helper"`,
+	} {
+		if !strings.Contains(lineage, required) {
+			t.Fatalf("lineage helper gate missing %q", required)
+		}
+	}
+	for _, required := range []string{
+		"release_phase='A0'", "release_phase='A11' prior_phase='A10'",
+		"prior_tree=", "prior_release_identity_mismatch",
+	} {
+		if !strings.Contains(coordinates, required) {
+			t.Fatalf("lineage coordinate helper missing %q", required)
+		}
+	}
+	if strings.Contains(lineage, "release_phase='A11' prior_phase='A10'") {
+		t.Fatal("lineage caller still owns the A11 coordinate table")
+	}
+}
+
+func TestReleaseDebtHomebrewCASHasDedicatedHelper(t *testing.T) {
+	t.Parallel()
+
+	bridge := readReleaseFile(t,
+		"scripts/companion-release/publish-homebrew-formula-bridge.sh")
+	gitHelper := readReleaseFile(t,
+		"scripts/companion-release/publish-homebrew-formula-bridge-git.sh")
+	for _, required := range []string{
+		"publish-homebrew-formula-bridge-git.sh",
+		`[[ -f "$git_helper" && ! -L "$git_helper" ]]`,
+		`source "$git_helper"`,
+	} {
+		if !strings.Contains(bridge, required) {
+			t.Fatalf("Homebrew helper gate missing %q", required)
+		}
+	}
+	for _, required := range []string{
+		"verify_frozen_formula", "verify_prior_tap_head", "publish_cask",
+		"api_json POST 'git/blobs'", "api_json POST 'git/trees'",
+		"api_json POST 'git/commits'", `api_json PATCH "git/refs/heads/${TAP_BRANCH}"`,
+	} {
+		if !strings.Contains(gitHelper, required) {
+			t.Fatalf("Homebrew CAS helper missing %q", required)
+		}
+	}
+	if strings.Contains(bridge, "publish_cask()") ||
+		strings.Contains(bridge, "verify_frozen_formula()") {
+		t.Fatal("Homebrew caller still owns Git CAS or Formula freeze behavior")
+	}
+}
+
+func TestReleaseDebtRuntimeAssertionsHaveDedicatedScript(t *testing.T) {
+	t.Parallel()
+
+	hardening := readReleaseFile(t,
+		"scripts/companion-release/tests/release-hardening-test.sh")
+	runtime := readReleaseFile(t,
+		"scripts/companion-release/tests/release-runtime-hardening-test.sh")
+	if !strings.Contains(hardening, `bash "$tests_dir/release-runtime-hardening-test.sh"`) {
+		t.Fatal("release hardening aggregator does not invoke runtime assertions")
+	}
+	for _, required := range []string{
+		"run_source_gate", "expired manifest window passed",
+		"unanchored self-signed receipt passed", "tampered manifest signature passed",
+	} {
+		if !strings.Contains(runtime, required) {
+			t.Fatalf("release runtime hardening helper missing %q", required)
+		}
+	}
+	if strings.Contains(hardening, "go build -trimpath -o") {
+		t.Fatal("release hardening aggregator still owns executable runtime assertions")
+	}
+}

--- a/internal/companionmanifest/release_debt_contract_test.go
+++ b/internal/companionmanifest/release_debt_contract_test.go
@@ -112,8 +112,6 @@ func TestReleaseDebtHomebrewCASHasDedicatedHelper(t *testing.T) {
 		"verify_frozen_formula", "verify_prior_tap_head", "publish_cask",
 		"api_json POST 'git/blobs'", "api_json POST 'git/trees'",
 		"api_json POST 'git/commits'", `api_json PATCH "git/refs/heads/${TAP_BRANCH}"`,
-		`printf -v "$destination"`, `sha256_file "$target" target_digest`,
-		`sha256_file "$current" current_digest`,
 	} {
 		if !strings.Contains(gitHelper, required) {
 			t.Fatalf("Homebrew CAS helper missing %q", required)
@@ -122,9 +120,6 @@ func TestReleaseDebtHomebrewCASHasDedicatedHelper(t *testing.T) {
 	if strings.Contains(bridge, "publish_cask()") ||
 		strings.Contains(bridge, "verify_frozen_formula()") {
 		t.Fatal("Homebrew caller still owns Git CAS or Formula freeze behavior")
-	}
-	if strings.Contains(gitHelper, `$(sha256_file`) {
-		t.Fatal("Homebrew digest helper crosses the temporary-evidence EXIT trap through command substitution")
 	}
 }
 

--- a/internal/companionmanifest/release_debt_contract_test.go
+++ b/internal/companionmanifest/release_debt_contract_test.go
@@ -17,6 +17,9 @@ func TestReleaseDebtSaturatedScriptsHaveExpansionHeadroom(t *testing.T) {
 		"scripts/companion-release/verify-public-key-lineage.sh",
 		"scripts/companion-release/publish-homebrew-formula-bridge.sh",
 		"scripts/companion-release/tests/release-hardening-test.sh",
+		"scripts/companion-release/produce.sh",
+		"scripts/companion-release/produce-public-key-receipt.sh",
+		"pkg/companionmanifest/release_public_key_receipt_lineage_test.go",
 	} {
 		data, err := os.ReadFile(filepath.Join(repositoryRoot(t), path))
 		if err != nil {
@@ -26,6 +29,38 @@ func TestReleaseDebtSaturatedScriptsHaveExpansionHeadroom(t *testing.T) {
 			t.Errorf("%s has %d lines, want <= %d for A12 headroom",
 				path, lines, releaseDebtHeadroomLimit)
 		}
+	}
+}
+
+func TestReleaseDebtProducerReceiptHasDedicatedHelper(t *testing.T) {
+	t.Parallel()
+
+	producer := readReleaseFile(t, "scripts/companion-release/produce.sh")
+	helper := readReleaseFile(t,
+		"scripts/companion-release/produce-public-key-receipt.sh")
+	for _, required := range []string{
+		"produce-public-key-receipt.sh",
+		`[[ -f "$public_key_receipt_helper" && ! -L "$public_key_receipt_helper"`,
+		`source "$public_key_receipt_helper"`,
+		"resolve_public_key_receipt_release_phase produce_public_key_receipt_bundle",
+	} {
+		if !strings.Contains(producer, required) {
+			t.Fatalf("producer receipt helper gate missing %q", required)
+		}
+	}
+	for _, required := range []string{
+		"release_phase='A0'", "release_phase='A11'",
+		"companion-manifest public-key-receipt",
+		"public key receipt independent verification failed",
+		"manifest_public_key_digest_mismatch",
+	} {
+		if !strings.Contains(helper, required) {
+			t.Fatalf("producer receipt helper missing %q", required)
+		}
+	}
+	if strings.Contains(producer, "release_phase='A11'") ||
+		strings.Contains(producer, "companion-manifest public-key-receipt") {
+		t.Fatal("producer caller still owns receipt phase coordinates or publication")
 	}
 }
 

--- a/internal/companionmanifest/release_debt_contract_test.go
+++ b/internal/companionmanifest/release_debt_contract_test.go
@@ -112,6 +112,8 @@ func TestReleaseDebtHomebrewCASHasDedicatedHelper(t *testing.T) {
 		"verify_frozen_formula", "verify_prior_tap_head", "publish_cask",
 		"api_json POST 'git/blobs'", "api_json POST 'git/trees'",
 		"api_json POST 'git/commits'", `api_json PATCH "git/refs/heads/${TAP_BRANCH}"`,
+		`printf -v "$destination"`, `sha256_file "$target" target_digest`,
+		`sha256_file "$current" current_digest`,
 	} {
 		if !strings.Contains(gitHelper, required) {
 			t.Fatalf("Homebrew CAS helper missing %q", required)
@@ -120,6 +122,9 @@ func TestReleaseDebtHomebrewCASHasDedicatedHelper(t *testing.T) {
 	if strings.Contains(bridge, "publish_cask()") ||
 		strings.Contains(bridge, "verify_frozen_formula()") {
 		t.Fatal("Homebrew caller still owns Git CAS or Formula freeze behavior")
+	}
+	if strings.Contains(gitHelper, `$(sha256_file`) {
+		t.Fatal("Homebrew digest helper crosses the temporary-evidence EXIT trap through command substitution")
 	}
 }
 

--- a/internal/companionmanifest/release_fixture_bash_test.go
+++ b/internal/companionmanifest/release_fixture_bash_test.go
@@ -51,6 +51,7 @@ case "${1-}" in
     trap 'rm -rf -- "$fixture_root"' EXIT
     cp -R -- "$(dirname -- "$source_script")" "$fixture_root/companion-release"
     fixture_script="$fixture_root/companion-release/produce.sh"
+    fixture_receipt_helper="$fixture_root/companion-release/produce-public-key-receipt.sh"
     /usr/bin/sed \
       -e 's|uname -s|printf Darwin|' \
       -e 's|codesign_tool=/usr/bin/codesign|codesign_tool="$COMPANION_CODESIGN_TOOL"|' \
@@ -61,6 +62,10 @@ case "${1-}" in
       -e 's|env -i PATH="$PATH" HOME="${HOME-}" TMPDIR="${TMPDIR:-/tmp}"|env|' \
       "$fixture_script" >"$fixture_script.next"
     mv -- "$fixture_script.next" "$fixture_script"
+    /usr/bin/sed \
+      -e 's|env -i PATH="$PATH" HOME="${HOME-}" TMPDIR="${TMPDIR:-/tmp}"|env|' \
+      "$fixture_receipt_helper" >"$fixture_receipt_helper.next"
+    mv -- "$fixture_receipt_helper.next" "$fixture_receipt_helper"
     /bin/bash "$fixture_script" "$@"
     ;;
   *) exec /bin/bash "$@" ;;

--- a/internal/companionmanifest/release_homebrew_formula_bridge_cask_test.go
+++ b/internal/companionmanifest/release_homebrew_formula_bridge_cask_test.go
@@ -19,6 +19,8 @@ var frozenFormulaDigests = []string{
 
 func TestHomebrewFormulaBridge_A11PinsCaskOnlyTapTransition(t *testing.T) {
 	source := readReleaseFile(t, "scripts/companion-release/publish-homebrew-formula-bridge.sh")
+	gitHelper := readReleaseFile(t,
+		"scripts/companion-release/publish-homebrew-formula-bridge-git.sh")
 	for _, required := range []string{
 		"readonly RELEASE_TAG='v0.50.82'",
 		"readonly RELEASE_VERSION='0.50.82'",
@@ -27,21 +29,33 @@ func TestHomebrewFormulaBridge_A11PinsCaskOnlyTapTransition(t *testing.T) {
 		"readonly FROZEN_FORMULA_BLOB='" + a11FrozenFormulaBlob + "'",
 		"readonly FORMULA_PATH='Formula/auto.rb'",
 		"COMPANION_HOMEBREW_POLICY", "cask-only",
+		`[[ -f "$git_helper" && ! -L "$git_helper" ]]`,
+		`source "$git_helper"`,
+	} {
+		if !strings.Contains(source, required) {
+			t.Fatalf("A11 Homebrew caller policy missing %q", required)
+		}
+	}
+	for _, required := range []string{
+		"verify_frozen_formula", "verify_idempotent_head_snapshot",
+		`api_json GET "git/commits/${head_sha}"`,
+		`api_json GET "git/trees/${tree_sha}?recursive=1"`,
 		"api_json POST 'git/blobs'", "api_json POST 'git/trees'",
 		"api_json POST 'git/commits'", "api_json PATCH \"git/refs/heads/${TAP_BRANCH}\"",
 		"'{base_tree:$base,tree:[{path:$path,mode:\"100644\",type:\"blob\",sha:$sha}]}'",
 		"'{message:$message,tree:$tree,parents:[$parent]}'",
 		"'{sha:$sha,force:false}'",
 	} {
-		if !strings.Contains(source, required) {
-			t.Fatalf("A11 Homebrew policy missing %q", required)
+		if !strings.Contains(gitHelper, required) {
+			t.Fatalf("A11 Homebrew Git CAS policy missing %q", required)
 		}
 	}
+	implementation := source + "\n" + gitHelper
 	for _, forbidden := range []string{
 		"reconcile_tap_file formula Formula", "Publish signed Formula",
 		"--method PUT",
 	} {
-		if strings.Contains(source, forbidden) {
+		if strings.Contains(implementation, forbidden) {
 			t.Fatalf("A11 production path can mutate the frozen Formula via %q", forbidden)
 		}
 	}

--- a/internal/companionmanifest/release_homebrew_formula_bridge_race_test.go
+++ b/internal/companionmanifest/release_homebrew_formula_bridge_race_test.go
@@ -1,0 +1,103 @@
+package companionmanifest
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHomebrewFormulaBridge_RejectsAlreadyCurrentFormulaRace(t *testing.T) {
+	fixture := newHomebrewBridgeFixture(t)
+	if output, err := fixture.run(nil); err != nil {
+		t.Fatalf("publish Cask fixture: %v\n%s", err, output)
+	}
+	writeTapRaceMarker(t, fixture, "idempotent-formula-race")
+	output, err := fixture.run(nil)
+	if err == nil || !strings.Contains(string(output), "idempotent tree") {
+		t.Fatalf("idempotent Formula race result: %v\n%s", err, output)
+	}
+	if got := fixture.updateCount(t, "cask"); got != "1" {
+		t.Fatalf("idempotent Formula race performed %s Cask updates", got)
+	}
+	if got := tapContentBlob(t, fixture, "formula.json"); got != "6666666666666666666666666666666666666666" {
+		t.Fatalf("idempotent Formula race blob = %s", got)
+	}
+}
+
+func TestHomebrewFormulaBridge_RejectsAlreadyCurrentFinalHeadRace(t *testing.T) {
+	fixture := newHomebrewBridgeFixture(t)
+	if output, err := fixture.run(nil); err != nil {
+		t.Fatalf("publish Cask fixture: %v\n%s", err, output)
+	}
+	if err := os.Remove(filepath.Join(fixture.state, "branch-get.calls")); err != nil {
+		t.Fatal(err)
+	}
+	writeTapRaceMarker(t, fixture, "idempotent-ref-race")
+	output, err := fixture.run(nil)
+	if err == nil || !strings.Contains(string(output), "head moved during idempotent verification") {
+		t.Fatalf("idempotent final-head race result: %v\n%s", err, output)
+	}
+	if got := fixture.updateCount(t, "cask"); got != "1" {
+		t.Fatalf("idempotent final-head race performed %s Cask updates", got)
+	}
+	if got := tapBranchHead(t, fixture); got != "4444444444444444444444444444444444444444" {
+		t.Fatalf("idempotent final-head race commit = %s", got)
+	}
+}
+
+func TestHomebrewFormulaBridge_RejectsAlreadyCurrentMalformedCaskBlob(t *testing.T) {
+	fixture := newHomebrewBridgeFixture(t)
+	if output, err := fixture.run(nil); err != nil {
+		t.Fatalf("publish Cask fixture: %v\n%s", err, output)
+	}
+	current := fixture.apiContent(t, "cask.json")
+	fixture.writeAPIContent(t, "cask.json", "not-a-git-blob", current)
+	output, err := fixture.run(nil)
+	if err == nil || !strings.Contains(string(output), "invalid blob SHA") {
+		t.Fatalf("idempotent malformed Cask blob result: %v\n%s", err, output)
+	}
+	if got := fixture.updateCount(t, "cask"); got != "1" {
+		t.Fatalf("malformed Cask blob performed %s Cask updates", got)
+	}
+}
+
+func writeTapRaceMarker(t *testing.T, fixture homebrewBridgeFixture, name string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(fixture.state, name), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func tapContentBlob(t *testing.T, fixture homebrewBridgeFixture, name string) string {
+	t.Helper()
+	payload, err := os.ReadFile(filepath.Join(fixture.state, name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var response struct {
+		SHA string `json:"sha"`
+	}
+	if err := json.Unmarshal(payload, &response); err != nil {
+		t.Fatal(err)
+	}
+	return response.SHA
+}
+
+func tapBranchHead(t *testing.T, fixture homebrewBridgeFixture) string {
+	t.Helper()
+	payload, err := os.ReadFile(filepath.Join(fixture.state, "branch.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var response struct {
+		Object struct {
+			SHA string `json:"sha"`
+		} `json:"object"`
+	}
+	if err := json.Unmarshal(payload, &response); err != nil {
+		t.Fatal(err)
+	}
+	return response.Object.SHA
+}

--- a/internal/companionmanifest/release_lineage_a10_test.go
+++ b/internal/companionmanifest/release_lineage_a10_test.go
@@ -96,15 +96,25 @@ func TestLineageVerifier_A10PinsExactImmutableA9Evidence(t *testing.T) {
 		}
 	}
 	lineage := readReleaseFile(t, "scripts/companion-release/verify-public-key-lineage.sh")
+	coordinates := readReleaseFile(t,
+		"scripts/companion-release/verify-public-key-lineage-coordinates.sh")
 	for _, required := range []string{
 		"release_phase='A10' prior_phase='A9'",
 		`prior_evidence_source='immutable A9 GitHub release'`,
 		`prior_tree="$A9_TREE_SHA"`,
 		`prior_tag_object="$A9_TAG_OBJECT_SHA" prior_checksums="$A9_CHECKSUMS_SHA256"`,
+	} {
+		if !strings.Contains(coordinates, required) {
+			t.Fatalf("A10 lineage coordinate contract missing %q", required)
+		}
+	}
+	for _, required := range []string{
 		`[[ "$(jq -er '.commit.tree.sha' "$commit_json")" == "$prior_tree" ]]`,
+		`[[ -f "$coordinates_helper" && ! -L "$coordinates_helper" ]]`,
+		`source "$coordinates_helper"`,
 	} {
 		if !strings.Contains(lineage, required) {
-			t.Fatalf("A10 lineage contract missing %q", required)
+			t.Fatalf("A10 lineage caller contract missing %q", required)
 		}
 	}
 }

--- a/internal/companionmanifest/release_lineage_a11_test.go
+++ b/internal/companionmanifest/release_lineage_a11_test.go
@@ -96,15 +96,25 @@ func TestLineageVerifier_A11PinsExactImmutableA10Evidence(t *testing.T) {
 		}
 	}
 	lineage := readReleaseFile(t, "scripts/companion-release/verify-public-key-lineage.sh")
+	coordinates := readReleaseFile(t,
+		"scripts/companion-release/verify-public-key-lineage-coordinates.sh")
 	for _, required := range []string{
 		"release_phase='A11' prior_phase='A10'",
 		`prior_evidence_source='immutable A10 GitHub release'`,
 		`prior_tree="$A10_TREE_SHA"`,
 		`prior_tag_object="$A10_TAG_OBJECT_SHA" prior_checksums="$A10_CHECKSUMS_SHA256"`,
+	} {
+		if !strings.Contains(coordinates, required) {
+			t.Fatalf("A11 lineage coordinate contract missing %q", required)
+		}
+	}
+	for _, required := range []string{
 		`[[ "$(jq -er '.commit.tree.sha' "$commit_json")" == "$prior_tree" ]]`,
+		`[[ -f "$coordinates_helper" && ! -L "$coordinates_helper" ]]`,
+		`source "$coordinates_helper"`,
 	} {
 		if !strings.Contains(lineage, required) {
-			t.Fatalf("A11 lineage contract missing %q", required)
+			t.Fatalf("A11 lineage caller contract missing %q", required)
 		}
 	}
 }

--- a/internal/companionmanifest/release_lineage_a8_test.go
+++ b/internal/companionmanifest/release_lineage_a8_test.go
@@ -76,13 +76,23 @@ func TestLineageVerifier_A8PinsExactImmutableA7Evidence(t *testing.T) {
 		}
 	}
 	lineage := readReleaseFile(t, "scripts/companion-release/verify-public-key-lineage.sh")
+	coordinates := readReleaseFile(t,
+		"scripts/companion-release/verify-public-key-lineage-coordinates.sh")
 	for _, required := range []string{
 		"release_phase='A8' prior_phase='A7'",
 		`prior_tree="$A7_TREE_SHA"`,
+	} {
+		if !strings.Contains(coordinates, required) {
+			t.Fatalf("A8 lineage coordinate contract missing %q", required)
+		}
+	}
+	for _, required := range []string{
 		`[[ "$(jq -er '.commit.tree.sha' "$commit_json")" == "$prior_tree" ]]`,
+		`[[ -f "$coordinates_helper" && ! -L "$coordinates_helper" ]]`,
+		`source "$coordinates_helper"`,
 	} {
 		if !strings.Contains(lineage, required) {
-			t.Fatalf("A8 lineage contract missing %q", required)
+			t.Fatalf("A8 lineage caller contract missing %q", required)
 		}
 	}
 }

--- a/internal/companionmanifest/release_lineage_a9_test.go
+++ b/internal/companionmanifest/release_lineage_a9_test.go
@@ -76,13 +76,23 @@ func TestLineageVerifier_A9PinsExactImmutableA8Evidence(t *testing.T) {
 		}
 	}
 	lineage := readReleaseFile(t, "scripts/companion-release/verify-public-key-lineage.sh")
+	coordinates := readReleaseFile(t,
+		"scripts/companion-release/verify-public-key-lineage-coordinates.sh")
 	for _, required := range []string{
 		"release_phase='A9' prior_phase='A8'",
 		`prior_tree="$A8_TREE_SHA"`,
+	} {
+		if !strings.Contains(coordinates, required) {
+			t.Fatalf("A9 lineage coordinate contract missing %q", required)
+		}
+	}
+	for _, required := range []string{
 		`[[ "$(jq -er '.commit.tree.sha' "$commit_json")" == "$prior_tree" ]]`,
+		`[[ -f "$coordinates_helper" && ! -L "$coordinates_helper" ]]`,
+		`source "$coordinates_helper"`,
 	} {
 		if !strings.Contains(lineage, required) {
-			t.Fatalf("A9 lineage contract missing %q", required)
+			t.Fatalf("A9 lineage caller contract missing %q", required)
 		}
 	}
 }

--- a/pkg/companionmanifest/release_fixture_bash_test.go
+++ b/pkg/companionmanifest/release_fixture_bash_test.go
@@ -7,6 +7,10 @@ import (
 	"testing"
 )
 
+// @AX:WARN [AUTO]: TestMain mutates the process-wide lineage fixture cache root.
+// @AX:REASON [AUTO]: Integration fixtures share this immutable cache; assign it before m.Run and remove it only after the suite completes.
+var lineageFixtureCacheRoot string
+
 func TestMain(m *testing.M) {
 	wrapperRoot, err := os.MkdirTemp("", "autopus-release-bash-")
 	if err != nil {
@@ -19,10 +23,17 @@ func TestMain(m *testing.M) {
 		_ = os.RemoveAll(wrapperRoot)
 		os.Exit(2)
 	}
+	lineageFixtureCacheRoot, err = os.MkdirTemp("", "autopus-lineage-cache-")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		_ = os.RemoveAll(wrapperRoot)
+		os.Exit(2)
+	}
 	previousPath := os.Getenv("PATH")
 	_ = os.Setenv("PATH", wrapperRoot+string(os.PathListSeparator)+previousPath)
 	code := m.Run()
 	_ = os.Setenv("PATH", previousPath)
+	_ = os.RemoveAll(lineageFixtureCacheRoot)
 	_ = os.RemoveAll(wrapperRoot)
 	os.Exit(code)
 }

--- a/pkg/companionmanifest/release_fixture_bash_test.go
+++ b/pkg/companionmanifest/release_fixture_bash_test.go
@@ -48,6 +48,7 @@ case "${1-}" in
     trap 'rm -rf -- "$fixture_root"' EXIT
     cp -R -- "$(dirname -- "$source_script")" "$fixture_root/companion-release"
     fixture_script="$fixture_root/companion-release/produce.sh"
+    fixture_receipt_helper="$fixture_root/companion-release/produce-public-key-receipt.sh"
     /usr/bin/sed \
       -e 's|uname -s|printf Darwin|' \
       -e 's|codesign_tool=/usr/bin/codesign|codesign_tool="$COMPANION_CODESIGN_TOOL"|' \
@@ -58,6 +59,10 @@ case "${1-}" in
       -e 's|env -i PATH="$PATH" HOME="${HOME-}" TMPDIR="${TMPDIR:-/tmp}"|env|' \
       "$fixture_script" >"$fixture_script.next"
     mv -- "$fixture_script.next" "$fixture_script"
+    /usr/bin/sed \
+      -e 's|env -i PATH="$PATH" HOME="${HOME-}" TMPDIR="${TMPDIR:-/tmp}"|env|' \
+      "$fixture_receipt_helper" >"$fixture_receipt_helper.next"
+    mv -- "$fixture_receipt_helper.next" "$fixture_receipt_helper"
     /bin/bash "$fixture_script" "$@"
     ;;
   *) exec /bin/bash "$@" ;;

--- a/pkg/companionmanifest/release_lineage_a10_test.go
+++ b/pkg/companionmanifest/release_lineage_a10_test.go
@@ -44,7 +44,7 @@ func TestReleasePublicKeyReceipt_GoReleaserA10FixtureProducesCurrentArtifacts(t 
 		t, tools, publicKeyReceiptA10Tag, publicKeyReceiptA10Version, true,
 	)
 	for _, architecture := range []string{"amd64", "arm64"} {
-		entries, err := decodeLineageArchive(evidence.archives[architecture])
+		entries, err := decodeLineageArchiveFile(evidence.archives[architecture])
 		if err != nil {
 			t.Fatalf("decode A10 %s archive: %v", architecture, err)
 		}

--- a/pkg/companionmanifest/release_lineage_a11_test.go
+++ b/pkg/companionmanifest/release_lineage_a11_test.go
@@ -44,7 +44,7 @@ func TestReleasePublicKeyReceipt_GoReleaserA11FixtureProducesCurrentArtifacts(t 
 		t, tools, publicKeyReceiptA11Tag, publicKeyReceiptA11Version, true,
 	)
 	for _, architecture := range []string{"amd64", "arm64"} {
-		entries, err := decodeLineageArchive(evidence.archives[architecture])
+		entries, err := decodeLineageArchiveFile(evidence.archives[architecture])
 		if err != nil {
 			t.Fatalf("decode A11 %s archive: %v", architecture, err)
 		}

--- a/pkg/companionmanifest/release_lineage_a2_test.go
+++ b/pkg/companionmanifest/release_lineage_a2_test.go
@@ -13,7 +13,7 @@ func TestReleasePublicKeyReceipt_GoReleaserA2FixtureProducesCurrentArtifacts(t *
 		t, tools, publicKeyReceiptA2Tag, publicKeyReceiptA2Version, true,
 	)
 	for _, architecture := range []string{"amd64", "arm64"} {
-		entries, err := decodeLineageArchive(evidence.archives[architecture])
+		entries, err := decodeLineageArchiveFile(evidence.archives[architecture])
 		if err != nil {
 			t.Fatalf("decode A2 %s archive: %v", architecture, err)
 		}

--- a/pkg/companionmanifest/release_lineage_a3_test.go
+++ b/pkg/companionmanifest/release_lineage_a3_test.go
@@ -13,7 +13,7 @@ func TestReleasePublicKeyReceipt_GoReleaserA3FixtureProducesCurrentArtifacts(t *
 		t, tools, publicKeyReceiptA3Tag, publicKeyReceiptA3Version, true,
 	)
 	for _, architecture := range []string{"amd64", "arm64"} {
-		entries, err := decodeLineageArchive(evidence.archives[architecture])
+		entries, err := decodeLineageArchiveFile(evidence.archives[architecture])
 		if err != nil {
 			t.Fatalf("decode A3 %s archive: %v", architecture, err)
 		}

--- a/pkg/companionmanifest/release_lineage_a4_test.go
+++ b/pkg/companionmanifest/release_lineage_a4_test.go
@@ -13,7 +13,7 @@ func TestReleasePublicKeyReceipt_GoReleaserA4FixtureProducesCurrentArtifacts(t *
 		t, tools, publicKeyReceiptA4Tag, publicKeyReceiptA4Version, true,
 	)
 	for _, architecture := range []string{"amd64", "arm64"} {
-		entries, err := decodeLineageArchive(evidence.archives[architecture])
+		entries, err := decodeLineageArchiveFile(evidence.archives[architecture])
 		if err != nil {
 			t.Fatalf("decode A4 %s archive: %v", architecture, err)
 		}

--- a/pkg/companionmanifest/release_lineage_a5_test.go
+++ b/pkg/companionmanifest/release_lineage_a5_test.go
@@ -29,7 +29,7 @@ func TestReleasePublicKeyReceipt_GoReleaserA5FixtureProducesCurrentArtifacts(t *
 		t, tools, publicKeyReceiptA5Tag, publicKeyReceiptA5Version, true,
 	)
 	for _, architecture := range []string{"amd64", "arm64"} {
-		entries, err := decodeLineageArchive(evidence.archives[architecture])
+		entries, err := decodeLineageArchiveFile(evidence.archives[architecture])
 		if err != nil {
 			t.Fatalf("decode A5 %s archive: %v", architecture, err)
 		}

--- a/pkg/companionmanifest/release_lineage_a5_test.go
+++ b/pkg/companionmanifest/release_lineage_a5_test.go
@@ -3,7 +3,6 @@ package companionmanifest
 import (
 	"bytes"
 	"encoding/base64"
-	"regexp"
 	"strings"
 	"testing"
 )
@@ -121,17 +120,4 @@ func exactA4TagVersionGuard(source string) bool {
 
 func exactA5TagVersionGuard(source string) bool {
 	return exactLineageTagVersionGuard(source, "74")
-}
-
-func exactLineageTagVersionGuard(source, patch string) bool {
-	patterns := []*regexp.Regexp{
-		regexp.MustCompile(`GITHUB_REF_NAME.{0,240}v0\.50\.` + patch + `.{0,400}COMPANION_VERSION.{0,240}0\.50\.` + patch),
-		regexp.MustCompile(`COMPANION_VERSION.{0,240}0\.50\.` + patch + `.{0,400}GITHUB_REF_NAME.{0,240}v0\.50\.` + patch),
-	}
-	for _, pattern := range patterns {
-		if pattern.MatchString(source) {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/companionmanifest/release_lineage_a6_test.go
+++ b/pkg/companionmanifest/release_lineage_a6_test.go
@@ -28,7 +28,7 @@ func TestReleasePublicKeyReceipt_GoReleaserA6FixtureProducesCurrentArtifacts(t *
 		t, tools, publicKeyReceiptA6Tag, publicKeyReceiptA6Version, true,
 	)
 	for _, architecture := range []string{"amd64", "arm64"} {
-		entries, err := decodeLineageArchive(evidence.archives[architecture])
+		entries, err := decodeLineageArchiveFile(evidence.archives[architecture])
 		if err != nil {
 			t.Fatalf("decode A6 %s archive: %v", architecture, err)
 		}

--- a/pkg/companionmanifest/release_lineage_a7_test.go
+++ b/pkg/companionmanifest/release_lineage_a7_test.go
@@ -35,7 +35,7 @@ func TestReleasePublicKeyReceipt_GoReleaserA7FixtureProducesCurrentArtifacts(t *
 		t, tools, publicKeyReceiptA7Tag, publicKeyReceiptA7Version, true,
 	)
 	for _, architecture := range []string{"amd64", "arm64"} {
-		entries, err := decodeLineageArchive(evidence.archives[architecture])
+		entries, err := decodeLineageArchiveFile(evidence.archives[architecture])
 		if err != nil {
 			t.Fatalf("decode A7 %s archive: %v", architecture, err)
 		}

--- a/pkg/companionmanifest/release_lineage_a8_test.go
+++ b/pkg/companionmanifest/release_lineage_a8_test.go
@@ -44,7 +44,7 @@ func TestReleasePublicKeyReceipt_GoReleaserA8FixtureProducesCurrentArtifacts(t *
 		t, tools, publicKeyReceiptA8Tag, publicKeyReceiptA8Version, true,
 	)
 	for _, architecture := range []string{"amd64", "arm64"} {
-		entries, err := decodeLineageArchive(evidence.archives[architecture])
+		entries, err := decodeLineageArchiveFile(evidence.archives[architecture])
 		if err != nil {
 			t.Fatalf("decode A8 %s archive: %v", architecture, err)
 		}

--- a/pkg/companionmanifest/release_lineage_a9_test.go
+++ b/pkg/companionmanifest/release_lineage_a9_test.go
@@ -44,7 +44,7 @@ func TestReleasePublicKeyReceipt_GoReleaserA9FixtureProducesCurrentArtifacts(t *
 		t, tools, publicKeyReceiptA9Tag, publicKeyReceiptA9Version, true,
 	)
 	for _, architecture := range []string{"amd64", "arm64"} {
-		entries, err := decodeLineageArchive(evidence.archives[architecture])
+		entries, err := decodeLineageArchiveFile(evidence.archives[architecture])
 		if err != nil {
 			t.Fatalf("decode A9 %s archive: %v", architecture, err)
 		}

--- a/pkg/companionmanifest/release_lineage_archive_fixture_test.go
+++ b/pkg/companionmanifest/release_lineage_archive_fixture_test.go
@@ -4,9 +4,12 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
-	"testing"
+	"os"
 )
 
 type lineageArchiveEntry struct {
@@ -15,11 +18,36 @@ type lineageArchiveEntry struct {
 }
 
 func decodeLineageArchive(data []byte) (map[string]lineageArchiveEntry, error) {
-	gzipReader, err := gzip.NewReader(bytes.NewReader(data))
+	if len(data) > maxLineageArchiveCompressedBytes {
+		return nil, fmt.Errorf("lineage archive source exceeds %d bytes",
+			maxLineageArchiveCompressedBytes)
+	}
+	return decodeLineageArchiveReader(bytes.NewReader(data))
+}
+
+// @AX:ANCHOR [AUTO]: Preserve validated file-backed decoding for lineage archive consumers.
+// @AX:REASON [AUTO]: Thirteen fixture call sites depend on bounded streaming and duplicate-entry rejection.
+func decodeLineageArchiveFile(path string) (map[string]lineageArchiveEntry, error) {
+	file, _, err := openLineageArchiveSource(path)
+	if err != nil {
+		return nil, err
+	}
+	entries, decodeErr := decodeLineageArchiveReader(file)
+	if err := errors.Join(decodeErr, file.Close()); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+func decodeLineageArchiveReader(
+	reader io.Reader,
+) (map[string]lineageArchiveEntry, error) {
+	gzipReader, err := gzip.NewReader(reader)
 	if err != nil {
 		return nil, err
 	}
 	entries := make(map[string]lineageArchiveEntry)
+	budget := lineageArchiveBudget{}
 	tarReader := tar.NewReader(gzipReader)
 	for {
 		header, nextErr := tarReader.Next()
@@ -30,85 +58,201 @@ func decodeLineageArchive(data []byte) (map[string]lineageArchiveEntry, error) {
 			_ = gzipReader.Close()
 			return nil, nextErr
 		}
-		entry, readErr := io.ReadAll(tarReader)
+		if err := budget.track(header); err != nil {
+			_ = gzipReader.Close()
+			return nil, err
+		}
+		if _, exists := entries[header.Name]; exists {
+			_ = gzipReader.Close()
+			return nil, fmt.Errorf("lineage archive entry %q is duplicated", header.Name)
+		}
+		entry, readErr := readLineageArchiveEntry(tarReader, header)
 		if readErr != nil {
 			_ = gzipReader.Close()
 			return nil, readErr
 		}
 		entries[header.Name] = lineageArchiveEntry{header: *header, data: entry}
 	}
-	if _, err := io.Copy(io.Discard, gzipReader); err != nil {
-		_ = gzipReader.Close()
-		return nil, err
-	}
-	if err := gzipReader.Close(); err != nil {
+	drainErr := drainLineageArchive(gzipReader)
+	if err := errors.Join(drainErr, gzipReader.Close()); err != nil {
 		return nil, err
 	}
 	return entries, nil
 }
 
-func rewriteLineageArchive(
-	t *testing.T,
-	data []byte,
-	mutate func(string, []byte) ([]byte, bool),
-) []byte {
-	t.Helper()
-	entries, err := orderedLineageArchiveEntries(data)
+// @AX:NOTE [AUTO]: [downgraded from ANCHOR — lowest fan_in under file cap] Stream the validated source and reject size drift.
+func lineageArchiveFileDigest(path string) (string, error) {
+	file, info, err := openLineageArchiveSource(path)
 	if err != nil {
-		t.Fatal(err)
+		return "", err
 	}
-	var output bytes.Buffer
-	gzipWriter, err := gzip.NewWriterLevel(&output, gzip.BestSpeed)
-	if err != nil {
-		t.Fatal(err)
+	digest := sha256.New()
+	written, copyErr := io.Copy(digest,
+		io.LimitReader(file, maxLineageArchiveCompressedBytes+1))
+	if copyErr == nil && written != info.Size() {
+		copyErr = errors.New("lineage archive source size changed during digest")
 	}
-	tarWriter := tar.NewWriter(gzipWriter)
-	for _, entry := range entries {
-		entryData, keep := mutate(entry.header.Name, append([]byte(nil), entry.data...))
-		if !keep {
-			continue
-		}
-		header := entry.header
-		header.Size = int64(len(entryData))
-		if err := tarWriter.WriteHeader(&header); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := tarWriter.Write(entryData); err != nil {
-			t.Fatal(err)
-		}
+	if err := errors.Join(copyErr, file.Close()); err != nil {
+		return "", err
 	}
-	if err := errors.Join(tarWriter.Close(), gzipWriter.Close()); err != nil {
-		t.Fatalf("finalize rewritten lineage archive: %v", err)
-	}
-	return output.Bytes()
+	return hex.EncodeToString(digest.Sum(nil)), nil
 }
 
-func orderedLineageArchiveEntries(data []byte) ([]lineageArchiveEntry, error) {
-	gzipReader, err := gzip.NewReader(bytes.NewReader(data))
+// @AX:ANCHOR [AUTO]: Preserve exact hard-link-or-exclusive-copy materialization semantics.
+// @AX:REASON [AUTO]: Ten fixture call sites rely on immutable identity checks and non-overwriting fallback behavior.
+func materializeLineageArchive(
+	source, target string,
+	link func(string, string) error,
+) (bool, error) {
+	input, sourceInfo, err := openLineageArchiveSource(source)
 	if err != nil {
-		return nil, err
+		return false, err
 	}
-	var entries []lineageArchiveEntry
+	defer func() { _ = input.Close() }()
+	linkErr := link(source, target)
+	if linkErr == nil {
+		targetInfo, statErr := os.Lstat(target)
+		if statErr != nil || !targetInfo.Mode().IsRegular() ||
+			!os.SameFile(sourceInfo, targetInfo) {
+			_ = os.Remove(target)
+			return false, errors.Join(
+				errors.New("hard-linked lineage archive identity mismatch"), statErr,
+			)
+		}
+		return true, nil
+	}
+	if err := copyLineageArchive(input, target, sourceInfo.Size()); err != nil {
+		return false, errors.Join(
+			fmt.Errorf("hard-link lineage archive: %w", linkErr),
+			fmt.Errorf("copy lineage archive: %w", err),
+		)
+	}
+	return false, nil
+}
+
+func copyLineageArchive(input *os.File, target string, expectedSize int64) (err error) {
+	output, err := os.OpenFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	complete := false
+	defer func() {
+		if !complete {
+			_ = os.Remove(target)
+		}
+	}()
+	written, copyErr := io.Copy(output,
+		io.LimitReader(input, maxLineageArchiveCompressedBytes+1))
+	if copyErr == nil && written != expectedSize {
+		copyErr = errors.New("lineage archive source size changed during copy")
+	}
+	err = errors.Join(copyErr, output.Sync(), output.Close())
+	if err != nil {
+		return err
+	}
+	complete = true
+	return nil
+}
+
+// @AX:ANCHOR [AUTO]: Preserve the exact-one-entry streaming rewrite contract.
+// @AX:REASON [AUTO]: Seven tamper fixtures rely on untouched entries streaming byte-for-byte and partial targets being removed.
+// @AX:WARN [AUTO]: This function coordinates more than eight fail-closed archive branches.
+// @AX:REASON [AUTO]: Open, read, budget, duplicate, missing, write, close, and cleanup ordering must remain atomic as a contract.
+func rewriteLineageArchiveTarget(
+	source, target, entryName string,
+	mutate func([]byte) ([]byte, bool),
+) (err error) {
+	input, _, err := openLineageArchiveSource(source)
+	if err != nil {
+		return err
+	}
+	gzipReader, err := gzip.NewReader(input)
+	if err != nil {
+		return errors.Join(err, input.Close())
+	}
+	output, err := os.OpenFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return errors.Join(err, gzipReader.Close(), input.Close())
+	}
+	gzipWriter, err := gzip.NewWriterLevel(output, gzip.BestSpeed)
+	if err != nil {
+		return errors.Join(err, output.Close(), gzipReader.Close(), input.Close(),
+			os.Remove(target))
+	}
 	tarReader := tar.NewReader(gzipReader)
+	tarWriter := tar.NewWriter(gzipWriter)
+	complete := false
+	defer func() {
+		if !complete {
+			_ = tarWriter.Close()
+			_ = gzipWriter.Close()
+			_ = output.Close()
+			_ = gzipReader.Close()
+			_ = input.Close()
+			_ = os.Remove(target)
+		}
+	}()
+	matches := 0
+	budget := lineageArchiveBudget{}
 	for {
 		header, nextErr := tarReader.Next()
 		if nextErr == io.EOF {
 			break
 		}
 		if nextErr != nil {
-			_ = gzipReader.Close()
-			return nil, nextErr
+			return nextErr
 		}
-		entry, readErr := io.ReadAll(tarReader)
-		if readErr != nil {
-			_ = gzipReader.Close()
-			return nil, readErr
+		if err := budget.track(header); err != nil {
+			return err
 		}
-		entries = append(entries, lineageArchiveEntry{header: *header, data: entry})
+		headerCopy := *header
+		if header.Name == entryName {
+			matches++
+			if matches > 1 {
+				return fmt.Errorf("lineage archive entry %q is duplicated", entryName)
+			}
+			entry, readErr := readLineageArchiveEntry(tarReader, header)
+			if readErr != nil {
+				return readErr
+			}
+			entry, keep := mutate(entry)
+			if !keep {
+				continue
+			}
+			if err := budget.replaceEntrySize(
+				entryName, header.Size, int64(len(entry)),
+			); err != nil {
+				return err
+			}
+			headerCopy.Size = int64(len(entry))
+			if err := tarWriter.WriteHeader(&headerCopy); err != nil {
+				return err
+			}
+			if _, err := io.Copy(tarWriter, bytes.NewReader(entry)); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := tarWriter.WriteHeader(&headerCopy); err != nil {
+			return err
+		}
+		written, copyErr := io.Copy(tarWriter, tarReader)
+		if copyErr != nil {
+			return copyErr
+		}
+		if written != header.Size {
+			return io.ErrUnexpectedEOF
+		}
 	}
-	if _, err := io.Copy(io.Discard, gzipReader); err != nil {
-		_ = gzipReader.Close()
-		return nil, err
+	if matches != 1 {
+		return fmt.Errorf("lineage archive entry %q is missing", entryName)
 	}
-	return entries, gzipReader.Close()
+	drainErr := drainLineageArchive(gzipReader)
+	err = errors.Join(drainErr, tarWriter.Close(), gzipWriter.Close(),
+		output.Sync(), output.Close(), gzipReader.Close(), input.Close())
+	if err != nil {
+		return err
+	}
+	complete = true
+	return nil
 }

--- a/pkg/companionmanifest/release_lineage_archive_limits_test.go
+++ b/pkg/companionmanifest/release_lineage_archive_limits_test.go
@@ -1,0 +1,112 @@
+package companionmanifest
+
+import (
+	"archive/tar"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+// @AX:NOTE [AUTO]: These limits admit release fixtures while bounding decompression bombs, entry fan-out, and trailing data.
+const (
+	maxLineageArchiveCompressedBytes = 64 << 20
+	maxLineageArchiveEntryBytes      = 64 << 20
+	maxLineageArchiveExpandedBytes   = 128 << 20
+	maxLineageArchiveEntries         = 256
+	maxLineageArchiveTrailingBytes   = 1 << 20
+)
+
+type lineageArchiveBudget struct {
+	entries  int
+	expanded int64
+}
+
+// @AX:ANCHOR [AUTO]: Keep entry count and expanded-size accounting in this common archive gate.
+// @AX:REASON [AUTO]: Decode, rewrite, and adversarial fixture tests rely on the same fail-closed budget semantics.
+func (budget *lineageArchiveBudget) track(header *tar.Header) error {
+	budget.entries++
+	if budget.entries > maxLineageArchiveEntries {
+		return fmt.Errorf("lineage archive has more than %d entries",
+			maxLineageArchiveEntries)
+	}
+	if header.Size < 0 || header.Size > maxLineageArchiveEntryBytes {
+		return fmt.Errorf("lineage archive entry %q has invalid size %d",
+			header.Name, header.Size)
+	}
+	if budget.expanded > maxLineageArchiveExpandedBytes-header.Size {
+		return fmt.Errorf("lineage archive expands beyond %d bytes",
+			maxLineageArchiveExpandedBytes)
+	}
+	budget.expanded += header.Size
+	return nil
+}
+
+func (budget *lineageArchiveBudget) replaceEntrySize(
+	name string, original, replacement int64,
+) error {
+	if replacement < 0 || replacement > maxLineageArchiveEntryBytes {
+		return fmt.Errorf("mutated lineage archive entry %q has invalid size %d",
+			name, replacement)
+	}
+	remaining := budget.expanded - original
+	if remaining < 0 || remaining > maxLineageArchiveExpandedBytes-replacement {
+		return fmt.Errorf("mutated lineage archive expands beyond %d bytes",
+			maxLineageArchiveExpandedBytes)
+	}
+	budget.expanded = remaining + replacement
+	return nil
+}
+
+// @AX:ANCHOR [AUTO]: Keep archive source validation centralized before any content is consumed.
+// @AX:REASON [AUTO]: Digest, decode, materialize, and rewrite callers depend on the same regular-file, size, and inode checks.
+func openLineageArchiveSource(path string) (*os.File, os.FileInfo, error) {
+	expected, err := os.Lstat(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !expected.Mode().IsRegular() {
+		return nil, nil, errors.New("lineage archive source is not a regular file")
+	}
+	if expected.Size() > maxLineageArchiveCompressedBytes {
+		return nil, nil, fmt.Errorf("lineage archive source exceeds %d bytes",
+			maxLineageArchiveCompressedBytes)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	current, statErr := file.Stat()
+	if statErr != nil || !current.Mode().IsRegular() ||
+		!os.SameFile(expected, current) || current.Size() != expected.Size() {
+		return nil, nil, errors.Join(
+			errors.New("lineage archive source identity changed during open"),
+			statErr, file.Close(),
+		)
+	}
+	return file, current, nil
+}
+
+func readLineageArchiveEntry(reader io.Reader, header *tar.Header) ([]byte, error) {
+	entry, err := io.ReadAll(io.LimitReader(reader, maxLineageArchiveEntryBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(entry)) != header.Size {
+		return nil, io.ErrUnexpectedEOF
+	}
+	return entry, nil
+}
+
+func drainLineageArchive(reader io.Reader) error {
+	read, err := io.Copy(io.Discard,
+		io.LimitReader(reader, maxLineageArchiveTrailingBytes+1))
+	if err != nil {
+		return err
+	}
+	if read > maxLineageArchiveTrailingBytes {
+		return fmt.Errorf("lineage archive trailing data exceeds %d bytes",
+			maxLineageArchiveTrailingBytes)
+	}
+	return nil
+}

--- a/pkg/companionmanifest/release_lineage_archive_security_test.go
+++ b/pkg/companionmanifest/release_lineage_archive_security_test.go
@@ -1,0 +1,170 @@
+package companionmanifest
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLineageArchiveSourcesRejectSymlinksAndOversizedFiles(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	source := filepath.Join(root, "source.tar.gz")
+	writeLineageMaterializationArchive(t, source,
+		map[string][]byte{"auto": []byte("binary")})
+	symlink := filepath.Join(root, "source-link.tar.gz")
+	if err := os.Symlink(source, symlink); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	checks := map[string]func() error{
+		"decode": func() error {
+			_, err := decodeLineageArchiveFile(symlink)
+			return err
+		},
+		"digest": func() error {
+			_, err := lineageArchiveFileDigest(symlink)
+			return err
+		},
+		"materialize": func() error {
+			_, err := materializeLineageArchive(symlink,
+				filepath.Join(root, "linked.tar.gz"), os.Link)
+			return err
+		},
+		"rewrite": func() error {
+			return rewriteLineageArchiveTarget(symlink,
+				filepath.Join(root, "rewritten.tar.gz"), "auto",
+				func(data []byte) ([]byte, bool) { return data, true })
+		},
+	}
+	for name, check := range checks {
+		if err := check(); err == nil {
+			t.Fatalf("%s accepted a symlink archive source", name)
+		}
+	}
+
+	oversized := filepath.Join(root, "oversized.tar.gz")
+	file, err := os.OpenFile(oversized, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := errors.Join(
+		file.Truncate(maxLineageArchiveCompressedBytes+1), file.Close(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := lineageArchiveFileDigest(oversized); err == nil {
+		t.Fatal("digest accepted an oversized compressed archive")
+	}
+}
+
+func TestMaterializeLineageArchiveRejectsWrongLinkedIdentity(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	source := filepath.Join(root, "source.tar.gz")
+	other := filepath.Join(root, "other.tar.gz")
+	target := filepath.Join(root, "target.tar.gz")
+	if err := os.WriteFile(source, []byte("source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(other, []byte("other"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := materializeLineageArchive(source, target,
+		func(string, string) error { return os.Link(other, target) })
+	if err == nil {
+		t.Fatal("materialization accepted a hard link to the wrong source")
+	}
+	if _, statErr := os.Lstat(target); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("identity mismatch left a target behind: %v", statErr)
+	}
+}
+
+func TestLineageArchiveBudgetsRejectOversizedEntryAndEntryCount(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	oversized := filepath.Join(root, "oversized-entry.tar.gz")
+	writeLineageArchiveHeaders(t, oversized, []tar.Header{{
+		Name: "manifest.json", Mode: 0o600,
+		Size: maxLineageArchiveEntryBytes + 1,
+	}}, false)
+	target := filepath.Join(root, "oversized-target.tar.gz")
+	err := rewriteLineageArchiveTarget(oversized, target, "manifest.json",
+		func(data []byte) ([]byte, bool) { return data, true })
+	if err == nil {
+		t.Fatal("rewrite accepted an oversized archive entry")
+	}
+	if _, statErr := os.Lstat(target); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("oversized entry left a partial target: %v", statErr)
+	}
+
+	headers := make([]tar.Header, maxLineageArchiveEntries+1)
+	for index := range headers {
+		headers[index] = tar.Header{Name: fmt.Sprintf("entries/%03d", index),
+			Mode: 0o600}
+	}
+	tooMany := filepath.Join(root, "too-many-entries.tar.gz")
+	writeLineageArchiveHeaders(t, tooMany, headers, true)
+	if _, err := decodeLineageArchiveFile(tooMany); err == nil {
+		t.Fatal("decode accepted too many archive entries")
+	}
+
+	budget := lineageArchiveBudget{}
+	for _, header := range []tar.Header{
+		{Name: "first", Size: maxLineageArchiveEntryBytes},
+		{Name: "second", Size: maxLineageArchiveEntryBytes},
+	} {
+		if err := budget.track(&header); err != nil {
+			t.Fatalf("valid bounded archive entry rejected: %v", err)
+		}
+	}
+	if err := budget.track(&tar.Header{Name: "overflow", Size: 1}); err == nil {
+		t.Fatal("archive expansion budget accepted an extra byte")
+	}
+	if err := budget.replaceEntrySize("second", maxLineageArchiveEntryBytes,
+		maxLineageArchiveEntryBytes+1); err == nil {
+		t.Fatal("archive mutation accepted an oversized replacement entry")
+	}
+	if err := budget.replaceEntrySize("second", maxLineageArchiveEntryBytes,
+		maxLineageArchiveEntryBytes); err != nil {
+		t.Fatalf("same-size archive mutation was rejected: %v", err)
+	}
+	if err := budget.replaceEntrySize("second", maxLineageArchiveEntryBytes,
+		maxLineageArchiveEntryBytes-1); err != nil {
+		t.Fatalf("shrinking archive mutation was rejected: %v", err)
+	}
+	overflowBudget := lineageArchiveBudget{expanded: maxLineageArchiveExpandedBytes}
+	if err := overflowBudget.replaceEntrySize("second", maxLineageArchiveEntryBytes-1,
+		maxLineageArchiveEntryBytes); err == nil {
+		t.Fatal("archive mutation exceeded the total expansion budget")
+	}
+}
+
+func writeLineageArchiveHeaders(
+	t *testing.T, path string, headers []tar.Header, finalize bool,
+) {
+	t.Helper()
+	output, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gzipWriter := gzip.NewWriter(output)
+	tarWriter := tar.NewWriter(gzipWriter)
+	for index := range headers {
+		if err := tarWriter.WriteHeader(&headers[index]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if finalize {
+		err = tarWriter.Close()
+	}
+	if err := errors.Join(err, gzipWriter.Close(), output.Close()); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/companionmanifest/release_lineage_executable_test.go
+++ b/pkg/companionmanifest/release_lineage_executable_test.go
@@ -117,16 +117,12 @@ func tamperLineageReleaseImmutable(t *testing.T, fixture *executableLineageFixtu
 
 func tamperLineageArchiveBytes(t *testing.T, fixture *executableLineageFixture) {
 	t.Helper()
-	fixture.archiveMutation = func(_ *testing.T, architecture string, data []byte) []byte {
-		if architecture == "amd64" {
-			return rewriteLineageArchive(t, data, func(name string, entry []byte) ([]byte, bool) {
-				if name == "README.md" {
-					return append(entry, '\n'), true
-				}
-				return entry, true
-			})
-		}
-		return data
+	fixture.archiveMutation = &lineageArchiveMutation{
+		architecture: "amd64",
+		entry:        "README.md",
+		mutate: func(_ *testing.T, data []byte) ([]byte, bool) {
+			return append(data, '\n'), true
+		},
 	}
 	fixture.writeEvidence(t)
 }
@@ -173,18 +169,16 @@ func replaceLineageArchiveBytes(
 	t *testing.T,
 	entryName string,
 	old, replacement []byte,
-) lineageArchiveMutation {
+) *lineageArchiveMutation {
 	t.Helper()
-	return func(t *testing.T, _ string, data []byte) []byte {
-		return rewriteLineageArchive(t, data, func(name string, entry []byte) ([]byte, bool) {
-			if name != entryName {
-				return entry, true
-			}
+	return &lineageArchiveMutation{
+		entry: entryName,
+		mutate: func(t *testing.T, entry []byte) ([]byte, bool) {
 			if bytes.Count(entry, old) != 1 {
 				t.Fatalf("tamper target %s is not exact", entryName)
 			}
 			return bytes.Replace(entry, old, replacement, 1), true
-		})
+		},
 	}
 }
 
@@ -237,7 +231,12 @@ func tamperLineageTargetCommit(t *testing.T, fixture *executableLineageFixture) 
 
 func tamperLineageArchiveEntry(t *testing.T, fixture *executableLineageFixture) {
 	t.Helper()
-	fixture.omitSignatureEntry = true
+	fixture.archiveMutation = &lineageArchiveMutation{
+		entry: lineageBundleName + "/public-key-receipt.sig",
+		mutate: func(*testing.T, []byte) ([]byte, bool) {
+			return nil, false
+		},
+	}
 	fixture.writeEvidence(t)
 }
 

--- a/pkg/companionmanifest/release_lineage_fixture_cache_test.go
+++ b/pkg/companionmanifest/release_lineage_fixture_cache_test.go
@@ -15,19 +15,40 @@ type goReleaserLineageCache struct {
 	evidence  *goReleaserA0Evidence
 }
 
-var goReleaserLineageCaches = map[string]*goReleaserLineageCache{
-	publicKeyReceiptA0Tag:  {version: lineageA0Version},
-	publicKeyReceiptA1Tag:  {version: lineageA1Version, annotated: true},
-	publicKeyReceiptA2Tag:  {version: publicKeyReceiptA2Version, annotated: true},
-	publicKeyReceiptA3Tag:  {version: publicKeyReceiptA3Version, annotated: true},
-	publicKeyReceiptA4Tag:  {version: publicKeyReceiptA4Version, annotated: true},
-	publicKeyReceiptA5Tag:  {version: publicKeyReceiptA5Version, annotated: true},
-	publicKeyReceiptA6Tag:  {version: publicKeyReceiptA6Version, annotated: true},
-	publicKeyReceiptA7Tag:  {version: publicKeyReceiptA7Version, annotated: true},
-	publicKeyReceiptA8Tag:  {version: publicKeyReceiptA8Version, annotated: true},
-	publicKeyReceiptA9Tag:  {version: publicKeyReceiptA9Version, annotated: true},
-	publicKeyReceiptA10Tag: {version: publicKeyReceiptA10Version, annotated: true},
-	publicKeyReceiptA11Tag: {version: publicKeyReceiptA11Version, annotated: true},
+type goReleaserLineageCoordinate struct {
+	tag       string
+	version   string
+	annotated bool
+}
+
+var goReleaserLineageCoordinates = []goReleaserLineageCoordinate{
+	{tag: publicKeyReceiptA0Tag, version: lineageA0Version},
+	{tag: publicKeyReceiptA1Tag, version: lineageA1Version, annotated: true},
+	{tag: publicKeyReceiptA2Tag, version: publicKeyReceiptA2Version, annotated: true},
+	{tag: publicKeyReceiptA3Tag, version: publicKeyReceiptA3Version, annotated: true},
+	{tag: publicKeyReceiptA4Tag, version: publicKeyReceiptA4Version, annotated: true},
+	{tag: publicKeyReceiptA5Tag, version: publicKeyReceiptA5Version, annotated: true},
+	{tag: publicKeyReceiptA6Tag, version: publicKeyReceiptA6Version, annotated: true},
+	{tag: publicKeyReceiptA7Tag, version: publicKeyReceiptA7Version, annotated: true},
+	{tag: publicKeyReceiptA8Tag, version: publicKeyReceiptA8Version, annotated: true},
+	{tag: publicKeyReceiptA9Tag, version: publicKeyReceiptA9Version, annotated: true},
+	{tag: publicKeyReceiptA10Tag, version: publicKeyReceiptA10Version, annotated: true},
+	{tag: publicKeyReceiptA11Tag, version: publicKeyReceiptA11Version, annotated: true},
+}
+
+var goReleaserLineageCaches = newGoReleaserLineageCaches()
+
+func newGoReleaserLineageCaches() map[string]*goReleaserLineageCache {
+	caches := make(map[string]*goReleaserLineageCache, len(goReleaserLineageCoordinates))
+	for _, coordinate := range goReleaserLineageCoordinates {
+		if _, exists := caches[coordinate.tag]; exists {
+			panic("duplicate GoReleaser lineage coordinate: " + coordinate.tag)
+		}
+		caches[coordinate.tag] = &goReleaserLineageCache{
+			version: coordinate.version, annotated: coordinate.annotated,
+		}
+	}
+	return caches
 }
 
 func produceGoReleaserFixtureEvidence(
@@ -43,12 +64,7 @@ func produceGoReleaserFixtureEvidence(
 		t.Fatalf("unsupported GoReleaser lineage cache coordinate %s/%s annotated=%t",
 			releaseTag, releaseVersion, annotated)
 	}
-	cache.once.Do(func() {
-		cache.runs.Add(1)
-		cache.evidence = produceUncachedGoReleaserFixtureEvidence(
-			t, tools, releaseTag, releaseVersion, annotated,
-		)
-	})
+	ensureGoReleaserLineageFixtures(t, tools)
 	if cache.evidence == nil {
 		t.Fatal("GoReleaser lineage cache produced no evidence")
 	}
@@ -69,25 +85,7 @@ func cloneGoReleaserEvidence(source *goReleaserA0Evidence) *goReleaserA0Evidence
 
 func TestGoReleaserLineageFixtures_ProcessCacheBuildsEachCoordinateOnce(t *testing.T) {
 	tools := newExecutableLineageTools(t)
-	cases := []struct {
-		tag       string
-		version   string
-		annotated bool
-	}{
-		{tag: publicKeyReceiptA0Tag, version: lineageA0Version},
-		{tag: publicKeyReceiptA1Tag, version: lineageA1Version, annotated: true},
-		{tag: publicKeyReceiptA2Tag, version: publicKeyReceiptA2Version, annotated: true},
-		{tag: publicKeyReceiptA3Tag, version: publicKeyReceiptA3Version, annotated: true},
-		{tag: publicKeyReceiptA4Tag, version: publicKeyReceiptA4Version, annotated: true},
-		{tag: publicKeyReceiptA5Tag, version: publicKeyReceiptA5Version, annotated: true},
-		{tag: publicKeyReceiptA6Tag, version: publicKeyReceiptA6Version, annotated: true},
-		{tag: publicKeyReceiptA7Tag, version: publicKeyReceiptA7Version, annotated: true},
-		{tag: publicKeyReceiptA8Tag, version: publicKeyReceiptA8Version, annotated: true},
-		{tag: publicKeyReceiptA9Tag, version: publicKeyReceiptA9Version, annotated: true},
-		{tag: publicKeyReceiptA10Tag, version: publicKeyReceiptA10Version, annotated: true},
-		{tag: publicKeyReceiptA11Tag, version: publicKeyReceiptA11Version, annotated: true},
-	}
-	for _, test := range cases {
+	for _, test := range goReleaserLineageCoordinates {
 		first := produceGoReleaserFixtureEvidence(t, tools, test.tag, test.version, test.annotated)
 		second := produceGoReleaserFixtureEvidence(t, tools, test.tag, test.version, test.annotated)
 		if first == second || !bytes.Equal(first.checksums, second.checksums) {
@@ -99,6 +97,20 @@ func TestGoReleaserLineageFixtures_ProcessCacheBuildsEachCoordinateOnce(t *testi
 	}
 	if runs := executableLineageToolsBuildRuns.Load(); runs != 1 {
 		t.Fatalf("executable lineage tool build runs = %d, want 1", runs)
+	}
+}
+
+func TestGoReleaserLineageFixtures_RegistryMatchesCache(t *testing.T) {
+	if len(goReleaserLineageCaches) != len(goReleaserLineageCoordinates) {
+		t.Fatalf("GoReleaser lineage cache size = %d, coordinates = %d",
+			len(goReleaserLineageCaches), len(goReleaserLineageCoordinates))
+	}
+	for _, coordinate := range goReleaserLineageCoordinates {
+		cache := goReleaserLineageCaches[coordinate.tag]
+		if cache == nil || cache.version != coordinate.version ||
+			cache.annotated != coordinate.annotated {
+			t.Fatalf("GoReleaser lineage cache drifted for %s", coordinate.tag)
+		}
 	}
 }
 

--- a/pkg/companionmanifest/release_lineage_fixture_cache_test.go
+++ b/pkg/companionmanifest/release_lineage_fixture_cache_test.go
@@ -57,9 +57,9 @@ func produceGoReleaserFixtureEvidence(
 
 func cloneGoReleaserEvidence(source *goReleaserA0Evidence) *goReleaserA0Evidence {
 	clone := *source
-	clone.archives = make(map[string][]byte, len(source.archives))
+	clone.archives = make(map[string]string, len(source.archives))
 	for architecture, archive := range source.archives {
-		clone.archives[architecture] = bytes.Clone(archive)
+		clone.archives[architecture] = archive
 	}
 	clone.checksums = bytes.Clone(source.checksums)
 	clone.receipt = bytes.Clone(source.receipt)

--- a/pkg/companionmanifest/release_lineage_fixture_io_test.go
+++ b/pkg/companionmanifest/release_lineage_fixture_io_test.go
@@ -110,13 +110,22 @@ func produceUncachedGoReleaserFixtureEvidence(
 	}
 
 	evidence := &goReleaserA0Evidence{
-		tag: releaseTag, version: releaseVersion, commit: commit, archives: map[string][]byte{},
+		tag: releaseTag, version: releaseVersion, commit: commit, archives: map[string]string{},
 	}
 	evidence.pins.tagObject = tagObject
+	cacheDirectory := filepath.Join(lineageFixtureCacheRoot, releaseTag)
+	if err := os.Mkdir(cacheDirectory, 0o700); err != nil {
+		t.Fatal(err)
+	}
 	for _, architecture := range []string{"amd64", "arm64"} {
 		name := fmt.Sprintf("autopus-adk_%s_darwin_%s.tar.gz", releaseVersion, architecture)
-		evidence.archives[architecture] = readLineageFile(t, filepath.Join(root, "dist", name))
-		entries, err := decodeLineageArchive(evidence.archives[architecture])
+		sourceArchive := filepath.Join(root, "dist", name)
+		cachedArchive := filepath.Join(cacheDirectory, name)
+		if _, err := materializeLineageArchive(sourceArchive, cachedArchive, os.Link); err != nil {
+			t.Fatalf("cache exact %s archive: %v", architecture, err)
+		}
+		evidence.archives[architecture] = cachedArchive
+		entries, err := decodeLineageArchiveFile(cachedArchive)
 		if err != nil {
 			t.Fatalf("decode exact %s archive: %v", architecture, err)
 		}
@@ -130,18 +139,26 @@ func produceUncachedGoReleaserFixtureEvidence(
 		}
 	}
 	evidence.checksums = readLineageFile(t, filepath.Join(root, "dist", "checksums.txt"))
-	evidence.pins = captureGoReleaserPins(evidence, privateKey, tagObject)
+	evidence.pins = captureGoReleaserPins(t, evidence, privateKey, tagObject)
 	evidence.pins.tree = tree
 	return evidence
 }
 
 func captureGoReleaserPins(
+	t *testing.T,
 	evidence *goReleaserA0Evidence,
 	privateKey ed25519.PrivateKey,
 	tagObject string,
 ) executableLineagePins {
-	amd64, _ := decodeLineageArchive(evidence.archives["amd64"])
-	arm64, _ := decodeLineageArchive(evidence.archives["arm64"])
+	t.Helper()
+	amd64Digest, err := lineageArchiveFileDigest(evidence.archives["amd64"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	arm64Digest, err := lineageArchiveFileDigest(evidence.archives["arm64"])
+	if err != nil {
+		t.Fatal(err)
+	}
 	receiptDigest, signatureDigest := lineageDigest(evidence.receipt), lineageDigest(evidence.signature)
 	return executableLineagePins{
 		commit: evidence.commit, tagObject: tagObject,
@@ -149,66 +166,11 @@ func captureGoReleaserPins(
 		record:        lineageRecordDigest(receiptDigest, signatureDigest),
 		publicKey:     lineageDigest(privateKey.Public().(ed25519.PublicKey)),
 		checksums:     lineageDigest(evidence.checksums),
-		amd64Archive:  lineageDigest(evidence.archives["amd64"]),
-		arm64Archive:  lineageDigest(evidence.archives["arm64"]),
-		amd64Manifest: lineageDigest(amd64["adk-companion-manifest.json"].data),
-		arm64Manifest: lineageDigest(arm64["adk-companion-manifest.json"].data),
+		amd64Archive:  amd64Digest,
+		arm64Archive:  arm64Digest,
+		amd64Manifest: evidence.pins.amd64Manifest,
+		arm64Manifest: evidence.pins.arm64Manifest,
 	}
-}
-
-func (fixture *executableLineageFixture) writeEvidence(t *testing.T) {
-	t.Helper()
-	if err := os.RemoveAll(fixture.assetsDir); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Mkdir(fixture.assetsDir, 0o700); err != nil {
-		t.Fatal(err)
-	}
-	assets := make([]executableLineageAsset, 0, 3)
-	for _, architecture := range []string{"amd64", "arm64"} {
-		name := fmt.Sprintf("autopus-adk_%s_darwin_%s.tar.gz", fixture.evidence.version, architecture)
-		data := append([]byte(nil), fixture.evidence.archives[architecture]...)
-		if fixture.archiveMutation != nil {
-			data = fixture.archiveMutation(t, architecture, data)
-		}
-		if fixture.omitSignatureEntry {
-			data = rewriteLineageArchive(t, data, func(name string, entry []byte) ([]byte, bool) {
-				return entry, name != lineageBundleName+"/public-key-receipt.sig"
-			})
-		}
-		if err := os.WriteFile(filepath.Join(fixture.assetsDir, name), data, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		digest := "sha256:" + lineageDigest(data)
-		if architecture == "amd64" && fixture.assetDigestOverride != "" {
-			digest = fixture.assetDigestOverride
-		}
-		assets = append(assets, executableLineageAsset{Name: name, State: "uploaded", Digest: digest})
-	}
-	checksumsName := "checksums.txt"
-	if err := os.WriteFile(filepath.Join(fixture.assetsDir, checksumsName), fixture.checksums, 0o600); err != nil {
-		t.Fatal(err)
-	}
-	assets = append(assets, executableLineageAsset{
-		Name: checksumsName, State: "uploaded", Digest: "sha256:" + lineageDigest(fixture.checksums),
-	})
-	writeLineageJSON(t, fixture.releaseJSON, executableLineageRelease{
-		TagName: fixture.releaseTag, TargetCommitish: fixture.targetCommit, Immutable: true, Assets: assets,
-	})
-	if fixture.tagObject == "" {
-		writeLineageJSON(t, fixture.tagJSON, map[string]any{
-			"object": map[string]string{"type": "commit", "sha": fixture.tagCommit},
-		})
-	} else {
-		writeLineageJSON(t, fixture.tagJSON, map[string]any{
-			"object": map[string]string{"type": "tag", "sha": fixture.tagObject},
-		})
-		writeLineageJSON(t, fixture.annotatedTagJSON, map[string]any{
-			"tag":    fixture.releaseTag,
-			"object": map[string]string{"type": "commit", "sha": fixture.tagCommit},
-		})
-	}
-	writeLineageJSON(t, fixture.commitJSON, map[string]any{"sha": fixture.evidence.commit, "commit": map[string]any{"tree": map[string]string{"sha": fixture.evidence.pins.tree}}})
 }
 
 func (fixture *executableLineageFixture) writeMockGitHub(t *testing.T) {
@@ -277,6 +239,11 @@ func (fixture *executableLineageFixture) writeProvisionedProductionScript(t *tes
 	}
 	pinsPath := filepath.Join(filepath.Dir(fixture.provisionedScriptPath), "verify-public-key-lineage-pins.sh")
 	if err := os.WriteFile(pinsPath, []byte(pinsSource), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	coordinates := releaseSourceFile(t, "scripts/companion-release/verify-public-key-lineage-coordinates.sh")
+	coordinatesPath := filepath.Join(filepath.Dir(fixture.provisionedScriptPath), "verify-public-key-lineage-coordinates.sh")
+	if err := os.WriteFile(coordinatesPath, coordinates, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	helper := releaseSourceFile(t, "scripts/companion-release/verify-public-key-lineage-archive.sh")

--- a/pkg/companionmanifest/release_lineage_fixture_materialize_test.go
+++ b/pkg/companionmanifest/release_lineage_fixture_materialize_test.go
@@ -1,0 +1,88 @@
+package companionmanifest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func (fixture *executableLineageFixture) writeEvidence(t *testing.T) {
+	t.Helper()
+	if err := os.RemoveAll(fixture.assetsDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(fixture.assetsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	assets := make([]executableLineageAsset, 0, 3)
+	for _, architecture := range []string{"amd64", "arm64"} {
+		name := fmt.Sprintf("autopus-adk_%s_darwin_%s.tar.gz",
+			fixture.evidence.version, architecture)
+		source := fixture.evidence.archives[architecture]
+		target := filepath.Join(fixture.assetsDir, name)
+		mutation := fixture.archiveMutation
+		if mutation != nil &&
+			(mutation.architecture == "" || mutation.architecture == architecture) {
+			err := rewriteLineageArchiveTarget(source, target, mutation.entry,
+				func(data []byte) ([]byte, bool) { return mutation.mutate(t, data) })
+			if err != nil {
+				t.Fatalf("rewrite %s lineage archive: %v", architecture, err)
+			}
+		} else if _, err := materializeLineageArchive(source, target, os.Link); err != nil {
+			t.Fatalf("materialize %s lineage archive: %v", architecture, err)
+		}
+		digest, err := lineageArchiveFileDigest(target)
+		if err != nil {
+			t.Fatalf("digest %s lineage archive: %v", architecture, err)
+		}
+		if architecture == "amd64" && fixture.assetDigestOverride != "" {
+			digest = fixture.assetDigestOverride
+		} else {
+			digest = "sha256:" + digest
+		}
+		assets = append(assets, executableLineageAsset{
+			Name: name, State: "uploaded", Digest: digest,
+		})
+	}
+	fixture.writeEvidenceMetadata(t, assets)
+}
+
+func (fixture *executableLineageFixture) writeEvidenceMetadata(
+	t *testing.T,
+	assets []executableLineageAsset,
+) {
+	t.Helper()
+	checksumsName := "checksums.txt"
+	if err := os.WriteFile(filepath.Join(fixture.assetsDir, checksumsName),
+		fixture.checksums, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	assets = append(assets, executableLineageAsset{
+		Name: checksumsName, State: "uploaded",
+		Digest: "sha256:" + lineageDigest(fixture.checksums),
+	})
+	writeLineageJSON(t, fixture.releaseJSON, executableLineageRelease{
+		TagName: fixture.releaseTag, TargetCommitish: fixture.targetCommit,
+		Immutable: true, Assets: assets,
+	})
+	if fixture.tagObject == "" {
+		writeLineageJSON(t, fixture.tagJSON, map[string]any{
+			"object": map[string]string{"type": "commit", "sha": fixture.tagCommit},
+		})
+	} else {
+		writeLineageJSON(t, fixture.tagJSON, map[string]any{
+			"object": map[string]string{"type": "tag", "sha": fixture.tagObject},
+		})
+		writeLineageJSON(t, fixture.annotatedTagJSON, map[string]any{
+			"tag":    fixture.releaseTag,
+			"object": map[string]string{"type": "commit", "sha": fixture.tagCommit},
+		})
+	}
+	writeLineageJSON(t, fixture.commitJSON, map[string]any{
+		"sha": fixture.evidence.commit,
+		"commit": map[string]any{
+			"tree": map[string]string{"sha": fixture.evidence.pins.tree},
+		},
+	})
+}

--- a/pkg/companionmanifest/release_lineage_fixture_test.go
+++ b/pkg/companionmanifest/release_lineage_fixture_test.go
@@ -50,14 +50,18 @@ type goReleaserA0Evidence struct {
 	tag       string
 	version   string
 	commit    string
-	archives  map[string][]byte
+	archives  map[string]string
 	checksums []byte
 	receipt   []byte
 	signature []byte
 	pins      executableLineagePins
 }
 
-type lineageArchiveMutation func(*testing.T, string, []byte) []byte
+type lineageArchiveMutation struct {
+	architecture string
+	entry        string
+	mutate       func(*testing.T, []byte) ([]byte, bool)
+}
 
 type executableLineageFixture struct {
 	root                  string
@@ -75,9 +79,8 @@ type executableLineageFixture struct {
 	currentTag            string
 	token                 string
 	checksums             []byte
-	archiveMutation       lineageArchiveMutation
+	archiveMutation       *lineageArchiveMutation
 	assetDigestOverride   string
-	omitSignatureEntry    bool
 	releaseJSON           string
 	tagJSON               string
 	annotatedTagJSON      string

--- a/pkg/companionmanifest/release_lineage_fixture_warmup_test.go
+++ b/pkg/companionmanifest/release_lineage_fixture_warmup_test.go
@@ -1,0 +1,49 @@
+package companionmanifest
+
+import (
+	"sync"
+	"testing"
+)
+
+// @AX:NOTE [AUTO]: Two concurrent GoReleaser fixtures saturate the four-core CI runner without unbounded process fan-out.
+const lineageFixtureWarmupParallelism = 2
+
+var goReleaserLineageWarmupOnce sync.Once
+
+func ensureGoReleaserLineageFixtures(t *testing.T, tools executableLineageTools) {
+	t.Helper()
+	goReleaserLineageWarmupOnce.Do(func() {
+		if !t.Run("bounded-fixture-warmup", func(t *testing.T) {
+			slots := make(chan struct{}, lineageFixtureWarmupParallelism)
+			for _, coordinate := range goReleaserLineageCoordinates {
+				coordinate := coordinate
+				t.Run(coordinate.tag, func(t *testing.T) {
+					t.Parallel()
+					slots <- struct{}{}
+					defer func() { <-slots }()
+					populateGoReleaserLineageCache(t, tools, coordinate)
+				})
+			}
+		}) {
+			t.FailNow()
+		}
+	})
+}
+
+func populateGoReleaserLineageCache(
+	t *testing.T,
+	tools executableLineageTools,
+	coordinate goReleaserLineageCoordinate,
+) {
+	t.Helper()
+	cache := goReleaserLineageCaches[coordinate.tag]
+	if cache == nil {
+		t.Fatalf("missing GoReleaser lineage cache for %s", coordinate.tag)
+	}
+	cache.once.Do(func() {
+		cache.runs.Add(1)
+		cache.evidence = produceUncachedGoReleaserFixtureEvidence(
+			t, tools, coordinate.tag, coordinate.version, coordinate.annotated,
+		)
+	})
+}

--- a/pkg/companionmanifest/release_lineage_helpers_test.go
+++ b/pkg/companionmanifest/release_lineage_helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -77,4 +78,87 @@ func a0LineagePinsProvisioned(t *testing.T, source string, api publicKeyReceiptA
 		}
 	}
 	return allProvisioned
+}
+
+// @AX:ANCHOR [AUTO]: Keep the reviewed release-script aggregation shared by all lineage policy tests.
+// @AX:REASON [AUTO]: Phase tests must inspect the same sorted production surface after helpers are split.
+func releaseScriptsText(t *testing.T) []byte {
+	t.Helper()
+	paths, err := filepath.Glob(filepath.Join("..", "..", "scripts", "companion-release", "*.sh"))
+	if err != nil || len(paths) == 0 {
+		t.Fatalf("find companion release scripts: %v", err)
+	}
+	sort.Strings(paths)
+	var combined strings.Builder
+	for _, path := range paths {
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatalf("read release script %s: %v", path, readErr)
+		}
+		combined.WriteString("\n# source: " + filepath.Base(path) + "\n")
+		combined.Write(data)
+	}
+	return []byte(combined.String())
+}
+
+func releaseProducerSurface(t *testing.T) []byte {
+	t.Helper()
+	var combined strings.Builder
+	for _, path := range []string{
+		"scripts/companion-release/produce.sh",
+		"scripts/companion-release/produce-public-key-receipt.sh",
+	} {
+		combined.WriteString("\n# source: " + filepath.Base(path) + "\n")
+		combined.Write(releaseSourceFile(t, path))
+	}
+	return []byte(combined.String())
+}
+
+func exactA0TagVersionGuard(source string) bool {
+	return exactLineageTagVersionGuard(source, "69")
+}
+
+func exactA2TagVersionGuard(source string) bool {
+	return exactLineageTagVersionGuard(source, "71")
+}
+
+func exactA3TagVersionGuard(source string) bool {
+	return exactLineageTagVersionGuard(source, "72")
+}
+
+func exactLineageTagVersionGuard(source, patch string) bool {
+	patterns := []*regexp.Regexp{
+		regexp.MustCompile(`GITHUB_REF_NAME.{0,240}v0\.50\.` + patch + `.{0,400}COMPANION_VERSION.{0,240}0\.50\.` + patch),
+		regexp.MustCompile(`COMPANION_VERSION.{0,240}0\.50\.` + patch + `.{0,400}GITHUB_REF_NAME.{0,240}v0\.50\.` + patch),
+	}
+	for _, pattern := range patterns {
+		if pattern.MatchString(source) {
+			return true
+		}
+	}
+	return false
+}
+
+func publicKeyReceiptLineageStep(t *testing.T, workflow publicKeyReceiptWorkflow) (int, publicKeyReceiptWorkflowStep) {
+	t.Helper()
+	index, step, ok := findPublicKeyReceiptLineageStep(workflow)
+	if !ok {
+		t.Fatal("missing production contract: release workflow has no prior-release receipt lineage preflight")
+	}
+	return index, step
+}
+
+func findPublicKeyReceiptLineageStep(workflow publicKeyReceiptWorkflow) (int, publicKeyReceiptWorkflowStep, bool) {
+	job, ok := workflow.Jobs["release"]
+	if !ok {
+		return -1, publicKeyReceiptWorkflowStep{}, false
+	}
+	for index, step := range job.Steps {
+		surface := strings.ToLower(step.Name + " " + step.Run)
+		if strings.Contains(surface, "public-key") &&
+			(strings.Contains(surface, "lineage") || strings.Contains(surface, "prior")) {
+			return index, step, true
+		}
+	}
+	return -1, publicKeyReceiptWorkflowStep{}, false
 }

--- a/pkg/companionmanifest/release_lineage_materialization_test.go
+++ b/pkg/companionmanifest/release_lineage_materialization_test.go
@@ -1,0 +1,275 @@
+package companionmanifest
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestLineageCachePathSurvivesProducerCleanup(t *testing.T) {
+	t.Parallel()
+
+	producerRoot := filepath.Join(t.TempDir(), "producer")
+	if err := os.Mkdir(producerRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Join(producerRoot, "baseline.tar.gz")
+	want := bytes.Repeat([]byte("cached-archive"), 128)
+	if err := os.WriteFile(source, want, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cached := filepath.Join(t.TempDir(), "baseline.tar.gz")
+	if _, err := materializeLineageArchive(source, cached, os.Link); err != nil {
+		t.Fatal(err)
+	}
+	evidence := goReleaserA0Evidence{archives: map[string]string{"amd64": cached}}
+	clone := cloneGoReleaserEvidence(&evidence)
+	if err := os.RemoveAll(producerRoot); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(clone.archives["amd64"])
+	if err != nil || !bytes.Equal(got, want) {
+		t.Fatalf("cached archive did not survive producer cleanup: %v", err)
+	}
+	if clone.archives["amd64"] != cached {
+		t.Fatal("lineage evidence clone did not reuse the immutable cache path")
+	}
+}
+
+func TestMaterializeLineageArchiveHardlinksOrStreamsExactBytes(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	source := filepath.Join(root, "source.tar.gz")
+	linked := filepath.Join(root, "linked.tar.gz")
+	copied := filepath.Join(root, "copied.tar.gz")
+	portableCopy := filepath.Join(root, "portable-copy.tar.gz")
+	want := bytes.Repeat([]byte("archive"), 1024)
+	if err := os.WriteFile(source, want, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	usedLink, err := materializeLineageArchive(source, linked, os.Link)
+	if err != nil || !usedLink {
+		t.Fatalf("hard-link materialization = %t, %v", usedLink, err)
+	}
+	assertSameLineageFile(t, source, linked, true, want)
+
+	linkAcrossDevices := func(oldPath, newPath string) error {
+		return &os.LinkError{Op: "link", Old: oldPath, New: newPath, Err: syscall.EXDEV}
+	}
+	usedLink, err = materializeLineageArchive(source, copied, linkAcrossDevices)
+	if err != nil || usedLink {
+		t.Fatalf("copy fallback materialization = %t, %v", usedLink, err)
+	}
+	assertSameLineageFile(t, source, copied, false, want)
+
+	linkUnavailable := errors.New("hard links disabled")
+	usedLink, err = materializeLineageArchive(source, portableCopy,
+		func(string, string) error { return linkUnavailable })
+	if err != nil || usedLink {
+		t.Fatalf("portable copy fallback = %t, %v", usedLink, err)
+	}
+	assertSameLineageFile(t, source, portableCopy, false, want)
+
+	occupied := filepath.Join(root, "occupied.tar.gz")
+	if err := os.WriteFile(occupied, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err = materializeLineageArchive(source, occupied,
+		func(string, string) error { return linkUnavailable })
+	if !errors.Is(err, linkUnavailable) || !errors.Is(err, os.ErrExist) {
+		t.Fatalf("joined link/copy error = %v", err)
+	}
+	if got := string(readLineageFile(t, occupied)); got != "keep" {
+		t.Fatalf("failed copy changed existing target to %q", got)
+	}
+}
+
+func TestRewriteLineageArchiveTargetStreamsOnlySelectedEntry(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	source := filepath.Join(root, "source.tar.gz")
+	target := filepath.Join(root, "target.tar.gz")
+	large := bytes.Repeat([]byte("untouched-architecture-entry"), 1<<16)
+	writeLineageMaterializationArchive(t, source, map[string][]byte{
+		"auto": large, "manifest.json": []byte("before"), "signature": []byte("sig"),
+	})
+	calls := 0
+	err := rewriteLineageArchiveTarget(
+		source, target, "manifest.json",
+		func(data []byte) ([]byte, bool) {
+			calls++
+			if !bytes.Equal(data, []byte("before")) {
+				t.Fatalf("target mutation received %d unrelated bytes", len(data))
+			}
+			return []byte("after"), true
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("target mutation calls = %d, want 1", calls)
+	}
+	entries, err := decodeLineageArchive(readLineageFile(t, target))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(entries["auto"].data, large) ||
+		!bytes.Equal(entries["manifest.json"].data, []byte("after")) ||
+		!bytes.Equal(entries["signature"].data, []byte("sig")) {
+		t.Fatal("target-only rewrite changed an untouched archive entry")
+	}
+}
+
+func TestLineageFixtureReusesUntouchedArchitectureAndRemovesTargetEntry(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	amd64Source := filepath.Join(root, "amd64-source.tar.gz")
+	arm64Source := filepath.Join(root, "arm64-source.tar.gz")
+	amd64Target := filepath.Join(root, "amd64-target.tar.gz")
+	arm64Target := filepath.Join(root, "arm64-target.tar.gz")
+	entries := map[string][]byte{"auto": []byte("binary"), "signature": []byte("sig")}
+	writeLineageMaterializationArchive(t, amd64Source, entries)
+	writeLineageMaterializationArchive(t, arm64Source, entries)
+	if err := rewriteLineageArchiveTarget(
+		amd64Source, amd64Target, "signature",
+		func([]byte) ([]byte, bool) { return nil, false },
+	); err != nil {
+		t.Fatal(err)
+	}
+	if usedLink, err := materializeLineageArchive(arm64Source, arm64Target, os.Link); err != nil || !usedLink {
+		t.Fatalf("untouched architecture reuse = %t, %v", usedLink, err)
+	}
+	assertSameLineageFile(t, arm64Source, arm64Target, true,
+		readLineageFile(t, arm64Source))
+	decoded, err := decodeLineageArchive(readLineageFile(t, amd64Target))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, present := decoded["signature"]; present {
+		t.Fatal("selected archive entry was not removed")
+	}
+	if string(decoded["auto"].data) != "binary" {
+		t.Fatal("entry removal changed an untouched archive entry")
+	}
+}
+
+func TestRewriteLineageArchiveTargetRequiresExactlyOneEntry(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	t.Run("missing", func(t *testing.T) {
+		source := filepath.Join(root, "missing-source.tar.gz")
+		target := filepath.Join(root, "missing-target.tar.gz")
+		writeLineageMaterializationArchive(t, source,
+			map[string][]byte{"auto": []byte("binary")})
+		calls := 0
+		err := rewriteLineageArchiveTarget(source, target, "manifest.json",
+			func(data []byte) ([]byte, bool) {
+				calls++
+				return data, true
+			})
+		if err == nil || calls != 0 {
+			t.Fatalf("missing target result = %v, mutation calls = %d", err, calls)
+		}
+		if _, statErr := os.Lstat(target); !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("missing target left partial output: %v", statErr)
+		}
+	})
+	t.Run("duplicate", func(t *testing.T) {
+		source := filepath.Join(root, "duplicate-source.tar.gz")
+		target := filepath.Join(root, "duplicate-target.tar.gz")
+		writeLineageMaterializationEntries(t, source, []lineageMaterializationEntry{
+			{name: "manifest.json", data: []byte("first")},
+			{name: "manifest.json", data: []byte("second")},
+		})
+		calls := 0
+		err := rewriteLineageArchiveTarget(source, target, "manifest.json",
+			func(data []byte) ([]byte, bool) {
+				calls++
+				return data, true
+			})
+		if err == nil || calls != 1 {
+			t.Fatalf("duplicate target result = %v, mutation calls = %d", err, calls)
+		}
+		if _, statErr := os.Lstat(target); !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("duplicate target left partial output: %v", statErr)
+		}
+	})
+}
+
+func assertSameLineageFile(
+	t *testing.T, source, target string, sameIdentity bool, want []byte,
+) {
+	t.Helper()
+	sourceInfo, err := os.Lstat(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	targetInfo, err := os.Lstat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.SameFile(sourceInfo, targetInfo) != sameIdentity {
+		t.Fatalf("materialized identity same = %t, want %t",
+			os.SameFile(sourceInfo, targetInfo), sameIdentity)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil || !bytes.Equal(got, want) {
+		t.Fatalf("materialized bytes differ: %v", err)
+	}
+}
+
+func writeLineageMaterializationArchive(
+	t *testing.T, path string, entries map[string][]byte,
+) {
+	t.Helper()
+	ordered := make([]lineageMaterializationEntry, 0, len(entries))
+	for _, name := range []string{"auto", "manifest.json", "signature"} {
+		if data, ok := entries[name]; ok {
+			ordered = append(ordered, lineageMaterializationEntry{name: name, data: data})
+		}
+	}
+	writeLineageMaterializationEntries(t, path, ordered)
+}
+
+type lineageMaterializationEntry struct {
+	name string
+	data []byte
+}
+
+func writeLineageMaterializationEntries(
+	t *testing.T, path string, entries []lineageMaterializationEntry,
+) {
+	t.Helper()
+	output, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gzipWriter := gzip.NewWriter(output)
+	tarWriter := tar.NewWriter(gzipWriter)
+	for _, entry := range entries {
+		header := &tar.Header{
+			Name: entry.name, Mode: 0o600, Size: int64(len(entry.data)),
+		}
+		if err := tarWriter.WriteHeader(header); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := io.Copy(tarWriter, bytes.NewReader(entry.data)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := errors.Join(tarWriter.Close(), gzipWriter.Close(), output.Close()); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/companionmanifest/release_public_key_receipt_lineage_test.go
+++ b/pkg/companionmanifest/release_public_key_receipt_lineage_test.go
@@ -1,10 +1,6 @@
 package companionmanifest
 
 import (
-	"os"
-	"path/filepath"
-	"regexp"
-	"sort"
 	"strings"
 	"testing"
 )
@@ -26,7 +22,7 @@ const (
 
 func TestReleasePublicKeyReceipt_LineageClaims_UseConjunctiveLongLivedWindow(t *testing.T) {
 	api := productionPublicKeyReceiptAPI(t)
-	producer := normalizedReleaseText(releaseSourceFile(t, "scripts/companion-release/produce.sh"))
+	producer := normalizedReleaseText(releaseProducerSurface(t))
 	if !strings.Contains(producer, "companion-manifest public-key-receipt") {
 		t.Fatal("missing production contract: release producer does not issue a public-key receipt")
 	}
@@ -212,86 +208,4 @@ func TestReleasePublicKeyReceipt_NonBootstrapPriorEvidenceFailures_BlockBeforeGo
 			}
 		})
 	}
-}
-
-func releaseScriptsText(t *testing.T) []byte {
-	t.Helper()
-	paths, err := filepath.Glob(filepath.Join("..", "..", "scripts", "companion-release", "*.sh"))
-	if err != nil || len(paths) == 0 {
-		t.Fatalf("find companion release scripts: %v", err)
-	}
-	sort.Strings(paths)
-	var combined strings.Builder
-	for _, path := range paths {
-		data, readErr := os.ReadFile(path)
-		if readErr != nil {
-			t.Fatalf("read release script %s: %v", path, readErr)
-		}
-		combined.WriteString("\n# source: " + filepath.Base(path) + "\n")
-		combined.Write(data)
-	}
-	return []byte(combined.String())
-}
-
-func exactA0TagVersionGuard(source string) bool {
-	patterns := []*regexp.Regexp{
-		regexp.MustCompile(`GITHUB_REF_NAME.{0,240}v0\.50\.69.{0,400}COMPANION_VERSION.{0,240}0\.50\.69`),
-		regexp.MustCompile(`COMPANION_VERSION.{0,240}0\.50\.69.{0,400}GITHUB_REF_NAME.{0,240}v0\.50\.69`),
-	}
-	for _, pattern := range patterns {
-		if pattern.MatchString(source) {
-			return true
-		}
-	}
-	return false
-}
-
-func exactA2TagVersionGuard(source string) bool {
-	patterns := []*regexp.Regexp{
-		regexp.MustCompile(`GITHUB_REF_NAME.{0,240}v0\.50\.71.{0,400}COMPANION_VERSION.{0,240}0\.50\.71`),
-		regexp.MustCompile(`COMPANION_VERSION.{0,240}0\.50\.71.{0,400}GITHUB_REF_NAME.{0,240}v0\.50\.71`),
-	}
-	for _, pattern := range patterns {
-		if pattern.MatchString(source) {
-			return true
-		}
-	}
-	return false
-}
-
-func exactA3TagVersionGuard(source string) bool {
-	patterns := []*regexp.Regexp{
-		regexp.MustCompile(`GITHUB_REF_NAME.{0,240}v0\.50\.72.{0,400}COMPANION_VERSION.{0,240}0\.50\.72`),
-		regexp.MustCompile(`COMPANION_VERSION.{0,240}0\.50\.72.{0,400}GITHUB_REF_NAME.{0,240}v0\.50\.72`),
-	}
-	for _, pattern := range patterns {
-		if pattern.MatchString(source) {
-			return true
-		}
-	}
-	return false
-}
-
-func publicKeyReceiptLineageStep(t *testing.T, workflow publicKeyReceiptWorkflow) (int, publicKeyReceiptWorkflowStep) {
-	t.Helper()
-	index, step, ok := findPublicKeyReceiptLineageStep(workflow)
-	if !ok {
-		t.Fatal("missing production contract: release workflow has no prior-release receipt lineage preflight")
-	}
-	return index, step
-}
-
-func findPublicKeyReceiptLineageStep(workflow publicKeyReceiptWorkflow) (int, publicKeyReceiptWorkflowStep, bool) {
-	job, ok := workflow.Jobs["release"]
-	if !ok {
-		return -1, publicKeyReceiptWorkflowStep{}, false
-	}
-	for index, step := range job.Steps {
-		surface := strings.ToLower(step.Name + " " + step.Run)
-		if strings.Contains(surface, "public-key") &&
-			(strings.Contains(surface, "lineage") || strings.Contains(surface, "prior")) {
-			return index, step, true
-		}
-	}
-	return -1, publicKeyReceiptWorkflowStep{}, false
 }

--- a/pkg/companionmanifest/release_public_key_receipt_wiring_test.go
+++ b/pkg/companionmanifest/release_public_key_receipt_wiring_test.go
@@ -96,7 +96,7 @@ func TestReleasePublicKeyReceipt_GoReleaserDarwinArchive_MatchesAtomicCLIArtifac
 
 func TestReleasePublicKeyReceipt_Producer_UsesSameKeyWithoutLeakAndSurfacesRollback(t *testing.T) {
 	api := productionPublicKeyReceiptAPI(t)
-	producer := normalizedReleaseText(releaseSourceFile(t, "scripts/companion-release/produce.sh"))
+	producer := normalizedReleaseText(releaseProducerSurface(t))
 	if !strings.Contains(producer, "companion-manifest public-key-receipt") {
 		t.Fatal("missing production contract: produce.sh never invokes the public-key-receipt CLI")
 	}

--- a/pkg/selfupdate/replacer.go
+++ b/pkg/selfupdate/replacer.go
@@ -36,6 +36,8 @@ func NewReplacer() *Replacer {
 }
 
 // Replace safely replaces the target binary with the new one.
+// @AX:ANCHOR [AUTO]: Preserve this public self-update replacement boundary.
+// @AX:REASON [AUTO]: CLI update flows and external consumers rely on its fail-closed replacement contract.
 func (r *Replacer) Replace(newBinaryPath, targetPath string) error {
 	return replaceWithOps(newBinaryPath, targetPath, defaultReplaceOps())
 }
@@ -56,7 +58,11 @@ func defaultReplaceOps() replaceOps {
 	}
 }
 
-func replaceWithOps(newBinaryPath, targetPath string, ops replaceOps) error {
+// @AX:ANCHOR [AUTO]: Preserve the injectable replacement transaction used by production and regression tests.
+// @AX:REASON [AUTO]: Fourteen callers depend on identity checks, cross-device fallback, cleanup, and recovery semantics.
+// @AX:WARN [AUTO]: This transaction contains more than eight filesystem decision branches.
+// @AX:REASON [AUTO]: Target identity, staging, cross-device copy, commit, cleanup, and recovery ordering must remain fail-closed.
+func replaceWithOps(newBinaryPath, targetPath string, ops replaceOps) (retErr error) {
 	targetInfo, err := regularBinaryInfo(ops.lstat, targetPath, "target")
 	if err != nil {
 		return err
@@ -79,7 +85,10 @@ func replaceWithOps(newBinaryPath, targetPath string, ops replaceOps) error {
 	cleanupStage := true
 	defer func() {
 		if cleanupStage {
-			_ = ops.removeAll(stageDir)
+			if cleanupErr := ops.removeAll(stageDir); cleanupErr != nil {
+				retErr = errors.Join(retErr,
+					fmt.Errorf("cleanup replacement directory: %w", cleanupErr))
+			}
 		}
 	}()
 

--- a/pkg/selfupdate/replacer_bindmount_test.go
+++ b/pkg/selfupdate/replacer_bindmount_test.go
@@ -1,0 +1,134 @@
+package selfupdate
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplaceWithOps_BindMountCommitWithoutStageIsSuccess(t *testing.T) {
+	t.Parallel()
+
+	newBinaryPath, targetPath := writeReplacementFixture(t)
+	external := t.TempDir()
+	backupPath := filepath.Join(external, "old-backup")
+	var stagedInfo os.FileInfo
+	ops := defaultReplaceOps()
+	ops.commit = func(stagePath, gotTargetPath string, expected os.FileInfo) error {
+		var err error
+		stagedInfo, err = os.Lstat(stagePath)
+		if err != nil {
+			return err
+		}
+		calls := 0
+		return commitWithAtomicSwap(stagePath, gotTargetPath, expected,
+			func(left, right string) error {
+				calls++
+				if calls != 1 {
+					return os.ErrNotExist
+				}
+				if err := os.Rename(right, backupPath); err != nil {
+					return err
+				}
+				return os.Rename(left, right)
+			}, func(string) error { return nil })
+	}
+
+	require.NoError(t, replaceWithOps(newBinaryPath, targetPath, ops))
+	assertInstalledBinary(t, targetPath, "new", 0o711)
+	targetInfo, err := os.Lstat(targetPath)
+	require.NoError(t, err)
+	require.True(t, os.SameFile(stagedInfo, targetInfo),
+		"committed target must be the pre-swap staged binary")
+	assertNoReplacementResidue(t, targetPath)
+}
+
+func TestReplaceWithOps_BindMountMissingStageWithDifferentTargetFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	newBinaryPath, targetPath := writeReplacementFixture(t)
+	external := t.TempDir()
+	backupPath := filepath.Join(external, "old-backup")
+	consumedStagePath := filepath.Join(external, "consumed-stage")
+	ops := defaultReplaceOps()
+	ops.commit = func(stagePath, gotTargetPath string, expected os.FileInfo) error {
+		calls := 0
+		return commitWithAtomicSwap(stagePath, gotTargetPath, expected,
+			func(left, right string) error {
+				calls++
+				if calls != 1 {
+					return os.ErrNotExist
+				}
+				if err := os.Rename(right, backupPath); err != nil {
+					return err
+				}
+				if err := os.Rename(left, consumedStagePath); err != nil {
+					return err
+				}
+				return os.WriteFile(right, []byte("different"), 0o700)
+			}, func(string) error { return nil })
+	}
+
+	err := replaceWithOps(newBinaryPath, targetPath, ops)
+	require.Error(t, err)
+	require.False(t, preservesReplacementStage(err))
+	require.NotContains(t, err.Error(), "recovery file preserved at")
+	require.ErrorIs(t, err, os.ErrNotExist)
+	assertInstalledBinary(t, targetPath, "different", 0o700)
+	assertNoReplacementResidue(t, targetPath)
+}
+
+func TestPreserveStageErrorRequiresExistingRecoveryFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "missing-auto")
+	err := rollbackAtomicSwap(
+		missing, filepath.Join(dir, "auto"), errors.New("stage vanished"),
+		func(string, string) error { return os.ErrNotExist },
+		func(string) error { return nil },
+	)
+	require.Error(t, err)
+	require.False(t, preservesReplacementStage(err))
+	require.NotContains(t, err.Error(), missing)
+	require.NotContains(t, err.Error(), "recovery file preserved at")
+}
+
+func TestReplaceWithOps_ReportsCleanupFailure(t *testing.T) {
+	t.Parallel()
+
+	t.Run("after successful commit", func(t *testing.T) {
+		newBinaryPath, targetPath := writeReplacementFixture(t)
+		cleanupErr := errors.New("injected cleanup failure")
+		ops := defaultReplaceOps()
+		ops.commit = func(stagePath, targetPath string, _ os.FileInfo) error {
+			if err := os.Remove(targetPath); err != nil {
+				return err
+			}
+			return os.Rename(stagePath, targetPath)
+		}
+		ops.removeAll = func(string) error { return cleanupErr }
+
+		err := replaceWithOps(newBinaryPath, targetPath, ops)
+		require.ErrorIs(t, err, cleanupErr)
+		require.Contains(t, err.Error(), "cleanup replacement directory")
+		assertInstalledBinary(t, targetPath, "new", 0o711)
+	})
+
+	t.Run("alongside commit failure", func(t *testing.T) {
+		newBinaryPath, targetPath := writeReplacementFixture(t)
+		commitErr := errors.New("injected commit failure")
+		cleanupErr := errors.New("injected cleanup failure")
+		ops := defaultReplaceOps()
+		ops.commit = func(string, string, os.FileInfo) error { return commitErr }
+		ops.removeAll = func(string) error { return cleanupErr }
+
+		err := replaceWithOps(newBinaryPath, targetPath, ops)
+		require.ErrorIs(t, err, commitErr)
+		require.ErrorIs(t, err, cleanupErr)
+		assertInstalledBinary(t, targetPath, "old", 0o711)
+	})
+}

--- a/pkg/selfupdate/replacer_bindmount_test.go
+++ b/pkg/selfupdate/replacer_bindmount_test.go
@@ -16,12 +16,20 @@ func TestReplaceWithOps_BindMountCommitWithoutStageIsSuccess(t *testing.T) {
 	external := t.TempDir()
 	backupPath := filepath.Join(external, "old-backup")
 	var stagedInfo os.FileInfo
+	committedStageIdentity := false
 	ops := defaultReplaceOps()
 	ops.commit = func(stagePath, gotTargetPath string, expected os.FileInfo) error {
-		var err error
-		stagedInfo, err = os.Lstat(stagePath)
+		stagedFile, err := os.Open(stagePath)
 		if err != nil {
 			return err
+		}
+		stagedInfo, err = stagedFile.Stat()
+		closeErr := stagedFile.Close()
+		if err != nil {
+			return err
+		}
+		if closeErr != nil {
+			return closeErr
 		}
 		calls := 0
 		return commitWithAtomicSwap(stagePath, gotTargetPath, expected,
@@ -33,15 +41,21 @@ func TestReplaceWithOps_BindMountCommitWithoutStageIsSuccess(t *testing.T) {
 				if err := os.Rename(right, backupPath); err != nil {
 					return err
 				}
-				return os.Rename(left, right)
+				if err := os.Rename(left, right); err != nil {
+					return err
+				}
+				committedInfo, err := os.Lstat(right)
+				if err != nil {
+					return err
+				}
+				committedStageIdentity = os.SameFile(stagedInfo, committedInfo)
+				return nil
 			}, func(string) error { return nil })
 	}
 
 	require.NoError(t, replaceWithOps(newBinaryPath, targetPath, ops))
 	assertInstalledBinary(t, targetPath, "new", 0o711)
-	targetInfo, err := os.Lstat(targetPath)
-	require.NoError(t, err)
-	require.True(t, os.SameFile(stagedInfo, targetInfo),
+	require.True(t, committedStageIdentity,
 		"committed target must be the pre-swap staged binary")
 	assertNoReplacementResidue(t, targetPath)
 }

--- a/pkg/selfupdate/replacer_commit_swap.go
+++ b/pkg/selfupdate/replacer_commit_swap.go
@@ -27,6 +27,10 @@ func preservesReplacementStage(err error) bool {
 	return errors.As(err, &target)
 }
 
+// @AX:ANCHOR [AUTO]: Preserve the atomic-swap commit contract across Darwin and Linux implementations.
+// @AX:REASON [AUTO]: Nine production and regression call sites depend on pre/post-swap inode verification and rollback behavior.
+// @AX:WARN [AUTO]: This commit path contains more than eight filesystem decision branches.
+// @AX:REASON [AUTO]: Inode identity, directory sync, rollback, and preserved-recovery ordering must remain fail-closed.
 func commitWithAtomicSwap(
 	stagePath, targetPath string,
 	expected os.FileInfo,
@@ -35,12 +39,19 @@ func commitWithAtomicSwap(
 ) error {
 	stageDir := filepath.Dir(stagePath)
 	targetDir := filepath.Dir(targetPath)
+	stagedInfo, err := regularBinaryInfo(os.Lstat, stagePath, "staged")
+	if err != nil {
+		return fmt.Errorf("inspect staged binary before atomic commit: %w", err)
+	}
 	currentInfo, err := os.Lstat(targetPath)
 	if err != nil {
 		return fmt.Errorf("inspect target before atomic commit: %w", err)
 	}
 	if !currentInfo.Mode().IsRegular() || !os.SameFile(expected, currentInfo) {
 		return errors.New("target binary changed before atomic commit")
+	}
+	if os.SameFile(stagedInfo, currentInfo) {
+		return errors.New("staged and target binary resolve to the same file")
 	}
 	if err := syncDir(stageDir); err != nil {
 		return fmt.Errorf("sync staged directory: %w", err)
@@ -49,11 +60,9 @@ func commitWithAtomicSwap(
 		return err
 	}
 
-	swappedInfo, verifyErr := os.Lstat(stagePath)
-	if verifyErr == nil && !os.SameFile(expected, swappedInfo) {
-		verifyErr = errors.New("target binary changed before atomic commit")
-	}
-	if verifyErr != nil {
+	if verifyErr := verifyAtomicSwapState(
+		stagePath, targetPath, expected, stagedInfo,
+	); verifyErr != nil {
 		return rollbackAtomicSwap(stagePath, targetPath, verifyErr, swap, syncDir)
 	}
 	if err := syncDir(targetDir); err != nil {
@@ -65,6 +74,31 @@ func commitWithAtomicSwap(
 	return nil
 }
 
+func verifyAtomicSwapState(
+	stagePath, targetPath string,
+	expectedTarget, expectedStage os.FileInfo,
+) error {
+	committedInfo, err := regularBinaryInfo(os.Lstat, targetPath, "committed target")
+	if err != nil {
+		return fmt.Errorf("inspect target after atomic commit: %w", err)
+	}
+	if !os.SameFile(expectedStage, committedInfo) {
+		return errors.New("staged binary identity changed during atomic commit")
+	}
+
+	recoveryInfo, err := os.Lstat(stagePath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect recovery binary after atomic commit: %w", err)
+	}
+	if !recoveryInfo.Mode().IsRegular() || !os.SameFile(expectedTarget, recoveryInfo) {
+		return errors.New("target binary changed before atomic commit")
+	}
+	return nil
+}
+
 func rollbackAtomicSwap(
 	stagePath, targetPath string,
 	cause error,
@@ -72,10 +106,14 @@ func rollbackAtomicSwap(
 	syncDir func(string) error,
 ) error {
 	if err := swap(stagePath, targetPath); err != nil {
-		return &preserveStageError{
-			stagePath: stagePath,
-			err:       errors.Join(cause, fmt.Errorf("swap back: %w", err)),
+		rollbackErr := errors.Join(cause, fmt.Errorf("swap back: %w", err))
+		if info, statErr := os.Lstat(stagePath); statErr == nil && info.Mode().IsRegular() {
+			return &preserveStageError{
+				stagePath: stagePath,
+				err:       rollbackErr,
+			}
 		}
+		return rollbackErr
 	}
 	stageDir := filepath.Dir(stagePath)
 	targetDir := filepath.Dir(targetPath)

--- a/scripts/companion-release/produce-public-key-receipt.sh
+++ b/scripts/companion-release/produce-public-key-receipt.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+[[ "${BASH_SOURCE[0]}" != "$0" ]] || {
+  printf 'companion release: public key receipt helper must be sourced\n' >&2
+  exit 1
+}
+
+# @AX:ANCHOR [AUTO]: Keep every shipped tag/version pair in one exact receipt-phase resolver.
+# @AX:REASON [AUTO]: The producer must reject mixed or unknown release coordinates before signing artifacts.
+resolve_public_key_receipt_release_phase() {
+  if [[ "$GITHUB_REF_NAME" == 'v0.50.69' && "$COMPANION_VERSION" == '0.50.69' ]]; then
+    release_phase='A0'
+  elif [[ "$GITHUB_REF_NAME" == 'v0.50.70' && "$COMPANION_VERSION" == '0.50.70' ]]; then
+    release_phase='A1'
+  elif [[ "$GITHUB_REF_NAME" == 'v0.50.71' && "$COMPANION_VERSION" == '0.50.71' ]]; then
+    release_phase='A2'
+  elif [[ "$GITHUB_REF_NAME" == 'v0.50.72' && "$COMPANION_VERSION" == '0.50.72' ]]; then
+    release_phase='A3'
+  elif [[ "$GITHUB_REF_NAME" == 'v0.50.73' && "$COMPANION_VERSION" == '0.50.73' ]]; then
+    release_phase='A4'
+  elif [[ "$GITHUB_REF_NAME" == 'v0.50.74' && "$COMPANION_VERSION" == '0.50.74' ]]; then
+    release_phase='A5'
+  elif [[ "$GITHUB_REF_NAME" == 'v0.50.77' && "$COMPANION_VERSION" == '0.50.77' ]]; then
+    release_phase='A6'
+  elif [[ "$GITHUB_REF_NAME" == 'v0.50.78' && "$COMPANION_VERSION" == '0.50.78' ]]; then
+    release_phase='A7'
+  elif [[ "$GITHUB_REF_NAME" == 'v0.50.79' && "$COMPANION_VERSION" == '0.50.79' ]]; then
+    release_phase='A8'
+  elif [[ "$GITHUB_REF_NAME" == 'v0.50.80' && "$COMPANION_VERSION" == '0.50.80' ]]; then
+    release_phase='A9'
+  elif [[ "$GITHUB_REF_NAME" == 'v0.50.81' && "$COMPANION_VERSION" == '0.50.81' ]]; then
+    release_phase='A10'
+  elif [[ "$GITHUB_REF_NAME" == 'v0.50.82' && "$COMPANION_VERSION" == '0.50.82' ]]; then
+    release_phase='A11'
+  else
+    fail 'public_key_receipt_release_identity_mismatch'
+  fi
+}
+
+produce_public_key_receipt_bundle() {
+  local artifact_path=$1
+  local manifest_path=$2
+  local signature_path=$3
+  local public_key_bundle_path=$4
+  local signing_key_digest_before=$5
+  local release_phase=$6
+  local bundle_entry_count entry signing_key_digest_after
+  local -a public_key_receipt_args
+
+  public_key_receipt_args=(companion-manifest public-key-receipt
+    --key-file "$COMPANION_SIGNING_KEY_FILE"
+    --bundle-output "$public_key_bundle_path"
+    --key-id "$COMPANION_KEY_ID"
+    --issued-at "$COMPANION_PUBLIC_KEY_RECEIPT_ISSUED_AT"
+    --expires-at "$COMPANION_PUBLIC_KEY_RECEIPT_EXPIRES_AT"
+    --handoff "$COMPANION_HANDOFF"
+    --minimum-rollback-floor "$COMPANION_ROLLBACK_FLOOR")
+  env -i PATH="$PATH" HOME="${HOME-}" TMPDIR="${TMPDIR:-/tmp}" \
+    "$COMPANION_SIGNER" "${public_key_receipt_args[@]}" >/dev/null \
+    || fail 'public key receipt production failed'
+  [[ -d "$public_key_bundle_path" && ! -L "$public_key_bundle_path" ]] \
+    || fail 'public key receipt production failed'
+  bundle_entry_count=$(find "$public_key_bundle_path" -mindepth 1 -maxdepth 1 -print | wc -l)
+  [[ "${bundle_entry_count//[[:space:]]/}" == '2' ]] \
+    || fail 'public key receipt production failed'
+  for entry in public-key-receipt.json public-key-receipt.sig; do
+    [[ -f "$public_key_bundle_path/$entry" && ! -L "$public_key_bundle_path/$entry" ]] \
+      || fail 'public key receipt production failed'
+  done
+  [[ "$(wc -c <"$public_key_bundle_path/public-key-receipt.sig" | tr -d '[:space:]')" == '64' ]] \
+    || fail 'public key receipt production failed'
+  env -i PATH="$PATH" HOME="${HOME-}" TMPDIR="${TMPDIR:-/tmp}" \
+    "$COMPANION_RECEIPT_VERIFIER" \
+    --receipt "$public_key_bundle_path/public-key-receipt.json" \
+    --signature "$public_key_bundle_path/public-key-receipt.sig" \
+    --signing-key "$COMPANION_SIGNING_KEY_FILE" \
+    --key-id "$COMPANION_KEY_ID" \
+    --issued-at "$COMPANION_PUBLIC_KEY_RECEIPT_ISSUED_AT" \
+    --expires-at "$COMPANION_PUBLIC_KEY_RECEIPT_EXPIRES_AT" \
+    --handoff "$COMPANION_HANDOFF" \
+    --minimum-rollback-floor "$COMPANION_ROLLBACK_FLOOR" \
+    || fail 'public key receipt independent verification failed'
+  if [[ -n "${COMPANION_MANIFEST_VERIFIER-}" ]]; then
+    env -i PATH="$PATH" HOME="${HOME-}" TMPDIR="${TMPDIR:-/tmp}" \
+      "$COMPANION_MANIFEST_VERIFIER" \
+      --artifact "$artifact_path" \
+      --manifest "$manifest_path" \
+      --signature "$signature_path" \
+      --receipt "$public_key_bundle_path/public-key-receipt.json" \
+      --receipt-signature "$public_key_bundle_path/public-key-receipt.sig" \
+      --signing-key "$COMPANION_SIGNING_KEY_FILE" \
+      --key-id "$COMPANION_KEY_ID" \
+      --version "$COMPANION_VERSION" \
+      --platform "$COMPANION_PLATFORM" \
+      --architecture "$COMPANION_ARCHITECTURE" \
+      --handoff "$COMPANION_HANDOFF" \
+      --minimum-rollback-floor "$COMPANION_ROLLBACK_FLOOR" \
+      || fail 'manifest and artifact independent verification failed'
+  fi
+  signing_key_digest_after=$(sha256_file "$COMPANION_SIGNING_KEY_FILE") \
+    || fail 'manifest_public_key_digest_mismatch'
+  [[ "$signing_key_digest_before" == "$signing_key_digest_after" ]] \
+    || fail 'manifest_public_key_digest_mismatch'
+  printf 'companion release: public key receipt phase %s produced\n' "$release_phase"
+}

--- a/scripts/companion-release/produce.sh
+++ b/scripts/companion-release/produce.sh
@@ -30,6 +30,16 @@ for name in COMPANION_ARTIFACT COMPANION_TARGET COMPANION_ARCHITECTURE COMPANION
 done
 
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+public_key_receipt_helper="$script_dir/produce-public-key-receipt.sh"
+[[ -f "$public_key_receipt_helper" && ! -L "$public_key_receipt_helper" && \
+   -r "$public_key_receipt_helper" ]] \
+  || fail 'public key receipt helper is missing or unsafe'
+# shellcheck source=produce-public-key-receipt.sh
+source "$public_key_receipt_helper"
+for helper_function in resolve_public_key_receipt_release_phase produce_public_key_receipt_bundle; do
+  declare -F "$helper_function" >/dev/null 2>&1 \
+    || fail 'public key receipt helper contract is incomplete'
+done
 "$script_dir/validate-environment.sh"
 
 [[ "$(uname -s)" == 'Darwin' ]] || fail 'Darwin release requires macOS'
@@ -55,33 +65,7 @@ public_key_receipt_enabled=0
 if [[ -n "${COMPANION_PUBLIC_KEY_RECEIPT_ISSUED_AT-}" ]]; then
   public_key_receipt_enabled=1
   require_environment GITHUB_REF_NAME
-  if [[ "$GITHUB_REF_NAME" == 'v0.50.69' && "$COMPANION_VERSION" == '0.50.69' ]]; then
-    release_phase='A0'
-  elif [[ "$GITHUB_REF_NAME" == 'v0.50.70' && "$COMPANION_VERSION" == '0.50.70' ]]; then
-    release_phase='A1'
-  elif [[ "$GITHUB_REF_NAME" == 'v0.50.71' && "$COMPANION_VERSION" == '0.50.71' ]]; then
-    release_phase='A2'
-  elif [[ "$GITHUB_REF_NAME" == 'v0.50.72' && "$COMPANION_VERSION" == '0.50.72' ]]; then
-    release_phase='A3'
-  elif [[ "$GITHUB_REF_NAME" == 'v0.50.73' && "$COMPANION_VERSION" == '0.50.73' ]]; then
-    release_phase='A4'
-  elif [[ "$GITHUB_REF_NAME" == 'v0.50.74' && "$COMPANION_VERSION" == '0.50.74' ]]; then
-    release_phase='A5'
-  elif [[ "$GITHUB_REF_NAME" == 'v0.50.77' && "$COMPANION_VERSION" == '0.50.77' ]]; then
-    release_phase='A6'
-  elif [[ "$GITHUB_REF_NAME" == 'v0.50.78' && "$COMPANION_VERSION" == '0.50.78' ]]; then
-    release_phase='A7'
-  elif [[ "$GITHUB_REF_NAME" == 'v0.50.79' && "$COMPANION_VERSION" == '0.50.79' ]]; then
-    release_phase='A8'
-  elif [[ "$GITHUB_REF_NAME" == 'v0.50.80' && "$COMPANION_VERSION" == '0.50.80' ]]; then
-    release_phase='A9'
-  elif [[ "$GITHUB_REF_NAME" == 'v0.50.81' && "$COMPANION_VERSION" == '0.50.81' ]]; then
-    release_phase='A10'
-  elif [[ "$GITHUB_REF_NAME" == 'v0.50.82' && "$COMPANION_VERSION" == '0.50.82' ]]; then
-    release_phase='A11'
-  else
-    fail 'public_key_receipt_release_identity_mismatch'
-  fi
+  resolve_public_key_receipt_release_phase
 fi
 
 artifact="$COMPANION_ARTIFACT"
@@ -239,60 +223,8 @@ mv -f -- "$receipt_temp" "$receipt_path"
 receipt_temp=''
 
 if [[ "$public_key_receipt_enabled" == '1' ]]; then
-  public_key_receipt_args=(companion-manifest public-key-receipt
-    --key-file "$COMPANION_SIGNING_KEY_FILE"
-    --bundle-output "$public_key_bundle_path"
-    --key-id "$COMPANION_KEY_ID"
-    --issued-at "$COMPANION_PUBLIC_KEY_RECEIPT_ISSUED_AT"
-    --expires-at "$COMPANION_PUBLIC_KEY_RECEIPT_EXPIRES_AT"
-    --handoff "$COMPANION_HANDOFF"
-    --minimum-rollback-floor "$COMPANION_ROLLBACK_FLOOR")
-  env -i PATH="$PATH" HOME="${HOME-}" TMPDIR="${TMPDIR:-/tmp}" \
-    "$COMPANION_SIGNER" "${public_key_receipt_args[@]}" >/dev/null \
-    || fail 'public key receipt production failed'
-  [[ -d "$public_key_bundle_path" && ! -L "$public_key_bundle_path" ]] \
-    || fail 'public key receipt production failed'
-  bundle_entry_count=$(find "$public_key_bundle_path" -mindepth 1 -maxdepth 1 -print | wc -l)
-  [[ "${bundle_entry_count//[[:space:]]/}" == '2' ]] \
-    || fail 'public key receipt production failed'
-  for entry in public-key-receipt.json public-key-receipt.sig; do
-    [[ -f "$public_key_bundle_path/$entry" && ! -L "$public_key_bundle_path/$entry" ]] \
-      || fail 'public key receipt production failed'
-  done
-  [[ "$(wc -c <"$public_key_bundle_path/public-key-receipt.sig" | tr -d '[:space:]')" == '64' ]] \
-    || fail 'public key receipt production failed'
-  env -i PATH="$PATH" HOME="${HOME-}" TMPDIR="${TMPDIR:-/tmp}" \
-    "$COMPANION_RECEIPT_VERIFIER" \
-    --receipt "$public_key_bundle_path/public-key-receipt.json" \
-    --signature "$public_key_bundle_path/public-key-receipt.sig" \
-    --signing-key "$COMPANION_SIGNING_KEY_FILE" \
-    --key-id "$COMPANION_KEY_ID" \
-    --issued-at "$COMPANION_PUBLIC_KEY_RECEIPT_ISSUED_AT" \
-    --expires-at "$COMPANION_PUBLIC_KEY_RECEIPT_EXPIRES_AT" \
-    --handoff "$COMPANION_HANDOFF" \
-    --minimum-rollback-floor "$COMPANION_ROLLBACK_FLOOR" \
-    || fail 'public key receipt independent verification failed'
-  if [[ -n "${COMPANION_MANIFEST_VERIFIER-}" ]]; then
-    env -i PATH="$PATH" HOME="${HOME-}" TMPDIR="${TMPDIR:-/tmp}" \
-      "$COMPANION_MANIFEST_VERIFIER" \
-      --artifact "$artifact_path" \
-      --manifest "$manifest_path" \
-      --signature "$signature_path" \
-      --receipt "$public_key_bundle_path/public-key-receipt.json" \
-      --receipt-signature "$public_key_bundle_path/public-key-receipt.sig" \
-      --signing-key "$COMPANION_SIGNING_KEY_FILE" \
-      --key-id "$COMPANION_KEY_ID" \
-      --version "$COMPANION_VERSION" \
-      --platform "$COMPANION_PLATFORM" \
-      --architecture "$COMPANION_ARCHITECTURE" \
-      --handoff "$COMPANION_HANDOFF" \
-      --minimum-rollback-floor "$COMPANION_ROLLBACK_FLOOR" \
-      || fail 'manifest and artifact independent verification failed'
-  fi
-  signing_key_digest_after=$(sha256_file "$COMPANION_SIGNING_KEY_FILE") \
-    || fail 'manifest_public_key_digest_mismatch'
-  [[ "$signing_key_digest_before" == "$signing_key_digest_after" ]] \
-    || fail 'manifest_public_key_digest_mismatch'
-  printf 'companion release: public key receipt phase %s produced\n' "$release_phase"
+  produce_public_key_receipt_bundle \
+    "$artifact_path" "$manifest_path" "$signature_path" \
+    "$public_key_bundle_path" "$signing_key_digest_before" "$release_phase"
 fi
 succeeded=1

--- a/scripts/companion-release/publish-homebrew-formula-bridge-git.sh
+++ b/scripts/companion-release/publish-homebrew-formula-bridge-git.sh
@@ -100,11 +100,12 @@ decode_api_content() {
 }
 
 sha256_file() {
-  local output digest
-  output=$("${sha256_command[@]}" "$1") || return 1
+  local path="$1" destination="$2" output digest
+  output=$("${sha256_command[@]}" "$path") || return 1
   digest="${output%%[[:space:]]*}"
   [[ "$digest" =~ ^[0-9a-f]{64}$ ]] || return 1
-  printf '%s' "$digest"
+  # @AX:REASON [AUTO]: Keep the caller in the trap-owning shell so temporary evidence cannot outlive its digest boundary.
+  printf -v "$destination" '%s' "$digest"
 }
 
 # @AX:ANCHOR [AUTO]: Preserve the sole compare-and-swap mutation orchestrator for the Homebrew tap.
@@ -128,8 +129,8 @@ publish_cask() {
   decode_api_content "$response" "$current"
   blob=$(jq -er '.sha | select(type == "string" and test("^[0-9a-f]{40}$"))' \
     "$response") || fail "Homebrew tap ${label} response has an invalid blob SHA"
-  target_digest=$(sha256_file "$target") || fail "cannot digest target ${label}"
-  current_digest=$(sha256_file "$current") || fail "cannot digest current ${label}"
+  sha256_file "$target" target_digest || fail "cannot digest target ${label}"
+  sha256_file "$current" current_digest || fail "cannot digest current ${label}"
   if [[ "$target_digest" == "$current_digest" ]] && cmp -s "$target" "$current"; then
     verify_idempotent_head_snapshot "$remote_path" "$blob" "$label"
     printf 'homebrew cask publication: %s is already current\n' "$label"

--- a/scripts/companion-release/publish-homebrew-formula-bridge-git.sh
+++ b/scripts/companion-release/publish-homebrew-formula-bridge-git.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+
+# @AX:ANCHOR [AUTO]: Preserve the authenticated Contents API read boundary.
+# @AX:REASON [AUTO]: Formula and Cask evidence must be read from the pinned tap repository and branch.
+api_get() {
+  local path="$1" output="$2"
+  if ! GH_TOKEN="$tap_token" gh api \
+    -H 'Accept: application/vnd.github+json' \
+    "repos/${TAP_REPOSITORY}/contents/${path}?ref=${TAP_BRANCH}" \
+    >"$output" 2>"$temp_dir/gh-error"; then
+    fail "cannot read ${path} from the Homebrew tap"
+  fi
+}
+
+# @AX:ANCHOR [AUTO]: Preserve the authenticated Git Data API request boundary.
+# @AX:REASON [AUTO]: Commit, tree, blob, and ref evidence must share identical token and error-isolation handling.
+api_json() {
+  local method="$1" endpoint="$2" input="$3" output="$4" label="$5"
+  local -a args=(api --method "$method" -H 'Accept: application/vnd.github+json'
+    "repos/${TAP_REPOSITORY}/${endpoint}")
+  [[ -z "$input" ]] || args+=(--input "$input")
+  if ! GH_TOKEN="$tap_token" gh "${args[@]}" >"$output" 2>"$temp_dir/gh-error"; then
+    fail "$label"
+  fi
+}
+
+verify_frozen_formula() {
+  local response="$temp_dir/formula-response.json" blob
+  api_get "$FORMULA_PATH" "$response"
+  blob=$(jq -er '.sha | select(type == "string" and test("^[0-9a-f]{40}$"))' \
+    "$response") || fail 'Homebrew tap Formula response has an invalid blob SHA'
+  [[ "$blob" == "$FROZEN_FORMULA_BLOB" ]] \
+    || fail 'published Formula differs from the frozen v0.50.71 blob'
+}
+
+verify_prior_tap_head() {
+  local response="$temp_dir/prior-tap-head.json" head_sha
+  api_json GET "git/ref/heads/${TAP_BRANCH}" '' "$response" \
+    'cannot read the Homebrew tap branch head'
+  head_sha=$(jq -er --arg ref "refs/heads/${TAP_BRANCH}" '
+    select(type == "object" and .ref == $ref and .object.type == "commit") |
+    .object.sha | select(type == "string" and test("^[0-9a-f]{40}$"))
+  ' "$response") || fail 'Homebrew tap branch head response is invalid'
+  [[ "$head_sha" == "$PRIOR_TAP_COMMIT" ]] \
+    || fail 'Homebrew tap branch differs from the pinned v0.50.81 predecessor commit'
+}
+
+# @AX:NOTE [AUTO]: [downgraded from ANCHOR — fan_in=1 under file cap] Bind idempotent success to one stable head, tree, Cask, and Formula snapshot.
+verify_idempotent_head_snapshot() {
+  local remote_path="$1" cask_blob="$2" label="$3"
+  local ref_response="$temp_dir/idempotent-ref.json"
+  local commit_response="$temp_dir/idempotent-commit.json"
+  local tree_response="$temp_dir/idempotent-tree.json"
+  local final_ref_response="$temp_dir/idempotent-final-ref.json"
+  local head_sha tree_sha
+  api_json GET "git/ref/heads/${TAP_BRANCH}" '' "$ref_response" \
+    "cannot read the Homebrew tap ${label} idempotent head"
+  head_sha=$(jq -er --arg ref "refs/heads/${TAP_BRANCH}" '
+    select(type == "object" and .ref == $ref and .object.type == "commit" and
+      (.object.url | type) == "string" and (.object.url | length) > 0) |
+    .object.sha | select(type == "string" and test("^[0-9a-f]{40}$"))
+  ' "$ref_response") || fail "Homebrew tap ${label} idempotent head response is invalid"
+  api_json GET "git/commits/${head_sha}" '' "$commit_response" \
+    "cannot read the Homebrew tap ${label} idempotent commit"
+  tree_sha=$(jq -er --arg commit "$head_sha" '
+    select(type == "object" and .sha == $commit and (.tree | type) == "object" and
+      (.url | type) == "string" and (.url | length) > 0) |
+    .tree.sha | select(type == "string" and test("^[0-9a-f]{40}$"))
+  ' "$commit_response") || fail "Homebrew tap ${label} idempotent commit response is invalid"
+  api_json GET "git/trees/${tree_sha}?recursive=1" '' "$tree_response" \
+    "cannot read the Homebrew tap ${label} idempotent tree"
+  jq -e --arg tree "$tree_sha" --arg cask "$remote_path" --arg blob "$cask_blob" \
+    --arg formula "$FORMULA_PATH" --arg frozen "$FROZEN_FORMULA_BLOB" '
+    type == "object" and .sha == $tree and .truncated == false and
+    (.tree | type) == "array" and
+    ([.tree[] | select(.path == $cask)] | length) == 1 and
+    ([.tree[] | select(.path == $cask and .mode == "100644" and
+      .type == "blob" and .sha == $blob)] | length) == 1 and
+    ([.tree[] | select(.path == $formula)] | length) == 1 and
+    ([.tree[] | select(.path == $formula and .mode == "100644" and
+      .type == "blob" and .sha == $frozen)] | length) == 1
+  ' "$tree_response" >/dev/null \
+    || fail "Homebrew tap ${label} idempotent tree does not preserve exact Cask/Formula blobs"
+  api_json GET "git/ref/heads/${TAP_BRANCH}" '' "$final_ref_response" \
+    "cannot reread the Homebrew tap ${label} idempotent head"
+  jq -e --arg ref "refs/heads/${TAP_BRANCH}" --arg head "$head_sha" '
+    type == "object" and .ref == $ref and .object.type == "commit" and
+    .object.sha == $head and (.object.url | type) == "string" and
+    (.object.url | length) > 0
+  ' "$final_ref_response" >/dev/null \
+    || fail "Homebrew tap ${label} head moved during idempotent verification"
+}
+
+decode_api_content() {
+  local response="$1" output="$2" encoded
+  encoded=$(jq -er '.content | select(type == "string")' "$response") \
+    || fail 'Homebrew tap response is missing encoded content'
+  printf '%s' "$encoded" | tr -d '\r\n' | "${base64_decode[@]}" >"$output" \
+    || fail 'Homebrew tap content is not valid base64'
+}
+
+sha256_file() {
+  local output digest
+  output=$("${sha256_command[@]}" "$1") || return 1
+  digest="${output%%[[:space:]]*}"
+  [[ "$digest" =~ ^[0-9a-f]{64}$ ]] || return 1
+  printf '%s' "$digest"
+}
+
+# @AX:ANCHOR [AUTO]: Preserve the sole compare-and-swap mutation orchestrator for the Homebrew tap.
+# @AX:REASON [AUTO]: Publication must advance only the pinned predecessor through blob, tree, commit, and non-force ref updates.
+# @AX:WARN [AUTO]: This function contains more than eight publication and verification branches.
+# @AX:REASON [AUTO]: Predecessor, frozen Formula, Cask blob, tree, commit, ref CAS, and post-read checks must remain ordered.
+publish_cask() {
+  local stem="$1" label="$2" remote_path="$3" target="$4" prior_blob="$5"
+  local commit_message="$6" drift_message="$7"
+  local response="$temp_dir/${stem}-response.json"
+  local current="$temp_dir/${stem}-current.rb"
+  local target_digest current_digest blob encoded prior_tree new_blob new_tree new_commit
+  local prior_commit_response="$temp_dir/prior-commit.json" blob_request="$temp_dir/${stem}-blob-request.json"
+  local blob_response="$temp_dir/${stem}-blob-response.json" tree_request="$temp_dir/${stem}-tree-request.json"
+  local tree_response="$temp_dir/${stem}-tree-response.json" tree_evidence_response="$temp_dir/${stem}-tree-evidence-response.json"
+  local commit_request="$temp_dir/${stem}-commit-request.json" commit_response="$temp_dir/${stem}-commit-response.json"
+  local ref_request="$temp_dir/${stem}-ref-request.json" ref_response="$temp_dir/${stem}-ref-response.json"
+  local final_ref_response="$temp_dir/${stem}-final-ref-response.json"
+
+  api_get "$remote_path" "$response"
+  decode_api_content "$response" "$current"
+  blob=$(jq -er '.sha | select(type == "string" and test("^[0-9a-f]{40}$"))' \
+    "$response") || fail "Homebrew tap ${label} response has an invalid blob SHA"
+  target_digest=$(sha256_file "$target") || fail "cannot digest target ${label}"
+  current_digest=$(sha256_file "$current") || fail "cannot digest current ${label}"
+  if [[ "$target_digest" == "$current_digest" ]] && cmp -s "$target" "$current"; then
+    verify_idempotent_head_snapshot "$remote_path" "$blob" "$label"
+    printf 'homebrew cask publication: %s is already current\n' "$label"
+    return 0
+  fi
+
+  verify_prior_tap_head
+  [[ "$blob" == "$prior_blob" ]] || fail "$drift_message"
+  api_json GET "git/commits/${PRIOR_TAP_COMMIT}" '' "$prior_commit_response" \
+    'cannot read the pinned Homebrew tap predecessor commit'
+  prior_tree=$(jq -er --arg commit "$PRIOR_TAP_COMMIT" '
+    select(type == "object" and .sha == $commit and (.parents | type) == "array" and
+      (.url | type) == "string" and (.url | length) > 0) |
+    .tree.sha | select(type == "string" and test("^[0-9a-f]{40}$"))
+  ' "$prior_commit_response") || fail 'pinned Homebrew predecessor commit response is invalid'
+  encoded=$(base64 <"$target" | tr -d '\r\n') \
+    || fail "cannot encode target ${label}"
+  jq -n --arg content "$encoded" '{content:$content,encoding:"base64"}' \
+    >"$blob_request" || fail "cannot construct ${label} blob request"
+  api_json POST 'git/blobs' "$blob_request" "$blob_response" \
+    "cannot create Homebrew tap ${label} blob"
+  new_blob=$(jq -er '
+    select(type == "object" and (.url | type) == "string" and (.url | length) > 0) |
+    .sha | select(type == "string" and test("^[0-9a-f]{40}$"))
+  ' "$blob_response") || fail "Homebrew tap ${label} blob response is invalid"
+  jq -n --arg base "$prior_tree" --arg path "$remote_path" --arg sha "$new_blob" \
+    '{base_tree:$base,tree:[{path:$path,mode:"100644",type:"blob",sha:$sha}]}' \
+    >"$tree_request" || fail "cannot construct ${label} tree request"
+  api_json POST 'git/trees' "$tree_request" "$tree_response" \
+    "cannot create Homebrew tap ${label} tree"
+  new_tree=$(jq -er '
+    select(type == "object" and .truncated == false and (.tree | type) == "array" and
+      (.url | type) == "string" and (.url | length) > 0) |
+    .sha | select(type == "string" and test("^[0-9a-f]{40}$"))
+  ' "$tree_response") || fail "Homebrew tap ${label} tree response is invalid"
+  api_json GET "git/trees/${new_tree}?recursive=1" '' "$tree_evidence_response" \
+    "cannot verify Homebrew tap ${label} tree"
+  jq -e --arg tree "$new_tree" --arg cask "$remote_path" --arg blob "$new_blob" \
+    --arg formula "$FORMULA_PATH" --arg frozen "$FROZEN_FORMULA_BLOB" '
+    type == "object" and .sha == $tree and .truncated == false and
+    (.tree | type) == "array" and
+    ([.tree[] | select(.path == $cask and .mode == "100644" and
+      .type == "blob" and .sha == $blob)] | length) == 1 and
+    ([.tree[] | select(.path == $formula and .mode == "100644" and
+      .type == "blob" and .sha == $frozen)] | length) == 1
+  ' "$tree_evidence_response" >/dev/null \
+    || fail "Homebrew tap ${label} tree does not preserve exact Cask/Formula blobs"
+  jq -n --arg message "$commit_message" --arg tree "$new_tree" \
+    --arg parent "$PRIOR_TAP_COMMIT" \
+    '{message:$message,tree:$tree,parents:[$parent]}' >"$commit_request" \
+    || fail "cannot construct ${label} commit request"
+  api_json POST 'git/commits' "$commit_request" "$commit_response" \
+    "cannot create Homebrew tap ${label} commit"
+  new_commit=$(jq -er --arg message "$commit_message" --arg tree "$new_tree" \
+    --arg parent "$PRIOR_TAP_COMMIT" '
+    select(type == "object" and (.url | type) == "string" and (.url | length) > 0 and
+      .message == $message and .tree.sha == $tree and
+      (.parents | type) == "array" and (.parents | length) == 1 and
+      .parents[0].sha == $parent) |
+    .sha | select(type == "string" and test("^[0-9a-f]{40}$"))
+  ' "$commit_response") || fail "Homebrew tap ${label} commit response is invalid"
+  jq -n --arg sha "$new_commit" '{sha:$sha,force:false}' >"$ref_request" \
+    || fail "cannot construct ${label} ref request"
+  api_json PATCH "git/refs/heads/${TAP_BRANCH}" "$ref_request" "$ref_response" \
+    "Homebrew tap ${label} expected-head update failed"
+  jq -e --arg ref "refs/heads/${TAP_BRANCH}" --arg commit "$new_commit" '
+    type == "object" and .ref == $ref and .object.type == "commit" and
+    .object.sha == $commit and (.object.url | type) == "string" and
+    (.object.url | length) > 0
+  ' "$ref_response" >/dev/null || fail "Homebrew tap ${label} ref response is invalid"
+  api_json GET "git/ref/heads/${TAP_BRANCH}" '' "$final_ref_response" \
+    'cannot verify the final Homebrew tap branch head'
+  jq -e --arg ref "refs/heads/${TAP_BRANCH}" --arg commit "$new_commit" '
+    type == "object" and .ref == $ref and .object.type == "commit" and
+    .object.sha == $commit and (.object.url | type) == "string" and
+    (.object.url | length) > 0
+  ' "$final_ref_response" >/dev/null || fail "Homebrew tap ${label} head moved after publication"
+
+  api_get "$remote_path" "$response"
+  decode_api_content "$response" "$current"
+  [[ "$(jq -er '.sha' "$response")" == "$new_blob" ]] && cmp -s "$target" "$current" \
+    || fail "Homebrew tap ${label} differs after publication"
+  printf 'homebrew cask publication: %s published and verified\n' "$label"
+}

--- a/scripts/companion-release/publish-homebrew-formula-bridge-git.sh
+++ b/scripts/companion-release/publish-homebrew-formula-bridge-git.sh
@@ -100,12 +100,11 @@ decode_api_content() {
 }
 
 sha256_file() {
-  local path="$1" destination="$2" output digest
-  output=$("${sha256_command[@]}" "$path") || return 1
+  local output digest
+  output=$("${sha256_command[@]}" "$1") || return 1
   digest="${output%%[[:space:]]*}"
   [[ "$digest" =~ ^[0-9a-f]{64}$ ]] || return 1
-  # @AX:REASON [AUTO]: Keep the caller in the trap-owning shell so temporary evidence cannot outlive its digest boundary.
-  printf -v "$destination" '%s' "$digest"
+  printf '%s' "$digest"
 }
 
 # @AX:ANCHOR [AUTO]: Preserve the sole compare-and-swap mutation orchestrator for the Homebrew tap.
@@ -129,8 +128,8 @@ publish_cask() {
   decode_api_content "$response" "$current"
   blob=$(jq -er '.sha | select(type == "string" and test("^[0-9a-f]{40}$"))' \
     "$response") || fail "Homebrew tap ${label} response has an invalid blob SHA"
-  sha256_file "$target" target_digest || fail "cannot digest target ${label}"
-  sha256_file "$current" current_digest || fail "cannot digest current ${label}"
+  target_digest=$(sha256_file "$target") || fail "cannot digest target ${label}"
+  current_digest=$(sha256_file "$current") || fail "cannot digest current ${label}"
   if [[ "$target_digest" == "$current_digest" ]] && cmp -s "$target" "$current"; then
     verify_idempotent_head_snapshot "$remote_path" "$blob" "$label"
     printf 'homebrew cask publication: %s is already current\n' "$label"

--- a/scripts/companion-release/publish-homebrew-formula-bridge.sh
+++ b/scripts/companion-release/publish-homebrew-formula-bridge.sh
@@ -123,54 +123,16 @@ trap 'exit 1' HUP INT TERM
 temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/autopus-homebrew-bridge.XXXXXX") \
   || fail 'cannot create private temporary directory'
 
-api_get() {
-  local path="$1" output="$2"
-  if ! GH_TOKEN="$tap_token" gh api \
-    -H 'Accept: application/vnd.github+json' \
-    "repos/${TAP_REPOSITORY}/contents/${path}?ref=${TAP_BRANCH}" \
-    >"$output" 2>"$temp_dir/gh-error"; then
-    fail "cannot read ${path} from the Homebrew tap"
-  fi
-}
-
-api_json() {
-  local method="$1" endpoint="$2" input="$3" output="$4" label="$5"
-  local -a args=(api --method "$method" -H 'Accept: application/vnd.github+json'
-    "repos/${TAP_REPOSITORY}/${endpoint}")
-  [[ -z "$input" ]] || args+=(--input "$input")
-  if ! GH_TOKEN="$tap_token" gh "${args[@]}" >"$output" 2>"$temp_dir/gh-error"; then
-    fail "$label"
-  fi
-}
-
-verify_frozen_formula() {
-  local response="$temp_dir/formula-response.json" blob
-  api_get "$FORMULA_PATH" "$response"
-  blob=$(jq -er '.sha | select(type == "string" and test("^[0-9a-f]{40}$"))' \
-    "$response") || fail 'Homebrew tap Formula response has an invalid blob SHA'
-  [[ "$blob" == "$FROZEN_FORMULA_BLOB" ]] \
-    || fail 'published Formula differs from the frozen v0.50.71 blob'
-}
-
-verify_prior_tap_head() {
-  local response="$temp_dir/prior-tap-head.json" head_sha
-  api_json GET "git/ref/heads/${TAP_BRANCH}" '' "$response" \
-    'cannot read the Homebrew tap branch head'
-  head_sha=$(jq -er --arg ref "refs/heads/${TAP_BRANCH}" '
-    select(type == "object" and .ref == $ref and .object.type == "commit") |
-    .object.sha | select(type == "string" and test("^[0-9a-f]{40}$"))
-  ' "$response") || fail 'Homebrew tap branch head response is invalid'
-  [[ "$head_sha" == "$PRIOR_TAP_COMMIT" ]] \
-    || fail 'Homebrew tap branch differs from the pinned v0.50.81 predecessor commit'
-}
-
-decode_api_content() {
-  local response="$1" output="$2" encoded
-  encoded=$(jq -er '.content | select(type == "string")' "$response") \
-    || fail 'Homebrew tap response is missing encoded content'
-  printf '%s' "$encoded" | tr -d '\r\n' | "${base64_decode[@]}" >"$output" \
-    || fail 'Homebrew tap content is not valid base64'
-}
+git_helper="$script_dir/publish-homebrew-formula-bridge-git.sh"
+[[ -f "$git_helper" && ! -L "$git_helper" ]] \
+  || fail 'Formula bridge Git helper is not a regular non-symlink file'
+# shellcheck source=publish-homebrew-formula-bridge-git.sh
+source "$git_helper"
+for contract in api_get api_json verify_frozen_formula verify_prior_tap_head \
+  decode_api_content sha256_file publish_cask
+do
+  declare -F "$contract" >/dev/null || fail 'Formula bridge Git contract is incomplete'
+done
 
 cask_target="$temp_dir/cask-target.rb"
 render_homebrew_cask "$cask_target" "$RELEASE_VERSION" \
@@ -181,117 +143,6 @@ if [[ -n "${COMPANION_CASK_PATH-}" ]]; then
   cmp -s "$cask_target" "$COMPANION_CASK_PATH" \
     || fail 'GoReleaser Cask output differs from the canonical renderer'
 fi
-
-sha256_file() {
-  local output digest
-  output=$("${sha256_command[@]}" "$1") || return 1
-  digest="${output%%[[:space:]]*}"
-  [[ "$digest" =~ ^[0-9a-f]{64}$ ]] || return 1
-  printf '%s' "$digest"
-}
-
-publish_cask() {
-  local stem="$1" label="$2" remote_path="$3" target="$4" prior_blob="$5"
-  local commit_message="$6" drift_message="$7"
-  local response="$temp_dir/${stem}-response.json"
-  local current="$temp_dir/${stem}-current.rb"
-  local target_digest current_digest blob encoded prior_tree new_blob new_tree new_commit
-  local prior_commit_response="$temp_dir/prior-commit.json" blob_request="$temp_dir/${stem}-blob-request.json"
-  local blob_response="$temp_dir/${stem}-blob-response.json" tree_request="$temp_dir/${stem}-tree-request.json"
-  local tree_response="$temp_dir/${stem}-tree-response.json" tree_evidence_response="$temp_dir/${stem}-tree-evidence-response.json"
-  local commit_request="$temp_dir/${stem}-commit-request.json" commit_response="$temp_dir/${stem}-commit-response.json"
-  local ref_request="$temp_dir/${stem}-ref-request.json" ref_response="$temp_dir/${stem}-ref-response.json"
-  local final_ref_response="$temp_dir/${stem}-final-ref-response.json"
-
-  api_get "$remote_path" "$response"
-  decode_api_content "$response" "$current"
-  target_digest=$(sha256_file "$target") || fail "cannot digest target ${label}"
-  current_digest=$(sha256_file "$current") || fail "cannot digest current ${label}"
-  if [[ "$target_digest" == "$current_digest" ]] && cmp -s "$target" "$current"; then
-    printf 'homebrew cask publication: %s is already current\n' "$label"
-    return 0
-  fi
-
-  verify_prior_tap_head
-  blob=$(jq -er '.sha | select(type == "string" and test("^[0-9a-f]{40}$"))' \
-    "$response") || fail "Homebrew tap ${label} response has an invalid blob SHA"
-  [[ "$blob" == "$prior_blob" ]] || fail "$drift_message"
-  api_json GET "git/commits/${PRIOR_TAP_COMMIT}" '' "$prior_commit_response" \
-    'cannot read the pinned Homebrew tap predecessor commit'
-  prior_tree=$(jq -er --arg commit "$PRIOR_TAP_COMMIT" '
-    select(type == "object" and .sha == $commit and (.parents | type) == "array" and
-      (.url | type) == "string" and (.url | length) > 0) |
-    .tree.sha | select(type == "string" and test("^[0-9a-f]{40}$"))
-  ' "$prior_commit_response") || fail 'pinned Homebrew predecessor commit response is invalid'
-  encoded=$(base64 <"$target" | tr -d '\r\n') \
-    || fail "cannot encode target ${label}"
-  jq -n --arg content "$encoded" '{content:$content,encoding:"base64"}' \
-    >"$blob_request" || fail "cannot construct ${label} blob request"
-  api_json POST 'git/blobs' "$blob_request" "$blob_response" \
-    "cannot create Homebrew tap ${label} blob"
-  new_blob=$(jq -er '
-    select(type == "object" and (.url | type) == "string" and (.url | length) > 0) |
-    .sha | select(type == "string" and test("^[0-9a-f]{40}$"))
-  ' "$blob_response") || fail "Homebrew tap ${label} blob response is invalid"
-  jq -n --arg base "$prior_tree" --arg path "$remote_path" --arg sha "$new_blob" \
-    '{base_tree:$base,tree:[{path:$path,mode:"100644",type:"blob",sha:$sha}]}' \
-    >"$tree_request" || fail "cannot construct ${label} tree request"
-  api_json POST 'git/trees' "$tree_request" "$tree_response" \
-    "cannot create Homebrew tap ${label} tree"
-  new_tree=$(jq -er '
-    select(type == "object" and .truncated == false and (.tree | type) == "array" and
-      (.url | type) == "string" and (.url | length) > 0) |
-    .sha | select(type == "string" and test("^[0-9a-f]{40}$"))
-  ' "$tree_response") || fail "Homebrew tap ${label} tree response is invalid"
-  api_json GET "git/trees/${new_tree}?recursive=1" '' "$tree_evidence_response" \
-    "cannot verify Homebrew tap ${label} tree"
-  jq -e --arg tree "$new_tree" --arg cask "$remote_path" --arg blob "$new_blob" \
-    --arg formula "$FORMULA_PATH" --arg frozen "$FROZEN_FORMULA_BLOB" '
-    type == "object" and .sha == $tree and .truncated == false and
-    (.tree | type) == "array" and
-    ([.tree[] | select(.path == $cask and .mode == "100644" and
-      .type == "blob" and .sha == $blob)] | length) == 1 and
-    ([.tree[] | select(.path == $formula and .mode == "100644" and
-      .type == "blob" and .sha == $frozen)] | length) == 1
-  ' "$tree_evidence_response" >/dev/null \
-    || fail "Homebrew tap ${label} tree does not preserve exact Cask/Formula blobs"
-  jq -n --arg message "$commit_message" --arg tree "$new_tree" \
-    --arg parent "$PRIOR_TAP_COMMIT" \
-    '{message:$message,tree:$tree,parents:[$parent]}' >"$commit_request" \
-    || fail "cannot construct ${label} commit request"
-  api_json POST 'git/commits' "$commit_request" "$commit_response" \
-    "cannot create Homebrew tap ${label} commit"
-  new_commit=$(jq -er --arg message "$commit_message" --arg tree "$new_tree" \
-    --arg parent "$PRIOR_TAP_COMMIT" '
-    select(type == "object" and (.url | type) == "string" and (.url | length) > 0 and
-      .message == $message and .tree.sha == $tree and
-      (.parents | type) == "array" and (.parents | length) == 1 and
-      .parents[0].sha == $parent) |
-    .sha | select(type == "string" and test("^[0-9a-f]{40}$"))
-  ' "$commit_response") || fail "Homebrew tap ${label} commit response is invalid"
-  jq -n --arg sha "$new_commit" '{sha:$sha,force:false}' >"$ref_request" \
-    || fail "cannot construct ${label} ref request"
-  api_json PATCH "git/refs/heads/${TAP_BRANCH}" "$ref_request" "$ref_response" \
-    "Homebrew tap ${label} expected-head update failed"
-  jq -e --arg ref "refs/heads/${TAP_BRANCH}" --arg commit "$new_commit" '
-    type == "object" and .ref == $ref and .object.type == "commit" and
-    .object.sha == $commit and (.object.url | type) == "string" and
-    (.object.url | length) > 0
-  ' "$ref_response" >/dev/null || fail "Homebrew tap ${label} ref response is invalid"
-  api_json GET "git/ref/heads/${TAP_BRANCH}" '' "$final_ref_response" \
-    'cannot verify the final Homebrew tap branch head'
-  jq -e --arg ref "refs/heads/${TAP_BRANCH}" --arg commit "$new_commit" '
-    type == "object" and .ref == $ref and .object.type == "commit" and
-    .object.sha == $commit and (.object.url | type) == "string" and
-    (.object.url | length) > 0
-  ' "$final_ref_response" >/dev/null || fail "Homebrew tap ${label} head moved after publication"
-
-  api_get "$remote_path" "$response"
-  decode_api_content "$response" "$current"
-  [[ "$(jq -er '.sha' "$response")" == "$new_blob" ]] && cmp -s "$target" "$current" \
-    || fail "Homebrew tap ${label} differs after publication"
-  printf 'homebrew cask publication: %s published and verified\n' "$label"
-}
 
 verify_frozen_formula
 publish_cask cask Cask "$CASK_PATH" "$cask_target" "$PRIOR_CASK_BLOB" \

--- a/scripts/companion-release/tests/release-hardening-test.sh
+++ b/scripts/companion-release/tests/release-hardening-test.sh
@@ -13,12 +13,12 @@ config="$repo/.goreleaser.yaml"
 release="$repo/.github/workflows/release.yaml"
 recovery="$repo/.github/workflows/homebrew-formula-bridge-recovery.yaml"
 source_gate="$script_dir/validate-source.sh"
-environment_gate="$script_dir/validate-environment.sh"
-lineage_archive="$script_dir/verify-public-key-lineage-archive.sh"
 lineage="$script_dir/verify-public-key-lineage.sh"
+lineage_coordinates="$script_dir/verify-public-key-lineage-coordinates.sh"
 lineage_pins="$script_dir/verify-public-key-lineage-pins.sh"
 producer="$script_dir/produce.sh"
 homebrew_bridge="$script_dir/publish-homebrew-formula-bridge.sh"
+homebrew_git_helper="$script_dir/publish-homebrew-formula-bridge-git.sh"
 current_release_gate="$script_dir/verify-current-release.sh"
 
 # GoReleaser must render, but never publish, the Cask or mutate tagged source.
@@ -47,15 +47,16 @@ contains "$homebrew_bridge" "readonly PRIOR_CASK_BLOB='c6edb108d821d88914e12d2c1
 contains "$homebrew_bridge" "readonly FROZEN_FORMULA_BLOB='4ebc6c38925002dec00759823d4dd847a499818a'"
 contains "$homebrew_bridge" 'COMPANION_HOMEBREW_POLICY'
 contains "$homebrew_bridge" "readonly FORMULA_PATH='Formula/auto.rb'"
-contains "$homebrew_bridge" 'verify_frozen_formula'
-not_contains "$homebrew_bridge" 'reconcile_tap_file formula Formula'
-contains "$homebrew_bridge" "api_json POST 'git/blobs'"
-contains "$homebrew_bridge" "api_json POST 'git/trees'"
-contains "$homebrew_bridge" "api_json POST 'git/commits'"
-contains "$homebrew_bridge" 'api_json PATCH "git/refs/heads/${TAP_BRANCH}"'
-contains "$homebrew_bridge" '{base_tree:$base,tree:['
-contains "$homebrew_bridge" "'{sha:\$sha,force:false}'"
-not_contains "$homebrew_bridge" '--method PUT'
+contains "$homebrew_bridge" 'source "$git_helper"'
+contains "$homebrew_git_helper" 'verify_frozen_formula'
+not_contains "$homebrew_git_helper" 'reconcile_tap_file formula Formula'
+contains "$homebrew_git_helper" "api_json POST 'git/blobs'"
+contains "$homebrew_git_helper" "api_json POST 'git/trees'"
+contains "$homebrew_git_helper" "api_json POST 'git/commits'"
+contains "$homebrew_git_helper" 'api_json PATCH "git/refs/heads/${TAP_BRANCH}"'
+contains "$homebrew_git_helper" '{base_tree:$base,tree:['
+contains "$homebrew_git_helper" "'{sha:\$sha,force:false}'"
+not_contains "$homebrew_git_helper" '--method PUT'
 
 # Production/recovery source coordinates must bind to externally approved exact values.
 for workflow in "$release" "$recovery"; do
@@ -89,6 +90,7 @@ contains "$source_gate" "readonly A9_A8_ANCESTOR_SHA='dd0c2759ed5435d4634011e349
 contains "$source_gate" "readonly A10_A9_ANCESTOR_SHA='c9c4f49d48022eb0c8d72ee7b520136a4f21f176'"
 contains "$source_gate" "readonly A11_A10_ANCESTOR_SHA='54536edc09c37a634532c2c9b51e62869d393db4'"
 contains "$lineage" 'source "$pins_helper"'
+contains "$lineage" 'source "$coordinates_helper"'
 contains "$lineage_pins" "A4_TAG_OBJECT_SHA='b1ebab0af82536f8a4bc1ed93f31f82f6c53d008'"
 contains "$lineage_pins" "A4_CHECKSUMS_SHA256='a30e0893f1565919e9e90dd7e1f2b19e5487024b0373f66de56729e1d747e7d1'"
 contains "$lineage_pins" "A4_AMD64_ARCHIVE_SHA256='da7f6ef4396591ff0b728f976536d261ecb084038fffab7c7662a6f7329ade2a'"
@@ -140,10 +142,10 @@ contains "$lineage_pins" "A10_AMD64_ARCHIVE_SHA256='b745eaddd8c70cb415aca4290121
 contains "$lineage_pins" "A10_ARM64_ARCHIVE_SHA256='71a40ee709f34fb29bb562cde4587e2da1db1d6e8bc300d0edb4cfe63f8bec3c'"
 contains "$lineage_pins" "A10_AMD64_MANIFEST_SHA256='98b38d8d59c5d146234e5a5f9bae26e80f8af0f699ac23e3f9fed5e59b32321e'"
 contains "$lineage_pins" "A10_ARM64_MANIFEST_SHA256='976aa2bbeedd4e32b522373f6bf75a93b15f6813c4373c638c27d2cb98e4f00a'"
-contains "$lineage" "release_phase='A8' prior_phase='A7'"
-contains "$lineage" "release_phase='A9' prior_phase='A8'"
-contains "$lineage" "release_phase='A10' prior_phase='A9'"
-contains "$lineage" "release_phase='A11' prior_phase='A10'"
+contains "$lineage_coordinates" "release_phase='A8' prior_phase='A7'"
+contains "$lineage_coordinates" "release_phase='A9' prior_phase='A8'"
+contains "$lineage_coordinates" "release_phase='A10' prior_phase='A9'"
+contains "$lineage_coordinates" "release_phase='A11' prior_phase='A10'"
 contains "$lineage" '.commit.tree.sha'
 contains "$producer" "GITHUB_REF_NAME\" == 'v0.50.82'"
 contains "$producer" "release_phase='A11'"
@@ -170,130 +172,7 @@ contains "$current_release_gate" '.size > 0'
 contains "$current_release_gate" '^sha256:[0-9a-f]{64}$'
 contains "$current_release_gate" 'for archive in "${EXPECTED_ARCHIVES[@]}"'
 
-temp=$(mktemp -d "${TMPDIR:-/tmp}/release-hardening-test.XXXXXX")
-trap 'rm -rf -- "$temp"' EXIT
-git clone -q --no-hardlinks --no-tags "$repo" "$temp/source"
-git -C "$temp/source" config user.name 'Release Test'
-git -C "$temp/source" config user.email release-test@example.invalid
-git -C "$temp/source" tag -am 'A11 fixture' v0.50.82
-commit=$(git -C "$temp/source" rev-parse HEAD)
-tree=$(git -C "$temp/source" rev-parse 'HEAD^{tree}')
-if [[ "${tree: -1}" == '0' ]]; then
-  wrong_tree="${tree%?}1"
-else
-  wrong_tree="${tree%?}0"
-fi
-run_source_gate() {
-  local approved_commit="${1-}" approved_tree="${2-}"
-  env GITHUB_REF_NAME=v0.50.82 GITHUB_REF_TYPE=tag GITHUB_SHA="$commit" \
-    GITHUB_OUTPUT="$temp/source-output" COMPANION_SOURCE_PIN_REQUIRED=1 \
-    COMPANION_APPROVED_SOURCE_COMMIT="$approved_commit" \
-    COMPANION_APPROVED_SOURCE_TREE="$approved_tree" \
-    bash "$source_gate"
-}
-if (cd "$temp/source" && run_source_gate '' '') >/dev/null 2>&1; then
-  fail 'missing approved source pins passed'
-fi
-if (cd "$temp/source" && run_source_gate "$commit" "$wrong_tree") >/dev/null 2>&1; then
-  fail 'wrong approved source tree passed'
-fi
-(cd "$temp/source" && run_source_gate "$commit" "$tree") >/dev/null
-
-# Current-time checks must reject expired production material.
-touch "$temp/key" "$temp/api-key"
-chmod 0600 "$temp/key" "$temp/api-key"
-printf '#!/usr/bin/env bash\nexit 0\n' >"$temp/tool"
-chmod 0700 "$temp/tool"
-format_time() {
-  if date -u -r "$1" '+%Y-%m-%dT%H:%M:%SZ' >/dev/null 2>&1; then
-    date -u -r "$1" '+%Y-%m-%dT%H:%M:%SZ'
-  else
-    date -u -d "@$1" '+%Y-%m-%dT%H:%M:%SZ'
-  fi
-}
-now=$(date -u '+%s')
-validation_env=(
-  COMPANION_BUILD_PROVENANCE=github-actions:fixture@0123456789abcdef
-  COMPANION_HANDOFF=v1 COMPANION_ROLLBACK_FLOOR=5069
-  COMPANION_KEY_ID=adk-release-2026-q3-b0 COMPANION_SIGNING_KEY_FILE="$temp/key"
-  COMPANION_SIGNER="$temp/tool" COMPANION_RECEIPT_VERIFIER="$temp/tool"
-  COMPANION_MANIFEST_VERIFIER="$temp/tool" COMPANION_RELEASE_TIME_VALIDATION_REQUIRED=1
-  COMPANION_PUBLIC_KEY_RECEIPT_MINIMUM_LIFETIME_SECONDS=31536000
-  COMPANION_PUBLIC_KEY_RECEIPT_ISSUED_AT="$(format_time "$((now - 86400))")"
-  COMPANION_PUBLIC_KEY_RECEIPT_EXPIRES_AT="$(format_time "$((now + 31536001))")"
-  APPLE_SIGNING_IDENTITY='Developer ID Application: Fixture (GP2PFA2PUV)'
-  APPLE_API_KEY=FIXTURE APPLE_API_ISSUER=123e4567-e89b-42d3-a456-426614174000
-  APPLE_API_KEY_PATH="$temp/api-key"
-)
-env "${validation_env[@]}" COMPANION_ISSUED_AT="$(format_time "$((now - 60))")" \
-  COMPANION_EXPIRES_AT="$(format_time "$((now + 3600))")" bash "$environment_gate"
-if env "${validation_env[@]}" COMPANION_ISSUED_AT="$(format_time "$((now - 7200))")" \
-  COMPANION_EXPIRES_AT="$(format_time "$((now - 3600))")" bash "$environment_gate" >/dev/null 2>&1; then
-  fail 'expired manifest window passed'
-fi
-
-# The independent verifier must bind receipt key -> manifest signature -> artifact.
-verifier="$temp/manifest-verifier"
-go build -trimpath -o "$verifier" "$repo/scripts/companion-release/manifestverify"
-go run "$tests_dir/testdata/generate-manifest-fixture.go" "$temp/manifest"
-trusted_key_sha=$(jq -er '.public_key_sha256' "$temp/manifest/public-key-receipt.json")
-install -m 0600 "$temp/manifest/signing-key" "$temp/trusted-signing-key"
-common_verify_args=(
-  --artifact "$temp/manifest/auto" --manifest "$temp/manifest/adk-companion-manifest.json"
-  --signature "$temp/manifest/adk-companion-manifest.sig"
-  --receipt "$temp/manifest/public-key-receipt.json"
-  --receipt-signature "$temp/manifest/public-key-receipt.sig"
-  --key-id adk-release-2026-q3-b0 --version 0.50.71 --platform darwin
-  --architecture arm64 --handoff v1 --minimum-rollback-floor 5069
-)
-signing_verify_args=("${common_verify_args[@]}" --signing-key "$temp/trusted-signing-key")
-pin_verify_args=("${common_verify_args[@]}" --public-key-sha256 "$trusted_key_sha")
-"$verifier" "${signing_verify_args[@]}"
-"$verifier" "${pin_verify_args[@]}"
-if "$verifier" "${common_verify_args[@]}" >/dev/null 2>&1; then
-  fail 'unanchored self-signed receipt passed'
-fi
-if "$verifier" "${signing_verify_args[@]}" --public-key-sha256 "$trusted_key_sha" \
-  >/dev/null 2>&1; then
-  fail 'ambiguous duplicate trust anchors passed'
-fi
-if "$verifier" "${common_verify_args[@]}" \
-  --signing-key "$temp/manifest/inconsistent-signing-key" >/dev/null 2>&1; then
-  fail 'inconsistent private/public signing key passed'
-fi
-printf 'tamper\n' >>"$temp/manifest/auto"
-if "$verifier" "${signing_verify_args[@]}" >/dev/null 2>&1; then fail 'tampered artifact passed'; fi
-printf 'signed companion artifact\n' >"$temp/manifest/auto"
-manifest_signature="$temp/manifest/adk-companion-manifest.sig"
-signature_size_before=$(wc -c <"$manifest_signature")
-(( signature_size_before == 64 )) || fail 'fixture manifest signature length drifted'
-signature_byte_before=$(od -An -tu1 -N1 "$manifest_signature" | tr -d '[:space:]')
-case "$signature_byte_before" in
-  1) signature_byte_replacement=2 ;;
-  ''|*[!0-9]*) fail 'fixture manifest signature byte could not be read' ;;
-  *) signature_byte_replacement=1 ;;
-esac
-if (( signature_byte_replacement == 1 )); then printf '\001'; else printf '\002'; fi |
-  dd of="$manifest_signature" bs=1 seek=0 conv=notrunc 2>/dev/null
-signature_size_after=$(wc -c <"$manifest_signature")
-(( signature_size_after == signature_size_before )) || fail 'manifest signature tamper changed length'
-signature_byte_after=$(od -An -tu1 -N1 "$manifest_signature" | tr -d '[:space:]')
-[[ "$signature_byte_after" == "$signature_byte_replacement" ]] ||
-  fail 'manifest signature tamper did not write the replacement byte'
-[[ "$signature_byte_after" != "$signature_byte_before" ]] ||
-  fail 'manifest signature tamper was a no-op'
-if "$verifier" "${signing_verify_args[@]}" >/dev/null 2>&1; then fail 'tampered manifest signature passed'; fi
-go run "$tests_dir/testdata/generate-manifest-fixture.go" "$temp/manifest" \
-  'attacker replacement artifact'
-if "$verifier" "${signing_verify_args[@]}" >/dev/null 2>&1; then
-  fail 'replacement receipt, manifest, and artifact pair passed the signing-key anchor'
-fi
-if "$verifier" "${pin_verify_args[@]}" >/dev/null 2>&1; then
-  fail 'replacement receipt, manifest, and artifact pair passed the A0 key pin'
-fi
-contains "$lineage_archive" 'MANIFEST_SIGNATURE_NAME'
-contains "$lineage_archive" 'COMPANION_MANIFEST_VERIFIER'
-
+bash "$tests_dir/release-runtime-hardening-test.sh"
 bash "$tests_dir/release-homebrew-hardening-test.sh"
 
 printf 'release hardening test: PASS\n'

--- a/scripts/companion-release/tests/release-hardening-test.sh
+++ b/scripts/companion-release/tests/release-hardening-test.sh
@@ -17,6 +17,7 @@ lineage="$script_dir/verify-public-key-lineage.sh"
 lineage_coordinates="$script_dir/verify-public-key-lineage-coordinates.sh"
 lineage_pins="$script_dir/verify-public-key-lineage-pins.sh"
 producer="$script_dir/produce.sh"
+producer_receipt="$script_dir/produce-public-key-receipt.sh"
 homebrew_bridge="$script_dir/publish-homebrew-formula-bridge.sh"
 homebrew_git_helper="$script_dir/publish-homebrew-formula-bridge-git.sh"
 current_release_gate="$script_dir/verify-current-release.sh"
@@ -41,7 +42,7 @@ contains "$release" "COMPANION_CASK_PATH='dist/homebrew/Casks/auto.rb'"
 contains "$release" 'COMPANION_CHECKSUMS_PATH: ${{ steps.release-evidence.outputs.checksums-path }}'
 contains "$release" 'COMPANION_CHECKSUMS_PATH="$COMPANION_CHECKSUMS_PATH"'
 not_contains "$release" "COMPANION_CHECKSUMS_PATH='dist/checksums.txt'"
-contains "$producer" '--signing-key "$COMPANION_SIGNING_KEY_FILE"'
+contains "$producer_receipt" '--signing-key "$COMPANION_SIGNING_KEY_FILE"'
 contains "$homebrew_bridge" "readonly PRIOR_TAP_COMMIT='ab9a0e489ee34f8a075019c4acebb2a8ae61c290'"
 contains "$homebrew_bridge" "readonly PRIOR_CASK_BLOB='c6edb108d821d88914e12d2c1bf943540c63351e'"
 contains "$homebrew_bridge" "readonly FROZEN_FORMULA_BLOB='4ebc6c38925002dec00759823d4dd847a499818a'"
@@ -147,8 +148,8 @@ contains "$lineage_coordinates" "release_phase='A9' prior_phase='A8'"
 contains "$lineage_coordinates" "release_phase='A10' prior_phase='A9'"
 contains "$lineage_coordinates" "release_phase='A11' prior_phase='A10'"
 contains "$lineage" '.commit.tree.sha'
-contains "$producer" "GITHUB_REF_NAME\" == 'v0.50.82'"
-contains "$producer" "release_phase='A11'"
+contains "$producer_receipt" "GITHUB_REF_NAME\" == 'v0.50.82'"
+contains "$producer_receipt" "release_phase='A11'"
 contains "$homebrew_bridge" "readonly RELEASE_TAG='v0.50.82'"
 contains "$homebrew_bridge" "readonly RELEASE_VERSION='0.50.82'"
 contains "$release" 'timeout-minutes: 60'
@@ -174,5 +175,6 @@ contains "$current_release_gate" 'for archive in "${EXPECTED_ARCHIVES[@]}"'
 
 bash "$tests_dir/release-runtime-hardening-test.sh"
 bash "$tests_dir/release-homebrew-hardening-test.sh"
+bash "$tests_dir/release-producer-helper-hardening-test.sh"
 
 printf 'release hardening test: PASS\n'

--- a/scripts/companion-release/tests/release-homebrew-hardening-test.sh
+++ b/scripts/companion-release/tests/release-homebrew-hardening-test.sh
@@ -57,6 +57,35 @@ env "${bridge_env[@]}" bash "$script_dir/publish-homebrew-formula-bridge.sh"
    "$(<"$state/formula-get.calls")" == 2 ]] \
   || fail 'A11 Cask-only reconciler is not idempotent'
 
+# An already-current Cask must bind to one stable head with the frozen Formula.
+touch "$state/idempotent-formula-race"
+if env "${bridge_env[@]}" bash "$script_dir/publish-homebrew-formula-bridge.sh" \
+  >/dev/null 2>&1; then
+  fail 'A11 accepted idempotent Cask bytes across concurrent Formula drift'
+fi
+rm -f -- "$state/idempotent-formula-race"
+[[ "$(<"$state/ref-update.calls")" == 1 &&
+   "$(jq -er '.object.sha' "$state/branch.json")" == \
+     '8888888888888888888888888888888888888888' &&
+   "$(jq -er '.sha' "$state/formula.json")" == \
+     '6666666666666666666666666666666666666666' ]] \
+  || fail 'A11 mutated tap state after idempotent Formula drift'
+jq -n '{ref:"refs/heads/main",object:{type:"commit",sha:"3333333333333333333333333333333333333333",url:"https://example.invalid/target-commit"}}' \
+  >"$state/branch.json"
+jq -n --arg content "$(base64 <"$temp/frozen-formula.rb" | tr -d '\r\n')" \
+  '{sha:"4ebc6c38925002dec00759823d4dd847a499818a",content:$content}' >"$state/formula.json"
+rm -f -- "$state/branch-get.calls"
+touch "$state/idempotent-ref-race"
+if env "${bridge_env[@]}" bash "$script_dir/publish-homebrew-formula-bridge.sh" \
+  >/dev/null 2>&1; then
+  fail 'A11 accepted a branch move after idempotent tree verification'
+fi
+rm -f -- "$state/idempotent-ref-race"
+[[ "$(<"$state/ref-update.calls")" == 1 &&
+   "$(jq -er '.object.sha' "$state/branch.json")" == \
+     '4444444444444444444444444444444444444444' ]] \
+  || fail 'A11 updated Cask during idempotent head verification'
+
 # An update-needed retry must reject pre-existing tap-head or Formula drift.
 jq -n --arg content "$(base64 <"$temp/prior-cask.rb" | tr -d '\r\n')" \
   '{sha:"c6edb108d821d88914e12d2c1bf943540c63351e",content:$content}' >"$state/cask.json"

--- a/scripts/companion-release/tests/release-producer-helper-hardening-test.sh
+++ b/scripts/companion-release/tests/release-producer-helper-hardening-test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 077
+
+tests_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+script_dir=$(cd -- "$tests_dir/.." && pwd)
+producer="$script_dir/produce.sh"
+receipt_helper="$script_dir/produce-public-key-receipt.sh"
+fail() { printf 'release producer helper hardening test: %s\n' "$1" >&2; exit 1; }
+
+if bash "$receipt_helper" >/dev/null 2>&1; then
+  fail 'source-only receipt helper executed directly'
+fi
+
+resolve_phase() {
+  GITHUB_REF_NAME=$1 COMPANION_VERSION=$2 PRODUCER_RECEIPT_HELPER="$receipt_helper" \
+    bash -c '
+      set -euo pipefail
+      fail() { printf "%s\n" "$1" >&2; return 1; }
+      source "$PRODUCER_RECEIPT_HELPER"
+      resolve_public_key_receipt_release_phase
+      printf "%s" "$release_phase"
+    '
+}
+
+while read -r tag version phase; do
+  [[ "$(resolve_phase "$tag" "$version")" == "$phase" ]] \
+    || fail "exact ${phase} tag/version pair resolved incorrectly"
+done <<'CASES'
+v0.50.69 0.50.69 A0
+v0.50.70 0.50.70 A1
+v0.50.71 0.50.71 A2
+v0.50.72 0.50.72 A3
+v0.50.73 0.50.73 A4
+v0.50.74 0.50.74 A5
+v0.50.77 0.50.77 A6
+v0.50.78 0.50.78 A7
+v0.50.79 0.50.79 A8
+v0.50.80 0.50.80 A9
+v0.50.81 0.50.81 A10
+v0.50.82 0.50.82 A11
+CASES
+
+for mismatch in 'v0.50.82 0.50.81' 'v0.50.81 0.50.82' 'v0.50.83 0.50.83'; do
+  read -r tag version <<< "$mismatch"
+  if resolve_phase "$tag" "$version" >/dev/null 2>&1; then
+    fail "mixed or unknown release identity passed: ${tag}/${version}"
+  fi
+done
+
+temp=$(mktemp -d "${TMPDIR:-/tmp}/adk-producer-helper-gate.XXXXXX")
+trap 'rm -rf -- "$temp"' EXIT
+cp -- "$producer" "$temp/produce.sh"
+assert_gate_failure() {
+  local expected=$1 output
+  if output=$(COMPANION_PLATFORM=darwin COMPANION_ARTIFACT="$temp/auto" \
+    COMPANION_TARGET=darwin_arm64 COMPANION_ARCHITECTURE=arm64 \
+    COMPANION_VERSION=0.50.82 bash "$temp/produce.sh" 2>&1); then
+    fail "unsafe helper gate passed"
+  fi
+  [[ "$output" == *"$expected"* ]] || fail "helper gate diagnostic = ${output}"
+}
+
+assert_gate_failure 'public key receipt helper is missing or unsafe'
+ln -s -- "$receipt_helper" "$temp/produce-public-key-receipt.sh"
+assert_gate_failure 'public key receipt helper is missing or unsafe'
+rm -- "$temp/produce-public-key-receipt.sh"
+printf ':\n' > "$temp/produce-public-key-receipt.sh"
+assert_gate_failure 'public key receipt helper contract is incomplete'
+
+printf 'release producer helper hardening test: PASS\n'

--- a/scripts/companion-release/tests/release-runtime-hardening-test.sh
+++ b/scripts/companion-release/tests/release-runtime-hardening-test.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 077
+
+tests_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+script_dir=$(cd -- "$tests_dir/.." && pwd)
+repo=$(cd -- "$script_dir/../.." && pwd)
+fail() { printf 'release runtime hardening test: %s\n' "$1" >&2; exit 1; }
+contains() { grep -Fq -- "$2" "$1" || fail "$1 missing $2"; }
+
+source_gate="$script_dir/validate-source.sh"
+environment_gate="$script_dir/validate-environment.sh"
+lineage_archive="$script_dir/verify-public-key-lineage-archive.sh"
+
+temp=$(mktemp -d "${TMPDIR:-/tmp}/release-hardening-test.XXXXXX")
+trap 'rm -rf -- "$temp"' EXIT
+git clone -q --no-hardlinks --no-tags "$repo" "$temp/source"
+git -C "$temp/source" config user.name 'Release Test'
+git -C "$temp/source" config user.email release-test@example.invalid
+git -C "$temp/source" tag -am 'A11 fixture' v0.50.82
+commit=$(git -C "$temp/source" rev-parse HEAD)
+tree=$(git -C "$temp/source" rev-parse 'HEAD^{tree}')
+if [[ "${tree: -1}" == '0' ]]; then
+  wrong_tree="${tree%?}1"
+else
+  wrong_tree="${tree%?}0"
+fi
+run_source_gate() {
+  local approved_commit="${1-}" approved_tree="${2-}"
+  env GITHUB_REF_NAME=v0.50.82 GITHUB_REF_TYPE=tag GITHUB_SHA="$commit" \
+    GITHUB_OUTPUT="$temp/source-output" COMPANION_SOURCE_PIN_REQUIRED=1 \
+    COMPANION_APPROVED_SOURCE_COMMIT="$approved_commit" \
+    COMPANION_APPROVED_SOURCE_TREE="$approved_tree" \
+    bash "$source_gate"
+}
+if (cd "$temp/source" && run_source_gate '' '') >/dev/null 2>&1; then
+  fail 'missing approved source pins passed'
+fi
+if (cd "$temp/source" && run_source_gate "$commit" "$wrong_tree") >/dev/null 2>&1; then
+  fail 'wrong approved source tree passed'
+fi
+(cd "$temp/source" && run_source_gate "$commit" "$tree") >/dev/null
+
+# Current-time checks must reject expired production material.
+touch "$temp/key" "$temp/api-key"
+chmod 0600 "$temp/key" "$temp/api-key"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$temp/tool"
+chmod 0700 "$temp/tool"
+format_time() {
+  if date -u -r "$1" '+%Y-%m-%dT%H:%M:%SZ' >/dev/null 2>&1; then
+    date -u -r "$1" '+%Y-%m-%dT%H:%M:%SZ'
+  else
+    date -u -d "@$1" '+%Y-%m-%dT%H:%M:%SZ'
+  fi
+}
+now=$(date -u '+%s')
+validation_env=(
+  COMPANION_BUILD_PROVENANCE=github-actions:fixture@0123456789abcdef
+  COMPANION_HANDOFF=v1 COMPANION_ROLLBACK_FLOOR=5069
+  COMPANION_KEY_ID=adk-release-2026-q3-b0 COMPANION_SIGNING_KEY_FILE="$temp/key"
+  COMPANION_SIGNER="$temp/tool" COMPANION_RECEIPT_VERIFIER="$temp/tool"
+  COMPANION_MANIFEST_VERIFIER="$temp/tool" COMPANION_RELEASE_TIME_VALIDATION_REQUIRED=1
+  COMPANION_PUBLIC_KEY_RECEIPT_MINIMUM_LIFETIME_SECONDS=31536000
+  COMPANION_PUBLIC_KEY_RECEIPT_ISSUED_AT="$(format_time "$((now - 86400))")"
+  COMPANION_PUBLIC_KEY_RECEIPT_EXPIRES_AT="$(format_time "$((now + 31536001))")"
+  APPLE_SIGNING_IDENTITY='Developer ID Application: Fixture (GP2PFA2PUV)'
+  APPLE_API_KEY=FIXTURE APPLE_API_ISSUER=123e4567-e89b-42d3-a456-426614174000
+  APPLE_API_KEY_PATH="$temp/api-key"
+)
+env "${validation_env[@]}" COMPANION_ISSUED_AT="$(format_time "$((now - 60))")" \
+  COMPANION_EXPIRES_AT="$(format_time "$((now + 3600))")" bash "$environment_gate"
+if env "${validation_env[@]}" COMPANION_ISSUED_AT="$(format_time "$((now - 7200))")" \
+  COMPANION_EXPIRES_AT="$(format_time "$((now - 3600))")" bash "$environment_gate" >/dev/null 2>&1; then
+  fail 'expired manifest window passed'
+fi
+
+# The independent verifier must bind receipt key -> manifest signature -> artifact.
+verifier="$temp/manifest-verifier"
+go build -trimpath -o "$verifier" "$repo/scripts/companion-release/manifestverify"
+go run "$tests_dir/testdata/generate-manifest-fixture.go" "$temp/manifest"
+trusted_key_sha=$(jq -er '.public_key_sha256' "$temp/manifest/public-key-receipt.json")
+install -m 0600 "$temp/manifest/signing-key" "$temp/trusted-signing-key"
+common_verify_args=(
+  --artifact "$temp/manifest/auto" --manifest "$temp/manifest/adk-companion-manifest.json"
+  --signature "$temp/manifest/adk-companion-manifest.sig"
+  --receipt "$temp/manifest/public-key-receipt.json"
+  --receipt-signature "$temp/manifest/public-key-receipt.sig"
+  --key-id adk-release-2026-q3-b0 --version 0.50.71 --platform darwin
+  --architecture arm64 --handoff v1 --minimum-rollback-floor 5069
+)
+signing_verify_args=("${common_verify_args[@]}" --signing-key "$temp/trusted-signing-key")
+pin_verify_args=("${common_verify_args[@]}" --public-key-sha256 "$trusted_key_sha")
+"$verifier" "${signing_verify_args[@]}"
+"$verifier" "${pin_verify_args[@]}"
+if "$verifier" "${common_verify_args[@]}" >/dev/null 2>&1; then
+  fail 'unanchored self-signed receipt passed'
+fi
+if "$verifier" "${signing_verify_args[@]}" --public-key-sha256 "$trusted_key_sha" \
+  >/dev/null 2>&1; then
+  fail 'ambiguous duplicate trust anchors passed'
+fi
+if "$verifier" "${common_verify_args[@]}" \
+  --signing-key "$temp/manifest/inconsistent-signing-key" >/dev/null 2>&1; then
+  fail 'inconsistent private/public signing key passed'
+fi
+printf 'tamper\n' >>"$temp/manifest/auto"
+if "$verifier" "${signing_verify_args[@]}" >/dev/null 2>&1; then fail 'tampered artifact passed'; fi
+printf 'signed companion artifact\n' >"$temp/manifest/auto"
+manifest_signature="$temp/manifest/adk-companion-manifest.sig"
+signature_size_before=$(wc -c <"$manifest_signature")
+(( signature_size_before == 64 )) || fail 'fixture manifest signature length drifted'
+signature_byte_before=$(od -An -tu1 -N1 "$manifest_signature" | tr -d '[:space:]')
+case "$signature_byte_before" in
+  1) signature_byte_replacement=2 ;;
+  ''|*[!0-9]*) fail 'fixture manifest signature byte could not be read' ;;
+  *) signature_byte_replacement=1 ;;
+esac
+if (( signature_byte_replacement == 1 )); then printf '\001'; else printf '\002'; fi |
+  dd of="$manifest_signature" bs=1 seek=0 conv=notrunc 2>/dev/null
+signature_size_after=$(wc -c <"$manifest_signature")
+(( signature_size_after == signature_size_before )) || fail 'manifest signature tamper changed length'
+signature_byte_after=$(od -An -tu1 -N1 "$manifest_signature" | tr -d '[:space:]')
+[[ "$signature_byte_after" == "$signature_byte_replacement" ]] ||
+  fail 'manifest signature tamper did not write the replacement byte'
+[[ "$signature_byte_after" != "$signature_byte_before" ]] ||
+  fail 'manifest signature tamper was a no-op'
+if "$verifier" "${signing_verify_args[@]}" >/dev/null 2>&1; then fail 'tampered manifest signature passed'; fi
+go run "$tests_dir/testdata/generate-manifest-fixture.go" "$temp/manifest" \
+  'attacker replacement artifact'
+if "$verifier" "${signing_verify_args[@]}" >/dev/null 2>&1; then
+  fail 'replacement receipt, manifest, and artifact pair passed the signing-key anchor'
+fi
+if "$verifier" "${pin_verify_args[@]}" >/dev/null 2>&1; then
+  fail 'replacement receipt, manifest, and artifact pair passed the A0 key pin'
+fi
+contains "$lineage_archive" 'MANIFEST_SIGNATURE_NAME'
+contains "$lineage_archive" 'COMPANION_MANIFEST_VERIFIER'
+
+printf 'release runtime hardening test: PASS\n'

--- a/scripts/companion-release/tests/testdata/mock-tap-gh.sh
+++ b/scripts/companion-release/tests/testdata/mock-tap-gh.sh
@@ -7,6 +7,9 @@ readonly prior_tree='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 readonly target_blob='1111111111111111111111111111111111111111'
 readonly target_tree='2222222222222222222222222222222222222222'
 readonly target_commit='3333333333333333333333333333333333333333'
+readonly idempotent_race_commit='8888888888888888888888888888888888888888'
+readonly idempotent_race_tree='9999999999999999999999999999999999999999'
+readonly formula_drift_blob='6666666666666666666666666666666666666666'
 
 [[ "${1-}" == 'api' ]] || exit 64
 shift
@@ -36,6 +39,16 @@ increment() {
 case "$endpoint" in
   *contents/Casks/auto.rb*)
     [[ "$method" == 'GET' ]] || exit 64
+    if [[ -e "$MOCK_TAP_STATE/idempotent-formula-race" ]]; then
+      cat "$MOCK_TAP_STATE/cask.json"
+      jq -n --arg sha "$idempotent_race_commit" \
+        '{ref:"refs/heads/main",object:{type:"commit",sha:$sha,url:"https://example.invalid/idempotent-racer"}}' \
+        >"$MOCK_TAP_STATE/branch.json"
+      content=$(jq -er '.content' "$MOCK_TAP_STATE/formula.json")
+      jq -n --arg content "$content" --arg sha "$formula_drift_blob" \
+        '{sha:$sha,content:$content}' >"$MOCK_TAP_STATE/formula.json"
+      exit 0
+    fi
     exec cat "$MOCK_TAP_STATE/cask.json"
     ;;
   *contents/Formula/auto.rb*)
@@ -45,6 +58,12 @@ case "$endpoint" in
     ;;
   *git/ref/heads/main*)
     [[ "$method" == 'GET' ]] || exit 64
+    increment branch-get
+    if [[ -e "$MOCK_TAP_STATE/idempotent-ref-race" &&
+          "$(<"$MOCK_TAP_STATE/branch-get.calls")" == '2' ]]; then
+      jq -n '{ref:"refs/heads/main",object:{type:"commit",sha:"4444444444444444444444444444444444444444",url:"https://example.invalid/idempotent-ref-racer"}}' \
+        >"$MOCK_TAP_STATE/branch.json"
+    fi
     exec cat "$MOCK_TAP_STATE/branch.json"
     ;;
   *git/refs/heads/main*)
@@ -78,6 +97,18 @@ case "$endpoint" in
     jq -n --arg sha "$prior_commit" --arg tree "$prior_tree" \
       '{sha:$sha,tree:{sha:$tree},parents:[{sha:"7777777777777777777777777777777777777777"}],url:"https://example.invalid/prior-commit"}'
     ;;
+  *git/commits/"$target_commit"*)
+    [[ "$method" == 'GET' ]] || exit 64
+    jq -n --arg sha "$target_commit" --arg tree "$target_tree" \
+      --arg parent "$prior_commit" \
+      '{sha:$sha,tree:{sha:$tree},parents:[{sha:$parent}],url:"https://example.invalid/target-commit"}'
+    ;;
+  *git/commits/"$idempotent_race_commit"*)
+    [[ "$method" == 'GET' ]] || exit 64
+    jq -n --arg sha "$idempotent_race_commit" --arg tree "$idempotent_race_tree" \
+      --arg parent "$target_commit" \
+      '{sha:$sha,tree:{sha:$tree},parents:[{sha:$parent}],url:"https://example.invalid/idempotent-racer"}'
+    ;;
   *git/blobs*)
     [[ "$method" == 'POST' && -f "$input" ]] || exit 64
     [[ "$(jq -er '.encoding' "$input")" == 'base64' ]] || exit 65
@@ -93,6 +124,15 @@ case "$endpoint" in
       '{sha:$sha,truncated:false,tree:[
         {path:"Casks/auto.rb",mode:"100644",type:"blob",sha:$blob},
         {path:"Formula/auto.rb",mode:"100644",type:"blob",sha:"4ebc6c38925002dec00759823d4dd847a499818a"}
+      ]}'
+    ;;
+  *git/trees/"$idempotent_race_tree"*)
+    [[ "$method" == 'GET' ]] || exit 64
+    jq -n --arg sha "$idempotent_race_tree" --arg blob "$target_blob" \
+      --arg formula "$formula_drift_blob" \
+      '{sha:$sha,truncated:false,tree:[
+        {path:"Casks/auto.rb",mode:"100644",type:"blob",sha:$blob},
+        {path:"Formula/auto.rb",mode:"100644",type:"blob",sha:$formula}
       ]}'
     ;;
   *git/trees*)

--- a/scripts/companion-release/verify-public-key-lineage-coordinates.sh
+++ b/scripts/companion-release/verify-public-key-lineage-coordinates.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# @AX:NOTE [AUTO]: Append a phase only after immutable evidence pins exist; every phase trusts its direct predecessor.
+readonly A0_REPOSITORY='Insajin/autopus-adk' A0_TAG='v0.50.69' A0_VERSION='0.50.69'
+readonly A1_REPOSITORY='Insajin/autopus-adk' A1_TAG='v0.50.70' A1_VERSION='0.50.70'
+readonly A2_REPOSITORY='Insajin/autopus-adk' A2_TAG='v0.50.71' A2_VERSION='0.50.71'
+readonly A3_TAG='v0.50.72' A3_VERSION='0.50.72'
+readonly A3_REPOSITORY='Insajin/autopus-adk' A4_TAG='v0.50.73' A4_VERSION='0.50.73'
+readonly A4_REPOSITORY='Insajin/autopus-adk' A5_TAG='v0.50.74' A5_VERSION='0.50.74'
+readonly A5_REPOSITORY='Insajin/autopus-adk' A6_TAG='v0.50.77' A6_VERSION='0.50.77'
+readonly A6_REPOSITORY='Insajin/autopus-adk' A7_TAG='v0.50.78' A7_VERSION='0.50.78'
+readonly A7_REPOSITORY='Insajin/autopus-adk' A8_TAG='v0.50.79' A8_VERSION='0.50.79'
+readonly A8_REPOSITORY='Insajin/autopus-adk' A9_TAG='v0.50.80' A9_VERSION='0.50.80'
+readonly A9_REPOSITORY='Insajin/autopus-adk' A10_TAG='v0.50.81' A10_VERSION='0.50.81'
+readonly A10_REPOSITORY='Insajin/autopus-adk' A11_TAG='v0.50.82' A11_VERSION='0.50.82'
+readonly A0_EVIDENCE_SOURCE='immutable A0 GitHub release'
+
+require_environment GITHUB_REF_NAME
+COMPANION_VERSION="${GITHUB_REF_NAME#v}"
+prior_tree=''
+if [[ "$GITHUB_REF_NAME" == 'v0.50.69' && "$COMPANION_VERSION" == '0.50.69' ]]; then
+  release_phase='A0'
+  printf 'companion release lineage: %s bootstrap accepted for %s@%s\n' "$release_phase" "$A0_REPOSITORY" "$A0_TAG"
+  exit 0
+elif [[ "$GITHUB_REF_NAME" == "$A1_TAG" && "$COMPANION_VERSION" == "$A1_VERSION" ]]; then
+  release_phase='A1' prior_phase='A0' prior_repository="$A0_REPOSITORY" prior_evidence_source="$A0_EVIDENCE_SOURCE"
+  prior_tag="$A0_TAG" prior_version="$A0_VERSION" prior_commit="$A0_COMMIT_SHA"
+  prior_tag_object='' prior_checksums="$A0_CHECKSUMS_SHA256" prior_amd64_archive='' prior_arm64_archive=''
+  prior_amd64_manifest="$A0_AMD64_MANIFEST_SHA256" prior_arm64_manifest="$A0_ARM64_MANIFEST_SHA256"
+elif [[ "$GITHUB_REF_NAME" == "$A2_TAG" && "$COMPANION_VERSION" == "$A2_VERSION" ]]; then
+  release_phase='A2' prior_phase='A1' prior_repository="$A1_REPOSITORY" prior_evidence_source='immutable A1 GitHub release'
+  prior_tag="$A1_TAG" prior_version="$A1_VERSION" prior_commit="$A1_COMMIT_SHA"
+  prior_tag_object="$A1_TAG_OBJECT_SHA" prior_checksums="$A1_CHECKSUMS_SHA256" prior_amd64_archive="$A1_AMD64_ARCHIVE_SHA256" prior_arm64_archive="$A1_ARM64_ARCHIVE_SHA256"
+  prior_amd64_manifest="$A1_AMD64_MANIFEST_SHA256" prior_arm64_manifest="$A1_ARM64_MANIFEST_SHA256"
+elif [[ "$GITHUB_REF_NAME" == "$A3_TAG" && "$COMPANION_VERSION" == "$A3_VERSION" ]]; then
+  release_phase='A3' prior_phase='A2' prior_repository="$A2_REPOSITORY" prior_evidence_source='immutable A2 GitHub release'
+  prior_tag="$A2_TAG" prior_version="$A2_VERSION" prior_commit="$A2_COMMIT_SHA"
+  prior_tag_object="$A2_TAG_OBJECT_SHA" prior_checksums="$A2_CHECKSUMS_SHA256" prior_amd64_archive="$A2_AMD64_ARCHIVE_SHA256" prior_arm64_archive="$A2_ARM64_ARCHIVE_SHA256"
+  prior_amd64_manifest="$A2_AMD64_MANIFEST_SHA256" prior_arm64_manifest="$A2_ARM64_MANIFEST_SHA256"
+elif [[ "$GITHUB_REF_NAME" == "$A4_TAG" && "$COMPANION_VERSION" == "$A4_VERSION" ]]; then
+  release_phase='A4' prior_phase='A3' prior_repository="$A3_REPOSITORY" prior_evidence_source='immutable A3 GitHub release' prior_tag="$A3_TAG" prior_version="$A3_VERSION" prior_commit="$A3_COMMIT_SHA"
+  prior_tag_object="$A3_TAG_OBJECT_SHA" prior_checksums="$A3_CHECKSUMS_SHA256" prior_amd64_archive="$A3_AMD64_ARCHIVE_SHA256" prior_arm64_archive="$A3_ARM64_ARCHIVE_SHA256" prior_amd64_manifest="$A3_AMD64_MANIFEST_SHA256" prior_arm64_manifest="$A3_ARM64_MANIFEST_SHA256"
+elif [[ "$GITHUB_REF_NAME" == "$A5_TAG" && "$COMPANION_VERSION" == "$A5_VERSION" ]]; then
+  release_phase='A5' prior_phase='A4' prior_repository="$A4_REPOSITORY" prior_evidence_source='immutable A4 GitHub release' prior_tag="$A4_TAG" prior_version="$A4_VERSION" prior_commit="$A4_COMMIT_SHA"
+  prior_tag_object="$A4_TAG_OBJECT_SHA" prior_checksums="$A4_CHECKSUMS_SHA256" prior_amd64_archive="$A4_AMD64_ARCHIVE_SHA256" prior_arm64_archive="$A4_ARM64_ARCHIVE_SHA256" prior_amd64_manifest="$A4_AMD64_MANIFEST_SHA256" prior_arm64_manifest="$A4_ARM64_MANIFEST_SHA256"
+elif [[ "$GITHUB_REF_NAME" == "$A6_TAG" && "$COMPANION_VERSION" == "$A6_VERSION" ]]; then
+  release_phase='A6' prior_phase='A5' prior_repository="$A5_REPOSITORY" prior_evidence_source='immutable A5 GitHub release' prior_tag="$A5_TAG" prior_version="$A5_VERSION" prior_commit="$A5_COMMIT_SHA"
+  prior_tag_object="$A5_TAG_OBJECT_SHA" prior_checksums="$A5_CHECKSUMS_SHA256" prior_amd64_archive="$A5_AMD64_ARCHIVE_SHA256" prior_arm64_archive="$A5_ARM64_ARCHIVE_SHA256" prior_amd64_manifest="$A5_AMD64_MANIFEST_SHA256" prior_arm64_manifest="$A5_ARM64_MANIFEST_SHA256"
+elif [[ "$GITHUB_REF_NAME" == "$A7_TAG" && "$COMPANION_VERSION" == "$A7_VERSION" ]]; then
+  release_phase='A7' prior_phase='A6' prior_repository="$A6_REPOSITORY" prior_evidence_source='immutable A6 GitHub release' prior_tag="$A6_TAG" prior_version="$A6_VERSION" prior_commit="$A6_COMMIT_SHA"
+  prior_tag_object="$A6_TAG_OBJECT_SHA" prior_checksums="$A6_CHECKSUMS_SHA256" prior_amd64_archive="$A6_AMD64_ARCHIVE_SHA256" prior_arm64_archive="$A6_ARM64_ARCHIVE_SHA256" prior_amd64_manifest="$A6_AMD64_MANIFEST_SHA256" prior_arm64_manifest="$A6_ARM64_MANIFEST_SHA256"
+elif [[ "$GITHUB_REF_NAME" == "$A8_TAG" && "$COMPANION_VERSION" == "$A8_VERSION" ]]; then
+  release_phase='A8' prior_phase='A7' prior_repository="$A7_REPOSITORY" prior_evidence_source='immutable A7 GitHub release' prior_tag="$A7_TAG" prior_version="$A7_VERSION" prior_commit="$A7_COMMIT_SHA" prior_tree="$A7_TREE_SHA"
+  prior_tag_object="$A7_TAG_OBJECT_SHA" prior_checksums="$A7_CHECKSUMS_SHA256" prior_amd64_archive="$A7_AMD64_ARCHIVE_SHA256" prior_arm64_archive="$A7_ARM64_ARCHIVE_SHA256" prior_amd64_manifest="$A7_AMD64_MANIFEST_SHA256" prior_arm64_manifest="$A7_ARM64_MANIFEST_SHA256"
+elif [[ "$GITHUB_REF_NAME" == "$A9_TAG" && "$COMPANION_VERSION" == "$A9_VERSION" ]]; then
+  release_phase='A9' prior_phase='A8' prior_repository="$A8_REPOSITORY" prior_evidence_source='immutable A8 GitHub release' prior_tag="$A8_TAG" prior_version="$A8_VERSION" prior_commit="$A8_COMMIT_SHA" prior_tree="$A8_TREE_SHA"
+  prior_tag_object="$A8_TAG_OBJECT_SHA" prior_checksums="$A8_CHECKSUMS_SHA256" prior_amd64_archive="$A8_AMD64_ARCHIVE_SHA256" prior_arm64_archive="$A8_ARM64_ARCHIVE_SHA256" prior_amd64_manifest="$A8_AMD64_MANIFEST_SHA256" prior_arm64_manifest="$A8_ARM64_MANIFEST_SHA256"
+elif [[ "$GITHUB_REF_NAME" == "$A10_TAG" && "$COMPANION_VERSION" == "$A10_VERSION" ]]; then
+  release_phase='A10' prior_phase='A9' prior_repository="$A9_REPOSITORY" prior_evidence_source='immutable A9 GitHub release' prior_tag="$A9_TAG" prior_version="$A9_VERSION" prior_commit="$A9_COMMIT_SHA" prior_tree="$A9_TREE_SHA"
+  prior_tag_object="$A9_TAG_OBJECT_SHA" prior_checksums="$A9_CHECKSUMS_SHA256" prior_amd64_archive="$A9_AMD64_ARCHIVE_SHA256" prior_arm64_archive="$A9_ARM64_ARCHIVE_SHA256" prior_amd64_manifest="$A9_AMD64_MANIFEST_SHA256" prior_arm64_manifest="$A9_ARM64_MANIFEST_SHA256"
+elif [[ "$GITHUB_REF_NAME" == "$A11_TAG" && "$COMPANION_VERSION" == "$A11_VERSION" ]]; then
+  release_phase='A11' prior_phase='A10' prior_repository="$A10_REPOSITORY" prior_evidence_source='immutable A10 GitHub release' prior_tag="$A10_TAG" prior_version="$A10_VERSION" prior_commit="$A10_COMMIT_SHA" prior_tree="$A10_TREE_SHA"
+  prior_tag_object="$A10_TAG_OBJECT_SHA" prior_checksums="$A10_CHECKSUMS_SHA256" prior_amd64_archive="$A10_AMD64_ARCHIVE_SHA256" prior_arm64_archive="$A10_ARM64_ARCHIVE_SHA256" prior_amd64_manifest="$A10_AMD64_MANIFEST_SHA256" prior_arm64_manifest="$A10_ARM64_MANIFEST_SHA256"
+else
+  fail prior_release_identity_mismatch 'release is outside the frozen A0/A1/A2/A3/A4/A5/A6/A7/A8/A9/A10/A11 policy'
+fi

--- a/scripts/companion-release/verify-public-key-lineage.sh
+++ b/scripts/companion-release/verify-public-key-lineage.sh
@@ -1,78 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 umask 077
-readonly A0_REPOSITORY='Insajin/autopus-adk' A0_TAG='v0.50.69' A0_VERSION='0.50.69'
-readonly A1_REPOSITORY='Insajin/autopus-adk' A1_TAG='v0.50.70' A1_VERSION='0.50.70'
-readonly A2_REPOSITORY='Insajin/autopus-adk' A2_TAG='v0.50.71' A2_VERSION='0.50.71'
-readonly A3_TAG='v0.50.72' A3_VERSION='0.50.72'
-readonly A3_REPOSITORY='Insajin/autopus-adk' A4_TAG='v0.50.73' A4_VERSION='0.50.73'
-readonly A4_REPOSITORY='Insajin/autopus-adk' A5_TAG='v0.50.74' A5_VERSION='0.50.74'
-readonly A5_REPOSITORY='Insajin/autopus-adk' A6_TAG='v0.50.77' A6_VERSION='0.50.77'
-readonly A6_REPOSITORY='Insajin/autopus-adk' A7_TAG='v0.50.78' A7_VERSION='0.50.78'
-readonly A7_REPOSITORY='Insajin/autopus-adk' A8_TAG='v0.50.79' A8_VERSION='0.50.79'
-readonly A8_REPOSITORY='Insajin/autopus-adk' A9_TAG='v0.50.80' A9_VERSION='0.50.80'
-readonly A9_REPOSITORY='Insajin/autopus-adk' A10_TAG='v0.50.81' A10_VERSION='0.50.81'
-readonly A10_REPOSITORY='Insajin/autopus-adk' A11_TAG='v0.50.82' A11_VERSION='0.50.82'
 readonly BUNDLE_NAME='adk-companion-public-key-receipt.bundle' RECEIPT_NAME='public-key-receipt.json' SIGNATURE_NAME='public-key-receipt.sig'
 readonly MANIFEST_NAME='adk-companion-manifest.json' MANIFEST_SIGNATURE_NAME='adk-companion-manifest.sig' ARTIFACT_NAME='auto' CHECKSUMS_NAME='checksums.txt'
-readonly A0_EVIDENCE_SOURCE='immutable A0 GitHub release'
 readonly LOCAL_EVIDENCE_ERROR='fixture_or_local_evidence_forbidden'
 fail() { printf 'companion release lineage: %s: %s\n' "$1" "$2" >&2; exit 1; }
+require_environment() { local name="$1"; [[ -n "${!name-}" ]] || fail prior_evidence_unverifiable "missing ${name}"; }
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd) || fail prior_evidence_unverifiable 'cannot resolve lineage verifier directory'
 pins_helper="$script_dir/verify-public-key-lineage-pins.sh"
 [[ -f "$pins_helper" && ! -L "$pins_helper" ]] || fail prior_evidence_unverifiable 'lineage pin source is invalid'
 # shellcheck source=verify-public-key-lineage-pins.sh
 source "$pins_helper"
-require_environment() { local name="$1"; [[ -n "${!name-}" ]] || fail prior_evidence_unverifiable "missing ${name}"; }
-require_environment GITHUB_REF_NAME
-COMPANION_VERSION="${GITHUB_REF_NAME#v}"
-prior_tree=''
-if [[ "$GITHUB_REF_NAME" == 'v0.50.69' && "$COMPANION_VERSION" == '0.50.69' ]]; then
-  release_phase='A0'
-  printf 'companion release lineage: %s bootstrap accepted for %s@%s\n' "$release_phase" "$A0_REPOSITORY" "$A0_TAG"
-  exit 0
-elif [[ "$GITHUB_REF_NAME" == "$A1_TAG" && "$COMPANION_VERSION" == "$A1_VERSION" ]]; then
-  release_phase='A1' prior_phase='A0' prior_repository="$A0_REPOSITORY" prior_evidence_source="$A0_EVIDENCE_SOURCE"
-  prior_tag="$A0_TAG" prior_version="$A0_VERSION" prior_commit="$A0_COMMIT_SHA"
-  prior_tag_object='' prior_checksums="$A0_CHECKSUMS_SHA256" prior_amd64_archive='' prior_arm64_archive=''
-  prior_amd64_manifest="$A0_AMD64_MANIFEST_SHA256" prior_arm64_manifest="$A0_ARM64_MANIFEST_SHA256"
-elif [[ "$GITHUB_REF_NAME" == "$A2_TAG" && "$COMPANION_VERSION" == "$A2_VERSION" ]]; then
-  release_phase='A2' prior_phase='A1' prior_repository="$A1_REPOSITORY" prior_evidence_source='immutable A1 GitHub release'
-  prior_tag="$A1_TAG" prior_version="$A1_VERSION" prior_commit="$A1_COMMIT_SHA"
-  prior_tag_object="$A1_TAG_OBJECT_SHA" prior_checksums="$A1_CHECKSUMS_SHA256" prior_amd64_archive="$A1_AMD64_ARCHIVE_SHA256" prior_arm64_archive="$A1_ARM64_ARCHIVE_SHA256"
-  prior_amd64_manifest="$A1_AMD64_MANIFEST_SHA256" prior_arm64_manifest="$A1_ARM64_MANIFEST_SHA256"
-elif [[ "$GITHUB_REF_NAME" == "$A3_TAG" && "$COMPANION_VERSION" == "$A3_VERSION" ]]; then
-  release_phase='A3' prior_phase='A2' prior_repository="$A2_REPOSITORY" prior_evidence_source='immutable A2 GitHub release'
-  prior_tag="$A2_TAG" prior_version="$A2_VERSION" prior_commit="$A2_COMMIT_SHA"
-  prior_tag_object="$A2_TAG_OBJECT_SHA" prior_checksums="$A2_CHECKSUMS_SHA256" prior_amd64_archive="$A2_AMD64_ARCHIVE_SHA256" prior_arm64_archive="$A2_ARM64_ARCHIVE_SHA256"
-  prior_amd64_manifest="$A2_AMD64_MANIFEST_SHA256" prior_arm64_manifest="$A2_ARM64_MANIFEST_SHA256"
-elif [[ "$GITHUB_REF_NAME" == "$A4_TAG" && "$COMPANION_VERSION" == "$A4_VERSION" ]]; then
-  release_phase='A4' prior_phase='A3' prior_repository="$A3_REPOSITORY" prior_evidence_source='immutable A3 GitHub release' prior_tag="$A3_TAG" prior_version="$A3_VERSION" prior_commit="$A3_COMMIT_SHA"
-  prior_tag_object="$A3_TAG_OBJECT_SHA" prior_checksums="$A3_CHECKSUMS_SHA256" prior_amd64_archive="$A3_AMD64_ARCHIVE_SHA256" prior_arm64_archive="$A3_ARM64_ARCHIVE_SHA256" prior_amd64_manifest="$A3_AMD64_MANIFEST_SHA256" prior_arm64_manifest="$A3_ARM64_MANIFEST_SHA256"
-elif [[ "$GITHUB_REF_NAME" == "$A5_TAG" && "$COMPANION_VERSION" == "$A5_VERSION" ]]; then
-  release_phase='A5' prior_phase='A4' prior_repository="$A4_REPOSITORY" prior_evidence_source='immutable A4 GitHub release' prior_tag="$A4_TAG" prior_version="$A4_VERSION" prior_commit="$A4_COMMIT_SHA"
-  prior_tag_object="$A4_TAG_OBJECT_SHA" prior_checksums="$A4_CHECKSUMS_SHA256" prior_amd64_archive="$A4_AMD64_ARCHIVE_SHA256" prior_arm64_archive="$A4_ARM64_ARCHIVE_SHA256" prior_amd64_manifest="$A4_AMD64_MANIFEST_SHA256" prior_arm64_manifest="$A4_ARM64_MANIFEST_SHA256"
-elif [[ "$GITHUB_REF_NAME" == "$A6_TAG" && "$COMPANION_VERSION" == "$A6_VERSION" ]]; then
-  release_phase='A6' prior_phase='A5' prior_repository="$A5_REPOSITORY" prior_evidence_source='immutable A5 GitHub release' prior_tag="$A5_TAG" prior_version="$A5_VERSION" prior_commit="$A5_COMMIT_SHA"
-  prior_tag_object="$A5_TAG_OBJECT_SHA" prior_checksums="$A5_CHECKSUMS_SHA256" prior_amd64_archive="$A5_AMD64_ARCHIVE_SHA256" prior_arm64_archive="$A5_ARM64_ARCHIVE_SHA256" prior_amd64_manifest="$A5_AMD64_MANIFEST_SHA256" prior_arm64_manifest="$A5_ARM64_MANIFEST_SHA256"
-elif [[ "$GITHUB_REF_NAME" == "$A7_TAG" && "$COMPANION_VERSION" == "$A7_VERSION" ]]; then
-  release_phase='A7' prior_phase='A6' prior_repository="$A6_REPOSITORY" prior_evidence_source='immutable A6 GitHub release' prior_tag="$A6_TAG" prior_version="$A6_VERSION" prior_commit="$A6_COMMIT_SHA"
-  prior_tag_object="$A6_TAG_OBJECT_SHA" prior_checksums="$A6_CHECKSUMS_SHA256" prior_amd64_archive="$A6_AMD64_ARCHIVE_SHA256" prior_arm64_archive="$A6_ARM64_ARCHIVE_SHA256" prior_amd64_manifest="$A6_AMD64_MANIFEST_SHA256" prior_arm64_manifest="$A6_ARM64_MANIFEST_SHA256"
-elif [[ "$GITHUB_REF_NAME" == "$A8_TAG" && "$COMPANION_VERSION" == "$A8_VERSION" ]]; then
-  release_phase='A8' prior_phase='A7' prior_repository="$A7_REPOSITORY" prior_evidence_source='immutable A7 GitHub release' prior_tag="$A7_TAG" prior_version="$A7_VERSION" prior_commit="$A7_COMMIT_SHA" prior_tree="$A7_TREE_SHA"
-  prior_tag_object="$A7_TAG_OBJECT_SHA" prior_checksums="$A7_CHECKSUMS_SHA256" prior_amd64_archive="$A7_AMD64_ARCHIVE_SHA256" prior_arm64_archive="$A7_ARM64_ARCHIVE_SHA256" prior_amd64_manifest="$A7_AMD64_MANIFEST_SHA256" prior_arm64_manifest="$A7_ARM64_MANIFEST_SHA256"
-elif [[ "$GITHUB_REF_NAME" == "$A9_TAG" && "$COMPANION_VERSION" == "$A9_VERSION" ]]; then
-  release_phase='A9' prior_phase='A8' prior_repository="$A8_REPOSITORY" prior_evidence_source='immutable A8 GitHub release' prior_tag="$A8_TAG" prior_version="$A8_VERSION" prior_commit="$A8_COMMIT_SHA" prior_tree="$A8_TREE_SHA"
-  prior_tag_object="$A8_TAG_OBJECT_SHA" prior_checksums="$A8_CHECKSUMS_SHA256" prior_amd64_archive="$A8_AMD64_ARCHIVE_SHA256" prior_arm64_archive="$A8_ARM64_ARCHIVE_SHA256" prior_amd64_manifest="$A8_AMD64_MANIFEST_SHA256" prior_arm64_manifest="$A8_ARM64_MANIFEST_SHA256"
-elif [[ "$GITHUB_REF_NAME" == "$A10_TAG" && "$COMPANION_VERSION" == "$A10_VERSION" ]]; then
-  release_phase='A10' prior_phase='A9' prior_repository="$A9_REPOSITORY" prior_evidence_source='immutable A9 GitHub release' prior_tag="$A9_TAG" prior_version="$A9_VERSION" prior_commit="$A9_COMMIT_SHA" prior_tree="$A9_TREE_SHA"
-  prior_tag_object="$A9_TAG_OBJECT_SHA" prior_checksums="$A9_CHECKSUMS_SHA256" prior_amd64_archive="$A9_AMD64_ARCHIVE_SHA256" prior_arm64_archive="$A9_ARM64_ARCHIVE_SHA256" prior_amd64_manifest="$A9_AMD64_MANIFEST_SHA256" prior_arm64_manifest="$A9_ARM64_MANIFEST_SHA256"
-elif [[ "$GITHUB_REF_NAME" == "$A11_TAG" && "$COMPANION_VERSION" == "$A11_VERSION" ]]; then
-  release_phase='A11' prior_phase='A10' prior_repository="$A10_REPOSITORY" prior_evidence_source='immutable A10 GitHub release' prior_tag="$A10_TAG" prior_version="$A10_VERSION" prior_commit="$A10_COMMIT_SHA" prior_tree="$A10_TREE_SHA"
-  prior_tag_object="$A10_TAG_OBJECT_SHA" prior_checksums="$A10_CHECKSUMS_SHA256" prior_amd64_archive="$A10_AMD64_ARCHIVE_SHA256" prior_arm64_archive="$A10_ARM64_ARCHIVE_SHA256" prior_amd64_manifest="$A10_AMD64_MANIFEST_SHA256" prior_arm64_manifest="$A10_ARM64_MANIFEST_SHA256"
-else
-  fail prior_release_identity_mismatch 'release is outside the frozen A0/A1/A2/A3/A4/A5/A6/A7/A8/A9/A10/A11 policy'
-fi
+coordinates_helper="$script_dir/verify-public-key-lineage-coordinates.sh"
+[[ -f "$coordinates_helper" && ! -L "$coordinates_helper" ]] || fail prior_evidence_unverifiable 'lineage coordinate source is invalid'
+# shellcheck source=verify-public-key-lineage-coordinates.sh
+source "$coordinates_helper"
 archive_helper="$script_dir/verify-public-key-lineage-archive.sh"
 [[ -f "$archive_helper" && ! -L "$archive_helper" ]] || fail prior_evidence_unverifiable 'lineage archive verifier is invalid'
 # shellcheck source=verify-public-key-lineage-archive.sh


### PR DESCRIPTION
## 문제

- 릴리스 계보·Homebrew hardening 스크립트가 한 파일에 과도하게 집중돼 A12 확장 여유가 부족했습니다.
- GoReleaser 계보 fixture가 시나리오마다 Darwin 아카이브 전체를 메모리 복제·재압축해 CI 시간과 메모리를 소모했습니다.
- Docker Desktop bind mount에서는 atomic exchange 뒤 stage 경로가 사라질 수 있어, 실제 교체 성공을 rollback 실패로 잘못 판정했습니다.

## 변경

- 계보 좌표, 릴리스 runtime hardening, Homebrew Git Data API 책임을 전용 helper로 분리하고 250줄 headroom 계약을 추가했습니다.
- Homebrew already-current 경로를 동일한 stable head → commit → tree snapshot의 exact Cask·frozen Formula blob 검증에 묶었습니다.
- immutable archive path cache, hard-link 우선·exclusive streaming copy fallback, 선택 entry만 streaming rewrite하는 fixture 경계를 도입했습니다.
- archive source identity와 compressed/entry/expanded/count/trailing-data 상한을 fail-closed로 적용했습니다.
- self-update가 pre-swap staged inode와 committed target inode를 대조해 bind-mount 성공을 판정하고 cleanup 오류를 보존하도록 수정했습니다.
- 변경된 고 fan-in·고 복잡도·외부 API 경계에 `@AX` 계약을 기록했습니다.

## 검증

- Linux race: `pkg/selfupdate`, `pkg/companionmanifest`, `internal/companionmanifest` 통과
- focused archive race 3회 shuffle 통과
- release runtime/Homebrew/전체 hardening 통과
- 변경 셸 및 전체 셸 ShellCheck error severity 통과
- `go vet`, `golangci-lint`, `actionlint`, GoReleaser check, `git diff --check` 통과
- Correctness/Security Guardian의 기존 6개 finding 재검토: 모두 RESOLVED, release-blocking regression 0건
- Docker Desktop 실제 bind mount에서 공식 v0.50.81 → 패치 v0.50.82 self-update 성공, 최종 SHA-256 `78e4a0d4067d998ca3df2d6b636a69d32a848082aab6b7a5fd28525ac876e3af`, residue 0건

Closes #90
Closes #92
Closes #93
