### PR TITLE
fix(orchestra): pane 수명주기와 세션 경계를 수렴한다

### DIFF
--- a/.autopus/specs/SPEC-ORCH-018/spec.md
+++ b/.autopus/specs/SPEC-ORCH-018/spec.md
@@ -135,7 +135,7 @@ The `/auto idea` skill's Step 3 and Step 4 SHALL be updated to:
 THE SYSTEM SHALL provide an `auto orchestra inject --session-id <ID> --provider <name> "prompt"` command that sends a prompt to a specific provider's pane, abstracting the cmux `set-buffer`/`paste-buffer` details.
 
 **R12 (Session persistence file)**:
-WHEN `--yield-rounds` creates a session, THE SYSTEM SHALL write session metadata to `/tmp/autopus-orch-session-{ID}.json` containing pane IDs, provider configs, and round history, for use by `collect`, `inject`, and `cleanup` commands.
+WHEN `--yield-rounds` creates a session, THE SYSTEM SHALL exclusively create session metadata in the private `/tmp/autopus-orchestra-sessions/{ID}.json` path (directory `0700`, file `0600`) containing pane IDs, provider configs, and round history, for use by `collect`, `inject`, and `cleanup` commands. For patch-release compatibility, reads and removals SHALL fall back to the legacy `/tmp/autopus-orch-session-{ID}.json` basename only when the private entry does not exist, and SHALL reject symlinks, non-regular entries, identity changes, or a persisted ID that differs from the requested ID.
 
 ## File Inventory
 

--- a/internal/cli/orchestra_cleanup_test.go
+++ b/internal/cli/orchestra_cleanup_test.go
@@ -1,6 +1,9 @@
 package cli
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -53,4 +56,22 @@ func TestRunOrchestraCleanup_RemovesSessionFile(t *testing.T) {
 	// Session file should be removed
 	_, loadErr := orchestra.LoadSession(session.ID)
 	assert.Error(t, loadErr, "session should be removed after cleanup")
+}
+
+func TestRunOrchestraCleanup_RemovesLegacySessionFile(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	session := orchestra.OrchestraSession{
+		ID:        "legacy-cleanup",
+		Panes:     map[string]string{},
+		CreatedAt: time.Now(),
+	}
+	data, err := json.Marshal(session)
+	require.NoError(t, err)
+	path := filepath.Join(os.TempDir(), "autopus-orch-session-"+session.ID+".json")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+
+	require.NoError(t, runOrchestraCleanup(t.Context(), session.ID))
+
+	_, err = os.Lstat(path)
+	assert.ErrorIs(t, err, os.ErrNotExist)
 }

--- a/pkg/orchestra/detach.go
+++ b/pkg/orchestra/detach.go
@@ -11,6 +11,9 @@ import (
 // without waiting for completion. Only works with pane-capable terminals.
 // @AX:NOTE [AUTO] REQ-1 detach entry point — must return in <2s; no collectPaneResults or cleanupPanes; fan_in=2 (orchestra.go auto-detach, tests)
 func RunPaneOrchestraDetached(ctx context.Context, cfg OrchestraConfig) (string, error) {
+	if err := validateOrchestraProviderConfig(cfg); err != nil {
+		return "", err
+	}
 	if cfg.Terminal == nil || cfg.Terminal.Name() == "plain" {
 		return "", fmt.Errorf("detach mode requires a pane-capable terminal")
 	}

--- a/pkg/orchestra/headless_hook_test.go
+++ b/pkg/orchestra/headless_hook_test.go
@@ -96,6 +96,7 @@ func TestSendSessionEnvToPane_InvalidID_Rejected(t *testing.T) {
 	ctx := context.Background()
 
 	cases := []string{
+		"Orch-ABC",
 		"sid with space",
 		"sid;rm -rf /",
 		"sid$(whoami)",

--- a/pkg/orchestra/hook_session_root.go
+++ b/pkg/orchestra/hook_session_root.go
@@ -1,0 +1,227 @@
+package orchestra
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+)
+
+const hookBaseDirectoryName = "autopus"
+
+type hookSessionStorage struct {
+	mu            sync.Mutex
+	baseRoot      *os.Root
+	sessionRoot   *os.Root
+	baseInfo      fs.FileInfo
+	sessionInfo   fs.FileInfo
+	sessionName   string
+	ownsDirectory bool
+	closed        bool
+}
+
+func openValidatedHookDirectory(parent *os.Root, name, path, kind string) (*os.Root, fs.FileInfo, error) {
+	info, err := parent.Lstat(name)
+	if err != nil {
+		return nil, nil, fmt.Errorf("inspect %s: %w", kind, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return nil, nil, fmt.Errorf("%s is not a secure directory", kind)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o700 {
+		return nil, nil, fmt.Errorf("%s permissions are %o, want 700", kind, info.Mode().Perm())
+	}
+	if !surfaceDirSecure(path) {
+		return nil, nil, fmt.Errorf("%s ownership or permissions are insecure", kind)
+	}
+
+	root, err := parent.OpenRoot(name)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open %s: %w", kind, err)
+	}
+	openedInfo, err := root.Stat(".")
+	if err != nil {
+		_ = root.Close()
+		return nil, nil, fmt.Errorf("inspect opened %s: %w", kind, err)
+	}
+	if !os.SameFile(info, openedInfo) {
+		_ = root.Close()
+		return nil, nil, fmt.Errorf("%s changed while opening", kind)
+	}
+	return root, openedInfo, nil
+}
+
+func newHookSessionStorage(sessionID string) (*hookSessionStorage, string, error) {
+	if err := validateHookSessionID(sessionID); err != nil {
+		return nil, "", err
+	}
+	tempRoot, err := os.OpenRoot(os.TempDir())
+	if err != nil {
+		return nil, "", fmt.Errorf("open temp root: %w", err)
+	}
+	defer func() { _ = tempRoot.Close() }()
+
+	if err := tempRoot.Mkdir(hookBaseDirectoryName, 0o700); err != nil && !errors.Is(err, fs.ErrExist) {
+		return nil, "", fmt.Errorf("create hook base directory: %w", err)
+	}
+	basePath := filepath.Join(os.TempDir(), hookBaseDirectoryName)
+	baseRoot, baseInfo, err := openValidatedHookDirectory(
+		tempRoot, hookBaseDirectoryName, basePath, "hook base directory",
+	)
+	if err != nil {
+		return nil, "", err
+	}
+
+	ownsDirectory := false
+	if err := baseRoot.Mkdir(sessionID, 0o700); err == nil {
+		ownsDirectory = true
+	} else if !errors.Is(err, fs.ErrExist) {
+		_ = baseRoot.Close()
+		return nil, "", fmt.Errorf("create hook session directory: %w", err)
+	}
+	sessionPath := filepath.Join(basePath, sessionID)
+	sessionRoot, sessionInfo, err := openValidatedHookDirectory(
+		baseRoot, sessionID, sessionPath, "hook session directory",
+	)
+	if err != nil {
+		_ = baseRoot.Close()
+		return nil, "", err
+	}
+
+	return &hookSessionStorage{
+		baseRoot:      baseRoot,
+		sessionRoot:   sessionRoot,
+		baseInfo:      baseInfo,
+		sessionInfo:   sessionInfo,
+		sessionName:   sessionID,
+		ownsDirectory: ownsDirectory,
+	}, sessionPath, nil
+}
+
+func (s *hookSessionStorage) stat(name string) (fs.FileInfo, error) {
+	return s.sessionRoot.Stat(name)
+}
+
+func (s *hookSessionStorage) readFile(name string) ([]byte, error) {
+	return s.sessionRoot.ReadFile(name)
+}
+
+func (s *hookSessionStorage) remove(name string) error {
+	return s.sessionRoot.Remove(name)
+}
+
+func (s *hookSessionStorage) writeFile(name string, data []byte, perm os.FileMode) error {
+	return s.sessionRoot.WriteFile(name, data, perm)
+}
+
+func (s *hookSessionStorage) writeJSON(name string, value any) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("marshal json: %w", err)
+	}
+	temporary := name + ".tmp"
+	if err := s.sessionRoot.WriteFile(temporary, data, 0o600); err != nil {
+		return fmt.Errorf("write tmp file: %w", err)
+	}
+	if err := s.sessionRoot.Chmod(temporary, 0o600); err != nil {
+		_ = s.sessionRoot.Remove(temporary)
+		return fmt.Errorf("chmod tmp file: %w", err)
+	}
+	if err := s.sessionRoot.Rename(temporary, name); err != nil {
+		_ = s.sessionRoot.Remove(temporary)
+		return fmt.Errorf("rename %s -> %s: %w", temporary, name, err)
+	}
+	return nil
+}
+
+func (s *HookSession) statArtifact(name string) (fs.FileInfo, error) {
+	if s.storage != nil {
+		return s.storage.stat(name)
+	}
+	return os.Stat(filepath.Join(s.sessionDir, name))
+}
+
+func (s *HookSession) readArtifact(name string) ([]byte, error) {
+	if s.storage != nil {
+		return s.storage.readFile(name)
+	}
+	return os.ReadFile(filepath.Join(s.sessionDir, name))
+}
+
+func (s *HookSession) removeArtifact(name string) error {
+	if s.storage != nil {
+		return s.storage.remove(name)
+	}
+	return os.Remove(filepath.Join(s.sessionDir, name))
+}
+
+func (s *HookSession) writeArtifact(name string, data []byte, perm os.FileMode) error {
+	if s.storage != nil {
+		return s.storage.writeFile(name, data, perm)
+	}
+	return os.WriteFile(filepath.Join(s.sessionDir, name), data, perm)
+}
+
+func (s *HookSession) writeJSONArtifact(name string, value any) error {
+	if s.storage != nil {
+		return s.storage.writeJSON(name, value)
+	}
+	return atomicWriteJSON(filepath.Join(s.sessionDir, name), value)
+}
+
+func (s *HookSession) release() {
+	if s != nil && s.storage != nil {
+		s.storage.release()
+	}
+}
+
+func (s *hookSessionStorage) release() {
+	s.close(false)
+}
+
+func (s *hookSessionStorage) cleanup() {
+	s.close(true)
+}
+
+func (s *hookSessionStorage) close(removeOwned bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return
+	}
+	s.closed = true
+	if removeOwned && s.ownsDirectory {
+		s.removeOwnedDirectory()
+	}
+	_ = s.sessionRoot.Close()
+	_ = s.baseRoot.Close()
+}
+
+func (s *hookSessionStorage) removeOwnedDirectory() {
+	baseInfo, baseErr := s.baseRoot.Stat(".")
+	currentInfo, currentErr := s.baseRoot.Lstat(s.sessionName)
+	if baseErr != nil || currentErr != nil || !os.SameFile(s.baseInfo, baseInfo) ||
+		!currentInfo.IsDir() || !os.SameFile(s.sessionInfo, currentInfo) {
+		return
+	}
+	entries, err := fs.ReadDir(s.sessionRoot.FS(), ".")
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if err := s.sessionRoot.RemoveAll(entry.Name()); err != nil {
+			return
+		}
+	}
+	openedInfo, openedErr := s.sessionRoot.Stat(".")
+	currentInfo, currentErr = s.baseRoot.Lstat(s.sessionName)
+	if openedErr != nil || currentErr != nil || !os.SameFile(s.sessionInfo, openedInfo) ||
+		!currentInfo.IsDir() || !os.SameFile(s.sessionInfo, currentInfo) {
+		return
+	}
+	_ = s.baseRoot.Remove(s.sessionName)
+}

--- a/pkg/orchestra/hook_session_security_test.go
+++ b/pkg/orchestra/hook_session_security_test.go
@@ -1,0 +1,189 @@
+package orchestra
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func hookBasePath() string {
+	return filepath.Join(os.TempDir(), "autopus")
+}
+
+func TestNewHookSession_RejectsEmptyAndUnsafeIDs(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	for _, id := range []string{"", ".", "..", "../session", "a/b", `a\b`, "has space"} {
+		t.Run(id, func(t *testing.T) {
+			session, err := NewHookSession(id)
+			assert.Nil(t, session)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestNewHookSession_RejectsSymlinkedBase(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated Windows privileges")
+	}
+	t.Setenv("TMPDIR", t.TempDir())
+	external := filepath.Join(os.TempDir(), "external-base")
+	require.NoError(t, os.Mkdir(external, 0o700))
+	require.NoError(t, os.Symlink(external, hookBasePath()))
+
+	session, err := NewHookSession("safe-session")
+
+	assert.Nil(t, session)
+	assert.Error(t, err)
+	_, statErr := os.Stat(filepath.Join(external, "safe-session"))
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestNewHookSession_RejectsSymlinkedSession(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated Windows privileges")
+	}
+	t.Setenv("TMPDIR", t.TempDir())
+	require.NoError(t, os.Mkdir(hookBasePath(), 0o700))
+	external := filepath.Join(os.TempDir(), "external-session")
+	require.NoError(t, os.Mkdir(external, 0o700))
+	require.NoError(t, os.Symlink(external, filepath.Join(hookBasePath(), "linked-session")))
+
+	session, err := NewHookSession("linked-session")
+
+	assert.Nil(t, session)
+	assert.Error(t, err)
+	assert.DirExists(t, external)
+}
+
+func TestNewHookSession_RejectsInsecurePreclaimedDirectories(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix directory permissions are not available")
+	}
+	for _, target := range []string{"base", "session"} {
+		t.Run(target, func(t *testing.T) {
+			t.Setenv("TMPDIR", t.TempDir())
+			base := hookBasePath()
+			require.NoError(t, os.Mkdir(base, 0o700))
+			if target == "session" {
+				require.NoError(t, os.Mkdir(filepath.Join(base, "preclaimed"), 0o700))
+				require.NoError(t, os.Chmod(filepath.Join(base, "preclaimed"), 0o755))
+			} else {
+				require.NoError(t, os.Chmod(base, 0o755))
+			}
+
+			session, err := NewHookSession("preclaimed")
+			assert.Nil(t, session)
+			assert.ErrorContains(t, err, "permissions")
+		})
+	}
+}
+
+func TestHookSession_NonOwnerCleanupPreservesSecureExistingDirectory(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	dir := filepath.Join(hookBasePath(), "shared-session")
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	sentinel := filepath.Join(dir, "sentinel")
+	require.NoError(t, os.WriteFile(sentinel, []byte("shared"), 0o600))
+
+	session, err := NewHookSession("shared-session")
+	require.NoError(t, err)
+	session.Cleanup()
+
+	assert.DirExists(t, dir)
+	assert.FileExists(t, sentinel)
+}
+
+func TestHookSession_OwnerCleanupPreservesRenamedAndReplacementDirectories(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("open-directory rename behavior is platform-specific")
+	}
+	t.Setenv("TMPDIR", t.TempDir())
+	session, err := NewHookSession("owner-session")
+	require.NoError(t, err)
+	ownedSentinel := filepath.Join(session.Dir(), "owned-sentinel")
+	require.NoError(t, os.WriteFile(ownedSentinel, []byte("owned"), 0o600))
+
+	moved := filepath.Join(hookBasePath(), "moved-owner-session")
+	require.NoError(t, os.Rename(session.Dir(), moved))
+	require.NoError(t, os.Mkdir(session.Dir(), 0o700))
+	replacementSentinel := filepath.Join(session.Dir(), "replacement-sentinel")
+	require.NoError(t, os.WriteFile(replacementSentinel, []byte("replacement"), 0o600))
+
+	session.Cleanup()
+
+	assert.FileExists(t, filepath.Join(moved, "owned-sentinel"))
+	assert.FileExists(t, replacementSentinel)
+}
+
+func TestHookSession_OwnerCleanupDoesNotFollowExternalSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated Windows privileges")
+	}
+	t.Setenv("TMPDIR", t.TempDir())
+	session, err := NewHookSession("symlink-content")
+	require.NoError(t, err)
+	external := filepath.Join(os.TempDir(), "external-target")
+	require.NoError(t, os.WriteFile(external, []byte("keep"), 0o600))
+	require.NoError(t, os.Symlink(external, filepath.Join(session.Dir(), "outside-link")))
+
+	session.Cleanup()
+
+	data, err := os.ReadFile(external)
+	require.NoError(t, err)
+	assert.Equal(t, "keep", string(data))
+	assert.NoDirExists(t, session.Dir())
+}
+
+func TestHookSession_ArtifactMethodsRejectUnsafeProvider(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	session, err := NewHookSession("artifact-validation")
+	require.NoError(t, err)
+	defer session.Cleanup()
+	const unsafeProvider = "../claude"
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{name: "wait done", run: func() error { return session.WaitForDone(time.Millisecond, unsafeProvider) }},
+		{name: "wait done round", run: func() error { return session.WaitForDoneRound(time.Millisecond, unsafeProvider, 1) }},
+		{name: "wait done round ctx", run: func() error {
+			return session.WaitForDoneRoundCtx(context.Background(), time.Millisecond, unsafeProvider, 1)
+		}},
+		{name: "read result", run: func() error { _, err := session.ReadResult(unsafeProvider); return err }},
+		{name: "read result round", run: func() error { _, err := session.ReadResultRound(unsafeProvider, 1); return err }},
+		{name: "write input", run: func() error { return session.WriteInput(unsafeProvider, "prompt") }},
+		{name: "write input round", run: func() error { return session.WriteInputRound(unsafeProvider, 1, "prompt") }},
+		{name: "wait ready", run: func() error { return session.WaitForReady(time.Millisecond, unsafeProvider, 1) }},
+		{name: "wait ready ctx", run: func() error {
+			return session.WaitForReadyCtx(context.Background(), time.Millisecond, unsafeProvider, 1)
+		}},
+		{name: "write abort", run: func() error { return session.WriteAbortSignal(unsafeProvider, 1) }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.ErrorContains(t, test.run(), "unsafe")
+		})
+	}
+}
+
+func TestHookSession_OwnerAndReuserCleanupOrder(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	owner, err := NewHookSession("shared-owner")
+	require.NoError(t, err)
+	reuser, err := NewHookSession("shared-owner")
+	require.NoError(t, err)
+	require.NoError(t, reuser.WriteInput("claude", "prompt"))
+
+	reuser.Cleanup()
+	assert.DirExists(t, owner.Dir())
+	assert.FileExists(t, filepath.Join(owner.Dir(), RoundSignalName("claude", 0, "input.json")))
+
+	owner.Cleanup()
+	assert.NoDirExists(t, owner.Dir())
+}

--- a/pkg/orchestra/hook_signal.go
+++ b/pkg/orchestra/hook_signal.go
@@ -3,10 +3,8 @@ package orchestra
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"time"
 )
 
@@ -21,6 +19,7 @@ type HookSession struct {
 	sessionID     string
 	sessionDir    string
 	hookProviders map[string]bool
+	storage       *hookSessionStorage
 }
 
 // defaultHookProviders lists providers that have hooks by default.
@@ -35,16 +34,19 @@ var defaultHookProviders = map[string]bool{
 // Creates /tmp/autopus/{session-id}/ directory with 0o700 permissions.
 // @AX:ANCHOR [AUTO] fan_in=4 — called by interactive.go, interactive_debate.go, relay_pane.go, hook_watcher.go; do not change session dir layout
 func NewHookSession(sessionID string) (*HookSession, error) {
-	dir := filepath.Join(os.TempDir(), "autopus", sanitizeProviderName(sessionID))
-
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return nil, fmt.Errorf("create session dir: %w", err)
+	if err := validateHookSessionID(sessionID); err != nil {
+		return nil, fmt.Errorf("create hook session: %w", err)
+	}
+	storage, dir, err := newHookSessionStorage(sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("create hook session: %w", err)
 	}
 
 	return &HookSession{
 		sessionID:     sessionID,
 		sessionDir:    dir,
 		hookProviders: DefaultHookProviders(),
+		storage:       storage,
 	}, nil
 }
 
@@ -59,23 +61,27 @@ func (s *HookSession) ApplyProviderHooks(providers []ProviderConfig) {
 // Returns nil when the done file is detected, or error on timeout.
 // @AX:NOTE [AUTO] magic constant 200ms polling interval — balances responsiveness vs CPU; adjust with care
 func (s *HookSession) WaitForDone(timeout time.Duration, providers ...string) error {
+	if len(providers) > 0 {
+		if err := validateHookArtifactProvider(providers[0]); err != nil {
+			return err
+		}
+	}
 	deadline := time.After(timeout)
 	ticker := time.NewTicker(200 * time.Millisecond)
 	defer ticker.Stop()
 
 	// Use provider-specific done file if provider name is given (R1 protocol)
 	doneName := "done"
-	if len(providers) > 0 && providers[0] != "" {
-		doneName = sanitizeProviderName(providers[0]) + "-done"
+	if len(providers) > 0 {
+		doneName = providers[0] + "-done"
 	}
-	donePath := filepath.Join(s.sessionDir, doneName)
 
 	for {
 		select {
 		case <-deadline:
 			return fmt.Errorf("timeout waiting for done signal in session %s", s.sessionID)
 		case <-ticker.C:
-			if _, err := os.Stat(donePath); err == nil {
+			if _, err := s.statArtifact(doneName); err == nil {
 				return nil
 			}
 		}
@@ -86,6 +92,9 @@ func (s *HookSession) WaitForDone(timeout time.Duration, providers ...string) er
 // When round > 0, uses RoundSignalName to generate the filename;
 // otherwise falls back to the standard provider-done format.
 func (s *HookSession) WaitForDoneRound(timeout time.Duration, provider string, round int) error {
+	if err := validateHookArtifactProvider(provider); err != nil {
+		return err
+	}
 	if round > 0 {
 		doneName := RoundSignalName(provider, round, "done")
 		return s.waitForFileCtx(context.Background(), timeout, doneName)
@@ -95,6 +104,9 @@ func (s *HookSession) WaitForDoneRound(timeout time.Duration, provider string, r
 
 // WaitForDoneRoundCtx polls for the round-scoped done signal file, respecting context cancellation.
 func (s *HookSession) WaitForDoneRoundCtx(ctx context.Context, timeout time.Duration, provider string, round int) error {
+	if err := validateHookArtifactProvider(provider); err != nil {
+		return err
+	}
 	if round > 0 {
 		doneName := RoundSignalName(provider, round, "done")
 		return s.waitForFileCtx(ctx, timeout, doneName)
@@ -108,7 +120,6 @@ func (s *HookSession) waitForFileCtx(ctx context.Context, timeout time.Duration,
 	ticker := time.NewTicker(200 * time.Millisecond)
 	defer ticker.Stop()
 
-	path := filepath.Join(s.sessionDir, filename)
 	for {
 		select {
 		case <-ctx.Done():
@@ -116,7 +127,7 @@ func (s *HookSession) waitForFileCtx(ctx context.Context, timeout time.Duration,
 		case <-deadline:
 			return fmt.Errorf("timeout waiting for %s in session %s", filename, s.sessionID)
 		case <-ticker.C:
-			if _, err := os.Stat(path); err == nil {
+			if _, err := s.statArtifact(filename); err == nil {
 				return nil
 			}
 		}
@@ -127,10 +138,13 @@ func (s *HookSession) waitForFileCtx(ctx context.Context, timeout time.Duration,
 func (s *HookSession) ReadResult(providers ...string) (*HookResult, error) {
 	// Use provider-specific result file if provider name is given (R1 protocol)
 	resultName := "result.json"
-	if len(providers) > 0 && providers[0] != "" {
-		resultName = sanitizeProviderName(providers[0]) + "-result.json"
+	if len(providers) > 0 {
+		if err := validateHookArtifactProvider(providers[0]); err != nil {
+			return nil, err
+		}
+		resultName = providers[0] + "-result.json"
 	}
-	data, err := os.ReadFile(filepath.Join(s.sessionDir, resultName))
+	data, err := s.readArtifact(resultName)
 	if err != nil {
 		return nil, fmt.Errorf("read result file: %w", err)
 	}
@@ -147,6 +161,9 @@ func (s *HookSession) ReadResult(providers ...string) (*HookResult, error) {
 // When round > 0, uses RoundSignalName to generate the filename;
 // otherwise falls back to the standard provider-result.json format.
 func (s *HookSession) ReadResultRound(provider string, round int) (*HookResult, error) {
+	if err := validateHookArtifactProvider(provider); err != nil {
+		return nil, err
+	}
 	if round > 0 {
 		resultName := RoundSignalName(provider, round, "result.json")
 		return s.readResultFile(resultName)
@@ -179,7 +196,7 @@ func (s *HookSession) ResetAttempt(provider string, round int) error {
 		RoundSignalName(safeProvider, round, "abort"),
 	}
 	for _, name := range names {
-		if err := os.Remove(filepath.Join(s.sessionDir, name)); err != nil && !os.IsNotExist(err) {
+		if err := s.removeArtifact(name); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("reset hook attempt artifact %s: %w", name, err)
 		}
 	}
@@ -187,24 +204,12 @@ func (s *HookSession) ResetAttempt(provider string, round int) error {
 }
 
 func validateHookArtifactProvider(provider string) error {
-	if provider == "" {
-		return errors.New("hook provider name is empty")
-	}
-	for _, char := range provider {
-		if (char >= 'a' && char <= 'z') ||
-			(char >= 'A' && char <= 'Z') ||
-			(char >= '0' && char <= '9') ||
-			char == '_' || char == '-' {
-			continue
-		}
-		return fmt.Errorf("hook provider name contains unsafe character: %q", provider)
-	}
-	return nil
+	return validateSafeArtifactName("hook provider name", provider)
 }
 
 // readResultFile reads and parses a named result file from the session directory.
 func (s *HookSession) readResultFile(filename string) (*HookResult, error) {
-	data, err := os.ReadFile(filepath.Join(s.sessionDir, filename))
+	data, err := s.readArtifact(filename)
 	if err != nil {
 		return nil, fmt.Errorf("read result file: %w", err)
 	}
@@ -217,9 +222,11 @@ func (s *HookSession) readResultFile(filename string) (*HookResult, error) {
 	return &result, nil
 }
 
-// Cleanup removes the session directory and all its contents.
+// Cleanup removes an owned session directory. Reusers only close their handles.
 func (s *HookSession) Cleanup() {
-	_ = os.RemoveAll(s.sessionDir)
+	if s != nil && s.storage != nil {
+		s.storage.cleanup()
+	}
 }
 
 // HasHook checks if a provider has hook configuration available.
@@ -250,10 +257,12 @@ func (s *HookSession) WriteInput(provider, prompt string) error {
 // WriteInputRound writes a round-scoped input prompt file using atomic write.
 // Creates {provider}-round{N}-input.json with HookInput JSON.
 func (s *HookSession) WriteInputRound(provider string, round int, prompt string) error {
+	if err := validateHookArtifactProvider(provider); err != nil {
+		return err
+	}
 	filename := RoundSignalName(provider, round, "input.json")
-	path := filepath.Join(s.sessionDir, filename)
 	input := HookInput{Provider: provider, Round: round, Prompt: prompt}
-	return atomicWriteJSON(path, input)
+	return s.writeJSONArtifact(filename, input)
 }
 
 // WaitForReady polls for the provider's ready signal file (convenience wrapper).
@@ -264,6 +273,9 @@ func (s *HookSession) WaitForReady(timeout time.Duration, provider string, round
 // WaitForReadyCtx polls for the round-scoped ready signal file, respecting context.
 // Ready file format: {provider}-round{N}-ready
 func (s *HookSession) WaitForReadyCtx(ctx context.Context, timeout time.Duration, provider string, round int) error {
+	if err := validateHookArtifactProvider(provider); err != nil {
+		return err
+	}
 	readyName := RoundSignalName(provider, round, "ready")
 	return s.waitForFileCtx(ctx, timeout, readyName)
 }
@@ -271,7 +283,9 @@ func (s *HookSession) WaitForReadyCtx(ctx context.Context, timeout time.Duration
 // WriteAbortSignal creates an abort signal file to unblock hook input watchers.
 // R5-SAFETY: Prevents deadlock when Orchestra falls back to SendLongText.
 func (s *HookSession) WriteAbortSignal(provider string, round int) error {
+	if err := validateHookArtifactProvider(provider); err != nil {
+		return err
+	}
 	abortName := RoundSignalName(provider, round, "abort")
-	path := filepath.Join(s.sessionDir, abortName)
-	return os.WriteFile(path, []byte{}, 0o600)
+	return s.writeArtifact(abortName, []byte{}, 0o600)
 }

--- a/pkg/orchestra/hook_signal_test.go
+++ b/pkg/orchestra/hook_signal_test.go
@@ -198,20 +198,23 @@ func TestHookSession_SessionID(t *testing.T) {
 	assert.Equal(t, "test-session-id-check", sess.SessionID())
 }
 
-// TestHookSession_SpecialCharSessionID verifies that session IDs with
-// path traversal characters are sanitized.
+// TestHookSession_SpecialCharSessionID verifies that unsafe session IDs fail closed.
 func TestHookSession_SpecialCharSessionID(t *testing.T) {
 	t.Parallel()
 
 	sess, err := NewHookSession("test/../../../etc/passwd")
-	require.NoError(t, err)
-	defer sess.Cleanup()
+	assert.Nil(t, sess)
+	assert.Error(t, err)
+}
 
-	info, statErr := os.Stat(sess.Dir())
-	require.NoError(t, statErr)
-	assert.True(t, info.IsDir())
-	// Sanitized path must not contain path traversal components.
-	assert.NotContains(t, sess.Dir(), "..")
+func TestHookSession_UppercaseSessionIDFailsBeforeFilesystemMutation(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+
+	sess, err := NewHookSession("Alias-ABC")
+
+	assert.Nil(t, sess)
+	assert.ErrorContains(t, err, "lowercase")
+	assert.NoDirExists(t, filepath.Join(os.TempDir(), "autopus"))
 }
 
 // TestHookSession_ConcurrentWaitForDone verifies that multiple goroutines

--- a/pkg/orchestra/hook_watcher.go
+++ b/pkg/orchestra/hook_watcher.go
@@ -11,6 +11,12 @@ import (
 // For non-hook providers: returns a fallback response with placeholder output.
 // @AX:WARN [AUTO] concurrent goroutine per provider — guarded by mu sync.Mutex; goroutines inherit parent context timeout
 func WaitAndCollectHookResults(cfg OrchestraConfig, sessionID string) ([]ProviderResponse, error) {
+	if err := validateProviderConfigs(cfg.Providers); err != nil {
+		return nil, err
+	}
+	if err := validateHookSessionID(sessionID); err != nil {
+		return nil, err
+	}
 	session, err := NewHookSession(sessionID)
 	if err != nil {
 		return nil, err

--- a/pkg/orchestra/interactive.go
+++ b/pkg/orchestra/interactive.go
@@ -18,6 +18,9 @@ const promptSubmitDelay = 100 * time.Millisecond
 // RunInteractivePaneOrchestra runs interactive CLI orchestration with ReadScreen polling.
 // @AX:NOTE [AUTO] interactive orchestration entry point — fan_in=1 (pane_runner.go only); downgraded from ANCHOR
 func RunInteractivePaneOrchestra(ctx context.Context, cfg OrchestraConfig) (*OrchestraResult, error) {
+	if err := validateOrchestraProviderConfig(cfg); err != nil {
+		return nil, err
+	}
 	// R8: plain terminal -> fallback to sentinel mode
 	if cfg.Terminal == nil || cfg.Terminal.Name() == "plain" {
 		cfg.Interactive = false

--- a/pkg/orchestra/interactive_debate.go
+++ b/pkg/orchestra/interactive_debate.go
@@ -135,10 +135,13 @@ func runPaneDebate(ctx context.Context, cfg OrchestraConfig, rounds int, perRoun
 		log.Printf("[debate] splitProviderPanes failed: %v -- applying fallback policy", err)
 		return runFallback(ctx, cfg, err)
 	}
-	// R5: Skip pane cleanup when yield mode is active — keep panes alive.
-	if !cfg.YieldRounds {
-		defer cleanupInteractivePanes(cfg.Terminal, panes)
-	}
+	// Pane ownership transfers only after the yield session is durable.
+	ownsPanes := true
+	defer func() {
+		if ownsPanes {
+			cleanupInteractivePanes(cfg.Terminal, panes)
+		}
+	}()
 
 	if err := startPipeCapture(ctx, cfg.Terminal, panes); err != nil {
 		// Pipe-pane is for idle detection (secondary signal) only.
@@ -199,7 +202,10 @@ func runPaneDebate(ctx context.Context, cfg OrchestraConfig, rounds int, perRoun
 			fmt.Fprintf(os.Stderr, "[Debate] yield after round 1/%d\n", rounds)
 			sessionID := NewSessionID()
 			session := buildYieldSession(sessionID, panes, roundResponses, time.Now())
-			_ = SaveSession(session)
+			if err := SaveSession(session); err != nil {
+				return nil, fmt.Errorf("persist yield session: %w", err)
+			}
+			ownsPanes = false
 			output := BuildYieldOutput(cfg, panes, roundHistory, sessionID)
 			// surfMgr.Stop() removed — defer at line 115 handles cleanup.
 			// Explicit Stop here caused duplicate WarmPool.Close() calls.

--- a/pkg/orchestra/interactive_debate_round.go
+++ b/pkg/orchestra/interactive_debate_round.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"sort"
 	"strings"
 	"time"
 )
@@ -248,5 +249,26 @@ func executeRound(ctx context.Context, cfg OrchestraConfig, panes []paneInfo, ho
 			responses[i].EmptyOutput = true
 		}
 	}
+	return orderDebateResponses(responses, cfg.Providers)
+}
+
+func orderDebateResponses(responses []ProviderResponse, providers []ProviderConfig) []ProviderResponse {
+	providerOrder := make(map[string]int, len(providers))
+	for i, provider := range providers {
+		if _, exists := providerOrder[provider.Name]; !exists {
+			providerOrder[provider.Name] = i
+		}
+	}
+	sort.SliceStable(responses, func(i, j int) bool {
+		left, leftKnown := providerOrder[responses[i].Provider]
+		right, rightKnown := providerOrder[responses[j].Provider]
+		if leftKnown != rightKnown {
+			return leftKnown
+		}
+		if leftKnown {
+			return left < right
+		}
+		return responses[i].Provider < responses[j].Provider
+	})
 	return responses
 }

--- a/pkg/orchestra/interactive_debate_salvage_test.go
+++ b/pkg/orchestra/interactive_debate_salvage_test.go
@@ -1,0 +1,110 @@
+package orchestra
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type yieldSaveFailureTerminal struct {
+	mockTerminal
+	invalidTempDir string
+	setTempDir     func(string)
+}
+
+func (m *yieldSaveFailureTerminal) SendLongText(_ context.Context, _ terminal.PaneID, _ string) error {
+	return errors.New("force provider launch failure after pane provisioning")
+}
+
+func (m *yieldSaveFailureTerminal) FocusPane(_ context.Context, _ terminal.PaneID) error {
+	m.setTempDir(m.invalidTempDir)
+	return nil
+}
+
+func TestRunPaneDebate_YieldSaveFailureCleansOwnedPanes(t *testing.T) {
+	isolateSurfaceTracker(t)
+
+	workingDir := t.TempDir()
+	invalidTempDir := filepath.Join(workingDir, "not-a-directory")
+	require.NoError(t, os.WriteFile(invalidTempDir, []byte("block session persistence"), 0o600))
+	term := &yieldSaveFailureTerminal{
+		mockTerminal:   mockTerminal{name: "cmux"},
+		invalidTempDir: invalidTempDir,
+		setTempDir:     func(path string) { t.Setenv("TMPDIR", path) },
+	}
+	cfg := OrchestraConfig{
+		Providers:      []ProviderConfig{echoProvider("claude")},
+		Strategy:       StrategyDebate,
+		Prompt:         "yield only after durable session persistence",
+		TimeoutSeconds: 1,
+		Terminal:       term,
+		Interactive:    true,
+		YieldRounds:    true,
+		NoJudge:        true,
+		InitialDelay:   time.Millisecond,
+		WorkingDir:     workingDir,
+	}
+
+	result, err := runPaneDebate(context.Background(), cfg, 1, time.Second, time.Now())
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.ErrorContains(t, err, "persist yield session")
+	assert.Equal(t, []string{"pane-1"}, term.closeCalls,
+		"the pane stays locally owned and must close when persistence fails")
+	assert.NotContains(t, readTrackerRefs(surfaceTrackerFile(os.Getpid())), "pane-1",
+		"a successfully closed pane must be untracked")
+}
+
+func TestExecuteRound_OrdersResponsesAtDebateBoundary(t *testing.T) {
+	term := &mockTerminal{name: "cmux"}
+	cfg := OrchestraConfig{
+		Providers: []ProviderConfig{
+			{Name: "delta"},
+			{Name: "alpha"},
+		},
+		Strategy:       StrategyDebate,
+		Terminal:       term,
+		TimeoutSeconds: 1,
+		InitialDelay:   time.Nanosecond,
+	}
+	panes := []paneInfo{
+		{provider: ProviderConfig{Name: "unknown-z"}, paneID: "pane-z", skipWait: true},
+		{provider: ProviderConfig{Name: "alpha"}, paneID: "pane-a", skipWait: true},
+		{provider: ProviderConfig{Name: "unknown-a"}, paneID: "pane-u", skipWait: true},
+		{provider: ProviderConfig{Name: "delta"}, paneID: "pane-d", skipWait: true},
+	}
+
+	responses := executeRound(context.Background(), cfg, panes, nil, 1, nil)
+
+	assert.Equal(t, []string{"delta", "alpha", "unknown-a", "unknown-z"}, responseProviderNames(responses))
+}
+
+func TestWaitAndCollectResults_PreservesCollectionOrder(t *testing.T) {
+	panes := []paneInfo{
+		{provider: ProviderConfig{Name: "second"}, skipWait: true},
+		{provider: ProviderConfig{Name: "first"}, skipWait: true},
+	}
+
+	responses := waitAndCollectResults(
+		context.Background(), OrchestraConfig{}, panes, nil, time.Now(), nil, nil, 0,
+	)
+
+	assert.Equal(t, []string{"second", "first"}, responseProviderNames(responses),
+		"shared collection order must remain untouched for non-debate strategies")
+}
+
+func responseProviderNames(responses []ProviderResponse) []string {
+	names := make([]string, 0, len(responses))
+	for _, response := range responses {
+		names = append(names, response.Provider)
+	}
+	return names
+}

--- a/pkg/orchestra/pane_backend.go
+++ b/pkg/orchestra/pane_backend.go
@@ -42,6 +42,12 @@ func (b *InteractivePaneBackend) Name() string { return paneBackendName }
 // @AX:WARN [AUTO]: multi-stage terminal I/O with >=8 sequential failure branches; any new stage MUST preserve the SplitPane commit-point contract.
 // @AX:REASON: only terminal absence and SplitPane failure may invoke subprocess fallback; every failure after a non-empty pane ID must report ExecutedBackend=pane without running a provider subprocess.
 func (b *InteractivePaneBackend) Execute(ctx context.Context, req ProviderRequest) (*ProviderResponse, error) {
+	if err := validateOrchestraProviderConfig(b.cfg); err != nil {
+		return nil, err
+	}
+	if err := validateProviderRequest(req); err != nil {
+		return nil, err
+	}
 	if b.cfg.Terminal == nil {
 		// Defensive: no terminal means we cannot run a pane at all.
 		return paneProvisioningFallback(ctx, b.cfg, req, "interactive pane execution failed: no terminal attached")
@@ -76,6 +82,9 @@ func (b *InteractivePaneBackend) Execute(ctx context.Context, req ProviderReques
 	// reset is intentionally provider-scoped because sibling providers execute in
 	// parallel within the same HookSession directory.
 	hookSession := resolveHookSession(b.cfg)
+	if hookSession != nil {
+		defer hookSession.release()
+	}
 	if hookSession != nil && hookSession.HasHook(req.Config.Name) {
 		if resetErr := hookSession.ResetAttempt(req.Config.Name, req.Round); resetErr != nil {
 			return paneExecutionFailure(req, "interactive pane execution failed: reset hook attempt: "+resetErr.Error())

--- a/pkg/orchestra/pane_runner.go
+++ b/pkg/orchestra/pane_runner.go
@@ -31,6 +31,9 @@ type paneInfo struct {
 // Falls back to RunOrchestra for plain terminals or when pane creation fails.
 // @AX:NOTE [AUTO] pane-based orchestration entry point — 2 callers (runner.go, tests)
 func RunPaneOrchestra(ctx context.Context, cfg OrchestraConfig) (*OrchestraResult, error) {
+	if err := validateOrchestraProviderConfig(cfg); err != nil {
+		return nil, err
+	}
 	if !cfg.FallbackMode.IsValid() {
 		return nil, fmt.Errorf("unknown fallback mode %q", cfg.FallbackMode)
 	}

--- a/pkg/orchestra/pipeline.go
+++ b/pkg/orchestra/pipeline.go
@@ -35,6 +35,9 @@ func RunSubprocessPipeline(ctx context.Context, cfg SubprocessPipelineConfig) (*
 	if cfg.Backend == nil {
 		return nil, fmt.Errorf("pipeline: backend is nil")
 	}
+	if err := validateSubprocessPipelineProviders(cfg.Providers, cfg.Judge); err != nil {
+		return nil, fmt.Errorf("pipeline: %w", err)
+	}
 	contractCfg := subprocessPipelineContractConfig(cfg)
 	if result, err := preflightJudgeFamilySeparation(contractCfg); err != nil {
 		return result, err

--- a/pkg/orchestra/provider_validation.go
+++ b/pkg/orchestra/provider_validation.go
@@ -1,0 +1,88 @@
+package orchestra
+
+import (
+	"fmt"
+	"strings"
+)
+
+func validateSafeArtifactName(kind, name string) error {
+	if name == "" {
+		return fmt.Errorf("%s is empty", kind)
+	}
+	if name != sanitizeProviderName(name) {
+		return fmt.Errorf("%s %q is unsafe", kind, name)
+	}
+	return nil
+}
+
+func validateHookSessionID(sessionID string) error {
+	if err := validateSafeArtifactName("hook session ID", sessionID); err != nil {
+		return err
+	}
+	if sessionID != strings.ToLower(sessionID) {
+		return fmt.Errorf("hook session ID %q must use canonical lowercase", sessionID)
+	}
+	return nil
+}
+
+func providerCanonicalName(name string) string {
+	return strings.ToLower(name)
+}
+
+func validateProviderConfigs(providers []ProviderConfig) error {
+	rawNames := make(map[string]int, len(providers))
+	canonicalNames := make(map[string]string, len(providers))
+	for index, provider := range providers {
+		kind := fmt.Sprintf("provider[%d] name", index)
+		if err := validateSafeArtifactName(kind, provider.Name); err != nil {
+			return err
+		}
+		if first, exists := rawNames[provider.Name]; exists {
+			return fmt.Errorf("duplicate raw provider name %q at indexes %d and %d", provider.Name, first, index)
+		}
+		rawNames[provider.Name] = index
+
+		canonical := providerCanonicalName(provider.Name)
+		if first, exists := canonicalNames[canonical]; exists {
+			return fmt.Errorf("duplicate canonical provider name %q conflicts with %q", provider.Name, first)
+		}
+		canonicalNames[canonical] = provider.Name
+	}
+	return nil
+}
+
+func validateOrchestraProviderConfig(cfg OrchestraConfig) error {
+	if err := validateProviderConfigs(cfg.Providers); err != nil {
+		return err
+	}
+	if cfg.HookMode {
+		if err := validateHookSessionID(cfg.SessionID); err != nil {
+			return err
+		}
+	}
+	if cfg.JudgeProvider != "" {
+		if err := validateSafeArtifactName("judge provider name", cfg.JudgeProvider); err != nil {
+			return err
+		}
+	}
+	if cfg.JudgeConfig != nil && cfg.JudgeConfig.Name != "" {
+		if err := validateSafeArtifactName("judge config name", cfg.JudgeConfig.Name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateProviderRequest(req ProviderRequest) error {
+	if err := validateSafeArtifactName("provider request name", req.Provider); err != nil {
+		return err
+	}
+	return validateSafeArtifactName("provider config name", req.Config.Name)
+}
+
+func validateSubprocessPipelineProviders(providers []ProviderConfig, judge ProviderConfig) error {
+	if err := validateProviderConfigs(providers); err != nil {
+		return err
+	}
+	return validateSafeArtifactName("judge provider name", judge.Name)
+}

--- a/pkg/orchestra/provider_validation_test.go
+++ b/pkg/orchestra/provider_validation_test.go
@@ -1,0 +1,240 @@
+package orchestra
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateProviderConfigs_RejectsUnsafeAndDuplicateNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		providers []ProviderConfig
+		want      string
+	}{
+		{name: "empty", providers: []ProviderConfig{{Name: ""}}, want: "empty"},
+		{name: "unsafe", providers: []ProviderConfig{{Name: "../claude"}}, want: "unsafe"},
+		{name: "raw duplicate", providers: []ProviderConfig{{Name: "claude"}, {Name: "claude"}}, want: "duplicate raw"},
+		{name: "canonical duplicate", providers: []ProviderConfig{{Name: "claude"}, {Name: "Claude"}}, want: "duplicate canonical"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateProviderConfigs(tt.providers)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.want)
+		})
+	}
+}
+
+func TestValidateProviderConfigs_SingleUppercaseCustomNameIsAllowed(t *testing.T) {
+	t.Parallel()
+
+	assert.NoError(t, validateProviderConfigs([]ProviderConfig{{Name: "CustomAI"}}))
+}
+
+func TestValidateHookSessionID_RequiresCanonicalLowercase(t *testing.T) {
+	t.Parallel()
+
+	assert.NoError(t, validateHookSessionID("orch-abc_123"))
+	assert.ErrorContains(t, validateHookSessionID("Orch-ABC_123"), "lowercase")
+	assert.NoError(t, validateOrchestraProviderConfig(OrchestraConfig{
+		Providers:     []ProviderConfig{{Name: "CustomAI"}},
+		JudgeProvider: "JudgeAI",
+		JudgeConfig:   &ProviderConfig{Name: "JudgeConfigAI"},
+	}))
+}
+
+func TestOrchestraEntries_InvalidProviderFailsBeforePaneCreation(t *testing.T) {
+	entries := []struct {
+		name string
+		run  func(context.Context, OrchestraConfig) error
+	}{
+		{name: "run", run: func(ctx context.Context, cfg OrchestraConfig) error {
+			_, err := RunOrchestra(ctx, cfg)
+			return err
+		}},
+		{name: "pane", run: func(ctx context.Context, cfg OrchestraConfig) error {
+			_, err := RunPaneOrchestra(ctx, cfg)
+			return err
+		}},
+		{name: "interactive", run: func(ctx context.Context, cfg OrchestraConfig) error {
+			_, err := RunInteractivePaneOrchestra(ctx, cfg)
+			return err
+		}},
+		{name: "detached", run: func(ctx context.Context, cfg OrchestraConfig) error {
+			_, err := RunPaneOrchestraDetached(ctx, cfg)
+			return err
+		}},
+	}
+	for _, entry := range entries {
+		t.Run(entry.name, func(t *testing.T) {
+			term := newCmuxMock()
+			cfg := OrchestraConfig{
+				Providers: []ProviderConfig{{Name: "../claude", Binary: "echo"}},
+				Strategy:  StrategyConsensus,
+				Terminal:  term,
+			}
+
+			err := entry.run(context.Background(), cfg)
+
+			require.ErrorContains(t, err, "unsafe")
+			assert.Empty(t, term.splitPaneCalls)
+		})
+	}
+}
+
+func TestInteractivePaneBackend_InvalidProviderFailsBeforePaneCreation(t *testing.T) {
+	t.Parallel()
+	term := newCmuxMock()
+	backend := NewInteractivePaneBackend(OrchestraConfig{Terminal: term})
+
+	response, err := backend.Execute(context.Background(), ProviderRequest{
+		Provider: "../claude",
+		Config:   ProviderConfig{Name: "../claude", Binary: "claude"},
+	})
+
+	require.ErrorContains(t, err, "unsafe")
+	assert.Nil(t, response)
+	assert.Empty(t, term.splitPaneCalls)
+}
+
+func TestInteractivePaneBackend_InvalidBoundConfigFailsBeforePaneCreation(t *testing.T) {
+	t.Parallel()
+	term := newCmuxMock()
+	backend := NewInteractivePaneBackend(OrchestraConfig{
+		Terminal: term, Providers: []ProviderConfig{{Name: "unsafe/provider"}},
+	})
+
+	response, err := backend.Execute(context.Background(), ProviderRequest{
+		Provider: "claude",
+		Config:   ProviderConfig{Name: "claude", Binary: "claude"},
+	})
+
+	require.ErrorContains(t, err, "unsafe")
+	assert.Nil(t, response)
+	assert.Empty(t, term.splitPaneCalls)
+}
+
+func TestHookModeInvalidSessionIDFailsBeforePaneCreation(t *testing.T) {
+	entries := []struct {
+		name string
+		run  func(context.Context, OrchestraConfig) error
+	}{
+		{name: "pane", run: func(ctx context.Context, cfg OrchestraConfig) error {
+			_, err := RunPaneOrchestra(ctx, cfg)
+			return err
+		}},
+		{name: "interactive", run: func(ctx context.Context, cfg OrchestraConfig) error {
+			_, err := RunInteractivePaneOrchestra(ctx, cfg)
+			return err
+		}},
+	}
+	for _, sessionID := range []string{"", "../unsafe-session", "Orch-ABC"} {
+		for _, entry := range entries {
+			t.Run(entry.name+"/"+sessionID, func(t *testing.T) {
+				term := newCmuxMock()
+				err := entry.run(context.Background(), OrchestraConfig{
+					Providers: []ProviderConfig{{Name: "claude", Binary: "claude"}},
+					Strategy:  StrategyConsensus,
+					Terminal:  term,
+					HookMode:  true,
+					SessionID: sessionID,
+				})
+
+				require.Error(t, err)
+				assert.Empty(t, term.splitPaneCalls)
+			})
+		}
+	}
+}
+
+func TestInteractivePaneBackend_InvalidHookSessionFailsBeforePaneCreation(t *testing.T) {
+	t.Parallel()
+	term := newCmuxMock()
+	backend := NewInteractivePaneBackend(OrchestraConfig{
+		Terminal: term, HookMode: true, SessionID: "../unsafe-session",
+	})
+
+	response, err := backend.Execute(context.Background(), ProviderRequest{
+		Provider: "claude",
+		Config:   ProviderConfig{Name: "claude", Binary: "claude"},
+	})
+
+	require.ErrorContains(t, err, "unsafe")
+	assert.Nil(t, response)
+	assert.Empty(t, term.splitPaneCalls)
+}
+
+func TestWaitAndCollectHookResults_InvalidIdentityFailsBeforeSessionCreation(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	tests := []struct {
+		name      string
+		providers []ProviderConfig
+		sessionID string
+		want      string
+	}{
+		{name: "unsafe provider", providers: []ProviderConfig{{Name: "../claude"}}, sessionID: "safe-session", want: "unsafe"},
+		{name: "raw duplicate", providers: []ProviderConfig{{Name: "claude"}, {Name: "claude"}}, sessionID: "safe-session", want: "duplicate raw"},
+		{name: "canonical duplicate", providers: []ProviderConfig{{Name: "claude"}, {Name: "Claude"}}, sessionID: "safe-session", want: "duplicate canonical"},
+		{name: "unsafe session", providers: []ProviderConfig{{Name: "claude"}}, sessionID: "../session", want: "unsafe"},
+		{name: "noncanonical session", providers: []ProviderConfig{{Name: "claude"}}, sessionID: "Session-ABC", want: "lowercase"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			responses, err := WaitAndCollectHookResults(OrchestraConfig{
+				Providers: tt.providers,
+			}, tt.sessionID)
+
+			require.ErrorContains(t, err, tt.want)
+			assert.Nil(t, responses)
+		})
+	}
+}
+
+type providerValidationBackend struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (b *providerValidationBackend) Name() string { return "validation-test" }
+
+func (b *providerValidationBackend) Execute(_ context.Context, req ProviderRequest) (*ProviderResponse, error) {
+	b.mu.Lock()
+	b.calls++
+	b.mu.Unlock()
+	return &ProviderResponse{Provider: req.Provider, Output: `{}`}, nil
+}
+
+func TestRunSubprocessPipeline_InvalidProviderSetFailsBeforeDispatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		providers []ProviderConfig
+		judge     ProviderConfig
+		want      string
+	}{
+		{name: "unsafe participant", providers: []ProviderConfig{{Name: "../claude"}}, judge: ProviderConfig{Name: "judge"}, want: "unsafe"},
+		{name: "canonical participant duplicate", providers: []ProviderConfig{{Name: "claude"}, {Name: "Claude"}}, judge: ProviderConfig{Name: "judge"}, want: "duplicate canonical"},
+		{name: "unsafe judge", providers: []ProviderConfig{{Name: "claude"}}, judge: ProviderConfig{Name: "../judge"}, want: "unsafe"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			backend := &providerValidationBackend{}
+			_, err := RunSubprocessPipeline(context.Background(), SubprocessPipelineConfig{
+				Backend: backend, Providers: tt.providers, Judge: tt.judge,
+			})
+
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.want)
+			assert.Zero(t, backend.calls)
+		})
+	}
+}

--- a/pkg/orchestra/round_signal.go
+++ b/pkg/orchestra/round_signal.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 
 	"github.com/insajin/autopus-adk/pkg/terminal"
 )
@@ -48,18 +47,14 @@ func SendRoundEnvToPane(ctx context.Context, term terminal.Terminal, paneID term
 	return term.SendCommand(ctx, paneID, cmd)
 }
 
-// validSessionID matches safe session IDs (alphanumeric, hyphens, underscores only).
-// Prevents shell injection when the session ID is interpolated into an export command.
-var validSessionID = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
-
 // SendSessionEnvToPane sends "export AUTOPUS_SESSION_ID=<sid>" to the specified
 // terminal pane. This ensures the hook script (hook-claude-stop.sh) receives the
 // session ID via the pane's shell environment, not just the orchestrator process env.
-// Returns an error if the session ID contains characters outside [a-zA-Z0-9_-] to
-// prevent shell injection.
+// IDs must use the canonical lowercase artifact form to prevent shell injection
+// and case-insensitive filesystem aliases.
 func SendSessionEnvToPane(ctx context.Context, term terminal.Terminal, paneID terminal.PaneID, sessionID string) error {
-	if !validSessionID.MatchString(sessionID) {
-		return fmt.Errorf("SendSessionEnvToPane: invalid session ID %q (must match [a-zA-Z0-9_-]+)", sessionID)
+	if err := validateHookSessionID(sessionID); err != nil {
+		return fmt.Errorf("SendSessionEnvToPane: invalid session ID: %w", err)
 	}
 	// AUTOPUS_SESSION_DIR mirrors NewHookSession's path (os.TempDir based) so the
 	// provider's hooks write the ready/done signals to the exact directory the

--- a/pkg/orchestra/runner.go
+++ b/pkg/orchestra/runner.go
@@ -14,6 +14,9 @@ import (
 // @AX:ANCHOR: [AUTO] public API — 4 callers; do not change signature
 // @AX:REASON: CLI, pane fallback, spec-review loop, and tests rely on the result/error contract and degraded-provider propagation.
 func RunOrchestra(ctx context.Context, cfg OrchestraConfig) (*OrchestraResult, error) {
+	if err := validateOrchestraProviderConfig(cfg); err != nil {
+		return nil, err
+	}
 	if len(cfg.Providers) == 0 {
 		return nil, fmt.Errorf("providers 목록이 비어있습니다")
 	}

--- a/pkg/orchestra/session.go
+++ b/pkg/orchestra/session.go
@@ -2,18 +2,35 @@ package orchestra
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
+	"sync/atomic"
 	"time"
 
 	"github.com/insajin/autopus-adk/pkg/telemetry"
 )
 
+const sessionDirectoryName = "autopus-orchestra-sessions"
+
+var sessionFallbackCounter atomic.Uint64
+
+type sessionWritableFile interface {
+	Stat() (fs.FileInfo, error)
+	Chmod(os.FileMode) error
+	Write([]byte) (int, error)
+	Sync() error
+	Close() error
+}
+
 // OrchestraSession holds state for a yield-rounds orchestra session.
-// Persisted to /tmp/autopus-orch-session-{ID}.json for collect/cleanup commands.
 type OrchestraSession struct {
 	ID        string                      `json:"id"`
 	Panes     map[string]string           `json:"panes"` // provider name -> pane ID
@@ -38,46 +55,148 @@ type SessionProviderResponse struct {
 	UsageCapability UsageCapability           `json:"usage_capability"`
 }
 
-// NewSessionID generates a unique session ID: orch-{timestamp}-{random hex}.
+// NewSessionID uses 128 random bits and a collision-resistant fallback if the
+// operating system random source fails.
 func NewSessionID() string {
-	b := make([]byte, 4)
-	_, _ = rand.Read(b)
-	return fmt.Sprintf("orch-%d-%s", time.Now().UnixMilli(), hex.EncodeToString(b))
+	return newSessionID(rand.Reader)
 }
 
-// sessionFilePath returns the path for a session persistence file.
+func newSessionID(randomSource io.Reader) string {
+	randomBytes := make([]byte, 16)
+	var readErr error
+	if randomSource == nil {
+		readErr = errors.New("nil random source")
+	} else {
+		_, readErr = io.ReadFull(randomSource, randomBytes)
+	}
+	if readErr != nil {
+		counter := sessionFallbackCounter.Add(1)
+		seed := fmt.Sprintf("%d:%d:%d:%p", time.Now().UnixNano(), os.Getpid(), counter, &randomBytes)
+		digest := sha256.Sum256([]byte(seed))
+		copy(randomBytes, digest[:16])
+	}
+	return "orch-" + hex.EncodeToString(randomBytes)
+}
+
+func sessionDirectoryPath() string {
+	return filepath.Join(os.TempDir(), sessionDirectoryName)
+}
+
 func sessionFilePath(id string) string {
-	return filepath.Join(os.TempDir(), fmt.Sprintf("autopus-orch-session-%s.json", id))
+	if validateSafeArtifactName("session ID", id) != nil {
+		return ""
+	}
+	return filepath.Join(sessionDirectoryPath(), id+".json")
 }
 
-// SaveSession writes session metadata to a temp file with 0600 permissions.
+func openSessionRoot(create bool) (*os.Root, error) {
+	tempRoot, err := os.OpenRoot(os.TempDir())
+	if err != nil {
+		return nil, fmt.Errorf("open temp root: %w", err)
+	}
+	defer func() { _ = tempRoot.Close() }()
+
+	if create {
+		if err := tempRoot.Mkdir(sessionDirectoryName, 0o700); err != nil && !errors.Is(err, fs.ErrExist) {
+			return nil, fmt.Errorf("create session directory: %w", err)
+		}
+	}
+	info, err := tempRoot.Lstat(sessionDirectoryName)
+	if err != nil {
+		return nil, fmt.Errorf("inspect session directory: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return nil, fmt.Errorf("session directory is not a private directory")
+	}
+	root, err := tempRoot.OpenRoot(sessionDirectoryName)
+	if err != nil {
+		return nil, fmt.Errorf("open session directory: %w", err)
+	}
+	rootInfo, err := root.Stat(".")
+	if err != nil {
+		_ = root.Close()
+		return nil, fmt.Errorf("inspect opened session directory: %w", err)
+	}
+	if !os.SameFile(info, rootInfo) {
+		_ = root.Close()
+		return nil, fmt.Errorf("session directory changed while opening")
+	}
+	if runtime.GOOS != "windows" && rootInfo.Mode().Perm() != 0o700 {
+		_ = root.Close()
+		return nil, fmt.Errorf("session directory permissions are %o, want 700", rootInfo.Mode().Perm())
+	}
+	return root, nil
+}
+
+func sessionFilename(id string) (string, error) {
+	if err := validateSafeArtifactName("session ID", id); err != nil {
+		return "", fmt.Errorf("invalid session ID: %w", err)
+	}
+	return id + ".json", nil
+}
+
+// SaveSession atomically claims a private session file and never overwrites it.
 func SaveSession(session OrchestraSession) error {
+	name, err := sessionFilename(session.ID)
+	if err != nil {
+		return err
+	}
 	data, err := json.MarshalIndent(session, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal session: %w", err)
 	}
-	return os.WriteFile(sessionFilePath(session.ID), data, 0o600)
-}
-
-// LoadSession reads and parses a session file by ID.
-func LoadSession(id string) (*OrchestraSession, error) {
-	data, err := os.ReadFile(sessionFilePath(id))
+	root, err := openSessionRoot(true)
 	if err != nil {
-		return nil, fmt.Errorf("read session %s: %w", id, err)
+		return err
 	}
-	var session OrchestraSession
-	if err := json.Unmarshal(data, &session); err != nil {
-		return nil, fmt.Errorf("parse session %s: %w", id, err)
+	defer func() { _ = root.Close() }()
+
+	file, err := root.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create session %s: %w", session.ID, err)
 	}
-	return &session, nil
+	return persistCreatedSession(root, name, file, data)
 }
 
-// RemoveSession deletes the session persistence file.
-// Returns nil if the file doesn't exist (idempotent).
-func RemoveSession(id string) error {
-	err := os.Remove(sessionFilePath(id))
-	if os.IsNotExist(err) {
-		return nil
+func persistCreatedSession(root *os.Root, name string, file sessionWritableFile, data []byte) error {
+	createdInfo, statErr := file.Stat()
+	rollback := func(cause error) error {
+		closeErr := file.Close()
+		rollbackCreatedSession(root, name, createdInfo)
+		if closeErr != nil {
+			return errors.Join(cause, fmt.Errorf("close session: %w", closeErr))
+		}
+		return cause
 	}
-	return err
+	if statErr != nil {
+		return rollback(fmt.Errorf("inspect created session: %w", statErr))
+	}
+	if err := file.Chmod(0o600); err != nil {
+		return rollback(fmt.Errorf("set session permissions: %w", err))
+	}
+	written, err := file.Write(data)
+	if err == nil && written != len(data) {
+		err = io.ErrShortWrite
+	}
+	if err != nil {
+		return rollback(fmt.Errorf("write session: %w", err))
+	}
+	if err := file.Sync(); err != nil {
+		return rollback(fmt.Errorf("sync session: %w", err))
+	}
+	if err := file.Close(); err != nil {
+		rollbackCreatedSession(root, name, createdInfo)
+		return fmt.Errorf("close session: %w", err)
+	}
+	return nil
+}
+
+func rollbackCreatedSession(root *os.Root, name string, created fs.FileInfo) {
+	if created == nil {
+		return
+	}
+	current, err := root.Lstat(name)
+	if err == nil && current.Mode().IsRegular() && os.SameFile(created, current) {
+		_ = root.Remove(name)
+	}
 }

--- a/pkg/orchestra/session_failure_test.go
+++ b/pkg/orchestra/session_failure_test.go
@@ -1,0 +1,94 @@
+package orchestra
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type failingSessionFile struct {
+	info       fs.FileInfo
+	failPhase  string
+	closeCalls int
+}
+
+func (f *failingSessionFile) Stat() (fs.FileInfo, error) { return f.info, nil }
+func (f *failingSessionFile) Chmod(os.FileMode) error    { return nil }
+func (f *failingSessionFile) Write(data []byte) (int, error) {
+	if f.failPhase == "write" {
+		return 0, errors.New("injected write failure")
+	}
+	return len(data), nil
+}
+func (f *failingSessionFile) Sync() error {
+	if f.failPhase == "sync" {
+		return errors.New("injected sync failure")
+	}
+	return nil
+}
+func (f *failingSessionFile) Close() error {
+	f.closeCalls++
+	if f.failPhase == "close" {
+		return errors.New("injected close failure")
+	}
+	return nil
+}
+
+func TestPersistCreatedSession_FailureRollsBackOwnedEntry(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	root, err := openSessionRoot(true)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = root.Close() })
+
+	for _, phase := range []string{"write", "sync", "close"} {
+		t.Run(phase, func(t *testing.T) {
+			name := phase + ".json"
+			path := filepath.Join(sessionDirectoryPath(), name)
+			require.NoError(t, os.WriteFile(path, []byte("partial"), 0o600))
+			info, statErr := os.Stat(path)
+			require.NoError(t, statErr)
+			file := &failingSessionFile{info: info, failPhase: phase}
+
+			err := persistCreatedSession(root, name, file, []byte("payload"))
+
+			require.ErrorContains(t, err, phase+" session")
+			assert.Equal(t, 1, file.closeCalls)
+			_, statErr = os.Stat(path)
+			assert.ErrorIs(t, statErr, os.ErrNotExist)
+		})
+	}
+}
+
+func TestPersistCreatedSession_RollbackDoesNotDeleteReplacement(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("replacement identity behavior is platform-specific")
+	}
+	t.Setenv("TMPDIR", t.TempDir())
+	root, err := openSessionRoot(true)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = root.Close() })
+
+	name := "replacement.json"
+	path := filepath.Join(sessionDirectoryPath(), name)
+	require.NoError(t, os.WriteFile(path, []byte("owned"), 0o600))
+	ownedInfo, err := os.Stat(path)
+	require.NoError(t, err)
+	replacement := filepath.Join(sessionDirectoryPath(), "replacement-source.json")
+	require.NoError(t, os.WriteFile(replacement, []byte("replacement"), 0o600))
+	require.NoError(t, os.Rename(replacement, path))
+
+	err = persistCreatedSession(root, name, &failingSessionFile{
+		info: ownedInfo, failPhase: "write",
+	}, []byte("payload"))
+
+	require.Error(t, err)
+	data, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	assert.Equal(t, "replacement", string(data))
+}

--- a/pkg/orchestra/session_legacy.go
+++ b/pkg/orchestra/session_legacy.go
@@ -1,0 +1,156 @@
+package orchestra
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+)
+
+const legacySessionFilenamePrefix = "autopus-orch-session-"
+
+func legacySessionFilename(id string) (string, error) {
+	if err := validateSafeArtifactName("session ID", id); err != nil {
+		return "", fmt.Errorf("invalid session ID: %w", err)
+	}
+	return legacySessionFilenamePrefix + id + ".json", nil
+}
+
+func openLegacySessionRoot() (*os.Root, error) {
+	root, err := os.OpenRoot(os.TempDir())
+	if err != nil {
+		return nil, fmt.Errorf("open legacy session root: %w", err)
+	}
+	return root, nil
+}
+
+func readSessionEntry(root *os.Root, name, id string) (*OrchestraSession, fs.FileInfo, error) {
+	initialInfo, err := root.Lstat(name)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !initialInfo.Mode().IsRegular() {
+		return nil, nil, errors.New("session entry is not a regular file")
+	}
+
+	file, err := root.Open(name)
+	if err != nil {
+		return nil, nil, err
+	}
+	openedInfo, statErr := file.Stat()
+	currentInfo, currentErr := root.Lstat(name)
+	if statErr != nil || currentErr != nil || !currentInfo.Mode().IsRegular() ||
+		!os.SameFile(initialInfo, openedInfo) || !os.SameFile(openedInfo, currentInfo) {
+		_ = file.Close()
+		return nil, nil, errors.New("session entry changed while opening")
+	}
+
+	data, readErr := io.ReadAll(file)
+	closeErr := file.Close()
+	if readErr != nil {
+		return nil, nil, readErr
+	}
+	if closeErr != nil {
+		return nil, nil, fmt.Errorf("close session entry: %w", closeErr)
+	}
+
+	var session OrchestraSession
+	if err := json.Unmarshal(data, &session); err != nil {
+		return nil, nil, fmt.Errorf("parse session: %w", err)
+	}
+	if session.ID != id {
+		return nil, nil, fmt.Errorf("persisted ID %q does not match", session.ID)
+	}
+	return &session, openedInfo, nil
+}
+
+func loadSessionFromRoot(root *os.Root, name, id string) (*OrchestraSession, error) {
+	session, _, err := readSessionEntry(root, name, id)
+	if err != nil {
+		return nil, fmt.Errorf("read session %s: %w", id, err)
+	}
+	return session, nil
+}
+
+// LoadSession reads the private session path and falls back to the legacy
+// temp-root basename only when the private entry does not exist.
+func LoadSession(id string) (*OrchestraSession, error) {
+	name, err := sessionFilename(id)
+	if err != nil {
+		return nil, err
+	}
+	root, err := openSessionRoot(false)
+	if err == nil {
+		session, readErr := loadSessionFromRoot(root, name, id)
+		_ = root.Close()
+		if readErr == nil || !errors.Is(readErr, fs.ErrNotExist) {
+			return session, readErr
+		}
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return nil, fmt.Errorf("read session %s: %w", id, err)
+	}
+
+	legacyName, err := legacySessionFilename(id)
+	if err != nil {
+		return nil, err
+	}
+	legacyRoot, err := openLegacySessionRoot()
+	if err != nil {
+		return nil, fmt.Errorf("read session %s: %w", id, err)
+	}
+	defer func() { _ = legacyRoot.Close() }()
+	return loadSessionFromRoot(legacyRoot, legacyName, id)
+}
+
+func removeSessionFromRoot(root *os.Root, name, id string) error {
+	_, openedInfo, err := readSessionEntry(root, name, id)
+	if err != nil {
+		return err
+	}
+	currentInfo, err := root.Lstat(name)
+	if err != nil {
+		return err
+	}
+	if !currentInfo.Mode().IsRegular() || !os.SameFile(openedInfo, currentInfo) {
+		return errors.New("session entry changed before removal")
+	}
+	return root.Remove(name)
+}
+
+// RemoveSession removes the private session entry. When it is absent, a safe,
+// matching legacy entry is removed for patch-release compatibility.
+func RemoveSession(id string) error {
+	name, err := sessionFilename(id)
+	if err != nil {
+		return err
+	}
+	root, err := openSessionRoot(false)
+	if err == nil {
+		removeErr := removeSessionFromRoot(root, name, id)
+		_ = root.Close()
+		if removeErr == nil {
+			return nil
+		}
+		if !errors.Is(removeErr, fs.ErrNotExist) {
+			return fmt.Errorf("remove session %s: %w", id, removeErr)
+		}
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("remove session %s: %w", id, err)
+	}
+
+	legacyName, err := legacySessionFilename(id)
+	if err != nil {
+		return err
+	}
+	legacyRoot, err := openLegacySessionRoot()
+	if err != nil {
+		return fmt.Errorf("remove session %s: %w", id, err)
+	}
+	defer func() { _ = legacyRoot.Close() }()
+	if err := removeSessionFromRoot(legacyRoot, legacyName, id); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("remove session %s: %w", id, err)
+	}
+	return nil
+}

--- a/pkg/orchestra/session_legacy_test.go
+++ b/pkg/orchestra/session_legacy_test.go
@@ -1,0 +1,107 @@
+package orchestra
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func legacySessionTestPath(id string) string {
+	return filepath.Join(os.TempDir(), "autopus-orch-session-"+id+".json")
+}
+
+func writeLegacySessionForTest(t *testing.T, session OrchestraSession) string {
+	t.Helper()
+	data, err := json.Marshal(session)
+	require.NoError(t, err)
+	path := legacySessionTestPath(session.ID)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	return path
+}
+
+func TestLegacySession_LoadAndRemoveCompatibility(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	want := OrchestraSession{
+		ID:        "legacy-compatible",
+		Panes:     map[string]string{"claude": "pane-1"},
+		CreatedAt: time.Now().UTC().Truncate(time.Second),
+	}
+	path := writeLegacySessionForTest(t, want)
+
+	got, err := LoadSession(want.ID)
+	require.NoError(t, err)
+	assert.Equal(t, want.ID, got.ID)
+	assert.Equal(t, want.Panes, got.Panes)
+
+	require.NoError(t, RemoveSession(want.ID))
+	_, err = os.Lstat(path)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestLegacySession_SymlinkIsRejectedAndPreserved(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated Windows privileges")
+	}
+	t.Setenv("TMPDIR", t.TempDir())
+	target := filepath.Join(os.TempDir(), "outside.json")
+	require.NoError(t, os.WriteFile(target, []byte(`{"id":"legacy-linked"}`), 0o600))
+	link := legacySessionTestPath("legacy-linked")
+	require.NoError(t, os.Symlink(target, link))
+
+	_, loadErr := LoadSession("legacy-linked")
+	assert.Error(t, loadErr)
+	assert.Error(t, RemoveSession("legacy-linked"))
+
+	info, err := os.Lstat(link)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&os.ModeSymlink)
+	data, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, `{"id":"legacy-linked"}`, string(data))
+}
+
+func TestLegacySession_ForeignPersistedIDIsPreserved(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	path := legacySessionTestPath("requested")
+	writeLegacySessionForTest(t, OrchestraSession{ID: "requested"})
+	replacement := filepath.Join(os.TempDir(), "foreign-replacement.json")
+	require.NoError(t, os.WriteFile(replacement, []byte(`{"id":"foreign"}`), 0o600))
+	require.NoError(t, os.Rename(replacement, path))
+
+	_, loadErr := LoadSession("requested")
+	assert.ErrorContains(t, loadErr, "does not match")
+	assert.ErrorContains(t, RemoveSession("requested"), "does not match")
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, `{"id":"foreign"}`, string(data))
+}
+
+func TestLegacySession_DoesNotBypassUnsafeNewEntry(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated Windows privileges")
+	}
+	t.Setenv("TMPDIR", t.TempDir())
+	writeLegacySessionForTest(t, OrchestraSession{ID: "blocked-fallback"})
+	require.NoError(t, os.Mkdir(sessionDirectoryPath(), 0o700))
+	target := filepath.Join(os.TempDir(), "new-target.json")
+	require.NoError(t, os.WriteFile(target, []byte(`{"id":"blocked-fallback"}`), 0o600))
+	newEntry := isolatedSessionPath(t, "blocked-fallback")
+	require.NoError(t, os.Symlink(target, newEntry))
+
+	_, loadErr := LoadSession("blocked-fallback")
+	assert.Error(t, loadErr)
+	assert.Error(t, RemoveSession("blocked-fallback"))
+
+	info, err := os.Lstat(newEntry)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&os.ModeSymlink)
+	_, err = os.Stat(legacySessionTestPath("blocked-fallback"))
+	assert.NoError(t, err)
+}

--- a/pkg/orchestra/session_security_test.go
+++ b/pkg/orchestra/session_security_test.go
@@ -1,0 +1,133 @@
+package orchestra
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testSessionDirectory = "autopus-orchestra-sessions"
+
+type failingSessionRandomReader struct{}
+
+func (failingSessionRandomReader) Read(_ []byte) (int, error) {
+	return 0, errors.New("injected random source failure")
+}
+
+func isolatedSessionPath(t *testing.T, id string) string {
+	t.Helper()
+	return filepath.Join(os.TempDir(), testSessionDirectory, id+".json")
+}
+
+func TestSessionPersistence_InvalidIDsFailClosed(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+
+	invalidIDs := []string{"", ".", "..", "../victim", "/tmp/victim", `a\b`, "a/b", "has space"}
+	for _, id := range invalidIDs {
+		t.Run(id, func(t *testing.T) {
+			session := OrchestraSession{ID: id, CreatedAt: time.Now()}
+
+			assert.ErrorContains(t, SaveSession(session), "invalid session ID")
+			_, loadErr := LoadSession(id)
+			assert.ErrorContains(t, loadErr, "invalid session ID")
+			assert.ErrorContains(t, RemoveSession(id), "invalid session ID")
+		})
+	}
+}
+
+func TestSaveSession_UsesPrivateDedicatedDirectory(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	session := OrchestraSession{ID: "private-dir", CreatedAt: time.Now()}
+
+	require.NoError(t, SaveSession(session))
+	t.Cleanup(func() { _ = RemoveSession(session.ID) })
+
+	dirInfo, err := os.Stat(filepath.Dir(isolatedSessionPath(t, session.ID)))
+	require.NoError(t, err)
+	if runtime.GOOS != "windows" {
+		assert.Equal(t, os.FileMode(0o700), dirInfo.Mode().Perm())
+	}
+	fileInfo, err := os.Stat(isolatedSessionPath(t, session.ID))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), fileInfo.Mode().Perm())
+}
+
+func TestSaveSession_ExistingFileIsNeverOverwritten(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	path := isolatedSessionPath(t, "existing")
+	require.NoError(t, os.Mkdir(filepath.Dir(path), 0o700))
+	require.NoError(t, os.WriteFile(path, []byte("original"), 0o600))
+
+	err := SaveSession(OrchestraSession{ID: "existing", CreatedAt: time.Now()})
+
+	require.Error(t, err)
+	data, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	assert.Equal(t, "original", string(data))
+}
+
+func TestSessionPersistence_SymlinksFailClosed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated Windows privileges")
+	}
+	t.Setenv("TMPDIR", t.TempDir())
+	dir := filepath.Join(os.TempDir(), testSessionDirectory)
+	require.NoError(t, os.Mkdir(dir, 0o700))
+	target := filepath.Join(os.TempDir(), "outside-session.json")
+	require.NoError(t, os.WriteFile(target, []byte(`{"id":"linked"}`), 0o600))
+	link := isolatedSessionPath(t, "linked")
+	require.NoError(t, os.Symlink(target, link))
+
+	assert.Error(t, SaveSession(OrchestraSession{ID: "linked", CreatedAt: time.Now()}))
+	_, loadErr := LoadSession("linked")
+	assert.Error(t, loadErr)
+	assert.Error(t, RemoveSession("linked"))
+
+	data, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, `{"id":"linked"}`, string(data))
+	info, err := os.Lstat(link)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&os.ModeSymlink)
+}
+
+func TestSessionPersistence_SymlinkedDirectoryFailsClosed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated Windows privileges")
+	}
+	t.Setenv("TMPDIR", t.TempDir())
+	target := filepath.Join(os.TempDir(), "outside-session-dir")
+	require.NoError(t, os.Mkdir(target, 0o700))
+	require.NoError(t, os.Symlink(target, filepath.Join(os.TempDir(), testSessionDirectory)))
+
+	err := SaveSession(OrchestraSession{ID: "linked-dir", CreatedAt: time.Now()})
+
+	require.ErrorContains(t, err, "not a private directory")
+	_, statErr := os.Stat(filepath.Join(target, "linked-dir.json"))
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestNewSessionID_HasAtLeast128BitsAndSafeAlphabet(t *testing.T) {
+	t.Parallel()
+
+	id := NewSessionID()
+	assert.Regexp(t, regexp.MustCompile(`^orch-[0-9a-f]{32,}$`), id)
+}
+
+func TestNewSessionID_RandomFailureFallbackRemainsUnique(t *testing.T) {
+	t.Parallel()
+
+	id1 := newSessionID(failingSessionRandomReader{})
+	id2 := newSessionID(failingSessionRandomReader{})
+
+	assert.Regexp(t, regexp.MustCompile(`^orch-[0-9a-f]{32,}$`), id1)
+	assert.Regexp(t, regexp.MustCompile(`^orch-[0-9a-f]{32,}$`), id2)
+	assert.NotEqual(t, id1, id2)
+}


### PR DESCRIPTION
## 요약

- yield 세션이 영속화된 뒤에만 pane 소유권을 이전하고, 저장 실패 시 생성한 pane을 정리합니다.
- debate 응답을 provider 설정 순서로 안정화하되 공용 수집기와 `StrategyFastest`의 완료 순서는 유지합니다.
- 세션 저장소, legacy 호환 경계, HookSession 소유권, provider/hook identity 검증을 fail-closed로 강화합니다.
- macOS의 case-insensitive filesystem에서 hook session ID의 대소문자 별칭을 차단합니다.

Closes #97

## rescue 감사 결과

- 원본: `rescue/adk-mixed-dirty-20260716@21fbfd6b9a22da8f83a948d0519b00e064635b21`
- parent: `acb735cca0ef120cfed0d01863de09535310b5a3`
- 총 105개 파일 중 75개 companion/release 변경은 이미 반영됐거나 superseded 됐습니다.
- 나머지 약 30개 Orchestra WIP에는 broad judge/fallback/input/finalization 변경이 섞여 있어 전체 cherry-pick을 거부했습니다.
- 재현 가능한 S-001(yield 저장 실패 pane 소유권)과 S-002(debate 응답 순서)만 의미 단위로 구조했습니다.
- 구조 과정에서 발견한 세션 traversal/symlink/overwrite, provider case-fold, HookSession owner/reuser 부채도 별도 보안 커밋으로 닫았습니다.

## 검증

- RED/GREEN focused 회귀
- 신규 회귀 race `count=20`
- `go test -count=1 -timeout=300s ./pkg/orchestra`
- `go test -race -count=1 -timeout=300s ./pkg/orchestra`
- CLI cleanup/collect/session focused race
- 최신 `origin/main` rebase 후 핵심 orchestra/CLI race 재검증
- Windows amd64 orchestra 교차 컴파일
- `go vet ./...`
- `go build ./...`
- staged 및 최종 hygiene/architecture
- `git diff --check`, gofmt, tracked-but-ignored drift, 300줄 소스 제한
- 독립 convergence review: APPROVE
- 독립 security review: APPROVE

## 남은 릴리스 검증

- 실제 cmux에서 장시간 provider yield/collect canary는 A13 공개 릴리스 검증에서 확인합니다.
