### PR TITLE
fix(orchestra): 멀티프로바이더 pane 컨텍스트 복구

### DIFF
--- a/content/hooks/hook-claude-sessionstart.sh
+++ b/content/hooks/hook-claude-sessionstart.sh
@@ -1,32 +1,50 @@
 #!/bin/sh
-# hook-claude-sessionstart.sh — Claude Code SessionStart hook for autopus.
-# Writes a ready-signal file so the orchestrator can detect that the interactive
-# provider session is live via file IPC instead of screen scraping the prompt
-# (SPEC-ORCH-022). No-op unless AUTOPUS_SESSION_ID is set by the orchestrator.
-# POSIX shell compatible. Does not read or require stdin.
+# Claude Code SessionStart hook: atomically publishes the round-ready signal.
 set -e
 
 SESSION_ID="${AUTOPUS_SESSION_ID:-}"
 if [ -z "$SESSION_ID" ]; then
   exit 0
 fi
-
-# Validate session ID to prevent path traversal (alphanumeric, hyphen, underscore only).
 case "$SESSION_ID" in
   *[!a-zA-Z0-9_-]*) exit 0 ;;
 esac
 
 SESSION_DIR="${AUTOPUS_SESSION_DIR:-/tmp/autopus/${SESSION_ID}}"
-if [ ! -d "$SESSION_DIR" ]; then
+case "$SESSION_DIR" in
+  /*) ;;
+  *) exit 0 ;;
+esac
+if [ ! -d "$SESSION_DIR" ] || [ -L "$SESSION_DIR" ]; then
   exit 0
 fi
-
-# Round-scoped ready file name. Defaults to round 0 when AUTOPUS_ROUND is unset,
-# matching RoundSignalName(provider, 0, "ready") on the Go side.
 case "${AUTOPUS_ROUND:-}" in *[!0-9]*) AUTOPUS_ROUND="" ;; esac
 ROUND="${AUTOPUS_ROUND:-0}"
-READY_FILE="${SESSION_DIR}/claude-round${ROUND}-ready"
+READY_NAME="claude-round${ROUND}-ready"
 
-: > "${READY_FILE}"
-chmod 600 "${READY_FILE}" 2>/dev/null || true
+python3 -c "
+import os, secrets, sys
+directory_flags = os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0) | getattr(os, 'O_NOFOLLOW', 0)
+directory_fd = os.open(sys.argv[1], directory_flags)
+temporary = '.autopus-hook-' + secrets.token_hex(12)
+file_fd = -1
+try:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, 'O_NOFOLLOW', 0)
+    file_fd = os.open(temporary, flags, 0o600, dir_fd=directory_fd)
+    os.fchmod(file_fd, 0o600)
+    os.fsync(file_fd)
+    os.close(file_fd)
+    file_fd = -1
+    os.replace(temporary, sys.argv[2], src_dir_fd=directory_fd, dst_dir_fd=directory_fd)
+except Exception:
+    if file_fd >= 0:
+        os.close(file_fd)
+    try:
+        os.unlink(temporary, dir_fd=directory_fd)
+    except Exception:
+        pass
+    raise
+finally:
+    os.close(directory_fd)
+" "$SESSION_DIR" "$READY_NAME" 2>/dev/null || true
 exit 0

--- a/content/hooks/hook-claude-stop.sh
+++ b/content/hooks/hook-claude-stop.sh
@@ -1,108 +1,236 @@
 #!/bin/sh
 # hook-claude-stop.sh — Claude Code Stop hook for autopus result collection.
-# Reads hook JSON from stdin, extracts last_assistant_message,
-# writes result.json and done signal to the session directory.
-# POSIX shell compatible. No jq dependency — uses python3 for JSON.
+# POSIX shell compatible. Python provides confined JSON and file operations.
 set -e
 
 SESSION_ID="${AUTOPUS_SESSION_ID:-}"
 if [ -z "$SESSION_ID" ]; then
   exit 0
 fi
-
-# Validate session ID to prevent path traversal (alphanumeric, hyphen, underscore only)
 case "$SESSION_ID" in
   *[!a-zA-Z0-9_-]*) exit 0 ;;
 esac
 
 SESSION_DIR="${AUTOPUS_SESSION_DIR:-/tmp/autopus/${SESSION_ID}}"
-if [ ! -d "$SESSION_DIR" ]; then
+case "$SESSION_DIR" in
+  /*) ;;
+  *) exit 0 ;;
+esac
+if [ ! -d "$SESSION_DIR" ] || [ -L "$SESSION_DIR" ]; then
   exit 0
 fi
 
-# Determine round-scoped file names when AUTOPUS_ROUND is set (integer-only).
-case "${AUTOPUS_ROUND:-}" in *[!0-9]*) AUTOPUS_ROUND="" ;; esac
-if [ -n "$AUTOPUS_ROUND" ]; then
-  RESULT_FILE="${SESSION_DIR}/claude-round${AUTOPUS_ROUND}-result.json"
-  DONE_FILE="${SESSION_DIR}/claude-round${AUTOPUS_ROUND}-done"
+# Atomically replace one fixed artifact relative to a non-symlink session dir.
+atomic_write() {
+  python3 -c "
+import os, secrets, sys
+directory_flags = os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0) | getattr(os, 'O_NOFOLLOW', 0)
+directory_fd = os.open(sys.argv[1], directory_flags)
+temporary = '.autopus-hook-' + secrets.token_hex(12)
+file_fd = -1
+try:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, 'O_NOFOLLOW', 0)
+    file_fd = os.open(temporary, flags, 0o600, dir_fd=directory_fd)
+    remaining = memoryview(sys.argv[3].encode('utf-8'))
+    while remaining:
+        written = os.write(file_fd, remaining)
+        if written <= 0:
+            raise OSError('short write')
+        remaining = remaining[written:]
+    os.fchmod(file_fd, 0o600)
+    os.fsync(file_fd)
+    os.close(file_fd)
+    file_fd = -1
+    os.replace(temporary, sys.argv[2], src_dir_fd=directory_fd, dst_dir_fd=directory_fd)
+except Exception:
+    if file_fd >= 0:
+        os.close(file_fd)
+    try:
+        os.unlink(temporary, dir_fd=directory_fd)
+    except Exception:
+        pass
+    raise
+finally:
+    os.close(directory_fd)
+" "$SESSION_DIR" "$1" "$2" 2>/dev/null
+}
+
+# Resolve the effective round from the fixed parent environment and cursor.
+CURSOR_NAME="claude-round-cursor"
+EFFECTIVE_ROUND=$(python3 -c "
+import os, stat, sys
+def parse(value, allow_newline=False):
+    if allow_newline:
+        value = value.rstrip('\\r\\n')
+    if not value or any(ch < '0' or ch > '9' for ch in value):
+        return None
+    number = int(value)
+    return number if number <= 2147483646 else None
+env_round = parse(sys.argv[3])
+cursor_round = None
+directory_fd = file_fd = -1
+try:
+    directory_flags = os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0) | getattr(os, 'O_NOFOLLOW', 0)
+    directory_fd = os.open(sys.argv[1], directory_flags)
+    flags = os.O_RDONLY | getattr(os, 'O_NONBLOCK', 0) | getattr(os, 'O_NOFOLLOW', 0)
+    file_fd = os.open(sys.argv[2], flags, dir_fd=directory_fd)
+    info = os.fstat(file_fd)
+    if stat.S_ISREG(info.st_mode) and info.st_size <= 64:
+        with os.fdopen(file_fd, 'rb') as source:
+            file_fd = -1
+            raw = source.read(65)
+        if len(raw) <= 64:
+            cursor_round = parse(raw.decode('ascii'), True)
+except Exception:
+    pass
+finally:
+    if file_fd >= 0:
+        os.close(file_fd)
+    if directory_fd >= 0:
+        os.close(directory_fd)
+rounds = [value for value in (env_round, cursor_round) if value is not None]
+if rounds:
+    print(max(rounds))
+" "$SESSION_DIR" "$CURSOR_NAME" "${AUTOPUS_ROUND:-}" 2>/dev/null) || EFFECTIVE_ROUND=""
+
+if [ -n "$EFFECTIVE_ROUND" ]; then
+  RESULT_NAME="claude-round${EFFECTIVE_ROUND}-result.json"
+  DONE_NAME="claude-round${EFFECTIVE_ROUND}-done"
 else
-  RESULT_FILE="${SESSION_DIR}/claude-result.json"
-  DONE_FILE="${SESSION_DIR}/claude-done"
+  RESULT_NAME="claude-result.json"
+  DONE_NAME="claude-done"
 fi
 
-# Read hook JSON from stdin and extract last_assistant_message via python3.
-# Input is passed via stdin (not argv) to avoid shell injection. Result capture is
-# best-effort: an empty/absent message or a python failure must NOT suppress the
-# done signal below. The done file is the orchestrator's completion contract
-# (SPEC-ORCH-022) — the FileIPCDetector waits on it for the full provider budget,
-# so failing to write it strands the run on a long timeout instead of collecting
-# completion. Always emit a result file (empty output on failure) and never let a
-# chmod on a missing file abort the script under `set -e`.
-python3 -c "
-import json, sys
+# Parse stdin best-effort and atomically publish result before done. Both writes
+# are attempted; any artifact failure prevents this invocation from continuing.
+if ! python3 -c "
+import json, os, secrets, sys
+def atomic_write(directory_fd, name, body):
+    temporary = '.autopus-hook-' + secrets.token_hex(12)
+    file_fd = -1
+    try:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, 'O_NOFOLLOW', 0)
+        file_fd = os.open(temporary, flags, 0o600, dir_fd=directory_fd)
+        remaining = memoryview(body)
+        while remaining:
+            written = os.write(file_fd, remaining)
+            if written <= 0:
+                raise OSError('short write')
+            remaining = remaining[written:]
+        os.fchmod(file_fd, 0o600)
+        os.fsync(file_fd)
+        os.close(file_fd)
+        file_fd = -1
+        os.replace(temporary, name, src_dir_fd=directory_fd, dst_dir_fd=directory_fd)
+    except Exception:
+        if file_fd >= 0:
+            os.close(file_fd)
+        try:
+            os.unlink(temporary, dir_fd=directory_fd)
+        except Exception:
+            pass
+        raise
 try:
     data = json.load(sys.stdin)
 except Exception:
     data = {}
-msg = data.get('last_assistant_message', '') or ''
-with open(sys.argv[1], 'w') as f:
-    json.dump({'output': msg, 'exit_code': 0}, f)
-" "${RESULT_FILE}" 2>/dev/null || true
+if not isinstance(data, dict):
+    data = {}
+msg = data.get('last_assistant_message', '')
+if not isinstance(msg, str):
+    msg = ''
+directory_flags = os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0) | getattr(os, 'O_NOFOLLOW', 0)
+directory_fd = os.open(sys.argv[1], directory_flags)
+errors = []
+try:
+    for name, body in (
+        (sys.argv[2], json.dumps({'output': msg, 'exit_code': 0}).encode('utf-8')),
+        (sys.argv[3], b''),
+    ):
+        try:
+            atomic_write(directory_fd, name, body)
+        except Exception as error:
+            errors.append(error)
+finally:
+    os.close(directory_fd)
+if errors:
+    raise errors[0]
+" "$SESSION_DIR" "$RESULT_NAME" "$DONE_NAME" 2>/dev/null; then
+  exit 0
+fi
 
-chmod 600 "${RESULT_FILE}" 2>/dev/null || true
-
-# Write the done signal AFTER the result file (so result-reading collectors never
-# race an early done) and UNCONDITIONALLY (completion must be signalled even when
-# result extraction failed).
-: > "${DONE_FILE}"
-chmod 600 "${DONE_FILE}" 2>/dev/null || true
-
-# Send cmux completion signal for SignalDetector (SPEC-SURFCOMP-001 R8).
+# Send cmux completion signal without leaking helper output into Stop stdout.
 if command -v cmux >/dev/null 2>&1; then
-  if [ -n "$AUTOPUS_ROUND" ] && [ "$AUTOPUS_ROUND" -gt 1 ] 2>/dev/null; then
-    cmux wait-for -S "done-claude-round${AUTOPUS_ROUND}" 2>/dev/null || true
+  if [ -n "$EFFECTIVE_ROUND" ] && [ "$EFFECTIVE_ROUND" -gt 1 ] 2>/dev/null; then
+    cmux wait-for -S "done-claude-round${EFFECTIVE_ROUND}" >/dev/null 2>&1 || true
   else
-    cmux wait-for -S "done-claude" 2>/dev/null || true
+    cmux wait-for -S "done-claude" >/dev/null 2>&1 || true
   fi
 fi
 
-# --- Bidirectional IPC: Ready signal + Input watch loop (SPEC-ORCH-017) ---
-# Only activate for round-scoped sessions.
-if [ -n "$AUTOPUS_ROUND" ]; then
-  NEXT_ROUND=$((AUTOPUS_ROUND + 1))
-  READY_FILE="${SESSION_DIR}/claude-round${NEXT_ROUND}-ready"
-  INPUT_FILE="${SESSION_DIR}/claude-round${NEXT_ROUND}-input.json"
-  ABORT_FILE="${SESSION_DIR}/claude-round${NEXT_ROUND}-abort"
+# Bidirectional IPC is active only for round-scoped sessions.
+if [ -n "$EFFECTIVE_ROUND" ]; then
+  NEXT_ROUND=$((EFFECTIVE_ROUND + 1))
+  READY_NAME="claude-round${NEXT_ROUND}-ready"
+  INPUT_NAME="claude-round${NEXT_ROUND}-input.json"
+  ABORT_NAME="claude-round${NEXT_ROUND}-abort"
+  READY_FILE="${SESSION_DIR}/${READY_NAME}"
+  INPUT_FILE="${SESSION_DIR}/${INPUT_NAME}"
+  ABORT_FILE="${SESSION_DIR}/${ABORT_NAME}"
+  if ! atomic_write "$READY_NAME" ""; then
+    exit 0
+  fi
 
-  # Signal ready for next round input.
-  : > "${READY_FILE}"
-
-  # Poll for input file (200ms intervals, 120s timeout = 600 iterations).
-  # @AX:NOTE [AUTO] magic constants 200ms/600 iterations — must match Go-side fileIPCReadyTimeout budget
   WAIT_COUNT=0
   MAX_WAIT=600
   while [ "$WAIT_COUNT" -lt "$MAX_WAIT" ]; do
     if [ -f "$ABORT_FILE" ]; then
-      rm -f "${READY_FILE}" "${ABORT_FILE}"
+      rm -f "$READY_FILE" "$ABORT_FILE" 2>/dev/null || true
       exit 0
     fi
-    if [ -f "$INPUT_FILE" ]; then
-      PROMPT=$(python3 -c "
-import json, sys
-with open(sys.argv[1]) as f:
-    data = json.load(f)
-print(data.get('prompt', ''))
-" "${INPUT_FILE}") || PROMPT=""
-      rm -f "${INPUT_FILE}" "${READY_FILE}"
-      if [ -n "$PROMPT" ]; then
-        printf '%s' "$PROMPT"
+    if [ -e "$INPUT_FILE" ] || [ -L "$INPUT_FILE" ]; then
+      STOP_OUTPUT=$(python3 -c "
+import json, os, stat, sys
+directory_flags = os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0) | getattr(os, 'O_NOFOLLOW', 0)
+directory_fd = os.open(sys.argv[1], directory_flags)
+file_fd = -1
+try:
+    flags = os.O_RDONLY | getattr(os, 'O_NONBLOCK', 0) | getattr(os, 'O_NOFOLLOW', 0)
+    file_fd = os.open(sys.argv[2], flags, dir_fd=directory_fd)
+    info = os.fstat(file_fd)
+    if not stat.S_ISREG(info.st_mode) or info.st_size > 1024 * 1024:
+        raise ValueError('unsafe input file')
+    with os.fdopen(file_fd, 'rb') as source:
+        file_fd = -1
+        raw = source.read(1024 * 1024 + 1)
+    if len(raw) > 1024 * 1024:
+        raise ValueError('oversized input file')
+    data = json.loads(raw)
+    prompt = data.get('prompt', '') if isinstance(data, dict) else ''
+    provider = data.get('provider') if isinstance(data, dict) else None
+    round_number = data.get('round') if isinstance(data, dict) else None
+    valid_round = isinstance(round_number, int) and not isinstance(round_number, bool)
+    if provider == sys.argv[3] and valid_round and round_number == int(sys.argv[4]) and isinstance(prompt, str) and prompt:
+        sys.stdout.write(json.dumps({'decision': 'block', 'reason': prompt}, ensure_ascii=True, separators=(',', ':')))
+finally:
+    if file_fd >= 0:
+        os.close(file_fd)
+    os.close(directory_fd)
+" "$SESSION_DIR" "$INPUT_NAME" "claude" "$NEXT_ROUND" 2>/dev/null) || STOP_OUTPUT=""
+      if [ -n "$STOP_OUTPUT" ]; then
+        if ! atomic_write "$CURSOR_NAME" "$NEXT_ROUND"; then
+          rm -f "$INPUT_FILE" "$READY_FILE" 2>/dev/null || true
+          exit 0
+        fi
+        rm -f "$INPUT_FILE" "$READY_FILE" 2>/dev/null || true
+        printf '%s' "$STOP_OUTPUT"
+      else
+        rm -f "$INPUT_FILE" "$READY_FILE" 2>/dev/null || true
       fi
       exit 0
     fi
     python3 -c "import time; time.sleep(0.2)" || sleep 1
     WAIT_COUNT=$((WAIT_COUNT + 1))
   done
-
-  # Timeout — clean up ready signal and exit normally.
-  rm -f "${READY_FILE}"
+  rm -f "$READY_FILE" 2>/dev/null || true
 fi

--- a/content/hooks/hook-codex-sessionstart.sh
+++ b/content/hooks/hook-codex-sessionstart.sh
@@ -13,6 +13,10 @@ case "$SESSION_ID" in
   *[!a-zA-Z0-9_-]*) exit 0 ;;
 esac
 SESSION_DIR="${AUTOPUS_SESSION_DIR:-/tmp/autopus/${SESSION_ID}}"
+case "$SESSION_DIR" in
+  /*) ;;
+  *) exit 0 ;;
+esac
 if [ ! -d "$SESSION_DIR" ] || [ -L "$SESSION_DIR" ]; then
   exit 0
 fi

--- a/content/hooks/hook-codex-stop.sh
+++ b/content/hooks/hook-codex-stop.sh
@@ -16,23 +16,34 @@ case "$SESSION_ID" in
 esac
 
 SESSION_DIR="${AUTOPUS_SESSION_DIR:-/tmp/autopus/${SESSION_ID}}"
+case "$SESSION_DIR" in
+  /*) ;;
+  *) exit 0 ;;
+esac
 if [ ! -d "$SESSION_DIR" ] || [ -L "$SESSION_DIR" ]; then
   exit 0
 fi
 
-# Atomically replace a signal entry relative to an already-open, non-symlink
-# session directory. The temporary file is mode 0600 and a final symlink at the
-# target name is replaced rather than followed.
-atomic_touch() {
+# Atomically replace an entry relative to an already-open, non-symlink session
+# directory. The temporary file is mode 0600 and target symlinks are replaced.
+atomic_write() {
   python3 -c "
 import os, secrets, sys
 directory_flags = os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0) | getattr(os, 'O_NOFOLLOW', 0)
 directory_fd = os.open(sys.argv[1], directory_flags)
 temporary = '.autopus-hook-' + secrets.token_hex(12)
+body = sys.argv[3].encode('ascii')
 file_fd = -1
 try:
     file_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, 'O_NOFOLLOW', 0)
     file_fd = os.open(temporary, file_flags, 0o600, dir_fd=directory_fd)
+    os.fchmod(file_fd, 0o600)
+    remaining = memoryview(body)
+    while remaining:
+        written = os.write(file_fd, remaining)
+        if written <= 0:
+            raise OSError('short write')
+        remaining = remaining[written:]
     os.fsync(file_fd)
     os.close(file_fd)
     file_fd = -1
@@ -47,14 +58,50 @@ except Exception:
     raise
 finally:
     os.close(directory_fd)
-" "$SESSION_DIR" "$1" 2>/dev/null
+" "$SESSION_DIR" "$1" "$2" 2>/dev/null
 }
 
-# Determine round-scoped file names when AUTOPUS_ROUND is set (integer-only).
-case "${AUTOPUS_ROUND:-}" in *[!0-9]*) AUTOPUS_ROUND="" ;; esac
-if [ -n "$AUTOPUS_ROUND" ]; then
-  RESULT_NAME="codex-round${AUTOPUS_ROUND}-result.json"
-  DONE_NAME="codex-round${AUTOPUS_ROUND}-done"
+# Resolve the effective round from the environment and confined cursor file.
+CURSOR_NAME="codex-round-cursor"
+EFFECTIVE_ROUND=$(python3 -c "
+import os, stat, sys
+def parse(value, allow_newline=False):
+    if allow_newline:
+        value = value.rstrip('\\r\\n')
+    if not value or any(ch < '0' or ch > '9' for ch in value):
+        return None
+    number = int(value)
+    return number if number <= 2147483646 else None
+env_round = parse(sys.argv[3])
+cursor_round = None
+directory_fd = file_fd = -1
+try:
+    directory_flags = os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0) | getattr(os, 'O_NOFOLLOW', 0)
+    directory_fd = os.open(sys.argv[1], directory_flags)
+    file_flags = os.O_RDONLY | getattr(os, 'O_NONBLOCK', 0) | getattr(os, 'O_NOFOLLOW', 0)
+    file_fd = os.open(sys.argv[2], file_flags, dir_fd=directory_fd)
+    info = os.fstat(file_fd)
+    if stat.S_ISREG(info.st_mode) and info.st_size <= 64:
+        with os.fdopen(file_fd, 'rb') as source:
+            file_fd = -1
+            raw = source.read(65)
+        if len(raw) <= 64:
+            cursor_round = parse(raw.decode('ascii'), True)
+except Exception:
+    pass
+finally:
+    if file_fd >= 0:
+        os.close(file_fd)
+    if directory_fd >= 0:
+        os.close(directory_fd)
+rounds = [value for value in (env_round, cursor_round) if value is not None]
+if rounds:
+    print(max(rounds))
+" "$SESSION_DIR" "$CURSOR_NAME" "${AUTOPUS_ROUND:-}" 2>/dev/null) || EFFECTIVE_ROUND=""
+
+if [ -n "$EFFECTIVE_ROUND" ]; then
+  RESULT_NAME="codex-round${EFFECTIVE_ROUND}-result.json"
+  DONE_NAME="codex-round${EFFECTIVE_ROUND}-done"
 else
   RESULT_NAME="codex-result.json"
   DONE_NAME="codex-done"
@@ -157,17 +204,17 @@ finally:
 
 # Send cmux completion signal for SignalDetector (SPEC-SURFCOMP-001 R8).
 if command -v cmux >/dev/null 2>&1; then
-  if [ -n "$AUTOPUS_ROUND" ] && [ "$AUTOPUS_ROUND" -gt 1 ] 2>/dev/null; then
-    cmux wait-for -S "done-codex-round${AUTOPUS_ROUND}" 2>/dev/null || true
+  if [ -n "$EFFECTIVE_ROUND" ] && [ "$EFFECTIVE_ROUND" -gt 1 ] 2>/dev/null; then
+    cmux wait-for -S "done-codex-round${EFFECTIVE_ROUND}" >/dev/null 2>&1 || true
   else
-    cmux wait-for -S "done-codex" 2>/dev/null || true
+    cmux wait-for -S "done-codex" >/dev/null 2>&1 || true
   fi
 fi
 
 # --- Bidirectional IPC: Ready signal + Input watch loop (SPEC-ORCH-017) ---
 # Only activate for round-scoped sessions.
-if [ -n "$AUTOPUS_ROUND" ]; then
-  NEXT_ROUND=$((AUTOPUS_ROUND + 1))
+if [ -n "$EFFECTIVE_ROUND" ]; then
+  NEXT_ROUND=$((EFFECTIVE_ROUND + 1))
   READY_NAME="codex-round${NEXT_ROUND}-ready"
   INPUT_NAME="codex-round${NEXT_ROUND}-input.json"
   ABORT_NAME="codex-round${NEXT_ROUND}-abort"
@@ -176,7 +223,7 @@ if [ -n "$AUTOPUS_ROUND" ]; then
   ABORT_FILE="${SESSION_DIR}/${ABORT_NAME}"
 
   # Signal ready for next round input.
-  atomic_touch "$READY_NAME"
+  atomic_write "$READY_NAME" ""
 
   # Poll for input file (200ms intervals, 120s timeout = 600 iterations).
   # @AX:NOTE [AUTO] magic constants 200ms/600 iterations — must match Go-side fileIPCReadyTimeout budget
@@ -188,7 +235,7 @@ if [ -n "$AUTOPUS_ROUND" ]; then
       exit 0
     fi
     if [ -f "$INPUT_FILE" ]; then
-      PROMPT=$(python3 -c "
+      STOP_OUTPUT=$(python3 -c "
 import json, os, stat, sys
 directory_flags = os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0) | getattr(os, 'O_NOFOLLOW', 0)
 directory_fd = os.open(sys.argv[1], directory_flags)
@@ -202,15 +249,27 @@ try:
     with os.fdopen(file_fd) as source:
         file_fd = -1
         data = json.load(source)
-    print(data.get('prompt', '') if isinstance(data, dict) else '')
+    prompt = data.get('prompt', '') if isinstance(data, dict) else ''
+    provider = data.get('provider') if isinstance(data, dict) else None
+    round_number = data.get('round') if isinstance(data, dict) else None
+    valid_round = isinstance(round_number, int) and not isinstance(round_number, bool)
+    if provider == sys.argv[3] and valid_round and round_number == int(sys.argv[4]) and isinstance(prompt, str) and prompt:
+        sys.stdout.write(json.dumps(
+            {'decision': 'block', 'reason': prompt},
+            ensure_ascii=True,
+            separators=(',', ':'),
+        ))
 finally:
     if file_fd >= 0:
         os.close(file_fd)
     os.close(directory_fd)
-" "$SESSION_DIR" "$INPUT_NAME") || PROMPT=""
-      rm -f "${INPUT_FILE}" "${READY_FILE}"
-      if [ -n "$PROMPT" ]; then
-        printf '%s' "$PROMPT"
+" "$SESSION_DIR" "$INPUT_NAME" "codex" "$NEXT_ROUND") || STOP_OUTPUT=""
+      if [ -n "$STOP_OUTPUT" ]; then
+        atomic_write "$CURSOR_NAME" "$NEXT_ROUND"
+        rm -f "${INPUT_FILE}" "${READY_FILE}"
+        printf '%s' "$STOP_OUTPUT"
+      else
+        rm -f "${INPUT_FILE}" "${READY_FILE}"
       fi
       exit 0
     fi

--- a/content/hooks/hook-gemini-afteragent.sh
+++ b/content/hooks/hook-gemini-afteragent.sh
@@ -1,99 +1,234 @@
 #!/bin/sh
-# hook-gemini-afteragent.sh — Antigravity CLI AfterAgent hook for autopus result collection.
-# Reads hook JSON from stdin, extracts prompt_response,
-# writes result.json and done signal to the session directory.
-# POSIX shell compatible. No jq dependency — uses python3 for JSON.
+# hook-gemini-afteragent.sh — Gemini CLI AfterAgent result collector.
+# POSIX shell compatible. Python provides confined JSON and file operations.
 set -e
 
 SESSION_ID="${AUTOPUS_SESSION_ID:-}"
 if [ -z "$SESSION_ID" ]; then
   exit 0
 fi
-
-# Validate session ID to prevent path traversal (alphanumeric, hyphen, underscore only)
 case "$SESSION_ID" in
   *[!a-zA-Z0-9_-]*) exit 0 ;;
 esac
 
 SESSION_DIR="${AUTOPUS_SESSION_DIR:-/tmp/autopus/${SESSION_ID}}"
-if [ ! -d "$SESSION_DIR" ]; then
+case "$SESSION_DIR" in
+  /*) ;;
+  *) exit 0 ;;
+esac
+if [ ! -d "$SESSION_DIR" ] || [ -L "$SESSION_DIR" ]; then
   exit 0
 fi
 
-# Determine round-scoped file names when AUTOPUS_ROUND is set (integer-only).
-case "${AUTOPUS_ROUND:-}" in *[!0-9]*) AUTOPUS_ROUND="" ;; esac
-if [ -n "$AUTOPUS_ROUND" ]; then
-  RESULT_FILE="${SESSION_DIR}/gemini-round${AUTOPUS_ROUND}-result.json"
-  DONE_FILE="${SESSION_DIR}/gemini-round${AUTOPUS_ROUND}-done"
+atomic_write() {
+  python3 -c "
+import os, secrets, sys
+directory_flags = os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0) | getattr(os, 'O_NOFOLLOW', 0)
+directory_fd = os.open(sys.argv[1], directory_flags)
+temporary = '.autopus-hook-' + secrets.token_hex(12)
+file_fd = -1
+try:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, 'O_NOFOLLOW', 0)
+    file_fd = os.open(temporary, flags, 0o600, dir_fd=directory_fd)
+    remaining = memoryview(sys.argv[3].encode('utf-8'))
+    while remaining:
+        written = os.write(file_fd, remaining)
+        if written <= 0:
+            raise OSError('short write')
+        remaining = remaining[written:]
+    os.fchmod(file_fd, 0o600)
+    os.fsync(file_fd)
+    os.close(file_fd)
+    file_fd = -1
+    os.replace(temporary, sys.argv[2], src_dir_fd=directory_fd, dst_dir_fd=directory_fd)
+except Exception:
+    if file_fd >= 0:
+        os.close(file_fd)
+    try:
+        os.unlink(temporary, dir_fd=directory_fd)
+    except Exception:
+        pass
+    raise
+finally:
+    os.close(directory_fd)
+" "$SESSION_DIR" "$1" "$2" 2>/dev/null
+}
+
+CURSOR_NAME="gemini-round-cursor"
+EFFECTIVE_ROUND=$(python3 -c "
+import os, stat, sys
+def parse(value, allow_newline=False):
+    if allow_newline:
+        value = value.rstrip('\\r\\n')
+    if not value or any(ch < '0' or ch > '9' for ch in value):
+        return None
+    number = int(value)
+    return number if number <= 2147483646 else None
+env_round = parse(sys.argv[3])
+cursor_round = None
+directory_fd = file_fd = -1
+try:
+    directory_flags = os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0) | getattr(os, 'O_NOFOLLOW', 0)
+    directory_fd = os.open(sys.argv[1], directory_flags)
+    flags = os.O_RDONLY | getattr(os, 'O_NONBLOCK', 0) | getattr(os, 'O_NOFOLLOW', 0)
+    file_fd = os.open(sys.argv[2], flags, dir_fd=directory_fd)
+    info = os.fstat(file_fd)
+    if stat.S_ISREG(info.st_mode) and info.st_size <= 64:
+        with os.fdopen(file_fd, 'rb') as source:
+            file_fd = -1
+            raw = source.read(65)
+        if len(raw) <= 64:
+            cursor_round = parse(raw.decode('ascii'), True)
+except Exception:
+    pass
+finally:
+    if file_fd >= 0:
+        os.close(file_fd)
+    if directory_fd >= 0:
+        os.close(directory_fd)
+rounds = [value for value in (env_round, cursor_round) if value is not None]
+if rounds:
+    print(max(rounds))
+" "$SESSION_DIR" "$CURSOR_NAME" "${AUTOPUS_ROUND:-}" 2>/dev/null) || EFFECTIVE_ROUND=""
+
+if [ -n "$EFFECTIVE_ROUND" ]; then
+  RESULT_NAME="gemini-round${EFFECTIVE_ROUND}-result.json"
+  DONE_NAME="gemini-round${EFFECTIVE_ROUND}-done"
 else
-  RESULT_FILE="${SESSION_DIR}/gemini-result.json"
-  DONE_FILE="${SESSION_DIR}/gemini-done"
+  RESULT_NAME="gemini-result.json"
+  DONE_NAME="gemini-done"
 fi
 
-# Read hook JSON from stdin and extract prompt_response via python3.
-# Input is passed via stdin (not argv) to avoid shell injection.
-python3 -c "
-import json, sys
-data = json.load(sys.stdin)
+# Malformed or empty payloads still publish an empty result followed by done.
+if ! python3 -c "
+import json, os, secrets, sys
+def atomic_write(directory_fd, name, body):
+    temporary = '.autopus-hook-' + secrets.token_hex(12)
+    file_fd = -1
+    try:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, 'O_NOFOLLOW', 0)
+        file_fd = os.open(temporary, flags, 0o600, dir_fd=directory_fd)
+        remaining = memoryview(body)
+        while remaining:
+            written = os.write(file_fd, remaining)
+            if written <= 0:
+                raise OSError('short write')
+            remaining = remaining[written:]
+        os.fchmod(file_fd, 0o600)
+        os.fsync(file_fd)
+        os.close(file_fd)
+        file_fd = -1
+        os.replace(temporary, name, src_dir_fd=directory_fd, dst_dir_fd=directory_fd)
+    except Exception:
+        if file_fd >= 0:
+            os.close(file_fd)
+        try:
+            os.unlink(temporary, dir_fd=directory_fd)
+        except Exception:
+            pass
+        raise
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    data = {}
+if not isinstance(data, dict):
+    data = {}
 msg = data.get('prompt_response', '')
-if not msg:
-    sys.exit(0)
-result = {'output': msg, 'exit_code': 0}
-with open(sys.argv[1], 'w') as f:
-    json.dump(result, f)
-" "${RESULT_FILE}"
+if not isinstance(msg, str):
+    msg = ''
+directory_flags = os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0) | getattr(os, 'O_NOFOLLOW', 0)
+directory_fd = os.open(sys.argv[1], directory_flags)
+errors = []
+try:
+    for name, body in (
+        (sys.argv[2], json.dumps({'output': msg, 'exit_code': 0}).encode('utf-8')),
+        (sys.argv[3], b''),
+    ):
+        try:
+            atomic_write(directory_fd, name, body)
+        except Exception as error:
+            errors.append(error)
+finally:
+    os.close(directory_fd)
+if errors:
+    raise errors[0]
+" "$SESSION_DIR" "$RESULT_NAME" "$DONE_NAME" 2>/dev/null; then
+  exit 0
+fi
 
-chmod 600 "${RESULT_FILE}"
-
-# Write done signal (empty file).
-: > "${DONE_FILE}"
-
-# Send cmux completion signal for SignalDetector (SPEC-SURFCOMP-001 R8).
 if command -v cmux >/dev/null 2>&1; then
-  if [ -n "$AUTOPUS_ROUND" ] && [ "$AUTOPUS_ROUND" -gt 1 ] 2>/dev/null; then
-    cmux wait-for -S "done-gemini-round${AUTOPUS_ROUND}" 2>/dev/null || true
+  if [ -n "$EFFECTIVE_ROUND" ] && [ "$EFFECTIVE_ROUND" -gt 1 ] 2>/dev/null; then
+    cmux wait-for -S "done-gemini-round${EFFECTIVE_ROUND}" >/dev/null 2>&1 || true
   else
-    cmux wait-for -S "done-gemini" 2>/dev/null || true
+    cmux wait-for -S "done-gemini" >/dev/null 2>&1 || true
   fi
 fi
 
-# --- Bidirectional IPC: Ready signal + Input watch loop (SPEC-ORCH-017) ---
-# Only activate for round-scoped sessions.
-if [ -n "$AUTOPUS_ROUND" ]; then
-  NEXT_ROUND=$((AUTOPUS_ROUND + 1))
-  READY_FILE="${SESSION_DIR}/gemini-round${NEXT_ROUND}-ready"
-  INPUT_FILE="${SESSION_DIR}/gemini-round${NEXT_ROUND}-input.json"
-  ABORT_FILE="${SESSION_DIR}/gemini-round${NEXT_ROUND}-abort"
+if [ -n "$EFFECTIVE_ROUND" ]; then
+  NEXT_ROUND=$((EFFECTIVE_ROUND + 1))
+  READY_NAME="gemini-round${NEXT_ROUND}-ready"
+  INPUT_NAME="gemini-round${NEXT_ROUND}-input.json"
+  ABORT_NAME="gemini-round${NEXT_ROUND}-abort"
+  READY_FILE="${SESSION_DIR}/${READY_NAME}"
+  INPUT_FILE="${SESSION_DIR}/${INPUT_NAME}"
+  ABORT_FILE="${SESSION_DIR}/${ABORT_NAME}"
+  if ! atomic_write "$READY_NAME" ""; then
+    exit 0
+  fi
 
-  # Signal ready for next round input.
-  : > "${READY_FILE}"
-
-  # Poll for input file (200ms intervals, 120s timeout = 600 iterations).
-  # @AX:NOTE [AUTO] magic constants 200ms/600 iterations — must match Go-side fileIPCReadyTimeout budget
   WAIT_COUNT=0
   MAX_WAIT=600
   while [ "$WAIT_COUNT" -lt "$MAX_WAIT" ]; do
     if [ -f "$ABORT_FILE" ]; then
-      rm -f "${READY_FILE}" "${ABORT_FILE}"
+      rm -f "$READY_FILE" "$ABORT_FILE" 2>/dev/null || true
       exit 0
     fi
-    if [ -f "$INPUT_FILE" ]; then
+    if [ -e "$INPUT_FILE" ] || [ -L "$INPUT_FILE" ]; then
       PROMPT=$(python3 -c "
-import json, sys
-with open(sys.argv[1]) as f:
-    data = json.load(f)
-print(data.get('prompt', ''))
-" "${INPUT_FILE}") || PROMPT=""
-      rm -f "${INPUT_FILE}" "${READY_FILE}"
+import json, os, stat, sys
+directory_flags = os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0) | getattr(os, 'O_NOFOLLOW', 0)
+directory_fd = os.open(sys.argv[1], directory_flags)
+file_fd = -1
+try:
+    flags = os.O_RDONLY | getattr(os, 'O_NONBLOCK', 0) | getattr(os, 'O_NOFOLLOW', 0)
+    file_fd = os.open(sys.argv[2], flags, dir_fd=directory_fd)
+    info = os.fstat(file_fd)
+    if not stat.S_ISREG(info.st_mode) or info.st_size > 1024 * 1024:
+        raise ValueError('unsafe input file')
+    with os.fdopen(file_fd, 'rb') as source:
+        file_fd = -1
+        raw = source.read(1024 * 1024 + 1)
+    if len(raw) > 1024 * 1024:
+        raise ValueError('oversized input file')
+    data = json.loads(raw)
+    prompt = data.get('prompt', '') if isinstance(data, dict) else ''
+    provider = data.get('provider') if isinstance(data, dict) else None
+    round_number = data.get('round') if isinstance(data, dict) else None
+    valid_round = isinstance(round_number, int) and not isinstance(round_number, bool)
+    if provider == sys.argv[3] and valid_round and round_number == int(sys.argv[4]) and isinstance(prompt, str) and prompt:
+        sys.stdout.write(prompt)
+finally:
+    if file_fd >= 0:
+        os.close(file_fd)
+    os.close(directory_fd)
+" "$SESSION_DIR" "$INPUT_NAME" "gemini" "$NEXT_ROUND" 2>/dev/null) || PROMPT=""
       if [ -n "$PROMPT" ]; then
-        printf '%s' "$PROMPT"
+        if ! atomic_write "$CURSOR_NAME" "$NEXT_ROUND"; then
+          rm -f "$INPUT_FILE" "$READY_FILE" 2>/dev/null || true
+          exit 0
+        fi
+        rm -f "$INPUT_FILE" "$READY_FILE" 2>/dev/null || true
+        printf '%s' "$PROMPT" | python3 -c "
+import json, sys
+json.dump({'decision': 'block', 'reason': sys.stdin.read()}, sys.stdout)
+" 2>/dev/null || true
+      else
+        rm -f "$INPUT_FILE" "$READY_FILE" 2>/dev/null || true
       fi
       exit 0
     fi
     python3 -c "import time; time.sleep(0.2)" || sleep 1
     WAIT_COUNT=$((WAIT_COUNT + 1))
   done
-
-  # Timeout — clean up ready signal and exit normally.
-  rm -f "${READY_FILE}"
+  rm -f "$READY_FILE" 2>/dev/null || true
 fi

--- a/content/hooks/hook-gemini-sessionstart.sh
+++ b/content/hooks/hook-gemini-sessionstart.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
-# hook-gemini-sessionstart.sh — gemini session-start hook for autopus.
-# Writes a ready-signal file so the orchestrator detects session readiness via
-# file IPC instead of screen scraping (SPEC-ORCH-022). No-op unless
-# AUTOPUS_SESSION_ID is set. POSIX shell; does not require stdin.
+# Gemini session-start hook: atomically publishes the round-ready signal.
 set -e
 
 SESSION_ID="${AUTOPUS_SESSION_ID:-}"
@@ -12,13 +9,42 @@ fi
 case "$SESSION_ID" in
   *[!a-zA-Z0-9_-]*) exit 0 ;;
 esac
+
 SESSION_DIR="${AUTOPUS_SESSION_DIR:-/tmp/autopus/${SESSION_ID}}"
-if [ ! -d "$SESSION_DIR" ]; then
+case "$SESSION_DIR" in
+  /*) ;;
+  *) exit 0 ;;
+esac
+if [ ! -d "$SESSION_DIR" ] || [ -L "$SESSION_DIR" ]; then
   exit 0
 fi
 case "${AUTOPUS_ROUND:-}" in *[!0-9]*) AUTOPUS_ROUND="" ;; esac
 ROUND="${AUTOPUS_ROUND:-0}"
-READY_FILE="${SESSION_DIR}/gemini-round${ROUND}-ready"
-: > "${READY_FILE}"
-chmod 600 "${READY_FILE}" 2>/dev/null || true
+READY_NAME="gemini-round${ROUND}-ready"
+
+python3 -c "
+import os, secrets, sys
+directory_flags = os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0) | getattr(os, 'O_NOFOLLOW', 0)
+directory_fd = os.open(sys.argv[1], directory_flags)
+temporary = '.autopus-hook-' + secrets.token_hex(12)
+file_fd = -1
+try:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, 'O_NOFOLLOW', 0)
+    file_fd = os.open(temporary, flags, 0o600, dir_fd=directory_fd)
+    os.fchmod(file_fd, 0o600)
+    os.fsync(file_fd)
+    os.close(file_fd)
+    file_fd = -1
+    os.replace(temporary, sys.argv[2], src_dir_fd=directory_fd, dst_dir_fd=directory_fd)
+except Exception:
+    if file_fd >= 0:
+        os.close(file_fd)
+    try:
+        os.unlink(temporary, dir_fd=directory_fd)
+    except Exception:
+        pass
+    raise
+finally:
+    os.close(directory_fd)
+" "$SESSION_DIR" "$READY_NAME" 2>/dev/null || true
 exit 0

--- a/content/hooks/hook-gemini-stop.sh
+++ b/content/hooks/hook-gemini-stop.sh
@@ -1,0 +1,289 @@
+#!/bin/sh
+# hook-gemini-stop.sh — Antigravity CLI Stop hook for completion IPC.
+# Antigravity requires one JSON object on stdout for every exit path.
+set -e
+
+allow_stop() {
+  printf '{"decision":"stop"}\n'
+}
+
+SESSION_ID="${AUTOPUS_SESSION_ID:-}"
+if [ -z "$SESSION_ID" ]; then
+  allow_stop
+  exit 0
+fi
+case "$SESSION_ID" in
+  *[!a-zA-Z0-9_-]*) allow_stop; exit 0 ;;
+esac
+
+SESSION_DIR="${AUTOPUS_SESSION_DIR:-/tmp/autopus/${SESSION_ID}}"
+case "$SESSION_DIR" in
+  /*) ;;
+  *) allow_stop; exit 0 ;;
+esac
+if [ ! -d "$SESSION_DIR" ] || [ -L "$SESSION_DIR" ]; then
+  allow_stop
+  exit 0
+fi
+
+atomic_write() {
+  python3 -c "
+import os, secrets, sys
+directory_flags = os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0) | getattr(os, 'O_NOFOLLOW', 0)
+directory_fd = os.open(sys.argv[1], directory_flags)
+temporary = '.autopus-hook-' + secrets.token_hex(12)
+file_fd = -1
+try:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, 'O_NOFOLLOW', 0)
+    file_fd = os.open(temporary, flags, 0o600, dir_fd=directory_fd)
+    remaining = memoryview(sys.argv[3].encode('utf-8'))
+    while remaining:
+        written = os.write(file_fd, remaining)
+        if written <= 0:
+            raise OSError('short write')
+        remaining = remaining[written:]
+    os.fchmod(file_fd, 0o600)
+    os.fsync(file_fd)
+    os.close(file_fd)
+    file_fd = -1
+    os.replace(temporary, sys.argv[2], src_dir_fd=directory_fd, dst_dir_fd=directory_fd)
+except Exception:
+    if file_fd >= 0:
+        os.close(file_fd)
+    try:
+        os.unlink(temporary, dir_fd=directory_fd)
+    except Exception:
+        pass
+    raise
+finally:
+    os.close(directory_fd)
+" "$SESSION_DIR" "$1" "$2" 2>/dev/null
+}
+
+CURSOR_NAME="gemini-round-cursor"
+EFFECTIVE_ROUND=$(python3 -c "
+import os, stat, sys
+def parse(value, allow_newline=False):
+    if allow_newline:
+        value = value.rstrip('\\r\\n')
+    if not value or any(ch < '0' or ch > '9' for ch in value):
+        return None
+    number = int(value)
+    return number if number <= 2147483646 else None
+env_round = parse(sys.argv[3])
+cursor_round = None
+directory_fd = file_fd = -1
+try:
+    directory_flags = os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0) | getattr(os, 'O_NOFOLLOW', 0)
+    directory_fd = os.open(sys.argv[1], directory_flags)
+    flags = os.O_RDONLY | getattr(os, 'O_NONBLOCK', 0) | getattr(os, 'O_NOFOLLOW', 0)
+    file_fd = os.open(sys.argv[2], flags, dir_fd=directory_fd)
+    info = os.fstat(file_fd)
+    if stat.S_ISREG(info.st_mode) and info.st_size <= 64:
+        with os.fdopen(file_fd, 'rb') as source:
+            file_fd = -1
+            raw = source.read(65)
+        if len(raw) <= 64:
+            cursor_round = parse(raw.decode('ascii'), True)
+except Exception:
+    pass
+finally:
+    if file_fd >= 0:
+        os.close(file_fd)
+    if directory_fd >= 0:
+        os.close(directory_fd)
+rounds = [value for value in (env_round, cursor_round) if value is not None]
+if rounds:
+    print(max(rounds))
+" "$SESSION_DIR" "$CURSOR_NAME" "${AUTOPUS_ROUND:-}" 2>/dev/null) || EFFECTIVE_ROUND=""
+
+if [ -n "$EFFECTIVE_ROUND" ]; then
+  RESULT_NAME="gemini-round${EFFECTIVE_ROUND}-result.json"
+  DONE_NAME="gemini-round${EFFECTIVE_ROUND}-done"
+else
+  RESULT_NAME="gemini-result.json"
+  DONE_NAME="gemini-done"
+fi
+
+if ! python3 -c "
+import json, os, secrets, stat, sys
+def atomic_write(directory_fd, name, body):
+    temporary = '.autopus-hook-' + secrets.token_hex(12)
+    file_fd = -1
+    try:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, 'O_NOFOLLOW', 0)
+        file_fd = os.open(temporary, flags, 0o600, dir_fd=directory_fd)
+        remaining = memoryview(body)
+        while remaining:
+            written = os.write(file_fd, remaining)
+            if written <= 0:
+                raise OSError('short write')
+            remaining = remaining[written:]
+        os.fchmod(file_fd, 0o600)
+        os.fsync(file_fd)
+        os.close(file_fd)
+        file_fd = -1
+        os.replace(temporary, name, src_dir_fd=directory_fd, dst_dir_fd=directory_fd)
+    except Exception:
+        if file_fd >= 0:
+            os.close(file_fd)
+        try:
+            os.unlink(temporary, dir_fd=directory_fd)
+        except Exception:
+            pass
+        raise
+def transcript_message(data):
+    path = data.get('transcriptPath')
+    if not isinstance(path, str) or not os.path.isabs(path):
+        return ''
+    file_fd = -1
+    try:
+        flags = os.O_RDONLY | getattr(os, 'O_NOFOLLOW', 0)
+        file_fd = os.open(path, flags)
+        info = os.fstat(file_fd)
+        if not stat.S_ISREG(info.st_mode):
+            return ''
+        limit = 2 * 1024 * 1024
+        start = max(0, info.st_size - limit)
+        os.lseek(file_fd, start, os.SEEK_SET)
+        raw = os.read(file_fd, limit)
+        if start:
+            raw = raw.partition(b'\\n')[2]
+        message = ''
+        for line in raw.splitlines():
+            try:
+                item = json.loads(line)
+            except Exception:
+                continue
+            if item.get('source') == 'MODEL' and item.get('type') == 'PLANNER_RESPONSE':
+                content = item.get('content')
+                if isinstance(content, str) and content:
+                    message = content
+        return message
+    except Exception:
+        return ''
+    finally:
+        if file_fd >= 0:
+            os.close(file_fd)
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    data = {}
+if not isinstance(data, dict):
+    data = {}
+msg = ''
+for key in ('lastAssistantMessage', 'last_assistant_message', 'promptResponse', 'prompt_response'):
+    value = data.get(key)
+    if isinstance(value, str) and value:
+        msg = value
+        break
+if not msg:
+    msg = transcript_message(data)
+directory_flags = os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0) | getattr(os, 'O_NOFOLLOW', 0)
+directory_fd = os.open(sys.argv[1], directory_flags)
+errors = []
+try:
+    for name, body in (
+        (sys.argv[2], json.dumps({'output': msg, 'exit_code': 0}).encode('utf-8')),
+        (sys.argv[3], b''),
+    ):
+        try:
+            atomic_write(directory_fd, name, body)
+        except Exception as error:
+            errors.append(error)
+finally:
+    os.close(directory_fd)
+if errors:
+    raise errors[0]
+" "$SESSION_DIR" "$RESULT_NAME" "$DONE_NAME" 2>/dev/null; then
+  allow_stop
+  exit 0
+fi
+
+if command -v cmux >/dev/null 2>&1; then
+  if [ -n "$EFFECTIVE_ROUND" ] && [ "$EFFECTIVE_ROUND" -gt 1 ] 2>/dev/null; then
+    cmux wait-for -S "done-gemini-round${EFFECTIVE_ROUND}" >/dev/null 2>&1 || true
+  else
+    cmux wait-for -S "done-gemini" >/dev/null 2>&1 || true
+  fi
+fi
+
+if [ -z "$EFFECTIVE_ROUND" ]; then
+  allow_stop
+  exit 0
+fi
+
+NEXT_ROUND=$((EFFECTIVE_ROUND + 1))
+READY_NAME="gemini-round${NEXT_ROUND}-ready"
+INPUT_NAME="gemini-round${NEXT_ROUND}-input.json"
+ABORT_NAME="gemini-round${NEXT_ROUND}-abort"
+READY_FILE="${SESSION_DIR}/${READY_NAME}"
+INPUT_FILE="${SESSION_DIR}/${INPUT_NAME}"
+ABORT_FILE="${SESSION_DIR}/${ABORT_NAME}"
+if ! atomic_write "$READY_NAME" ""; then
+  allow_stop
+  exit 0
+fi
+
+WAIT_COUNT=0
+MAX_WAIT=600
+while [ "$WAIT_COUNT" -lt "$MAX_WAIT" ]; do
+  if [ -f "$ABORT_FILE" ]; then
+    rm -f "$READY_FILE" "$ABORT_FILE" 2>/dev/null || true
+    allow_stop
+    exit 0
+  fi
+  if [ -e "$INPUT_FILE" ] || [ -L "$INPUT_FILE" ]; then
+    PROMPT=$(python3 -c "
+import json, os, stat, sys
+directory_flags = os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0) | getattr(os, 'O_NOFOLLOW', 0)
+directory_fd = os.open(sys.argv[1], directory_flags)
+file_fd = -1
+try:
+    flags = os.O_RDONLY | getattr(os, 'O_NONBLOCK', 0) | getattr(os, 'O_NOFOLLOW', 0)
+    file_fd = os.open(sys.argv[2], flags, dir_fd=directory_fd)
+    info = os.fstat(file_fd)
+    if not stat.S_ISREG(info.st_mode) or info.st_size > 1024 * 1024:
+        raise ValueError('unsafe input file')
+    with os.fdopen(file_fd, 'rb') as source:
+        file_fd = -1
+        raw = source.read(1024 * 1024 + 1)
+    if len(raw) > 1024 * 1024:
+        raise ValueError('oversized input file')
+    data = json.loads(raw)
+    prompt = data.get('prompt', '') if isinstance(data, dict) else ''
+    provider = data.get('provider') if isinstance(data, dict) else None
+    round_number = data.get('round') if isinstance(data, dict) else None
+    valid_round = isinstance(round_number, int) and not isinstance(round_number, bool)
+    if provider == 'gemini' and valid_round and round_number == int(sys.argv[3]) and isinstance(prompt, str) and prompt:
+        sys.stdout.write(prompt)
+finally:
+    if file_fd >= 0:
+        os.close(file_fd)
+    os.close(directory_fd)
+" "$SESSION_DIR" "$INPUT_NAME" "$NEXT_ROUND" 2>/dev/null) || PROMPT=""
+    if [ -n "$PROMPT" ]; then
+      if ! atomic_write "$CURSOR_NAME" "$NEXT_ROUND"; then
+        rm -f "$INPUT_FILE" "$READY_FILE" 2>/dev/null || true
+        allow_stop
+        exit 0
+      fi
+      rm -f "$INPUT_FILE" "$READY_FILE" 2>/dev/null || true
+      if ! printf '%s' "$PROMPT" | python3 -c "
+import json, sys
+json.dump({'decision': 'continue', 'reason': sys.stdin.read()}, sys.stdout)
+" 2>/dev/null; then
+        allow_stop
+      fi
+    else
+      rm -f "$INPUT_FILE" "$READY_FILE" 2>/dev/null || true
+      allow_stop
+    fi
+    exit 0
+  fi
+  python3 -c "import time; time.sleep(0.2)" || sleep 1
+  WAIT_COUNT=$((WAIT_COUNT + 1))
+done
+
+rm -f "$READY_FILE" 2>/dev/null || true
+allow_stop

--- a/content/hooks/hook-opencode-complete.ts
+++ b/content/hooks/hook-opencode-complete.ts
@@ -1,90 +1,184 @@
-// Autopus orchestra result collector — opencode text.complete plugin.
-// Captures completed text and writes result JSON + done signal to session dir.
+// Autopus orchestra result collector — OpenCode text.complete plugin.
+import { randomBytes } from "crypto";
+import {
+  closeSync,
+  constants,
+  fchmodSync,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
+import { isAbsolute, join } from "path";
+
 const sessId = process.env.AUTOPUS_SESSION_ID;
-if (!sessId) process.exit(0);
+if (!sessId || !/^[a-zA-Z0-9_-]+$/.test(sessId)) process.exit(0);
 
-import { existsSync, writeFileSync, mkdirSync, unlinkSync, readFileSync } from "fs";
-import { join } from "path";
+const sessDir = process.env.AUTOPUS_SESSION_DIR || join("/tmp/autopus", sessId);
+if (!isAbsolute(sessDir)) process.exit(0);
+try {
+  const info = lstatSync(sessDir);
+  if (!info.isDirectory() || info.isSymbolicLink()) process.exit(0);
+} catch {
+  process.exit(0);
+}
 
-// Validate session ID to prevent path traversal (alphanumeric, hyphen, underscore only).
-if (!/^[a-zA-Z0-9_-]+$/.test(sessId)) process.exit(0);
+const cursorFile = "opencode-round-cursor";
+const maxCursorBytes = 64;
+const maxInputBytes = 1024 * 1024;
+const noFollow = constants.O_NOFOLLOW ?? 0;
+const nonBlock = constants.O_NONBLOCK ?? 0;
 
-const sessDir = join("/tmp/autopus", sessId);
-if (!existsSync(sessDir)) process.exit(0);
+function artifactPath(name: string): string {
+  if (name === "." || name === ".." || !/^[a-zA-Z0-9._-]+$/.test(name)) {
+    throw new Error("unsafe artifact name");
+  }
+  return join(sessDir, name);
+}
+
+function atomicWrite(name: string, body: string | Buffer): void {
+  const temporary = artifactPath(`.autopus-hook-${randomBytes(12).toString("hex")}`);
+  let fd = -1;
+  try {
+    fd = openSync(temporary, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | noFollow, 0o600);
+    writeFileSync(fd, body);
+    fchmodSync(fd, 0o600);
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = -1;
+    renameSync(temporary, artifactPath(name));
+  } catch (error) {
+    if (fd >= 0) {
+      try { closeSync(fd); } catch {}
+    }
+    try { unlinkSync(temporary); } catch {}
+    throw error;
+  }
+}
+
+function readRegular(name: string, maxBytes: number, encoding: BufferEncoding): string {
+  let fd = -1;
+  try {
+    fd = openSync(artifactPath(name), constants.O_RDONLY | nonBlock | noFollow);
+    const info = fstatSync(fd);
+    if (!info.isFile() || info.size > maxBytes) throw new Error("unsafe artifact");
+    const body = readFileSync(fd);
+    if (body.length > maxBytes) throw new Error("oversized artifact");
+    return body.toString(encoding);
+  } finally {
+    if (fd >= 0) closeSync(fd);
+  }
+}
+
+function artifactExists(name: string): boolean {
+  try {
+    lstatSync(artifactPath(name));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function removeArtifact(name: string): void {
+  try { unlinkSync(artifactPath(name)); } catch {}
+}
+
+function parseRound(value: string | undefined, allowNewline = false): number | null {
+  const candidate = allowNewline ? value?.replace(/[\r\n]+$/, "") : value;
+  if (!candidate || !/^[0-9]+$/.test(candidate)) return null;
+  const round = Number(candidate);
+  if (!Number.isSafeInteger(round) || round > 2147483646) return null;
+  return round;
+}
+
+function readCursorRound(): number | null {
+  try {
+    return parseRound(readRegular(cursorFile, maxCursorBytes, "ascii"), true);
+  } catch {
+    return null;
+  }
+}
 
 const chunks: Buffer[] = [];
-process.stdin.on("data", (chunk) => chunks.push(chunk));
+process.stdin.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
 process.stdin.on("end", () => {
   const input = Buffer.concat(chunks).toString();
   let text = "";
   try {
     const data = JSON.parse(input);
-    text = data.text || "";
+    text = typeof data.text === "string" ? data.text : "";
   } catch {
     text = input;
   }
   if (!text) process.exit(0);
 
-  const result = JSON.stringify({
-    output: text,
-    exit_code: 0,
-  });
-
-  // Use round-scoped file names when AUTOPUS_ROUND is set (integer-only validation).
-  const round = process.env.AUTOPUS_ROUND;
-  const validRound = round && /^\d+$/.test(round) ? round : null;
-  const suffix = validRound ? `-round${validRound}` : '';
+  const envRound = parseRound(process.env.AUTOPUS_ROUND);
+  const cursorRound = readCursorRound();
+  const effectiveRound = Math.max(envRound ?? -1, cursorRound ?? -1);
+  const validRound = effectiveRound >= 0 ? String(effectiveRound) : null;
+  const suffix = validRound ? `-round${validRound}` : "";
   const resultFile = `opencode${suffix}-result.json`;
   const doneFile = `opencode${suffix}-done`;
-
-  writeFileSync(join(sessDir, resultFile), result, { mode: 0o600 });
-  writeFileSync(join(sessDir, doneFile), "", { mode: 0o600 });
-
-  // --- Bidirectional IPC: Ready signal + Input watch loop (SPEC-ORCH-017) ---
-  if (validRound) {
-    const nextRound = String(Number(validRound) + 1);
-    const readyFile = `opencode-round${nextRound}-ready`;
-    const inputFile = `opencode-round${nextRound}-input.json`;
-    const abortFile = `opencode-round${nextRound}-abort`;
-
-    writeFileSync(join(sessDir, readyFile), "", { mode: 0o600 });
-
-    // Poll for input file (200ms intervals, 120s timeout).
-    // @AX:NOTE [AUTO] magic constants 200ms/120s — must match Go-side fileIPCReadyTimeout budget
-    let waited = 0;
-    const maxWait = 120000;
-    const poll = setInterval(() => {
-      waited += 200;
-      const abortPath = join(sessDir, abortFile);
-      const inputPath = join(sessDir, inputFile);
-
-      if (existsSync(abortPath)) {
-        clearInterval(poll);
-        try { unlinkSync(join(sessDir, readyFile)); } catch {}
-        try { unlinkSync(abortPath); } catch {}
-        process.exit(0);
-      }
-
-      if (existsSync(inputPath)) {
-        clearInterval(poll);
-        try {
-          const raw = readFileSync(inputPath, "utf-8");
-          const parsed = JSON.parse(raw);
-          const prompt = parsed.prompt || "";
-          try { unlinkSync(inputPath); } catch {}
-          try { unlinkSync(join(sessDir, readyFile)); } catch {}
-          if (prompt) {
-            process.stdout.write(prompt);
-          }
-        } catch {}
-        process.exit(0);
-      }
-
-      if (waited >= maxWait) {
-        clearInterval(poll);
-        try { unlinkSync(join(sessDir, readyFile)); } catch {}
-        process.exit(0);
-      }
-    }, 200);
+  try {
+    atomicWrite(resultFile, JSON.stringify({ output: text, exit_code: 0 }));
+    atomicWrite(doneFile, "");
+  } catch {
+    process.exit(0);
   }
+
+  if (!validRound) return;
+  const nextRound = String(Number(validRound) + 1);
+  const readyFile = `opencode-round${nextRound}-ready`;
+  const inputFile = `opencode-round${nextRound}-input.json`;
+  const abortFile = `opencode-round${nextRound}-abort`;
+  try {
+    atomicWrite(readyFile, "");
+  } catch {
+    process.exit(0);
+  }
+
+  let waited = 0;
+  const maxWait = 120000;
+  const poll = setInterval(() => {
+    waited += 200;
+    if (artifactExists(abortFile)) {
+      clearInterval(poll);
+      removeArtifact(readyFile);
+      removeArtifact(abortFile);
+      process.exit(0);
+    }
+
+    if (artifactExists(inputFile)) {
+      clearInterval(poll);
+      let prompt = "";
+      try {
+        const parsed = JSON.parse(readRegular(inputFile, maxInputBytes, "utf-8"));
+        const validInput = parsed.provider === "opencode" && parsed.round === Number(nextRound);
+        prompt = validInput && typeof parsed.prompt === "string" ? parsed.prompt : "";
+      } catch {}
+      if (prompt) {
+        try {
+          atomicWrite(cursorFile, `${nextRound}\n`);
+        } catch {
+          removeArtifact(inputFile);
+          removeArtifact(readyFile);
+          process.exit(0);
+        }
+      }
+      removeArtifact(inputFile);
+      removeArtifact(readyFile);
+      if (prompt) process.stdout.write(prompt);
+      process.exit(0);
+    }
+
+    if (waited >= maxWait) {
+      clearInterval(poll);
+      removeArtifact(readyFile);
+      process.exit(0);
+    }
+  }, 200);
 });

--- a/internal/cli/orchestra_cc21_test.go
+++ b/internal/cli/orchestra_cc21_test.go
@@ -66,7 +66,7 @@ func TestResolveCC21MonitorRuntime_Enabled(t *testing.T) {
 	require.NoError(t, os.WriteFile(claudePath, []byte("#!/bin/sh\necho 2.1.113\n"), 0o755))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(homeDir, ".claude", "settings.json"),
-		[]byte(`{"hooks":{"Stop":[{"command":"autopus"}]}}`),
+		[]byte(`{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"autopus hook stop"}]}]}}`),
 		0o644,
 	))
 

--- a/internal/cli/orchestra_cleanup.go
+++ b/internal/cli/orchestra_cleanup.go
@@ -2,8 +2,11 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
+	"sort"
 
 	"github.com/spf13/cobra"
 
@@ -11,10 +14,15 @@ import (
 	"github.com/insajin/autopus-adk/pkg/terminal"
 )
 
+var orchestraSessionTerminalDetector = terminal.DetectTerminal
+var orchestraSessionUpdater = orchestra.UpdateSession
+var orchestraSessionRemover = orchestra.RemoveSession
+
 // newOrchestraCleanupCmd creates the cleanup subcommand for orchestra.
 // Loads a persisted session, kills all panes, and removes the session file.
 func newOrchestraCleanupCmd() *cobra.Command {
 	var sessionID string
+	var workspaceRef string
 
 	cmd := &cobra.Command{
 		Use:   "cleanup",
@@ -24,11 +32,12 @@ func newOrchestraCleanupCmd() *cobra.Command {
 			if sessionID == "" {
 				return fmt.Errorf("--session-id is required")
 			}
-			return runOrchestraCleanup(cmd.Context(), sessionID)
+			return runOrchestraCleanupWithWorkspace(cmd.Context(), sessionID, workspaceRef)
 		},
 	}
 
 	cmd.Flags().StringVar(&sessionID, "session-id", "", "cleanup 대상 세션 ID (필수)")
+	cmd.Flags().StringVar(&workspaceRef, "workspace-ref", "", "legacy cmux 세션의 원 workspace ref")
 	_ = cmd.MarkFlagRequired("session-id")
 
 	return cmd
@@ -37,34 +46,76 @@ func newOrchestraCleanupCmd() *cobra.Command {
 // runOrchestraCleanup loads the session, kills panes, and removes the session file.
 // Idempotent: returns nil if session file is already missing.
 func runOrchestraCleanup(ctx context.Context, sessionID string) error {
+	return runOrchestraCleanupWithWorkspace(ctx, sessionID, "")
+}
+
+func runOrchestraCleanupWithWorkspace(ctx context.Context, sessionID, workspaceRef string) error {
 	session, err := orchestra.LoadSession(sessionID)
 	if err != nil {
-		// Session file missing — already cleaned or never created.
-		fmt.Fprintf(os.Stderr, "[cleanup] session %s: %v (may already be cleaned)\n", sessionID, err)
-		return nil
+		if errors.Is(err, fs.ErrNotExist) {
+			fmt.Fprintf(os.Stderr, "[cleanup] session %s already absent\n", sessionID)
+			return nil
+		}
+		return fmt.Errorf("load cleanup session %s: %w", sessionID, err)
 	}
-
-	// Detect terminal for pane cleanup.
-	term := terminal.DetectTerminal()
-
-	// Kill each pane referenced by the session.
-	killed := 0
-	for provider, paneID := range session.Panes {
-		if term != nil {
-			if killErr := term.Close(ctx, paneID); killErr != nil {
-				fmt.Fprintf(os.Stderr, "[cleanup] %s pane %s kill failed: %v\n", provider, paneID, killErr)
-			} else {
-				killed++
+	if len(session.Panes) == 0 {
+		if workspaceRef != "" {
+			if _, err := orchestra.ResolveSessionTerminalWithWorkspace(
+				session, orchestraSessionTerminalDetector(), workspaceRef,
+			); err != nil {
+				return fmt.Errorf("validate cleanup workspace override: %w", err)
 			}
 		}
+		if err := orchestraSessionRemover(sessionID); err != nil {
+			return fmt.Errorf("remove empty cleanup session %s: %w", sessionID, err)
+		}
+		fmt.Fprintf(os.Stderr, "[cleanup] session %s: no panes, session file removed\n", sessionID)
+		return nil
 	}
-
-	// Remove the session persistence file.
-	if removeErr := orchestra.RemoveSession(sessionID); removeErr != nil {
-		fmt.Fprintf(os.Stderr, "[cleanup] session file removal failed: %v\n", removeErr)
+	term, err := orchestra.ResolveSessionTerminalWithWorkspace(
+		session, orchestraSessionTerminalDetector(), workspaceRef,
+	)
+	if err != nil {
+		return fmt.Errorf("restore cleanup session %s terminal: %w", sessionID, err)
 	}
-
-	fmt.Fprintf(os.Stderr, "[cleanup] session %s: %d panes killed, session file removed\n",
-		sessionID, killed)
+	providers := make([]string, 0, len(session.Panes))
+	for provider := range session.Panes {
+		providers = append(providers, provider)
+	}
+	sort.Strings(providers)
+	closed := 0
+	remaining := make(map[string]string, len(session.Panes))
+	for provider, paneID := range session.Panes {
+		remaining[provider] = paneID
+	}
+	var closeErrors []error
+	for _, provider := range providers {
+		paneID := session.Panes[provider]
+		if closeErr := term.Close(ctx, paneID); closeErr != nil {
+			closeErrors = append(closeErrors, fmt.Errorf("%s pane %s: %w", provider, paneID, closeErr))
+			continue
+		}
+		closed++
+		delete(remaining, provider)
+	}
+	if len(closeErrors) > 0 {
+		if closed > 0 {
+			session.Panes = remaining
+			if updateErr := orchestraSessionUpdater(*session); updateErr != nil {
+				return fmt.Errorf("cleanup session %s: closed %d/%d panes but failed to persist retry set; original session retained: %w",
+					sessionID, closed, len(providers), errors.Join(errors.Join(closeErrors...), updateErr))
+			}
+		}
+		return fmt.Errorf("cleanup session %s: closed %d/%d panes; session retained for retry: %w",
+			sessionID, closed, len(providers), errors.Join(closeErrors...))
+	}
+	session.Panes = map[string]string{}
+	if err := orchestraSessionUpdater(*session); err != nil {
+		return fmt.Errorf("persist cleaned session %s tombstone: %w", sessionID, err)
+	}
+	if err := orchestraSessionRemover(sessionID); err != nil {
+		return fmt.Errorf("remove cleaned session %s: %w", sessionID, err)
+	}
+	fmt.Fprintf(os.Stderr, "[cleanup] session %s: %d panes closed, session file removed\n", sessionID, closed)
 	return nil
 }

--- a/internal/cli/orchestra_cleanup_legacy_test.go
+++ b/internal/cli/orchestra_cleanup_legacy_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/insajin/autopus-adk/pkg/orchestra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunOrchestraCleanup_LegacyTmuxPartialFailure_PersistsOnlyRetryPanes(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	term := &cleanupTerminal{
+		stubTerminal: stubTerminal{name: "tmux"},
+		closeErrors:  map[string]error{"%42": errors.New("pane busy")},
+	}
+	useCleanupTerminal(t, term)
+	session := orchestra.OrchestraSession{
+		ID: "legacy-partial", Panes: map[string]string{"claude": "%41", "codex": "%42"},
+	}
+	data, err := json.Marshal(session)
+	require.NoError(t, err)
+	path := filepath.Join(os.TempDir(), "autopus-orch-session-"+session.ID+".json")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+
+	err = runOrchestraCleanup(t.Context(), session.ID)
+
+	require.Error(t, err)
+	loaded, loadErr := orchestra.LoadSession(session.ID)
+	require.NoError(t, loadErr)
+	assert.Equal(t, map[string]string{"codex": "%42"}, loaded.Panes)
+	info, statErr := os.Stat(path)
+	require.NoError(t, statErr)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	delete(term.closeErrors, "%42")
+	require.NoError(t, runOrchestraCleanup(t.Context(), session.ID))
+	assert.Equal(t, 1, countString(term.closed, "%41"))
+	assert.Equal(t, 2, countString(term.closed, "%42"))
+	_, statErr = os.Stat(path)
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestOrchestraCleanup_V05085LegacyCmuxFile_ExplicitWorkspaceRecovers(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	term := &cleanupTerminal{
+		stubTerminal: stubTerminal{name: "cmux"}, workspaceRef: "workspace:99",
+		closeErrors: map[string]error{},
+	}
+	useCleanupTerminal(t, term)
+	session := orchestra.OrchestraSession{
+		ID: "v05085-cmux", Panes: map[string]string{"claude": "surface:1414"},
+	}
+	data, err := json.Marshal(session)
+	require.NoError(t, err)
+	path := filepath.Join(os.TempDir(), "autopus-orch-session-"+session.ID+".json")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	cmd := newOrchestraCleanupCmd()
+	cmd.SetArgs([]string{
+		"--session-id", session.ID, "--workspace-ref", "workspace:13",
+	})
+
+	require.NoError(t, cmd.Execute())
+
+	assert.Equal(t, []string{"surface:1414"}, term.closed)
+	_, statErr := os.Stat(path)
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}

--- a/internal/cli/orchestra_cleanup_retry_test.go
+++ b/internal/cli/orchestra_cleanup_retry_test.go
@@ -1,0 +1,124 @@
+package cli
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/orchestra"
+	"github.com/insajin/autopus-adk/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func isolateCleanupPersistenceSeams(t *testing.T) {
+	t.Helper()
+	originalUpdate := orchestraSessionUpdater
+	originalRemove := orchestraSessionRemover
+	t.Cleanup(func() {
+		orchestraSessionUpdater = originalUpdate
+		orchestraSessionRemover = originalRemove
+	})
+}
+
+func TestRunOrchestraCleanup_PartialUpdateFailure_RetryEventuallyRemoves(t *testing.T) {
+	isolateCleanupPersistenceSeams(t)
+	term := &cleanupTerminal{
+		stubTerminal: stubTerminal{name: "cmux"}, workspaceRef: "workspace:99",
+		closeErrors: map[string]error{"surface:1415": errors.New("pane busy")},
+	}
+	useCleanupTerminal(t, term)
+	session := orchestra.OrchestraSession{
+		ID: "cleanup-update-retry-" + orchestra.NewSessionID(), TerminalKind: "cmux",
+		WorkspaceRef: "workspace:13",
+		Panes:        map[string]string{"claude": "surface:1414", "codex": "surface:1415"},
+		CreatedAt:    time.Now(),
+	}
+	require.NoError(t, orchestra.SaveSession(session))
+	t.Cleanup(func() { _ = orchestra.RemoveSession(session.ID) })
+	updateCalls := 0
+	orchestraSessionUpdater = func(updated orchestra.OrchestraSession) error {
+		updateCalls++
+		if updateCalls == 1 {
+			return errors.New("injected update failure")
+		}
+		return orchestra.UpdateSession(updated)
+	}
+
+	firstErr := runOrchestraCleanup(t.Context(), session.ID)
+
+	require.Error(t, firstErr)
+	loaded, loadErr := orchestra.LoadSession(session.ID)
+	require.NoError(t, loadErr)
+	assert.Equal(t, session.Panes, loaded.Panes,
+		"atomic update failure must preserve the original retry set")
+	delete(term.closeErrors, "surface:1415")
+	require.NoError(t, runOrchestraCleanup(t.Context(), session.ID))
+	assert.Equal(t, 2, countString(term.closed, "surface:1414"),
+		"retry may safely close an already-absent pane")
+	_, loadErr = orchestra.LoadSession(session.ID)
+	assert.Error(t, loadErr)
+}
+
+func TestRunOrchestraCleanup_AllClosedRemoveFailure_RetrySkipsClose(t *testing.T) {
+	isolateCleanupPersistenceSeams(t)
+	term := &cleanupTerminal{
+		stubTerminal: stubTerminal{name: "cmux"}, workspaceRef: "workspace:99",
+		closeErrors: map[string]error{},
+	}
+	useCleanupTerminal(t, term)
+	session := orchestra.OrchestraSession{
+		ID: "cleanup-remove-retry-" + orchestra.NewSessionID(), TerminalKind: "cmux",
+		WorkspaceRef: "workspace:13", Panes: map[string]string{"claude": "surface:1414"},
+		CreatedAt: time.Now(),
+	}
+	require.NoError(t, orchestra.SaveSession(session))
+	t.Cleanup(func() { _ = orchestra.RemoveSession(session.ID) })
+	removeCalls := 0
+	orchestraSessionRemover = func(id string) error {
+		removeCalls++
+		if removeCalls == 1 {
+			return errors.New("injected remove failure")
+		}
+		return orchestra.RemoveSession(id)
+	}
+
+	firstErr := runOrchestraCleanup(t.Context(), session.ID)
+
+	require.Error(t, firstErr)
+	loaded, loadErr := orchestra.LoadSession(session.ID)
+	require.NoError(t, loadErr)
+	assert.Empty(t, loaded.Panes, "all-close must durably commit a tombstone before removal")
+	closedBeforeRetry := len(term.closed)
+	require.NoError(t, runOrchestraCleanup(t.Context(), session.ID))
+	assert.Len(t, term.closed, closedBeforeRetry, "tombstone retry must not close panes again")
+}
+
+func TestRunOrchestraCleanup_EmptyTombstone_RemoveRetryAvoidsTerminal(t *testing.T) {
+	isolateCleanupPersistenceSeams(t)
+	session := orchestra.OrchestraSession{
+		ID:    "cleanup-empty-retry-" + orchestra.NewSessionID(),
+		Panes: map[string]string{}, CreatedAt: time.Now(),
+	}
+	require.NoError(t, orchestra.SaveSession(session))
+	t.Cleanup(func() { _ = orchestra.RemoveSession(session.ID) })
+	originalDetector := orchestraSessionTerminalDetector
+	detectCalls := 0
+	orchestraSessionTerminalDetector = func() terminal.Terminal {
+		detectCalls++
+		return &terminal.PlainAdapter{}
+	}
+	t.Cleanup(func() { orchestraSessionTerminalDetector = originalDetector })
+	removeCalls := 0
+	orchestraSessionRemover = func(id string) error {
+		removeCalls++
+		if removeCalls == 1 {
+			return errors.New("injected remove failure")
+		}
+		return orchestra.RemoveSession(id)
+	}
+
+	require.Error(t, runOrchestraCleanup(t.Context(), session.ID))
+	require.NoError(t, runOrchestraCleanup(t.Context(), session.ID))
+	assert.Zero(t, detectCalls)
+}

--- a/internal/cli/orchestra_cleanup_test.go
+++ b/internal/cli/orchestra_cleanup_test.go
@@ -1,16 +1,66 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/insajin/autopus-adk/pkg/orchestra"
+	"github.com/insajin/autopus-adk/pkg/terminal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type cleanupTerminal struct {
+	stubTerminal
+	workspaceRef string
+	closed       []string
+	closeErrors  map[string]error
+	readOutput   string
+	readPanes    []terminal.PaneID
+	longTexts    []string
+	commands     []string
+}
+
+func (t *cleanupTerminal) Close(_ context.Context, ref string) error {
+	t.closed = append(t.closed, ref)
+	return t.closeErrors[ref]
+}
+
+func (t *cleanupTerminal) WorkspaceRef() (string, error) {
+	return t.workspaceRef, nil
+}
+
+func (t *cleanupTerminal) WithWorkspaceRef(ref string) (terminal.Terminal, error) {
+	t.workspaceRef = ref
+	return t, nil
+}
+
+func (t *cleanupTerminal) ReadScreen(_ context.Context, pane terminal.PaneID, _ terminal.ReadScreenOpts) (string, error) {
+	t.readPanes = append(t.readPanes, pane)
+	return t.readOutput, nil
+}
+
+func (t *cleanupTerminal) SendLongText(_ context.Context, _ terminal.PaneID, text string) error {
+	t.longTexts = append(t.longTexts, text)
+	return nil
+}
+
+func (t *cleanupTerminal) SendCommand(_ context.Context, _ terminal.PaneID, command string) error {
+	t.commands = append(t.commands, command)
+	return nil
+}
+
+func useCleanupTerminal(t *testing.T, term terminal.Terminal) {
+	t.Helper()
+	original := orchestraSessionTerminalDetector
+	orchestraSessionTerminalDetector = func() terminal.Terminal { return term }
+	t.Cleanup(func() { orchestraSessionTerminalDetector = original })
+}
 
 func TestNewOrchestraCleanupCmd_Flags(t *testing.T) {
 	t.Parallel()
@@ -19,6 +69,7 @@ func TestNewOrchestraCleanupCmd_Flags(t *testing.T) {
 	require.NotNil(t, cmd)
 	assert.Equal(t, "cleanup", cmd.Use)
 	assert.NotNil(t, cmd.Flags().Lookup("session-id"), "session-id flag must exist")
+	assert.NotNil(t, cmd.Flags().Lookup("workspace-ref"), "legacy cmux recovery flag must exist")
 }
 
 func TestNewOrchestraCleanupCmd_RequiresSessionID(t *testing.T) {
@@ -74,4 +125,101 @@ func TestRunOrchestraCleanup_RemovesLegacySessionFile(t *testing.T) {
 
 	_, err = os.Lstat(path)
 	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestRunOrchestraCleanup_AllPanesClosed_RemovesSessionAndIsIdempotent(t *testing.T) {
+	term := &cleanupTerminal{
+		stubTerminal: stubTerminal{name: "cmux"},
+		workspaceRef: "workspace:99",
+		closeErrors:  map[string]error{},
+	}
+	useCleanupTerminal(t, term)
+	session := orchestra.OrchestraSession{
+		ID:           "cleanup-success-" + orchestra.NewSessionID(),
+		TerminalKind: "cmux",
+		WorkspaceRef: "workspace:13",
+		Panes: map[string]string{
+			"claude": "surface:1414",
+			"codex":  "surface:1415",
+		},
+		CreatedAt: time.Now(),
+	}
+	require.NoError(t, orchestra.SaveSession(session))
+
+	require.NoError(t, runOrchestraCleanup(t.Context(), session.ID))
+	assert.ElementsMatch(t, []string{"surface:1414", "surface:1415"}, term.closed)
+	assert.Equal(t, "workspace:13", term.workspaceRef)
+	_, err := orchestra.LoadSession(session.ID)
+	assert.Error(t, err)
+
+	assert.NoError(t, runOrchestraCleanup(t.Context(), session.ID),
+		"a repeated cleanup after durable removal must be a no-op")
+}
+
+func TestRunOrchestraCleanup_PartialCloseFailure_ReturnsErrorAndKeepsSession(t *testing.T) {
+	closeFailure := errors.New("surface busy")
+	term := &cleanupTerminal{
+		stubTerminal: stubTerminal{name: "cmux"},
+		workspaceRef: "workspace:99",
+		closeErrors:  map[string]error{"surface:1415": closeFailure},
+	}
+	useCleanupTerminal(t, term)
+	session := orchestra.OrchestraSession{
+		ID:           "cleanup-partial-" + orchestra.NewSessionID(),
+		TerminalKind: "cmux",
+		WorkspaceRef: "workspace:13",
+		Panes: map[string]string{
+			"claude": "surface:1414",
+			"codex":  "surface:1415",
+		},
+		CreatedAt: time.Now(),
+	}
+	require.NoError(t, orchestra.SaveSession(session))
+	t.Cleanup(func() { _ = orchestra.RemoveSession(session.ID) })
+
+	err := runOrchestraCleanup(t.Context(), session.ID)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "1/2 panes")
+	loaded, loadErr := orchestra.LoadSession(session.ID)
+	require.NoError(t, loadErr)
+	assert.Equal(t, map[string]string{"codex": "surface:1415"}, loaded.Panes,
+		"only failed panes should remain in the durable retry handle")
+
+	delete(term.closeErrors, "surface:1415")
+	require.NoError(t, runOrchestraCleanup(t.Context(), session.ID))
+	assert.Equal(t, 1, countString(term.closed, "surface:1414"),
+		"a successful pane must not be targeted again during retry")
+	assert.Equal(t, 2, countString(term.closed, "surface:1415"))
+	_, loadErr = orchestra.LoadSession(session.ID)
+	assert.Error(t, loadErr)
+}
+
+func countString(values []string, target string) int {
+	count := 0
+	for _, value := range values {
+		if value == target {
+			count++
+		}
+	}
+	return count
+}
+
+func TestRunOrchestraCleanup_PlainBackend_ReturnsErrorAndKeepsSession(t *testing.T) {
+	useCleanupTerminal(t, &terminal.PlainAdapter{})
+	session := orchestra.OrchestraSession{
+		ID:           "cleanup-plain-" + orchestra.NewSessionID(),
+		TerminalKind: "plain",
+		Panes:        map[string]string{"claude": "surface:1414"},
+		CreatedAt:    time.Now(),
+	}
+	require.NoError(t, orchestra.SaveSession(session))
+	t.Cleanup(func() { _ = orchestra.RemoveSession(session.ID) })
+
+	err := runOrchestraCleanup(t.Context(), session.ID)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "plain")
+	_, loadErr := orchestra.LoadSession(session.ID)
+	assert.NoError(t, loadErr, "a no-op backend must not consume the salvage handle")
 }

--- a/internal/cli/orchestra_collect.go
+++ b/internal/cli/orchestra_collect.go
@@ -30,6 +30,7 @@ type CollectProviderResult struct {
 func newOrchestraCollectCmd() *cobra.Command {
 	var round int
 	var clean bool
+	var workspaceRef string
 
 	cmd := &cobra.Command{
 		Use:   "collect <session-id>",
@@ -49,9 +50,11 @@ func newOrchestraCollectCmd() *cobra.Command {
 				targetRound = len(session.Rounds)
 			}
 
-			term := terminal.DetectTerminal()
-			if term == nil {
-				return fmt.Errorf("no terminal multiplexer detected — collect requires cmux or tmux")
+			term, err := orchestra.ResolveSessionTerminalWithWorkspace(
+				session, orchestraSessionTerminalDetector(), workspaceRef,
+			)
+			if err != nil {
+				return fmt.Errorf("restore session %q terminal: %w", sessionID, err)
 			}
 
 			ctx := cmd.Context()
@@ -107,5 +110,6 @@ func newOrchestraCollectCmd() *cobra.Command {
 
 	cmd.Flags().IntVar(&round, "round", 0, "Round number to collect (0 = latest)")
 	cmd.Flags().BoolVar(&clean, "clean", false, "Apply TUI sanitizer (strip noise, preserve content)")
+	cmd.Flags().StringVar(&workspaceRef, "workspace-ref", "", "legacy cmux session workspace ref")
 	return cmd
 }

--- a/internal/cli/orchestra_collect_test.go
+++ b/internal/cli/orchestra_collect_test.go
@@ -14,6 +14,7 @@ func TestNewOrchestraCollectCmd_Flags(t *testing.T) {
 	require.NotNil(t, cmd)
 	assert.Equal(t, "collect <session-id>", cmd.Use)
 	assert.NotNil(t, cmd.Flags().Lookup("round"), "round flag must exist")
+	assert.NotNil(t, cmd.Flags().Lookup("workspace-ref"), "legacy cmux recovery flag must exist")
 }
 
 func TestNewOrchestraCollectCmd_RequiresArgs(t *testing.T) {

--- a/internal/cli/orchestra_failure_output.go
+++ b/internal/cli/orchestra_failure_output.go
@@ -17,6 +17,8 @@ type orchestraFailureReport struct {
 	Strategy         string                     `json:"strategy"`
 	Providers        []string                   `json:"providers"`
 	RunID            string                     `json:"run_id,omitempty"`
+	SessionID        string                     `json:"session_id,omitempty"`
+	CleanupCommand   string                     `json:"cleanup_command,omitempty"`
 	Duration         string                     `json:"duration,omitempty"`
 	Error            string                     `json:"error,omitempty"`
 	Summary          string                     `json:"summary,omitempty"`
@@ -64,6 +66,7 @@ func saveOrchestraDiagnosticsReport(prefix, command, strategy string, providers 
 		report.RunID = result.RunID
 		report.Duration = result.Duration.Round(time.Millisecond).String()
 		report.Summary = result.Summary
+		report.SessionID, report.CleanupCommand = orchestraRecoveryHandle(result)
 		if result.Reliability != nil {
 			report.ArtifactDir = result.Reliability.ArtifactDir
 		}
@@ -102,6 +105,10 @@ func renderOrchestraFailureSummary(timeout ResolvedOrchestraTimeout, result *orc
 		fmt.Fprintf(&sb, "- provider timeout %s: %s (%s)\n", detail.Provider, detail.Duration, detail.Source)
 	}
 	if result != nil {
+		if sessionID, cleanupCommand := orchestraRecoveryHandle(result); sessionID != "" {
+			fmt.Fprintf(&sb, "- session: %s\n", sessionID)
+			fmt.Fprintf(&sb, "- cleanup: %s\n", cleanupCommand)
+		}
 		for _, fp := range result.FailedProviders {
 			fmt.Fprintf(&sb, "- failure %s [%s]: %s\n", fp.Name, fp.FailureClass, fp.Error)
 			if fp.NextRemediation != "" {
@@ -119,6 +126,17 @@ func renderOrchestraFailureSummary(timeout ResolvedOrchestraTimeout, result *orc
 		fmt.Fprintf(&sb, "- diagnostics report: %s\n", reportPath)
 	}
 	return sb.String()
+}
+
+func orchestraRecoveryHandle(result *orchestra.OrchestraResult) (string, string) {
+	if result == nil || result.Yield == nil {
+		return "", ""
+	}
+	sessionID := strings.TrimSpace(result.Yield.SessionID)
+	if sessionID == "" {
+		return "", ""
+	}
+	return sessionID, "auto orchestra cleanup --session-id " + sessionID
 }
 
 func shouldTreatOrchestraResultAsFailure(result *orchestra.OrchestraResult) bool {

--- a/internal/cli/orchestra_failure_render_test.go
+++ b/internal/cli/orchestra_failure_render_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/insajin/autopus-adk/pkg/orchestra"
+	"github.com/insajin/autopus-adk/pkg/terminal"
 )
 
 func sampleResolvedTimeout() ResolvedOrchestraTimeout {
@@ -70,6 +72,18 @@ func TestRenderOrchestraFailureSummary_NilResultNoPath(t *testing.T) {
 	assert.Contains(t, out, "effective timeout: 540s")
 	assert.NotContains(t, out, "failure")
 	assert.NotContains(t, out, "diagnostics report")
+}
+
+func TestRenderOrchestraFailureSummary_BlockedYield_ExposesCleanupHandle(t *testing.T) {
+	t.Parallel()
+	result := sampleFailedResult()
+	result.TerminalState = orchestra.TerminalBlocked
+	result.Yield = &orchestra.YieldOutput{SessionID: "orch-recover-123"}
+
+	out := renderOrchestraFailureSummary(sampleResolvedTimeout(), result, "/tmp/report.json")
+
+	assert.Contains(t, out, "session: orch-recover-123")
+	assert.Contains(t, out, "cleanup: auto orchestra cleanup --session-id orch-recover-123")
 }
 
 // TestSynthesizeOrchestraFailureError_NilAndPopulated covers both branches.
@@ -170,6 +184,66 @@ func TestSaveOrchestraDiagnosticsReport_WritesJSON(t *testing.T) {
 	require.Len(t, report.FailedProviders, 2)
 	assert.Equal(t, "claude", report.FailedProviders[0].Name)
 	assert.Equal(t, []string{"increase timeout"}, report.RetryHints)
+}
+
+func TestSaveOrchestraFailureReport_BlockedYield_PersistsCleanupHandle(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	result := sampleFailedResult()
+	result.TerminalState = orchestra.TerminalBlocked
+	result.Yield = &orchestra.YieldOutput{SessionID: "orch-report-recover"}
+
+	path, err := saveOrchestraFailureReport(
+		"brainstorm", "debate", []string{"claude", "codex"},
+		sampleResolvedTimeout(), result, assertErr("quorum blocked"),
+	)
+	require.NoError(t, err)
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var report orchestraFailureReport
+	require.NoError(t, json.Unmarshal(raw, &report))
+	assert.Equal(t, "orch-report-recover", report.SessionID)
+	assert.Equal(t,
+		"auto orchestra cleanup --session-id orch-report-recover",
+		report.CleanupCommand,
+	)
+}
+
+func TestRunOrchestraCommand_BlockedYield_WritesRecoveryHandleToStderr(t *testing.T) {
+	t.Chdir(t.TempDir())
+	originalRun := runOrchestraExecute
+	originalDetector := runOrchestraTerminalDetector
+	t.Cleanup(func() {
+		runOrchestraExecute = originalRun
+		runOrchestraTerminalDetector = originalDetector
+	})
+	runOrchestraTerminalDetector = func() terminal.Terminal { return stubTerminal{name: "plain"} }
+	runOrchestraExecute = func(context.Context, orchestra.OrchestraConfig) (*orchestra.OrchestraResult, error) {
+		return &orchestra.OrchestraResult{
+			TerminalState:       orchestra.TerminalBlocked,
+			GateStatus:          "blocked",
+			DegradedReasons:     []string{"provider_quorum"},
+			ConfiguredProviders: []string{"claude", "gemini"},
+			QuorumRequired:      2,
+			Yield:               &orchestra.YieldOutput{SessionID: "orch-command-recover"},
+			FailedProviders: []orchestra.FailedProvider{
+				{Name: "claude", FailureClass: "timeout", Error: "deadline exceeded"},
+				{Name: "gemini", FailureClass: "timeout", Error: "deadline exceeded"},
+			},
+		}, nil
+	}
+	var runErr error
+	stderr := captureSpecReviewStderr(t, func() {
+		runErr = runOrchestraCommand(
+			context.Background(), "brainstorm", "consensus", []string{"claude", "gemini"},
+			30, "", "topic", 0, 0, OrchestraFlags{NoDetach: true},
+		)
+	})
+
+	require.Error(t, runErr)
+	assert.Contains(t, stderr, "session: orch-command-recover")
+	assert.Contains(t, stderr, "cleanup: auto orchestra cleanup --session-id orch-command-recover")
 }
 
 func countSubstr(s, sub string) int {

--- a/internal/cli/orchestra_helpers_hookmode_test.go
+++ b/internal/cli/orchestra_helpers_hookmode_test.go
@@ -120,6 +120,7 @@ func TestIsHookModeAvailable_CodexOnlyProject(t *testing.T) {
 		[]byte(`{"hooks":{"Stop":[{"hooks":[{"type":"command","command":".codex/hooks/autopus/hook-codex-stop.sh"}]}]}}`),
 		0o600,
 	))
+	writeHookFixture(t, projectRoot, ".codex/hooks/autopus/hook-codex-stop.sh", 0o700)
 
 	nestedDir := filepath.Join(projectRoot, "modules", "nested")
 	require.NoError(t, os.MkdirAll(nestedDir, 0o700))
@@ -134,6 +135,7 @@ func TestIsHookModeAvailable_CodexOnlyProject(t *testing.T) {
 // detected in the same way as user-global Claude hooks.
 func TestIsHookModeAvailable_GlobalCodexHook(t *testing.T) {
 	home := t.TempDir()
+	runtimeRoot := t.TempDir()
 	codexDir := filepath.Join(home, ".codex")
 	require.NoError(t, os.MkdirAll(codexDir, 0o700))
 	require.NoError(t, os.WriteFile(
@@ -141,8 +143,9 @@ func TestIsHookModeAvailable_GlobalCodexHook(t *testing.T) {
 		[]byte(`{"hooks":{"Stop":[{"hooks":[{"type":"command","command":".codex/hooks/autopus/hook-codex-stop.sh"}]}]}}`),
 		0o600,
 	))
+	writeHookFixture(t, runtimeRoot, ".codex/hooks/autopus/hook-codex-stop.sh", 0o700)
 	t.Setenv("HOME", home)
-	t.Chdir(t.TempDir())
+	t.Chdir(runtimeRoot)
 
 	assert.True(t, isHookModeAvailable(), "global Codex Stop hook must enable pane completion")
 }

--- a/internal/cli/orchestra_hook_discovery.go
+++ b/internal/cli/orchestra_hook_discovery.go
@@ -1,73 +1,266 @@
 package cli
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
-	"strings"
 )
 
-// @AX:NOTE [AUTO]: hook discovery checks Claude and Codex Stop hooks and uses autopus.yaml as the project-root boundary
+// @AX:NOTE [AUTO]: hook discovery merges user, project, and cwd wiring by precedence.
 func isHookModeAvailable() bool {
-	home, _ := os.UserHomeDir()
-	cwd, err := os.Getwd()
-	globalHooks := hookModeCandidates(home)
-	if err != nil {
-		return hookModeAvailableInCandidates(globalHooks...)
-	}
-	if hookModeAvailableInCandidates(globalHooks...) {
-		return true
-	}
-	if hookModeAvailableInCandidates(hookModeCandidates(cwd)...) {
-		return true
-	}
-	for dir := cwd; ; dir = filepath.Dir(dir) {
-		if _, err := os.Stat(filepath.Join(dir, "autopus.yaml")); err == nil {
-			return hookModeAvailableInCandidates(hookModeCandidates(dir)...)
-		}
-		if filepath.Dir(dir) == dir {
-			return false
-		}
+	return discoverHookCapabilities().anyCompletion()
+}
+
+type hookCapability struct {
+	completion bool
+	startup    bool
+}
+
+type hookDiscovery map[string]hookCapability
+
+func newHookDiscovery() hookDiscovery {
+	return hookDiscovery{
+		"claude":      {},
+		"codex":       {},
+		"antigravity": {},
+		"gemini":      {},
+		"opencode":    {},
 	}
 }
 
-type hookModeCandidate struct {
-	path  string
-	event string
+func (d hookDiscovery) capability(provider string) hookCapability {
+	return d[hookRuntimeFamily(provider, "")]
 }
 
-func hookModeCandidates(root string) []hookModeCandidate {
-	if root == "" {
-		return nil
-	}
-	return []hookModeCandidate{
-		{path: filepath.Join(root, ".claude", "settings.json"), event: "Stop"},
-		{path: filepath.Join(root, ".codex", "hooks.json"), event: "Stop"},
-	}
+func (d hookDiscovery) capabilityFor(name, binary string) hookCapability {
+	return d[hookRuntimeFamily(name, binary)]
 }
 
-func hookModeAvailableInCandidates(candidates ...hookModeCandidate) bool {
-	for _, candidate := range candidates {
-		if candidate.path == "" || candidate.event == "" {
-			continue
-		}
-		data, err := os.ReadFile(candidate.path)
-		if err != nil {
-			continue
-		}
-		settings := string(data)
-		if strings.Contains(settings, "autopus") && strings.Contains(settings, candidate.event) {
+func (d hookDiscovery) anyCompletion() bool {
+	for _, capability := range d {
+		if capability.completion {
 			return true
 		}
 	}
 	return false
 }
 
-// hookModeAvailableInDirs checks injected settings paths for both hook markers.
+func discoverHookCapabilities() hookDiscovery {
+	candidates := make([]hookModeCandidate, 0, 12)
+	runtimeRoot := effectiveHookRuntimeRoot()
+	for _, root := range hookDiscoveryRoots() {
+		candidates = append(candidates, hookModeCandidates(root, runtimeRoot)...)
+	}
+	return discoverHookCapabilitiesInCandidates(candidates...)
+}
+
+func hookDiscoveryRoots() []string {
+	roots := make([]string, 0, 3)
+	seen := make(map[string]bool, 3)
+	add := func(root string) {
+		root = filepath.Clean(root)
+		if root == "." || seen[root] {
+			return
+		}
+		seen[root] = true
+		roots = append(roots, root)
+	}
+
+	if home, err := os.UserHomeDir(); err == nil {
+		add(home)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return roots
+	}
+	if projectRoot := nearestAutopusRoot(cwd); projectRoot != "" {
+		add(projectRoot)
+	}
+	add(cwd)
+	return roots
+}
+
+func effectiveHookRuntimeRoot() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	if root := nearestAutopusRoot(cwd); root != "" {
+		return root
+	}
+	return filepath.Clean(cwd)
+}
+
+func nearestAutopusRoot(cwd string) string {
+	for dir := filepath.Clean(cwd); ; dir = filepath.Dir(dir) {
+		if _, err := os.Stat(filepath.Join(dir, "autopus.yaml")); err == nil {
+			return dir
+		}
+		if filepath.Dir(dir) == dir {
+			return ""
+		}
+	}
+}
+
+type hookModeCandidate struct {
+	path            string
+	configRoot      string // settings ownership; fallback when no execution root is available
+	runtimeRoot     string // effective project/cwd root used by generated hook commands
+	provider        string
+	container       string
+	completionEvent string
+	startupEvent    string
+	completionAsset string
+	startupAsset    string
+}
+
+func hookModeCandidates(root, runtimeRoot string) []hookModeCandidate {
+	if root == "" {
+		return nil
+	}
+	candidates := []hookModeCandidate{
+		{
+			configRoot: root, runtimeRoot: runtimeRoot,
+			path: filepath.Join(root, ".claude", "settings.json"), provider: "claude",
+			container: "hooks", completionEvent: "Stop", startupEvent: "SessionStart",
+			completionAsset: ".claude/hooks/autopus/hook-claude-stop.sh",
+			startupAsset:    ".claude/hooks/autopus/hook-claude-sessionstart.sh",
+		},
+	}
+	if isProjectHookRoot(root, runtimeRoot) {
+		candidates = append(candidates, hookModeCandidate{
+			configRoot: root, runtimeRoot: runtimeRoot,
+			path: filepath.Join(root, ".claude", "settings.local.json"), provider: "claude",
+			container: "hooks", completionEvent: "Stop", startupEvent: "SessionStart",
+			completionAsset: ".claude/hooks/autopus/hook-claude-stop.sh",
+			startupAsset:    ".claude/hooks/autopus/hook-claude-sessionstart.sh",
+		})
+	}
+	return append(candidates,
+		hookModeCandidate{
+			configRoot: root, runtimeRoot: runtimeRoot,
+			path: filepath.Join(root, ".codex", "hooks.json"), provider: "codex",
+			container: "hooks", completionEvent: "Stop", startupEvent: "SessionStart",
+			completionAsset: ".codex/hooks/autopus/hook-codex-stop.sh",
+			startupAsset:    ".codex/hooks/autopus/hook-codex-sessionstart.sh",
+		},
+		hookModeCandidate{
+			configRoot: root, runtimeRoot: runtimeRoot,
+			path: filepath.Join(root, ".agents", "hooks.json"), provider: "antigravity",
+			container: "autopus", completionEvent: "Stop",
+			completionAsset: ".gemini/hooks/autopus/hook-gemini-stop.sh",
+		},
+		hookModeCandidate{
+			configRoot: root, runtimeRoot: runtimeRoot,
+			path: filepath.Join(root, ".gemini", "settings.json"), provider: "gemini",
+			container: "hooks", completionEvent: "AfterAgent",
+			completionAsset: ".gemini/hooks/autopus/hook-gemini-afteragent.sh",
+		},
+	)
+}
+
+func isProjectHookRoot(root, runtimeRoot string) bool {
+	home, err := os.UserHomeDir()
+	return err != nil || filepath.Clean(root) != filepath.Clean(home) ||
+		filepath.Clean(root) == filepath.Clean(runtimeRoot)
+}
+
+func discoverHookCapabilitiesInCandidates(candidates ...hookModeCandidate) hookDiscovery {
+	discovery := newHookDiscovery()
+	claudeHooks := hookCapability{}
+	claudeDisabled := false
+	// Candidates are ordered from broadest to nearest scope. Claude hook arrays
+	// accumulate while its disableAllHooks scalar follows nearest-value wins;
+	// other provider schemas retain explicit active/disabled precedence.
+	for _, candidate := range candidates {
+		decision := readHookCapabilityDecision(candidate)
+		provider := hookRuntimeFamily(candidate.provider, "")
+		if provider == "claude" {
+			if decision.completion == hookActive {
+				claudeHooks.completion = true
+			}
+			if decision.startup == hookActive {
+				claudeHooks.startup = true
+			}
+			if decision.disableAllSet {
+				claudeDisabled = decision.disableAll
+			}
+			continue
+		}
+		current := discovery[provider]
+		applyHookDecision(&current.completion, decision.completion)
+		applyHookDecision(&current.startup, decision.startup)
+		discovery[provider] = current
+	}
+	if claudeDisabled {
+		claudeHooks = hookCapability{}
+	}
+	discovery["claude"] = claudeHooks
+	return discovery
+}
+
+func readHookCapabilityDecision(candidate hookModeCandidate) hookCapabilityDecision {
+	if candidate.path == "" || candidate.provider == "" || candidate.container == "" {
+		return hookCapabilityDecision{}
+	}
+	data, err := os.ReadFile(candidate.path)
+	if err != nil {
+		return hookCapabilityDecision{}
+	}
+	var document map[string]any
+	if json.Unmarshal(data, &document) != nil {
+		return hookCapabilityDecision{}
+	}
+	isClaude := hookRuntimeFamily(candidate.provider, "") == "claude"
+	decision := hookCapabilityDecision{}
+	if isClaude {
+		if disabled, ok := document["disableAllHooks"].(bool); ok {
+			decision.disableAllSet = true
+			decision.disableAll = disabled
+		}
+	} else if hooksDocumentDisabled(document) {
+		return disabledCandidateEvents(candidate)
+	}
+	events, ok := document[candidate.container].(map[string]any)
+	if !ok {
+		return decision
+	}
+	if !isClaude && hookScopeDisabled(events) {
+		return disabledCandidateEvents(candidate)
+	}
+	assetRoot := hookCandidateAssetRoot(candidate)
+	decision.completion = hookEventDecision(
+		events, candidate.completionEvent, assetRoot, candidate.completionAsset, !isClaude,
+	)
+	decision.startup = hookEventDecision(
+		events, candidate.startupEvent, assetRoot, candidate.startupAsset, !isClaude,
+	)
+	return decision
+}
+
+func hookCandidateAssetRoot(candidate hookModeCandidate) string {
+	if hookRuntimeFamily(candidate.provider, "") == "antigravity" && candidate.configRoot != "" {
+		return candidate.configRoot
+	}
+	if candidate.runtimeRoot != "" {
+		return candidate.runtimeRoot
+	}
+	return candidate.configRoot
+}
+
+func hookModeAvailableInCandidates(candidates ...hookModeCandidate) bool {
+	return discoverHookCapabilitiesInCandidates(candidates...).anyCompletion()
+}
+
+// hookModeAvailableInDirs checks injected Claude settings paths for Stop hooks.
 // Callers provide fixed paths; user-supplied path segments are not accepted.
 func hookModeAvailableInDirs(globalPath, projectPath string) bool {
 	candidates := make([]hookModeCandidate, 0, 2)
 	for _, path := range []string{globalPath, projectPath} {
-		candidates = append(candidates, hookModeCandidate{path: path, event: "Stop"})
+		candidates = append(candidates, hookModeCandidate{
+			path: path, runtimeRoot: effectiveHookRuntimeRoot(),
+			provider: "claude", container: "hooks", completionEvent: "Stop",
+		})
 	}
 	return hookModeAvailableInCandidates(candidates...)
 }

--- a/internal/cli/orchestra_hook_discovery_policy_test.go
+++ b/internal/cli/orchestra_hook_discovery_policy_test.go
@@ -1,0 +1,174 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/orchestra"
+)
+
+const managedAntigravityHookCommand = `"$(git rev-parse --show-toplevel 2>/dev/null || (cd .. && pwd))/.gemini/hooks/autopus/hook-gemini-stop.sh"`
+
+func TestHookDiscovery_BareSemanticCommandDelegatesAssetOwnership(t *testing.T) {
+	assert.Equal(t, hookActive, hookCommandDecision("autopus hook stop", "", ""))
+}
+
+func TestHookDiscovery_RuntimeFamilyUsesProviderBinaryBeforeGenericName(t *testing.T) {
+	_, root, _ := setupHookDiscoveryProject(t)
+	writeHookFixture(t, root, ".gemini/hooks/autopus/hook-gemini-stop.sh", 0o700)
+	writeHookDiscoveryFixture(t, root, ".agents/hooks.json", `{
+		"autopus":{"enabled":true,"Stop":[{"command":`+
+		strconv.Quote(managedAntigravityHookCommand)+`}]}
+	}`)
+	providers := []orchestra.ProviderConfig{
+		{Name: "gemini", Binary: "agy"},
+		{Name: "gemini", Binary: "gemini"},
+		{Name: "antigravity", Binary: "/opt/bin/gemini-cli"},
+	}
+
+	applyDiscoveredHookCapabilities(providers, discoverHookCapabilities())
+
+	assertProviderHook(t, providers[0], true)
+	assertProviderHook(t, providers[1], false)
+	assertProviderHook(t, providers[2], false)
+}
+
+func TestHookDiscovery_AntigravityHomeConfigUsesConfigRoot(t *testing.T) {
+	tests := []struct {
+		name         string
+		assetAtHome  bool
+		assetProject bool
+		want         bool
+	}{
+		{"home asset", true, false, true},
+		{"project-only asset", false, true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home, root, _ := setupHookDiscoveryProject(t)
+			writeHookDiscoveryFixture(t, home, ".agents/hooks.json", `{
+				"autopus":{"enabled":true,"Stop":[{"command":`+
+				strconv.Quote(managedAntigravityHookCommand)+`}]}
+			}`)
+			if tt.assetAtHome {
+				writeHookFixture(t, home, ".gemini/hooks/autopus/hook-gemini-stop.sh", 0o700)
+			}
+			if tt.assetProject {
+				writeHookFixture(t, root, ".gemini/hooks/autopus/hook-gemini-stop.sh", 0o700)
+			}
+
+			got := discoverHookCapabilities().capability("antigravity").completion
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestHookDiscovery_WrongRuntimeEventsAreIgnored(t *testing.T) {
+	_, root, _ := setupHookDiscoveryProject(t)
+	writeHookDiscoveryFixture(t, root, ".agents/hooks.json", `{
+		"autopus":{"AfterAgent":[{"hooks":[{"command":"autopus hook after-agent"}]}]}
+	}`)
+	writeHookDiscoveryFixture(t, root, ".gemini/settings.json", `{
+		"hooks":{"Stop":[{"hooks":[{"command":"autopus hook stop"}]}]}
+	}`)
+
+	discovery := discoverHookCapabilities()
+
+	assert.Equal(t, hookCapability{}, discovery.capability("antigravity"))
+	assert.Equal(t, hookCapability{}, discovery.capability("gemini"))
+}
+
+func TestHookDiscovery_WrongManagedAssetForRuntimeIsIgnored(t *testing.T) {
+	_, root, _ := setupHookDiscoveryProject(t)
+	writeHookFixture(t, root, ".gemini/hooks/autopus/hook-gemini-afteragent.sh", 0o700)
+	wrongCommand := `"${GEMINI_PROJECT_DIR:-.}"/.gemini/hooks/autopus/hook-gemini-afteragent.sh`
+	writeHookDiscoveryFixture(t, root, ".agents/hooks.json", `{
+		"autopus":{"Stop":[{"command":`+strconv.Quote(wrongCommand)+`}]}
+	}`)
+
+	assert.Equal(t, hookCapability{}, discoverHookCapabilities().capability("antigravity"))
+}
+
+func TestHookDiscovery_DisabledScopesAreInactive(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		doc  string
+	}{
+		{
+			"global disable", ".claude/settings.json",
+			`{"disableAllHooks":true,"hooks":{"Stop":[{"hooks":[{"command":"autopus hook stop"}]}]}}`,
+		},
+		{
+			"document disabled", ".agents/hooks.json",
+			`{"enabled":false,"autopus":{"Stop":[{"command":"autopus hook stop"}]}}`,
+		},
+		{
+			"container disabled", ".agents/hooks.json",
+			`{"autopus":{"enabled":false,"Stop":[{"hooks":[{"command":"autopus hook stop"}]}]}}`,
+		},
+		{
+			"entry disabled", ".agents/hooks.json",
+			`{"autopus":{"Stop":[{"enabled":false,"hooks":[{"command":"autopus hook stop"}]}]}}`,
+		},
+		{
+			"handler disabled", ".agents/hooks.json",
+			`{"autopus":{"Stop":[{"hooks":[{"enabled":false,"command":"autopus hook stop"}]}]}}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, root, _ := setupHookDiscoveryProject(t)
+			writeHookDiscoveryFixture(t, root, tt.path, tt.doc)
+
+			assert.False(t, discoverHookCapabilities().anyCompletion())
+		})
+	}
+}
+
+func TestHookDiscovery_ManagedAssetMustBeRegularAndExecutable(t *testing.T) {
+	tests := []struct {
+		name string
+		mode os.FileMode
+		make bool
+		want bool
+	}{
+		{"missing", 0, false, false},
+		{"present executable", 0o700, true, true},
+		{"present non-executable", 0o600, true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, root, _ := setupHookDiscoveryProject(t)
+			if tt.make {
+				writeHookFixture(t, root, ".gemini/hooks/autopus/hook-gemini-stop.sh", tt.mode)
+			}
+			writeHookDiscoveryFixture(t, root, ".agents/hooks.json", `{
+				"autopus":{"Stop":[{"command":`+
+				strconv.Quote(managedAntigravityHookCommand)+`}]}
+			}`)
+
+			got := discoverHookCapabilities().capability("antigravity").completion
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func writeHookFixture(t *testing.T, root, relativePath string, mode os.FileMode) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(relativePath))
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\n"), mode))
+}
+
+func assertProviderHook(t *testing.T, provider orchestra.ProviderConfig, want bool) {
+	t.Helper()
+	if assert.NotNil(t, provider.HasHook) {
+		assert.Equal(t, want, *provider.HasHook)
+	}
+}

--- a/internal/cli/orchestra_hook_discovery_precedence_test.go
+++ b/internal/cli/orchestra_hook_discovery_precedence_test.go
@@ -1,0 +1,185 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	codexRelativeStopCommand = `.codex/hooks/autopus/hook-codex-stop.sh`
+	claudeDynamicStopCommand = `"${CLAUDE_PROJECT_DIR:-.}"/.claude/hooks/autopus/hook-claude-stop.sh`
+)
+
+func TestHookDiscovery_RelativeManagedAssetMustBeExecutable(t *testing.T) {
+	tests := []struct {
+		name string
+		mode os.FileMode
+		make bool
+		want bool
+	}{
+		{"missing", 0, false, false},
+		{"non executable", 0o600, true, false},
+		{"executable", 0o700, true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, root, _ := setupHookDiscoveryProject(t)
+			if tt.make {
+				writeHookFixture(t, root, codexRelativeStopCommand, tt.mode)
+			}
+			writeHookDiscoveryFixture(t, root, ".codex/hooks.json", `{
+				"hooks":{"Stop":[{"hooks":[{"command":"`+codexRelativeStopCommand+`"}]}]}
+			}`)
+
+			got := discoverHookCapabilities().capability("codex").completion
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestHookDiscovery_HomeDynamicCommandUsesEffectiveProjectRoot(t *testing.T) {
+	tests := []struct {
+		name         string
+		assetAtHome  bool
+		assetProject bool
+		want         bool
+	}{
+		{"project asset", false, true, true},
+		{"home-only asset", true, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home, root, _ := setupHookDiscoveryProject(t)
+			writeHookDiscoveryFixture(t, home, ".claude/settings.json", `{
+				"hooks":{"Stop":[{"hooks":[{"command":`+strconv.Quote(claudeDynamicStopCommand)+`}]}]}
+			}`)
+			if tt.assetAtHome {
+				writeHookFixture(t, home, ".claude/hooks/autopus/hook-claude-stop.sh", 0o700)
+			}
+			if tt.assetProject {
+				writeHookFixture(t, root, ".claude/hooks/autopus/hook-claude-stop.sh", 0o700)
+			}
+
+			got := discoverHookCapabilities().capability("claude").completion
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestHookDiscovery_NearerDisableOverridesHomeActive(t *testing.T) {
+	home, root, _ := setupHookDiscoveryProject(t)
+	writeClaudeStopDocument(t, home, `{
+		"hooks":{"Stop":[{"hooks":[{"command":"autopus hook stop"}]}]}
+	}`)
+	writeClaudeStopDocument(t, root, `{
+		"disableAllHooks":true,
+		"hooks":{"Stop":[{"hooks":[{"command":"autopus hook stop"}]}]}
+	}`)
+
+	assert.False(t, discoverHookCapabilities().capability("claude").completion)
+}
+
+func TestHookDiscovery_NearerEventAbsenceKeepsHomeCapability(t *testing.T) {
+	home, root, _ := setupHookDiscoveryProject(t)
+	writeClaudeStopDocument(t, home, `{
+		"hooks":{"Stop":[{"hooks":[{"command":"autopus hook stop"}]}]}
+	}`)
+	writeClaudeStopDocument(t, root, `{
+		"hooks":{"PreToolUse":[{"hooks":[{"command":"user hook"}]}]}
+	}`)
+
+	assert.True(t, discoverHookCapabilities().capability("claude").completion)
+}
+
+func TestHookDiscovery_ProjectHookEntryDoesNotOverrideInheritedClaudeDisable(t *testing.T) {
+	home, root, _ := setupHookDiscoveryProject(t)
+	writeClaudeStopDocument(t, home, `{
+		"disableAllHooks":true,
+		"hooks":{"Stop":[{"hooks":[{"command":"autopus hook stop"}]}]}
+	}`)
+	writeClaudeStopDocument(t, root, `{
+		"hooks":{"Stop":[{"hooks":[{"command":"autopus hook stop"}]}]}
+	}`)
+
+	assert.False(t, discoverHookCapabilities().capability("claude").completion)
+}
+
+func TestHookDiscovery_NearerClaudeDisableFalseReenablesInheritedHooks(t *testing.T) {
+	home, root, _ := setupHookDiscoveryProject(t)
+	writeClaudeStopDocument(t, home, `{
+		"disableAllHooks":true,
+		"hooks":{"Stop":[{"hooks":[{"command":"autopus hook stop"}]}]}
+	}`)
+	writeClaudeStopDocument(t, root, `{"disableAllHooks":false,"hooks":{}}`)
+
+	assert.True(t, discoverHookCapabilities().capability("claude").completion)
+}
+
+func TestHookDiscovery_ClaudeEntryEnabledFalseIsNotADisableOracle(t *testing.T) {
+	home, root, _ := setupHookDiscoveryProject(t)
+	writeClaudeStopDocument(t, home, `{
+		"hooks":{"Stop":[{"hooks":[{"command":"autopus hook stop"}]}]}
+	}`)
+	writeClaudeStopDocument(t, root, `{
+		"hooks":{"Stop":[{"enabled":false,"hooks":[{"command":"autopus hook stop"}]}]}
+	}`)
+
+	assert.True(t, discoverHookCapabilities().capability("claude").completion)
+}
+
+func TestHookDiscovery_ClaudeProjectLocalDisableOverridesProjectSettings(t *testing.T) {
+	_, root, _ := setupHookDiscoveryProject(t)
+	writeClaudeStopDocument(t, root, `{
+		"hooks":{
+			"Stop":[{"hooks":[{"command":"autopus hook stop"}]}],
+			"SessionStart":[{"hooks":[{"command":"autopus hook session-start"}]}]
+		}
+	}`)
+	writeClaudeLocalDocument(t, root, `{"disableAllHooks":true,"hooks":{}}`)
+
+	assert.Equal(t, hookCapability{}, discoverHookCapabilities().capability("claude"))
+}
+
+func TestHookDiscovery_ClaudeProjectLocalFalseReenablesInheritedHooks(t *testing.T) {
+	_, root, _ := setupHookDiscoveryProject(t)
+	writeClaudeStopDocument(t, root, `{
+		"disableAllHooks":true,
+		"hooks":{
+			"Stop":[{"hooks":[{"command":"autopus hook stop"}]}],
+			"SessionStart":[{"hooks":[{"command":"autopus hook session-start"}]}]
+		}
+	}`)
+	writeClaudeLocalDocument(t, root, `{"disableAllHooks":false,"hooks":{}}`)
+
+	assert.Equal(t,
+		hookCapability{completion: true, startup: true},
+		discoverHookCapabilities().capability("claude"),
+	)
+}
+
+func TestHookDiscovery_DuplicateProjectRootIsStable(t *testing.T) {
+	home, root, _ := setupHookDiscoveryProject(t)
+	writeClaudeStopDocument(t, root, `{
+		"hooks":{"Stop":[{"hooks":[{"command":"autopus hook stop"}]}]}
+	}`)
+
+	assert.True(t, discoverHookCapabilities().capability("claude").completion)
+
+	t.Chdir(root)
+	assert.Equal(t, []string{filepath.Clean(home), filepath.Clean(root)}, hookDiscoveryRoots())
+	assert.True(t, discoverHookCapabilities().capability("claude").completion)
+}
+
+func writeClaudeStopDocument(t *testing.T, root, document string) {
+	t.Helper()
+	writeHookDiscoveryFixture(t, root, ".claude/settings.json", document)
+}
+
+func writeClaudeLocalDocument(t *testing.T, root, document string) {
+	t.Helper()
+	writeHookDiscoveryFixture(t, root, ".claude/settings.local.json", document)
+}

--- a/internal/cli/orchestra_hook_discovery_runtime.go
+++ b/internal/cli/orchestra_hook_discovery_runtime.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// hookRuntimeFamily resolves the hook configuration surface that the selected
+// executable actually consumes. Binary wins over a generic provider name so a
+// provider named "gemini" can correctly select either agy or the legacy CLI.
+func hookRuntimeFamily(name, binary string) string {
+	if runtime := knownHookRuntime(binaryIdentity(binary)); runtime != "" {
+		return runtime
+	}
+	if runtime := knownHookRuntime(binaryIdentity(name)); runtime != "" {
+		return runtime
+	}
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+func binaryIdentity(value string) string {
+	value = strings.ReplaceAll(strings.TrimSpace(value), `\`, "/")
+	value = strings.TrimSuffix(strings.ToLower(filepath.Base(value)), ".exe")
+	return value
+}
+
+func knownHookRuntime(identity string) string {
+	switch identity {
+	case "claude", "claude-code":
+		return "claude"
+	case "codex":
+		return "codex"
+	case "agy", "antigravity", "antigravity-cli":
+		return "antigravity"
+	case "gemini", "gemini-cli":
+		return "gemini"
+	case "opencode":
+		return "opencode"
+	default:
+		return ""
+	}
+}

--- a/internal/cli/orchestra_hook_discovery_snapshot_test.go
+++ b/internal/cli/orchestra_hook_discovery_snapshot_test.go
@@ -1,0 +1,187 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverHookCapabilities_UnionsGlobalCWDAndNearestProjectRoot(t *testing.T) {
+	home, projectRoot, cwd := setupHookDiscoveryProject(t)
+	writeHookDiscoveryFixture(t, home, ".claude/settings.json", `{
+		"hooks":{"Stop":[{"hooks":[{"command":"autopus hook stop"}]}]}
+	}`)
+	writeHookDiscoveryFixture(t, cwd, ".claude/settings.json", `{
+		"hooks":{"SessionStart":[{"hooks":[{"command":"autopus hook session-start"}]}]}
+	}`)
+	writeHookDiscoveryFixture(t, projectRoot, ".codex/hooks.json", `{
+		"hooks":{
+			"Stop":[{"hooks":[{"command":".codex/hooks/autopus/hook-codex-stop.sh"}]}],
+			"SessionStart":[{"hooks":[{"command":".codex/hooks/autopus/hook-codex-sessionstart.sh"}]}]
+		}
+	}`)
+	writeHookFixture(t, projectRoot, ".codex/hooks/autopus/hook-codex-stop.sh", 0o700)
+	writeHookFixture(t, projectRoot, ".codex/hooks/autopus/hook-codex-sessionstart.sh", 0o700)
+
+	discovery := discoverHookCapabilities()
+
+	assert.Equal(t, []string{home, projectRoot, cwd}, hookDiscoveryRoots())
+	assert.Equal(t, hookActive, readHookCapabilityDecision(
+		hookModeCandidates(home, projectRoot)[0],
+	).completion)
+	assert.Equal(t, hookActive, readHookCapabilityDecision(
+		hookModeCandidates(cwd, projectRoot)[0],
+	).startup)
+	direct := discoverHookCapabilitiesInCandidates(
+		hookModeCandidates(home, projectRoot)[0],
+		hookModeCandidates(cwd, projectRoot)[0],
+	)
+	assert.Equal(t, hookCapability{completion: true, startup: true}, direct.capability("claude"))
+	assert.Equal(t, hookCapability{completion: true, startup: true}, discovery.capability("claude"))
+	assert.Equal(t, hookCapability{completion: true, startup: true}, discovery.capability("codex"))
+	assert.Equal(t, hookCapability{}, discovery.capability("gemini"))
+	assert.Equal(t, hookCapability{}, discovery.capability("opencode"))
+	assert.True(t, discovery.anyCompletion())
+}
+
+func TestDiscoverHookCapabilities_FullCurrentClaudeAndCodexInstalls(t *testing.T) {
+	_, projectRoot, _ := setupHookDiscoveryProject(t)
+	writeHookDiscoveryFixture(t, projectRoot, ".claude/settings.json", `{
+		"hooks":{
+			"Stop":[{"hooks":[{"command":".claude/hooks/autopus/hook-claude-stop.sh"}]}],
+			"SessionStart":[{"hooks":[{"command":".claude/hooks/autopus/hook-claude-sessionstart.sh"}]}]
+		}
+	}`)
+	writeHookDiscoveryFixture(t, projectRoot, ".codex/hooks.json", `{
+		"hooks":{
+			"Stop":[{"hooks":[{"command":".codex/hooks/autopus/hook-codex-stop.sh"}]}],
+			"SessionStart":[{"hooks":[{"command":".codex/hooks/autopus/hook-codex-sessionstart.sh"}]}]
+		}
+	}`)
+	for _, asset := range []string{
+		".claude/hooks/autopus/hook-claude-stop.sh",
+		".claude/hooks/autopus/hook-claude-sessionstart.sh",
+		".codex/hooks/autopus/hook-codex-stop.sh",
+		".codex/hooks/autopus/hook-codex-sessionstart.sh",
+	} {
+		writeHookFixture(t, projectRoot, asset, 0o700)
+	}
+
+	discovery := discoverHookCapabilities()
+
+	assert.Equal(t, hookCapability{completion: true, startup: true}, discovery.capability("claude"))
+	assert.Equal(t, hookCapability{completion: true, startup: true}, discovery.capability("codex"))
+}
+
+func TestDiscoverHookCapabilities_SeparatesAntigravityAndLegacyGeminiSurfaces(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		content   string
+		provider  string
+		unrelated string
+	}{
+		{
+			name: "antigravity Stop hooks",
+			path: ".agents/hooks.json",
+			content: `{"autopus":{"enabled":true,"Stop":[{
+				"command":".gemini/hooks/autopus/hook-gemini-stop.sh"
+			}]}}`,
+			provider:  "antigravity",
+			unrelated: "gemini",
+		},
+		{
+			name: "legacy Gemini AfterAgent settings",
+			path: ".gemini/settings.json",
+			content: `{"hooks":{"AfterAgent":[{"hooks":[{
+				"command":".gemini/hooks/autopus/hook-gemini-afteragent.sh"
+			}]}]}}`,
+			provider:  "gemini",
+			unrelated: "antigravity",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, projectRoot, _ := setupHookDiscoveryProject(t)
+			writeHookDiscoveryFixture(t, projectRoot, tt.path, tt.content)
+			asset := ".gemini/hooks/autopus/hook-gemini-afteragent.sh"
+			if tt.provider == "antigravity" {
+				asset = ".gemini/hooks/autopus/hook-gemini-stop.sh"
+			}
+			writeHookFixture(t, projectRoot, asset, 0o700)
+
+			discovery := discoverHookCapabilities()
+
+			assert.Equal(t, hookCapability{completion: true}, discovery.capability(tt.provider))
+			assert.Equal(t, hookCapability{}, discovery.capability(tt.unrelated))
+		})
+	}
+}
+
+func TestHookDiscoveryCapability_ResolvesKnownRuntimeAliasesWithoutCrossFamilyLeak(t *testing.T) {
+	discovery := newHookDiscovery()
+	discovery["claude"] = hookCapability{completion: true, startup: true}
+	discovery["antigravity"] = hookCapability{completion: true}
+
+	for _, alias := range []string{"claude-code"} {
+		assert.Equal(t, discovery.capability("claude"), discovery.capability(alias), alias)
+	}
+	for _, alias := range []string{"antigravity", "antigravity-cli", "agy"} {
+		assert.Equal(t, discovery.capability("antigravity"), discovery.capability(alias), alias)
+	}
+	assert.Equal(t, hookCapability{}, discovery.capability("gemini"))
+	assert.Equal(t, hookCapability{}, discovery.capability("gemini-cli"))
+}
+
+func TestDiscoverHookCapabilities_RequiresManagedCommandInActualEvent(t *testing.T) {
+	_, projectRoot, _ := setupHookDiscoveryProject(t)
+	writeHookDiscoveryFixture(t, projectRoot, ".claude/settings.json", `{
+		"description":"autopus Stop",
+		"hooks":{"Stop":[{"hooks":[{"command":"user-stop-hook.sh"}]}]}
+	}`)
+
+	discovery := discoverHookCapabilities()
+
+	assert.Equal(t, hookCapability{}, discovery.capability("claude"))
+	assert.False(t, isHookModeAvailable())
+}
+
+func TestIsHookModeAvailable_RequiresCompletionEvent(t *testing.T) {
+	_, projectRoot, _ := setupHookDiscoveryProject(t)
+	writeHookDiscoveryFixture(t, projectRoot, ".claude/settings.json", `{
+		"hooks":{"SessionStart":[{"hooks":[{"command":"autopus hook session-start"}]}]}
+	}`)
+
+	discovery := discoverHookCapabilities()
+
+	assert.True(t, discovery.capability("claude").startup)
+	assert.False(t, discovery.capability("claude").completion)
+	assert.False(t, isHookModeAvailable(), "startup-only wiring must not enable completion collection")
+}
+
+func setupHookDiscoveryProject(t *testing.T) (home, projectRoot, cwd string) {
+	t.Helper()
+	home = t.TempDir()
+	projectRoot = t.TempDir()
+	cwd = filepath.Join(projectRoot, "modules", "nested")
+	require.NoError(t, os.MkdirAll(cwd, 0o700))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectRoot, "autopus.yaml"),
+		[]byte("project: hook-discovery-test\n"),
+		0o600,
+	))
+	t.Setenv("HOME", home)
+	t.Chdir(cwd)
+	return home, projectRoot, cwd
+}
+
+func writeHookDiscoveryFixture(t *testing.T, root, relativePath, content string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(relativePath))
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+}

--- a/internal/cli/orchestra_hook_discovery_validation.go
+++ b/internal/cli/orchestra_hook_discovery_validation.go
@@ -1,0 +1,184 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type hookDecision uint8
+
+const (
+	hookUnspecified hookDecision = iota
+	hookDisabled
+	hookActive
+)
+
+type hookCapabilityDecision struct {
+	completion    hookDecision
+	startup       hookDecision
+	disableAllSet bool
+	disableAll    bool
+}
+
+func applyHookDecision(target *bool, decision hookDecision) {
+	switch decision {
+	case hookDisabled:
+		*target = false
+	case hookActive:
+		*target = true
+	}
+}
+
+func disabledCandidateEvents(candidate hookModeCandidate) hookCapabilityDecision {
+	decision := hookCapabilityDecision{}
+	if candidate.completionEvent != "" {
+		decision.completion = hookDisabled
+	}
+	if candidate.startupEvent != "" {
+		decision.startup = hookDisabled
+	}
+	return decision
+}
+
+func hooksDocumentDisabled(document map[string]any) bool {
+	return hookScopeDisabled(document)
+}
+
+func hookScopeDisabled(scope map[string]any) bool {
+	enabled, exists := scope["enabled"].(bool)
+	return exists && !enabled
+}
+
+func hookEventDecision(
+	events map[string]any,
+	event, root, expectedAsset string,
+	honorEnabled bool,
+) hookDecision {
+	if event == "" {
+		return hookUnspecified
+	}
+	value, exists := events[event]
+	if !exists {
+		// An absent event never overrides a broader scope. Provider-specific
+		// scalar/container disable decisions are resolved separately.
+		return hookUnspecified
+	}
+	return inspectHookCommands(value, root, expectedAsset, honorEnabled)
+}
+
+func inspectHookCommands(value any, root, expectedAsset string, honorEnabled bool) hookDecision {
+	switch value := value.(type) {
+	case []any:
+		decision := hookUnspecified
+		for _, item := range value {
+			decision = combineHookDecisions(
+				decision, inspectHookCommands(item, root, expectedAsset, honorEnabled),
+			)
+		}
+		return decision
+	case map[string]any:
+		if honorEnabled && hookScopeDisabled(value) {
+			if containsAutopusHookCommand(value) {
+				return hookDisabled
+			}
+			return hookUnspecified
+		}
+		decision := hookUnspecified
+		for key, item := range value {
+			if strings.EqualFold(key, "command") {
+				if command, ok := item.(string); ok {
+					decision = combineHookDecisions(
+						decision, hookCommandDecision(command, root, expectedAsset),
+					)
+				}
+			}
+			decision = combineHookDecisions(
+				decision, inspectHookCommands(item, root, expectedAsset, honorEnabled),
+			)
+		}
+		return decision
+	}
+	return hookUnspecified
+}
+
+func combineHookDecisions(left, right hookDecision) hookDecision {
+	if left == hookActive || right == hookActive {
+		return hookActive
+	}
+	if left == hookDisabled || right == hookDisabled {
+		return hookDisabled
+	}
+	return hookUnspecified
+}
+
+func hookCommandDecision(command, root, expectedAsset string) hookDecision {
+	if isSemanticAutopusHookCommand(command) {
+		// An explicit `autopus hook ...` command delegates asset ownership to the
+		// installed binary and therefore has no project script to stat here.
+		return hookActive
+	}
+	if !isManagedHookScriptCommand(command) {
+		return hookUnspecified
+	}
+	if !commandReferencesExpectedAsset(command, expectedAsset) ||
+		!managedHookAssetExecutable(root, expectedAsset) {
+		return hookDisabled
+	}
+	return hookActive
+}
+
+func isSemanticAutopusHookCommand(command string) bool {
+	fields := strings.Fields(strings.TrimSpace(command))
+	if len(fields) < 2 {
+		return false
+	}
+	executable := strings.Trim(fields[0], `"'`)
+	return binaryIdentity(executable) == "autopus" && strings.EqualFold(fields[1], "hook")
+}
+
+func isManagedHookScriptCommand(command string) bool {
+	command = strings.ToLower(strings.ReplaceAll(command, `\`, "/"))
+	return strings.Contains(command, "/hooks/autopus/")
+}
+
+func commandReferencesExpectedAsset(command, expectedAsset string) bool {
+	command = filepath.ToSlash(strings.ReplaceAll(command, `\`, "/"))
+	expectedAsset = filepath.ToSlash(filepath.Clean(expectedAsset))
+	return expectedAsset != "" && strings.Contains(command, expectedAsset)
+}
+
+func managedHookAssetExecutable(root, expectedAsset string) bool {
+	if root == "" || expectedAsset == "" || filepath.IsAbs(expectedAsset) || !filepath.IsLocal(expectedAsset) {
+		return false
+	}
+	info, err := os.Lstat(filepath.Join(root, filepath.FromSlash(expectedAsset)))
+	if err != nil || !info.Mode().IsRegular() {
+		return false
+	}
+	return info.Mode().Perm()&0o111 != 0
+}
+
+func containsAutopusHookCommand(value any) bool {
+	switch value := value.(type) {
+	case []any:
+		for _, item := range value {
+			if containsAutopusHookCommand(item) {
+				return true
+			}
+		}
+	case map[string]any:
+		for key, item := range value {
+			if strings.EqualFold(key, "command") {
+				if command, ok := item.(string); ok &&
+					(isSemanticAutopusHookCommand(command) || isManagedHookScriptCommand(command)) {
+					return true
+				}
+			}
+			if containsAutopusHookCommand(item) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/cli/orchestra_hookmode.go
+++ b/internal/cli/orchestra_hookmode.go
@@ -15,7 +15,11 @@ import (
 func applyHookMode(cfg *orchestra.OrchestraConfig) {
 	cfg.HookMode = false
 	cfg.SessionID = ""
-	if !hookCollectionEligible(cfg.Terminal, cfg.SubprocessMode, isHookModeAvailable()) {
+	discovery := discoverHookCapabilities()
+	applyDiscoveredHookCapabilities(cfg.Providers, discovery)
+	if !hookCollectionEligible(
+		cfg.Terminal, cfg.SubprocessMode, selectedProviderHasCompletionHook(cfg.Providers),
+	) {
 		return
 	}
 	cfg.HookMode = true
@@ -27,6 +31,31 @@ func applyHookMode(cfg *orchestra.OrchestraConfig) {
 	if cfg.MonitorTimeout <= 0 {
 		cfg.MonitorTimeout = runtime.PatternTimeout
 	}
+}
+
+func applyDiscoveredHookCapabilities(providers []orchestra.ProviderConfig, discovery hookDiscovery) {
+	for i := range providers {
+		capability := discovery.capabilityFor(providers[i].Name, providers[i].Binary)
+		if providers[i].HasHook == nil {
+			providers[i].HasHook = hookCapabilityOverride(capability.completion)
+		}
+		if providers[i].HasStartupHook == nil {
+			providers[i].HasStartupHook = hookCapabilityOverride(capability.startup)
+		}
+	}
+}
+
+func selectedProviderHasCompletionHook(providers []orchestra.ProviderConfig) bool {
+	for i := range providers {
+		if providers[i].HasHook != nil && *providers[i].HasHook {
+			return true
+		}
+	}
+	return false
+}
+
+func hookCapabilityOverride(value bool) *bool {
+	return &value
 }
 
 // hookCollectionEligible reports whether hook-IPC done-file collection can run:

--- a/internal/cli/orchestra_hookmode_test.go
+++ b/internal/cli/orchestra_hookmode_test.go
@@ -81,6 +81,7 @@ func TestRunOrchestraCommand_CodexHookEnablesPaneIPC(t *testing.T) {
 		[]byte(`{"hooks":{"Stop":[{"hooks":[{"type":"command","command":".codex/hooks/autopus/hook-codex-stop.sh"}]}]}}`),
 		0o600,
 	))
+	writeHookFixture(t, projectRoot, ".codex/hooks/autopus/hook-codex-stop.sh", 0o700)
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("AUTOPUS_PLATFORM", "codex")
 	t.Chdir(projectRoot)
@@ -99,7 +100,7 @@ func TestRunOrchestraCommand_CodexHookEnablesPaneIPC(t *testing.T) {
 	}
 
 	err := runOrchestraCommand(
-		context.Background(), "plan", "consensus", []string{"claude"},
+		context.Background(), "plan", "consensus", []string{"codex"},
 		30, "", "topic", 0, 0, OrchestraFlags{NoDetach: true},
 	)
 	require.NoError(t, err)
@@ -120,4 +121,143 @@ func TestApplyHookMode_ForcedSubprocessClearsLegacyPaneState(t *testing.T) {
 
 	assert.False(t, cfg.HookMode)
 	assert.Empty(t, cfg.SessionID)
+}
+
+func TestApplyHookMode_StopOnlySetsIndependentProviderCapabilities(t *testing.T) {
+	_, projectRoot, _ := setupHookDiscoveryProject(t)
+	writeHookDiscoveryFixture(t, projectRoot, ".claude/settings.json", `{
+		"hooks":{"Stop":[{"hooks":[{"command":"autopus hook stop"}]}]}
+	}`)
+	on := true
+	off := false
+	cfg := orchestra.OrchestraConfig{
+		Terminal: stubTerminal{name: "cmux"},
+		Providers: []orchestra.ProviderConfig{
+			{Name: "claude"},
+			{Name: "codex"},
+			{Name: "gemini", HasHook: &off, HasStartupHook: &on},
+		},
+	}
+
+	applyHookMode(&cfg)
+
+	require.True(t, cfg.HookMode)
+	assertHookCapabilities(t, cfg.Providers[0], true, false)
+	assertHookCapabilities(t, cfg.Providers[1], false, false)
+	assertHookCapabilities(t, cfg.Providers[2], false, true)
+}
+
+func TestApplyHookMode_CodexOnlyDoesNotEnableClaudeDefaults(t *testing.T) {
+	_, projectRoot, _ := setupHookDiscoveryProject(t)
+	writeHookDiscoveryFixture(t, projectRoot, ".codex/hooks.json", `{
+		"hooks":{
+			"Stop":[{"hooks":[{"command":".codex/hooks/autopus/hook-codex-stop.sh"}]}],
+			"SessionStart":[{"hooks":[{"command":".codex/hooks/autopus/hook-codex-sessionstart.sh"}]}]
+		}
+	}`)
+	writeHookFixture(t, projectRoot, ".codex/hooks/autopus/hook-codex-stop.sh", 0o700)
+	writeHookFixture(t, projectRoot, ".codex/hooks/autopus/hook-codex-sessionstart.sh", 0o700)
+	cfg := orchestra.OrchestraConfig{
+		Terminal:  stubTerminal{name: "cmux"},
+		Providers: []orchestra.ProviderConfig{{Name: "claude"}, {Name: "codex"}},
+	}
+
+	applyHookMode(&cfg)
+
+	require.True(t, cfg.HookMode)
+	assertHookCapabilities(t, cfg.Providers[0], false, false)
+	assertHookCapabilities(t, cfg.Providers[1], true, true)
+}
+
+func TestApplyHookMode_KnownAliasesPreserveNamesAndExplicitOverrides(t *testing.T) {
+	_, projectRoot, _ := setupHookDiscoveryProject(t)
+	writeHookDiscoveryFixture(t, projectRoot, ".claude/settings.json", `{
+		"hooks":{
+			"Stop":[{"hooks":[{"command":"autopus hook stop"}]}],
+			"SessionStart":[{"hooks":[{"command":"autopus hook session-start"}]}]
+		}
+	}`)
+	writeHookDiscoveryFixture(t, projectRoot, ".agents/hooks.json", `{
+		"autopus":{"Stop":[{"hooks":[{"command":"autopus hook stop"}]}]}
+	}`)
+	off, on := false, true
+	cfg := orchestra.OrchestraConfig{
+		Terminal: stubTerminal{name: "cmux"},
+		Providers: []orchestra.ProviderConfig{
+			{Name: "claude-code"},
+			{Name: "antigravity", Binary: "agy"},
+			{Name: "antigravity-cli", Binary: "antigravity"},
+			{Name: "gemini-cli", HasHook: &off, HasStartupHook: &on},
+			{Name: "agy", Binary: "agy"},
+		},
+	}
+
+	applyHookMode(&cfg)
+
+	require.True(t, cfg.HookMode)
+	assert.Equal(t,
+		[]string{"claude-code", "antigravity", "antigravity-cli", "gemini-cli", "agy"},
+		[]string{
+			cfg.Providers[0].Name, cfg.Providers[1].Name, cfg.Providers[2].Name,
+			cfg.Providers[3].Name, cfg.Providers[4].Name,
+		},
+	)
+	assertHookCapabilities(t, cfg.Providers[0], true, true)
+	assertHookCapabilities(t, cfg.Providers[1], true, false)
+	assertHookCapabilities(t, cfg.Providers[2], true, false)
+	assertHookCapabilities(t, cfg.Providers[3], false, true)
+	assertHookCapabilities(t, cfg.Providers[4], true, false)
+}
+
+func TestApplyHookMode_ExplicitSelectedCompletionEnablesHookModeWithoutDiscovery(t *testing.T) {
+	setupHookDiscoveryProject(t)
+	on := true
+	cfg := orchestra.OrchestraConfig{
+		Terminal: stubTerminal{name: "cmux"},
+		Providers: []orchestra.ProviderConfig{
+			{Name: "opencode", Binary: "opencode", HasHook: &on},
+			{Name: "custom", Binary: "custom", HasHook: &on},
+		},
+	}
+
+	applyHookMode(&cfg)
+
+	assert.True(t, cfg.HookMode)
+	assert.NotEmpty(t, cfg.SessionID)
+	assertHookCapabilities(t, cfg.Providers[0], true, false)
+	assertHookCapabilities(t, cfg.Providers[1], true, false)
+}
+
+func TestApplyHookMode_EligibilityUsesSelectedResolvedCapabilities(t *testing.T) {
+	_, projectRoot, _ := setupHookDiscoveryProject(t)
+	writeHookDiscoveryFixture(t, projectRoot, ".claude/settings.json", `{
+		"hooks":{"Stop":[{"hooks":[{"command":"autopus hook stop"}]}]}
+	}`)
+	off := false
+	cfg := orchestra.OrchestraConfig{
+		Terminal: stubTerminal{name: "cmux"},
+		Providers: []orchestra.ProviderConfig{{
+			Name: "claude", Binary: "claude", HasHook: &off,
+		}},
+	}
+
+	applyHookMode(&cfg)
+
+	assert.False(t, cfg.HookMode)
+	assert.Empty(t, cfg.SessionID)
+	assertHookCapabilities(t, cfg.Providers[0], false, false)
+}
+
+func assertHookCapabilities(
+	t *testing.T,
+	provider orchestra.ProviderConfig,
+	wantCompletion, wantStartup bool,
+) {
+	t.Helper()
+	if assert.NotNil(t, provider.HasHook) {
+		assert.Equal(t, wantCompletion, *provider.HasHook)
+	}
+	if assert.NotNil(t, provider.HasStartupHook) {
+		assert.Equal(t, wantStartup, *provider.HasStartupHook)
+	}
 }

--- a/internal/cli/orchestra_inject.go
+++ b/internal/cli/orchestra_inject.go
@@ -11,12 +11,15 @@ import (
 	"github.com/insajin/autopus-adk/pkg/terminal"
 )
 
+var orchestraInjectSubmitDelay = 500 * time.Millisecond
+
 // newOrchestraInjectCmd creates the "orchestra inject" subcommand.
 // Sends a prompt to a specific provider's pane in an existing session.
 func newOrchestraInjectCmd() *cobra.Command {
 	var (
-		sessionID string
-		provider  string
+		sessionID    string
+		provider     string
+		workspaceRef string
 	)
 
 	cmd := &cobra.Command{
@@ -31,12 +34,13 @@ func newOrchestraInjectCmd() *cobra.Command {
 			if provider == "" {
 				return fmt.Errorf("--provider is required")
 			}
-			return runOrchestraInject(cmd, sessionID, provider, args[0])
+			return runOrchestraInjectWithWorkspace(cmd, sessionID, provider, workspaceRef, args[0])
 		},
 	}
 
 	cmd.Flags().StringVar(&sessionID, "session-id", "", "세션 ID")
 	cmd.Flags().StringVar(&provider, "provider", "", "프롬프트를 보낼 프로바이더 이름")
+	cmd.Flags().StringVar(&workspaceRef, "workspace-ref", "", "legacy cmux 세션의 원 workspace ref")
 	_ = cmd.MarkFlagRequired("session-id")
 	_ = cmd.MarkFlagRequired("provider")
 
@@ -45,6 +49,10 @@ func newOrchestraInjectCmd() *cobra.Command {
 
 // runOrchestraInject loads a session, finds the provider's pane, and sends the prompt.
 func runOrchestraInject(cmd *cobra.Command, sessionID, provider, prompt string) error {
+	return runOrchestraInjectWithWorkspace(cmd, sessionID, provider, "", prompt)
+}
+
+func runOrchestraInjectWithWorkspace(cmd *cobra.Command, sessionID, provider, workspaceRef, prompt string) error {
 	session, err := orchestra.LoadSession(sessionID)
 	if err != nil {
 		return fmt.Errorf("session %s not found: %w", sessionID, err)
@@ -59,9 +67,11 @@ func runOrchestraInject(cmd *cobra.Command, sessionID, provider, prompt string) 
 		return fmt.Errorf("provider %q not found in session (available: %v)", provider, available)
 	}
 
-	term := terminal.DetectTerminal()
-	if term == nil {
-		return fmt.Errorf("no terminal multiplexer detected — inject requires cmux or tmux")
+	term, err := orchestra.ResolveSessionTerminalWithWorkspace(
+		session, orchestraSessionTerminalDetector(), workspaceRef,
+	)
+	if err != nil {
+		return fmt.Errorf("restore session %s terminal: %w", sessionID, err)
 	}
 
 	ctx := cmd.Context()
@@ -72,7 +82,7 @@ func runOrchestraInject(cmd *cobra.Command, sessionID, provider, prompt string) 
 	}
 
 	// Send Enter to submit the prompt
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(orchestraInjectSubmitDelay)
 	if err := term.SendCommand(ctx, terminal.PaneID(paneID), "\n"); err != nil {
 		fmt.Fprintf(os.Stderr, "[inject] SendCommand (Enter) failed: %v — prompt may need manual submit\n", err)
 	}

--- a/internal/cli/orchestra_inject.go
+++ b/internal/cli/orchestra_inject.go
@@ -47,11 +47,8 @@ func newOrchestraInjectCmd() *cobra.Command {
 	return cmd
 }
 
-// runOrchestraInject loads a session, finds the provider's pane, and sends the prompt.
-func runOrchestraInject(cmd *cobra.Command, sessionID, provider, prompt string) error {
-	return runOrchestraInjectWithWorkspace(cmd, sessionID, provider, "", prompt)
-}
-
+// runOrchestraInjectWithWorkspace loads a session, restores its terminal context,
+// and sends the prompt to the requested provider pane.
 func runOrchestraInjectWithWorkspace(cmd *cobra.Command, sessionID, provider, workspaceRef, prompt string) error {
 	session, err := orchestra.LoadSession(sessionID)
 	if err != nil {

--- a/internal/cli/orchestra_receipt_output.go
+++ b/internal/cli/orchestra_receipt_output.go
@@ -44,6 +44,9 @@ func writeOrchestraCLIOutput(w io.Writer, result *orchestra.OrchestraResult, for
 		_, err := fmt.Fprintln(w, result.Merged)
 		return err
 	}
+	if result.Yield != nil {
+		return orchestra.WriteYieldOutput(w, *result.Yield)
+	}
 	if result.RunReceipt == nil || result.RunReceipt.Schema != orchestra.OrchestrationReceiptSchema {
 		return fmt.Errorf("orchestra output: typed %s receipt is required", orchestra.OrchestrationReceiptSchema)
 	}

--- a/internal/cli/orchestra_receipt_output_test.go
+++ b/internal/cli/orchestra_receipt_output_test.go
@@ -37,6 +37,47 @@ func TestWriteOrchestraCLIOutput_JSONIncludesTypedReceiptAndMergedResult(t *test
 	require.NotNil(t, payload.Receipt)
 	assert.Equal(t, orchestra.OrchestrationReceiptSchema, payload.Receipt.Schema)
 	assert.Equal(t, "blocked", payload.Receipt.GateStatus)
+	assert.NotContains(t, out.String(), `"session_id"`)
+	assert.NotContains(t, out.String(), `"round_history"`)
+	assert.NotContains(t, out.String(), `"panes"`)
+}
+
+func TestWriteOrchestraCLIOutput_JSONYield_PreservesSessionContract(t *testing.T) {
+	t.Parallel()
+
+	want := orchestra.YieldOutput{
+		Strategy:  "debate",
+		Rounds:    1,
+		SessionID: "orch-yield-json",
+		Panes: map[string]string{
+			"claude": "surface:41",
+			"codex":  "surface:42",
+		},
+		RoundHistory: []orchestra.YieldRound{{
+			Round: 1,
+			Responses: []orchestra.YieldResponse{{
+				Provider: "claude",
+				Output:   "round one response",
+			}},
+		}},
+	}
+	result := &orchestra.OrchestraResult{
+		Merged: "generic output must not replace the yield contract",
+		RunReceipt: &orchestra.OrchestrationRunReceipt{
+			Schema: orchestra.OrchestrationReceiptSchema,
+		},
+		Yield: &want,
+	}
+	var out bytes.Buffer
+
+	err := writeOrchestraCLIOutput(&out, result, orchestraOutputJSON)
+
+	require.NoError(t, err)
+	var got orchestra.YieldOutput
+	require.NoError(t, json.Unmarshal(out.Bytes(), &got), "stdout must contain exactly one JSON document")
+	assert.Equal(t, want, got)
+	assert.NotContains(t, out.String(), orchestraCLIOutputSchema)
+	assert.NotContains(t, out.String(), "generic output must not replace the yield contract")
 }
 
 func TestWriteOrchestraCLIOutput_JSONFailsClosedWithoutReceipt(t *testing.T) {

--- a/internal/cli/orchestra_session_commands_context_test.go
+++ b/internal/cli/orchestra_session_commands_context_test.go
@@ -1,0 +1,161 @@
+package cli
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/orchestra"
+	"github.com/insajin/autopus-adk/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrchestraCollect_PersistedWorkspace_ReadsOriginalPaneContext(t *testing.T) {
+	term := &cleanupTerminal{
+		stubTerminal: stubTerminal{name: "cmux"}, workspaceRef: "workspace:99",
+		readOutput: "provider response", closeErrors: map[string]error{},
+	}
+	useCleanupTerminal(t, term)
+	session := orchestra.OrchestraSession{
+		ID: "collect-context-" + orchestra.NewSessionID(), TerminalKind: "cmux",
+		WorkspaceRef: "workspace:13", Panes: map[string]string{"claude": "surface:1414"},
+		Providers: []orchestra.SessionProviderConfig{{Name: "claude", Binary: "claude"}},
+		CreatedAt: time.Now(),
+	}
+	require.NoError(t, orchestra.SaveSession(session))
+	t.Cleanup(func() { _ = orchestra.RemoveSession(session.ID) })
+	cmd := newOrchestraCollectCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{session.ID})
+
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, "workspace:13", term.workspaceRef)
+	assert.Equal(t, []terminal.PaneID{"surface:1414"}, term.readPanes)
+	assert.Contains(t, stdout.String(), "provider response")
+}
+
+func TestOrchestraInject_PersistedWorkspace_TargetsOriginalPaneContext(t *testing.T) {
+	term := &cleanupTerminal{
+		stubTerminal: stubTerminal{name: "cmux"}, workspaceRef: "workspace:99",
+		closeErrors: map[string]error{},
+	}
+	useCleanupTerminal(t, term)
+	originalDelay := orchestraInjectSubmitDelay
+	orchestraInjectSubmitDelay = 0
+	t.Cleanup(func() { orchestraInjectSubmitDelay = originalDelay })
+	session := orchestra.OrchestraSession{
+		ID: "inject-context-" + orchestra.NewSessionID(), TerminalKind: "cmux",
+		WorkspaceRef: "workspace:13", Panes: map[string]string{"claude": "surface:1414"},
+		CreatedAt: time.Now(),
+	}
+	require.NoError(t, orchestra.SaveSession(session))
+	t.Cleanup(func() { _ = orchestra.RemoveSession(session.ID) })
+	cmd := newOrchestraInjectCmd()
+	cmd.SetArgs([]string{"--session-id", session.ID, "--provider", "claude", "follow up"})
+
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, "workspace:13", term.workspaceRef)
+	assert.Equal(t, []string{"follow up"}, term.longTexts)
+	assert.Equal(t, []string{"\n"}, term.commands)
+}
+
+func TestOrchestraCollect_LegacyCmuxSession_DoesNotGuessCurrentWorkspace(t *testing.T) {
+	term := &cleanupTerminal{
+		stubTerminal: stubTerminal{name: "cmux"}, workspaceRef: "workspace:99",
+		closeErrors: map[string]error{},
+	}
+	useCleanupTerminal(t, term)
+	session := orchestra.OrchestraSession{
+		ID:        "collect-legacy-" + orchestra.NewSessionID(),
+		Panes:     map[string]string{"claude": "surface:1414"},
+		Providers: []orchestra.SessionProviderConfig{{Name: "claude"}}, CreatedAt: time.Now(),
+	}
+	require.NoError(t, orchestra.SaveSession(session))
+	t.Cleanup(func() { _ = orchestra.RemoveSession(session.ID) })
+	cmd := newOrchestraCollectCmd()
+	cmd.SetArgs([]string{session.ID})
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "legacy session")
+	assert.Empty(t, term.readPanes)
+}
+
+func TestOrchestraCollect_LegacyCmuxSession_ExplicitWorkspaceSucceeds(t *testing.T) {
+	term := &cleanupTerminal{
+		stubTerminal: stubTerminal{name: "cmux"}, workspaceRef: "workspace:99",
+		readOutput: "legacy response", closeErrors: map[string]error{},
+	}
+	useCleanupTerminal(t, term)
+	session := orchestra.OrchestraSession{
+		ID:        "collect-legacy-override-" + orchestra.NewSessionID(),
+		Panes:     map[string]string{"claude": "surface:1414"},
+		Providers: []orchestra.SessionProviderConfig{{Name: "claude"}}, CreatedAt: time.Now(),
+	}
+	require.NoError(t, orchestra.SaveSession(session))
+	t.Cleanup(func() { _ = orchestra.RemoveSession(session.ID) })
+	cmd := newOrchestraCollectCmd()
+	cmd.SetArgs([]string{"--workspace-ref", "workspace:13", session.ID})
+
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, "workspace:13", term.workspaceRef)
+	assert.Equal(t, []terminal.PaneID{"surface:1414"}, term.readPanes)
+}
+
+func TestOrchestraInject_LegacyCmuxSession_ExplicitWorkspaceSucceeds(t *testing.T) {
+	term := &cleanupTerminal{
+		stubTerminal: stubTerminal{name: "cmux"}, workspaceRef: "workspace:99",
+		closeErrors: map[string]error{},
+	}
+	useCleanupTerminal(t, term)
+	originalDelay := orchestraInjectSubmitDelay
+	orchestraInjectSubmitDelay = 0
+	t.Cleanup(func() { orchestraInjectSubmitDelay = originalDelay })
+	session := orchestra.OrchestraSession{
+		ID:    "inject-legacy-override-" + orchestra.NewSessionID(),
+		Panes: map[string]string{"claude": "surface:1414"}, CreatedAt: time.Now(),
+	}
+	require.NoError(t, orchestra.SaveSession(session))
+	t.Cleanup(func() { _ = orchestra.RemoveSession(session.ID) })
+	cmd := newOrchestraInjectCmd()
+	cmd.SetArgs([]string{
+		"--session-id", session.ID, "--provider", "claude",
+		"--workspace-ref", "workspace:13", "follow up",
+	})
+
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, "workspace:13", term.workspaceRef)
+	assert.Equal(t, []string{"follow up"}, term.longTexts)
+}
+
+func TestOrchestraCleanup_LegacyCmuxSession_ExplicitWorkspaceSucceeds(t *testing.T) {
+	term := &cleanupTerminal{
+		stubTerminal: stubTerminal{name: "cmux"}, workspaceRef: "workspace:99",
+		closeErrors: map[string]error{},
+	}
+	useCleanupTerminal(t, term)
+	session := orchestra.OrchestraSession{
+		ID:    "cleanup-legacy-override-" + orchestra.NewSessionID(),
+		Panes: map[string]string{"claude": "surface:1414"}, CreatedAt: time.Now(),
+	}
+	require.NoError(t, orchestra.SaveSession(session))
+	cmd := newOrchestraCleanupCmd()
+	cmd.SetArgs([]string{
+		"--session-id", session.ID, "--workspace-ref", "workspace:13",
+	})
+
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, "workspace:13", term.workspaceRef)
+	assert.Equal(t, []string{"surface:1414"}, term.closed)
+	_, err := orchestra.LoadSession(session.ID)
+	assert.Error(t, err)
+}
+
+func TestNewOrchestraInjectCmd_ExposesLegacyWorkspaceFlag(t *testing.T) {
+	cmd := newOrchestraInjectCmd()
+
+	assert.NotNil(t, cmd.Flags().Lookup("workspace-ref"))
+}

--- a/pkg/adapter/gemini/gemini.go
+++ b/pkg/adapter/gemini/gemini.go
@@ -3,6 +3,7 @@ package gemini
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -169,7 +170,7 @@ func (a *Adapter) Generate(ctx context.Context, cfg *config.HarnessConfig) (*ada
 	}
 	files = append(files, statusFiles...)
 
-	hookConfigs := a.configuredHooks(cfg)
+	hookConfigs := a.configuredAntigravityHooks(cfg)
 	hookFiles, err := a.writeAntigravityHooksJSON(hookConfigs)
 	if err != nil {
 		return nil, err
@@ -180,6 +181,15 @@ func (a *Adapter) Generate(ctx context.Context, cfg *config.HarnessConfig) (*ada
 	if err != nil {
 		return nil, err
 	}
+	completionHookAssets, err := prepareGeminiCompletionHookAssets()
+	if err != nil {
+		return nil, err
+	}
+	rollbackHooks, err := applyGeminiManagedHookAssets(a.root, completionHookAssets)
+	if err != nil {
+		return nil, err
+	}
+	files = append(files, completionHookAssets...)
 
 	a.installAntigravityPluginIfAvailable(ctx)
 
@@ -190,7 +200,7 @@ func (a *Adapter) Generate(ctx context.Context, cfg *config.HarnessConfig) (*ada
 
 	m := adapter.ManifestFromFiles(adapterName, pf)
 	if err := m.Save(a.root); err != nil {
-		return nil, fmt.Errorf("매니페스트 저장 실패: %w", err)
+		return nil, errors.Join(fmt.Errorf("매니페스트 저장 실패: %w", err), rollbackHooks())
 	}
 
 	return pf, nil

--- a/pkg/adapter/gemini/gemini_antigravity_test.go
+++ b/pkg/adapter/gemini/gemini_antigravity_test.go
@@ -1,9 +1,11 @@
 package gemini
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -23,6 +25,16 @@ func TestPrepareAntigravityHooksJSON_UsesOfficialSchema(t *testing.T) {
 		Type:    "command",
 		Command: "auto check --arch --quiet --warn-only",
 		Timeout: 30,
+	}, {
+		Event:   "PreInvocation",
+		Type:    "command",
+		Command: "auto ready",
+		Timeout: 10,
+	}, {
+		Event:   "Stop",
+		Type:    "command",
+		Command: "hook-gemini-stop.sh",
+		Timeout: 300,
 	}}
 
 	files, err := a.prepareAntigravityHooksJSON(hooks)
@@ -36,6 +48,72 @@ func TestPrepareAntigravityHooksJSON_UsesOfficialSchema(t *testing.T) {
 	entries := autopus["PreToolUse"].([]any)
 	first := entries[0].(map[string]any)
 	assert.Equal(t, "run_command", first["matcher"])
+	assert.Contains(t, first, "hooks")
+
+	for _, event := range []string{"PreInvocation", "Stop"} {
+		entries := autopus[event].([]any)
+		handler := entries[0].(map[string]any)
+		assert.Equal(t, "command", handler["type"])
+		assert.NotContains(t, handler, "matcher")
+		assert.NotContains(t, handler, "hooks")
+	}
+}
+
+func TestGenerate_WritesProviderSpecificCompletionHookEvents(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, err := NewWithRoot(dir, WithoutPluginInstall()).Generate(
+		context.Background(), config.DefaultFullConfig("test-project"),
+	)
+	require.NoError(t, err)
+
+	settings := readJSONDocument(t, filepath.Join(dir, ".gemini", "settings.json"))
+	legacyHooks := requireJSONObject(t, settings["hooks"])
+	assert.Contains(t, legacyHooks, "AfterAgent")
+	assert.NotContains(t, legacyHooks, "Stop")
+
+	agents := readJSONDocument(t, filepath.Join(dir, ".agents", "hooks.json"))
+	agyHooks := requireJSONObject(t, agents["autopus"])
+	assert.Contains(t, agyHooks, "Stop")
+	assert.NotContains(t, agyHooks, "AfterAgent")
+	stop := agyHooks["Stop"].([]any)[0].(map[string]any)
+	assert.NotContains(t, stop, "hooks", "Stop must be a flat handler list")
+}
+
+func TestGenerate_AntigravityStopCommandRunsOutsideGit(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, err := NewWithRoot(dir, WithoutPluginInstall()).Generate(
+		context.Background(), config.DefaultFullConfig("test-project"),
+	)
+	require.NoError(t, err)
+
+	agents := readJSONDocument(t, filepath.Join(dir, ".agents", "hooks.json"))
+	hooks := requireJSONObject(t, agents["autopus"])
+	handler := hooks["Stop"].([]any)[0].(map[string]any)
+	command := handler["command"].(string)
+	cmd := exec.Command("sh", "-c", command)
+	cmd.Dir = filepath.Join(dir, ".agents")
+	cmd.Env = []string{"PATH=/nonexistent", "AUTOPUS_SESSION_ID="}
+	stdout, err := cmd.Output()
+	require.NoError(t, err)
+	assert.Equal(t, `{"decision":"stop"}`, string(bytes.TrimSpace(stdout)))
+}
+
+func TestApplyGeminiHooks_RemovesStaleManagedCompletionEvents(t *testing.T) {
+	settings := map[string]any{"hooks": map[string]any{
+		"AfterAgent": []any{"stale legacy"},
+		"Stop":       []any{"stale antigravity"},
+		"UserEvent":  []any{"preserve"},
+	}}
+	applyGeminiHooksAndPermissions(settings, []adapter.HookConfig{{
+		Event: "AfterAgent", Type: "command", Command: "legacy-hook", Timeout: 300,
+	}}, nil)
+
+	hooks := settings["hooks"].(map[string]any)
+	assert.Contains(t, hooks, "AfterAgent")
+	assert.NotContains(t, hooks, "Stop")
+	assert.Equal(t, []any{"preserve"}, hooks["UserEvent"])
 }
 
 func TestPrepareAntigravityPluginJSON(t *testing.T) {

--- a/pkg/adapter/gemini/gemini_completion_hook.go
+++ b/pkg/adapter/gemini/gemini_completion_hook.go
@@ -18,10 +18,7 @@ import (
 const geminiCompletionHookAssetName = "hook-gemini-afteragent.sh"
 
 var (
-	geminiManagedHookDirectory = filepath.Join(".gemini", "hooks", "autopus")
-	geminiCompletionHookTarget = filepath.Join(
-		geminiManagedHookDirectory, geminiCompletionHookAssetName,
-	)
+	geminiManagedHookDirectory     = filepath.Join(".gemini", "hooks", "autopus")
 	geminiCompletionHookAssetNames = []string{
 		geminiCompletionHookAssetName,
 		"hook-gemini-stop.sh",
@@ -56,7 +53,7 @@ func writeGeminiManagedHookAsset(rootPath string, asset adapter.FileMapping, mod
 	if err != nil {
 		return fmt.Errorf("Gemini project root 열기 실패: %w", err)
 	}
-	defer root.Close()
+	defer func() { _ = root.Close() }()
 
 	target, err := cleanGeminiManagedHookTarget(asset.TargetPath)
 	if err != nil {
@@ -205,7 +202,7 @@ func snapshotGeminiManagedHookAsset(
 	if err != nil {
 		return snapshot, fmt.Errorf("Gemini project root 열기 실패: %w", err)
 	}
-	defer root.Close()
+	defer func() { _ = root.Close() }()
 
 	if err := ensureGeminiHookDirectories(root, filepath.Dir(target), false); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -264,7 +261,7 @@ func removeGeminiManagedHookAsset(rootPath string, asset adapter.FileMapping) er
 	if err != nil {
 		return fmt.Errorf("Gemini project root 열기 실패: %w", err)
 	}
-	defer root.Close()
+	defer func() { _ = root.Close() }()
 	if err := ensureGeminiHookDirectories(root, filepath.Dir(target), false); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil

--- a/pkg/adapter/gemini/gemini_completion_hook.go
+++ b/pkg/adapter/gemini/gemini_completion_hook.go
@@ -1,0 +1,282 @@
+package gemini
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	contentfs "github.com/insajin/autopus-adk/content"
+	"github.com/insajin/autopus-adk/pkg/adapter"
+)
+
+const geminiCompletionHookAssetName = "hook-gemini-afteragent.sh"
+
+var (
+	geminiManagedHookDirectory = filepath.Join(".gemini", "hooks", "autopus")
+	geminiCompletionHookTarget = filepath.Join(
+		geminiManagedHookDirectory, geminiCompletionHookAssetName,
+	)
+	geminiCompletionHookAssetNames = []string{
+		geminiCompletionHookAssetName,
+		"hook-gemini-stop.sh",
+	}
+)
+
+func prepareGeminiCompletionHookAssets() ([]adapter.FileMapping, error) {
+	assets := make([]adapter.FileMapping, 0, len(geminiCompletionHookAssetNames))
+	for _, name := range geminiCompletionHookAssetNames {
+		data, err := contentfs.FS.ReadFile("hooks/" + name)
+		if err != nil {
+			return nil, fmt.Errorf("Gemini completion hook asset 읽기 실패 %s: %w", name, err)
+		}
+		assets = append(assets, adapter.FileMapping{
+			TargetPath:      filepath.Join(geminiManagedHookDirectory, name),
+			OverwritePolicy: adapter.OverwriteAlways,
+			Checksum:        checksum(string(data)),
+			Content:         data,
+		})
+	}
+	return assets, nil
+}
+
+// writeGeminiCompletionHookAsset confines the managed executable to the
+// project root and refuses symlinked parents or non-regular targets.
+func writeGeminiCompletionHookAsset(rootPath string, asset adapter.FileMapping) error {
+	return writeGeminiManagedHookAsset(rootPath, asset, 0o755)
+}
+
+func writeGeminiManagedHookAsset(rootPath string, asset adapter.FileMapping, mode os.FileMode) error {
+	root, err := os.OpenRoot(rootPath)
+	if err != nil {
+		return fmt.Errorf("Gemini project root 열기 실패: %w", err)
+	}
+	defer root.Close()
+
+	target, err := cleanGeminiManagedHookTarget(asset.TargetPath)
+	if err != nil {
+		return err
+	}
+	if err := ensureGeminiHookDirectories(root, filepath.Dir(target), true); err != nil {
+		return err
+	}
+	if info, statErr := root.Lstat(target); statErr == nil {
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("Gemini completion hook target must be a regular file: %s", target)
+		}
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		return fmt.Errorf("Gemini completion hook target 검사 실패: %w", statErr)
+	}
+
+	temporary, file, err := createGeminiHookTemporary(root, filepath.Dir(target))
+	if err != nil {
+		return err
+	}
+	committed := false
+	defer func() {
+		_ = file.Close()
+		if !committed {
+			_ = root.Remove(temporary)
+		}
+	}()
+	if _, err := io.Copy(file, bytes.NewReader(asset.Content)); err != nil {
+		return fmt.Errorf("Gemini completion hook 임시 파일 쓰기 실패: %w", err)
+	}
+	if err := file.Chmod(mode.Perm()); err != nil {
+		return fmt.Errorf("Gemini completion hook 실행 권한 설정 실패: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("Gemini completion hook 동기화 실패: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("Gemini completion hook 닫기 실패: %w", err)
+	}
+	if err := root.Rename(temporary, target); err != nil {
+		return fmt.Errorf("Gemini completion hook 교체 실패: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func ensureGeminiHookDirectories(root *os.Root, dir string, create bool) error {
+	current := ""
+	for _, part := range strings.Split(filepath.Clean(dir), string(filepath.Separator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		current = filepath.Join(current, part)
+		info, err := root.Lstat(current)
+		if errors.Is(err, os.ErrNotExist) && create {
+			if err := root.Mkdir(current, 0o755); err != nil && !errors.Is(err, os.ErrExist) {
+				return fmt.Errorf("Gemini completion hook 디렉터리 생성 실패 %s: %w", current, err)
+			}
+			info, err = root.Lstat(current)
+		}
+		if err != nil {
+			return fmt.Errorf("Gemini completion hook 디렉터리 검사 실패 %s: %w", current, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return fmt.Errorf("Gemini completion hook parent must be a directory: %s", current)
+		}
+	}
+	return nil
+}
+
+func createGeminiHookTemporary(root *os.Root, dir string) (string, *os.File, error) {
+	for attempt := 0; attempt < 16; attempt++ {
+		random := make([]byte, 8)
+		if _, err := rand.Read(random); err != nil {
+			return "", nil, fmt.Errorf("Gemini completion hook 임시 이름 생성 실패: %w", err)
+		}
+		path := filepath.Join(dir, ".autopus-hook.tmp-"+hex.EncodeToString(random))
+		file, err := root.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if errors.Is(err, os.ErrExist) {
+			continue
+		}
+		if err != nil {
+			return "", nil, fmt.Errorf("Gemini completion hook 임시 파일 생성 실패: %w", err)
+		}
+		return path, file, nil
+	}
+	return "", nil, errors.New("Gemini completion hook 임시 이름 생성 한도 초과")
+}
+
+func cleanGeminiManagedHookTarget(path string) (string, error) {
+	clean := filepath.Clean(path)
+	relative, err := filepath.Rel(geminiManagedHookDirectory, clean)
+	if err != nil || clean == "." || filepath.IsAbs(clean) || !filepath.IsLocal(clean) ||
+		relative == "." || !filepath.IsLocal(relative) || filepath.Dir(relative) != "." {
+		return "", fmt.Errorf("invalid Gemini completion hook target: %s", path)
+	}
+	return clean, nil
+}
+
+func isGeminiManagedHookAsset(asset adapter.FileMapping) bool {
+	_, err := cleanGeminiManagedHookTarget(asset.TargetPath)
+	return err == nil
+}
+
+type geminiManagedHookSnapshot struct {
+	asset   adapter.FileMapping
+	exists  bool
+	content []byte
+	mode    os.FileMode
+}
+
+func applyGeminiManagedHookAssets(
+	rootPath string,
+	assets []adapter.FileMapping,
+) (func() error, error) {
+	snapshots := make([]geminiManagedHookSnapshot, 0, len(assets))
+	for _, asset := range assets {
+		snapshot, err := snapshotGeminiManagedHookAsset(rootPath, asset)
+		if err != nil {
+			return nil, err
+		}
+		snapshots = append(snapshots, snapshot)
+	}
+
+	for index, asset := range assets {
+		if err := writeGeminiCompletionHookAsset(rootPath, asset); err != nil {
+			restoreErr := restoreGeminiManagedHookAssets(rootPath, snapshots[:index])
+			return nil, errors.Join(err, restoreErr)
+		}
+	}
+	return func() error {
+		return restoreGeminiManagedHookAssets(rootPath, snapshots)
+	}, nil
+}
+
+func snapshotGeminiManagedHookAsset(
+	rootPath string,
+	asset adapter.FileMapping,
+) (geminiManagedHookSnapshot, error) {
+	target, err := cleanGeminiManagedHookTarget(asset.TargetPath)
+	if err != nil {
+		return geminiManagedHookSnapshot{}, err
+	}
+	snapshot := geminiManagedHookSnapshot{asset: asset}
+	root, err := os.OpenRoot(rootPath)
+	if err != nil {
+		return snapshot, fmt.Errorf("Gemini project root 열기 실패: %w", err)
+	}
+	defer root.Close()
+
+	if err := ensureGeminiHookDirectories(root, filepath.Dir(target), false); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return snapshot, nil
+		}
+		return snapshot, err
+	}
+	info, err := root.Lstat(target)
+	if errors.Is(err, os.ErrNotExist) {
+		return snapshot, nil
+	}
+	if err != nil {
+		return snapshot, fmt.Errorf("Gemini completion hook target 검사 실패: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return snapshot, fmt.Errorf("Gemini completion hook target must be a regular file: %s", target)
+	}
+	file, err := root.Open(target)
+	if err != nil {
+		return snapshot, fmt.Errorf("Gemini completion hook snapshot 열기 실패: %w", err)
+	}
+	content, readErr := io.ReadAll(file)
+	closeErr := file.Close()
+	if readErr != nil || closeErr != nil {
+		return snapshot, errors.Join(readErr, closeErr)
+	}
+	snapshot.exists = true
+	snapshot.content = content
+	snapshot.mode = info.Mode().Perm()
+	return snapshot, nil
+}
+
+func restoreGeminiManagedHookAssets(rootPath string, snapshots []geminiManagedHookSnapshot) error {
+	var restoreErr error
+	for index := len(snapshots) - 1; index >= 0; index-- {
+		snapshot := snapshots[index]
+		if snapshot.exists {
+			snapshot.asset.Content = snapshot.content
+			restoreErr = errors.Join(
+				restoreErr,
+				writeGeminiManagedHookAsset(rootPath, snapshot.asset, snapshot.mode),
+			)
+			continue
+		}
+		restoreErr = errors.Join(restoreErr, removeGeminiManagedHookAsset(rootPath, snapshot.asset))
+	}
+	return restoreErr
+}
+
+func removeGeminiManagedHookAsset(rootPath string, asset adapter.FileMapping) error {
+	target, err := cleanGeminiManagedHookTarget(asset.TargetPath)
+	if err != nil {
+		return err
+	}
+	root, err := os.OpenRoot(rootPath)
+	if err != nil {
+		return fmt.Errorf("Gemini project root 열기 실패: %w", err)
+	}
+	defer root.Close()
+	if err := ensureGeminiHookDirectories(root, filepath.Dir(target), false); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if err := root.Remove(target); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("Gemini completion hook rollback 제거 실패: %w", err)
+	}
+	// Remove only empty shells created by the managed writer. User-owned files
+	// keep their parent directories intact.
+	_ = root.Remove(geminiManagedHookDirectory)
+	_ = root.Remove(filepath.Dir(geminiManagedHookDirectory))
+	return nil
+}

--- a/pkg/adapter/gemini/gemini_completion_hook_test.go
+++ b/pkg/adapter/gemini/gemini_completion_hook_test.go
@@ -1,0 +1,252 @@
+package gemini
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/insajin/autopus-adk/pkg/adapter"
+	"github.com/insajin/autopus-adk/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testGeminiCompletionHookTarget  = ".gemini/hooks/autopus/hook-gemini-afteragent.sh"
+	testGeminiCompletionHookCommand = `"${GEMINI_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"/.gemini/hooks/autopus/hook-gemini-afteragent.sh`
+	testGeminiStopHookTarget        = ".gemini/hooks/autopus/hook-gemini-stop.sh"
+	testGeminiStopHookCommand       = `"$(cd .. && pwd)/.gemini/hooks/autopus/hook-gemini-stop.sh"`
+)
+
+func TestGenerate_InstallsGeminiOwnedCompletionHookContract(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	generated, err := NewWithRoot(root, WithoutPluginInstall()).Generate(
+		context.Background(), config.DefaultFullConfig("gemini-only"),
+	)
+	require.NoError(t, err)
+
+	assertGeminiCompletionHookContracts(t, root)
+	assertMappingContainsPath(t, generated.Files, testGeminiCompletionHookTarget)
+	assertMappingContainsPath(t, generated.Files, testGeminiStopHookTarget)
+	manifest, err := adapter.LoadManifest(root, adapterName)
+	require.NoError(t, err)
+	require.NotNil(t, manifest)
+	assert.Contains(t, manifest.Files, testGeminiCompletionHookTarget)
+	assert.Contains(t, manifest.Files, testGeminiStopHookTarget)
+	assert.NoDirExists(t, filepath.Join(root, ".claude"), "Gemini-only install must not depend on Claude assets")
+}
+
+func TestUpdate_RestoresCompletionHookAndPreservesUserConfig(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	a := NewWithRoot(root, WithoutPluginInstall())
+	cfg := config.DefaultFullConfig("gemini-only")
+	_, err := a.Generate(context.Background(), cfg)
+	require.NoError(t, err)
+
+	settingsPath := filepath.Join(root, ".gemini", "settings.json")
+	settings := readJSONDocument(t, settingsPath)
+	settings["userSetting"] = map[string]any{"preserve": true}
+	settingsHooks := requireJSONObject(t, settings["hooks"])
+	settingsHooks["UserEvent"] = []any{map[string]any{"command": "user-hook"}}
+	writeJSONDocument(t, settingsPath, settings)
+
+	agentsHooksPath := filepath.Join(root, ".agents", "hooks.json")
+	agentsHooks := readJSONDocument(t, agentsHooksPath)
+	agentsHooks["user"] = map[string]any{"enabled": true}
+	writeJSONDocument(t, agentsHooksPath, agentsHooks)
+
+	assetPath := filepath.Join(root, filepath.FromSlash(testGeminiCompletionHookTarget))
+	require.NoError(t, os.WriteFile(assetPath, []byte("stale\n"), 0o600))
+	require.NoError(t, os.Chmod(assetPath, 0o600))
+
+	updated, err := a.Update(context.Background(), cfg)
+	require.NoError(t, err)
+
+	assertGeminiCompletionHookContracts(t, root)
+	assertMappingContainsPath(t, updated.Files, testGeminiCompletionHookTarget)
+	assertMappingContainsPath(t, updated.Files, testGeminiStopHookTarget)
+	manifest, err := adapter.LoadManifest(root, adapterName)
+	require.NoError(t, err)
+	require.NotNil(t, manifest)
+	assert.Contains(t, manifest.Files, testGeminiCompletionHookTarget)
+	assert.Contains(t, manifest.Files, testGeminiStopHookTarget)
+	updatedSettings := readJSONDocument(t, settingsPath)
+	assert.Equal(t, map[string]any{"preserve": true}, updatedSettings["userSetting"])
+	assert.Contains(t, requireJSONObject(t, updatedSettings["hooks"]), "UserEvent")
+	assert.Contains(t, readJSONDocument(t, agentsHooksPath), "user")
+	assert.NoDirExists(t, filepath.Join(root, ".claude"), "Gemini-only update must not create Claude assets")
+}
+
+func TestGenerate_RejectsSymlinkedCompletionHookParent(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".gemini"), 0o755))
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, ".gemini", "hooks")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	_, err := NewWithRoot(root, WithoutPluginInstall()).Generate(
+		context.Background(), config.DefaultFullConfig("gemini-only"),
+	)
+	require.Error(t, err)
+	assert.NoFileExists(t, filepath.Join(outside, "autopus", "hook-gemini-afteragent.sh"))
+	assert.NoFileExists(t, filepath.Join(outside, "autopus", "hook-gemini-stop.sh"))
+}
+
+func TestClean_RemovesGeminiCompletionHookAsset(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	a := NewWithRoot(root, WithoutPluginInstall())
+	_, err := a.Generate(context.Background(), config.DefaultFullConfig("gemini-only"))
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(root, filepath.FromSlash(testGeminiCompletionHookTarget)))
+	assert.FileExists(t, filepath.Join(root, filepath.FromSlash(testGeminiStopHookTarget)))
+
+	require.NoError(t, a.Clean(context.Background()))
+	assert.NoFileExists(t, filepath.Join(root, filepath.FromSlash(testGeminiCompletionHookTarget)))
+	assert.NoFileExists(t, filepath.Join(root, filepath.FromSlash(testGeminiStopHookTarget)))
+}
+
+func TestGenerate_AntigravityStopCommandUsesConfigParentInsideOuterGit(t *testing.T) {
+	t.Parallel()
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git is required for the nested repository contract")
+	}
+	outer := t.TempDir()
+	require.NoError(t, exec.Command(gitPath, "init", "--quiet", outer).Run())
+	root := filepath.Join(outer, "nested-project")
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	_, err = NewWithRoot(root, WithoutPluginInstall()).Generate(
+		context.Background(), config.DefaultFullConfig("nested-project"),
+	)
+	require.NoError(t, err)
+
+	command := flatHookCommand(t, filepath.Join(root, ".agents", "hooks.json"), "autopus", "Stop")
+	cmd := exec.Command("sh", "-c", command)
+	cmd.Dir = filepath.Join(root, ".agents")
+	cmd.Env = append(os.Environ(), "AUTOPUS_SESSION_ID=")
+	stdout, err := cmd.Output()
+	require.NoError(t, err, "Stop command must resolve from the hooks.json directory")
+	assert.JSONEq(t, `{"decision":"stop"}`, string(stdout))
+}
+
+func assertGeminiCompletionHookContracts(t *testing.T, root string) {
+	t.Helper()
+	settingsCommand := groupedHookCommand(
+		t, filepath.Join(root, ".gemini", "settings.json"), "hooks", "AfterAgent",
+	)
+	agentsCommand := flatHookCommand(t, filepath.Join(root, ".agents", "hooks.json"), "autopus", "Stop")
+	assert.Equal(t, testGeminiCompletionHookCommand, settingsCommand)
+	assert.Equal(t, testGeminiStopHookCommand, agentsCommand)
+	assertGeminiManagedHookExecutable(t, root, testGeminiCompletionHookTarget)
+	assertGeminiManagedHookExecutable(t, root, testGeminiStopHookTarget)
+	assertLegacyGeminiHookRunsFromNestedDirectory(t, root, settingsCommand)
+	assertAntigravityHookRunsFromAgentsDirectory(t, root, agentsCommand)
+}
+
+func assertGeminiManagedHookExecutable(t *testing.T, root, target string) {
+	t.Helper()
+	assetPath := filepath.Join(root, filepath.FromSlash(target))
+	info, err := os.Stat(assetPath)
+	require.NoError(t, err, "managed completion command target must exist")
+	assert.True(t, info.Mode().IsRegular())
+	assert.NotZero(t, info.Mode().Perm()&0o111, "managed completion command target must be executable")
+}
+
+func assertLegacyGeminiHookRunsFromNestedDirectory(t *testing.T, root, command string) {
+	t.Helper()
+	nested := filepath.Join(root, "nested", "work")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+	binDir := t.TempDir()
+	fakeGit := filepath.Join(binDir, "git")
+	require.NoError(t, os.WriteFile(fakeGit, []byte("#!/bin/sh\nprintf '%s\\n' \"$GEMINI_TEST_PROJECT_ROOT\"\n"), 0o755))
+
+	cmd := exec.Command("sh", "-c", command)
+	cmd.Dir = nested
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"GEMINI_TEST_PROJECT_ROOT="+root,
+		"AUTOPUS_SESSION_ID=",
+	)
+	require.NoError(t, cmd.Run(), "project-root command must execute from a nested working directory")
+}
+
+func assertAntigravityHookRunsFromAgentsDirectory(t *testing.T, root, command string) {
+	t.Helper()
+	cmd := exec.Command("sh", "-c", command)
+	cmd.Dir = filepath.Join(root, ".agents")
+	cmd.Env = append(os.Environ(), "AUTOPUS_SESSION_ID=")
+	stdout, err := cmd.Output()
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"decision":"stop"}`, string(stdout))
+}
+
+func groupedHookCommand(t *testing.T, path, container, event string) string {
+	t.Helper()
+	document := readJSONDocument(t, path)
+	events := requireJSONObject(t, document[container])
+	entries, ok := events[event].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, entries)
+	entry := requireJSONObject(t, entries[0])
+	handlers, ok := entry["hooks"].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, handlers)
+	handler := requireJSONObject(t, handlers[0])
+	command, ok := handler["command"].(string)
+	require.True(t, ok)
+	return command
+}
+
+func flatHookCommand(t *testing.T, path, container, event string) string {
+	t.Helper()
+	document := readJSONDocument(t, path)
+	events := requireJSONObject(t, document[container])
+	entries, ok := events[event].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, entries)
+	handler := requireJSONObject(t, entries[0])
+	command, ok := handler["command"].(string)
+	require.True(t, ok)
+	return command
+}
+
+func readJSONDocument(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var document map[string]any
+	require.NoError(t, json.Unmarshal(data, &document))
+	return document
+}
+
+func writeJSONDocument(t *testing.T, path string, document map[string]any) {
+	t.Helper()
+	data, err := json.MarshalIndent(document, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, append(data, '\n'), 0o644))
+}
+
+func requireJSONObject(t *testing.T, value any) map[string]any {
+	t.Helper()
+	object, ok := value.(map[string]any)
+	require.True(t, ok)
+	return object
+}
+
+func assertMappingContainsPath(t *testing.T, mappings []adapter.FileMapping, path string) {
+	t.Helper()
+	for _, mapping := range mappings {
+		if filepath.ToSlash(mapping.TargetPath) == path {
+			return
+		}
+	}
+	t.Errorf("mapping does not contain %s", path)
+}

--- a/pkg/adapter/gemini/gemini_generate_atomicity_test.go
+++ b/pkg/adapter/gemini/gemini_generate_atomicity_test.go
@@ -1,0 +1,139 @@
+package gemini
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/insajin/autopus-adk/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerate_SecondManagedHookFailureRestoresFirstAndManifest(t *testing.T) {
+	t.Parallel()
+	for _, setup := range []struct {
+		name   string
+		second func(t *testing.T, target, outside string)
+	}{
+		{
+			name: "directory",
+			second: func(t *testing.T, target, _ string) {
+				require.NoError(t, os.Mkdir(target, 0o755))
+			},
+		},
+		{
+			name: "symlink",
+			second: func(t *testing.T, target, outside string) {
+				if err := os.Symlink(outside, target); err != nil {
+					t.Skipf("symlink unavailable: %v", err)
+				}
+			},
+		},
+	} {
+		setup := setup
+		t.Run(setup.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			geminiAdapter := NewWithRoot(root, WithoutPluginInstall())
+			cfg := config.DefaultFullConfig("gemini-only")
+			_, err := geminiAdapter.Generate(context.Background(), cfg)
+			require.NoError(t, err)
+
+			firstPath := filepath.Join(root, filepath.FromSlash(testGeminiCompletionHookTarget))
+			firstBefore := []byte("user-owned-after-agent\n")
+			require.NoError(t, os.WriteFile(firstPath, firstBefore, 0o600))
+			require.NoError(t, os.Chmod(firstPath, 0o600))
+			manifestPath := filepath.Join(root, ".autopus", adapterName+"-manifest.json")
+			manifestBefore, err := os.ReadFile(manifestPath)
+			require.NoError(t, err)
+
+			secondPath := filepath.Join(root, filepath.FromSlash(testGeminiStopHookTarget))
+			require.NoError(t, os.Remove(secondPath))
+			outside := filepath.Join(t.TempDir(), "outside-hook.sh")
+			outsideBefore := []byte("outside-owned\n")
+			require.NoError(t, os.WriteFile(outside, outsideBefore, 0o600))
+			setup.second(t, secondPath, outside)
+
+			_, err = geminiAdapter.Generate(context.Background(), cfg)
+			require.Error(t, err)
+
+			firstAfter, readErr := os.ReadFile(firstPath)
+			require.NoError(t, readErr)
+			assert.True(t, bytes.Equal(firstBefore, firstAfter), "first managed hook bytes changed")
+			firstInfo, statErr := os.Stat(firstPath)
+			require.NoError(t, statErr)
+			assert.Equal(t, os.FileMode(0o600), firstInfo.Mode().Perm())
+			manifestAfter, readErr := os.ReadFile(manifestPath)
+			require.NoError(t, readErr)
+			assert.True(t, bytes.Equal(manifestBefore, manifestAfter), "manifest changed")
+			outsideAfter, readErr := os.ReadFile(outside)
+			require.NoError(t, readErr)
+			assert.Equal(t, outsideBefore, outsideAfter)
+			if setup.name == "directory" {
+				assert.DirExists(t, secondPath)
+			} else {
+				linkTarget, linkErr := os.Readlink(secondPath)
+				require.NoError(t, linkErr)
+				assert.Equal(t, outside, linkTarget)
+			}
+		})
+	}
+}
+
+func TestGenerate_ManifestSaveFailureRestoresManagedHooks(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	geminiAdapter := NewWithRoot(root, WithoutPluginInstall())
+	cfg := config.DefaultFullConfig("gemini-only")
+	_, err := geminiAdapter.Generate(context.Background(), cfg)
+	require.NoError(t, err)
+
+	staleHooks := map[string]struct {
+		content []byte
+		mode    os.FileMode
+	}{
+		testGeminiCompletionHookTarget: {[]byte("stale-after-agent\n"), 0o600},
+		testGeminiStopHookTarget:       {[]byte("stale-stop\n"), 0o640},
+	}
+	for target, state := range staleHooks {
+		path := filepath.Join(root, filepath.FromSlash(target))
+		require.NoError(t, os.WriteFile(path, state.content, state.mode))
+		require.NoError(t, os.Chmod(path, state.mode))
+	}
+
+	manifestPath := filepath.Join(root, ".autopus", adapterName+"-manifest.json")
+	require.NoError(t, os.Remove(manifestPath))
+	require.NoError(t, os.Mkdir(manifestPath, 0o755))
+
+	_, err = geminiAdapter.Generate(context.Background(), cfg)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "매니페스트 저장 실패")
+	for target, expected := range staleHooks {
+		path := filepath.Join(root, filepath.FromSlash(target))
+		actual, readErr := os.ReadFile(path)
+		require.NoError(t, readErr)
+		assert.True(t, bytes.Equal(expected.content, actual), "%s bytes changed", target)
+		info, statErr := os.Stat(path)
+		require.NoError(t, statErr)
+		assert.Equal(t, expected.mode, info.Mode().Perm())
+	}
+	assert.DirExists(t, manifestPath)
+}
+
+func TestGenerate_ManifestSaveFailureRemovesNewManagedHookDirectories(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	manifestPath := filepath.Join(root, ".autopus", adapterName+"-manifest.json")
+	require.NoError(t, os.MkdirAll(manifestPath, 0o755))
+
+	_, err := NewWithRoot(root, WithoutPluginInstall()).Generate(
+		context.Background(), config.DefaultFullConfig("gemini-only"),
+	)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "매니페스트 저장 실패")
+	assert.NoDirExists(t, filepath.Join(root, ".gemini", "hooks"))
+	assert.DirExists(t, manifestPath)
+}

--- a/pkg/adapter/gemini/gemini_hooks.go
+++ b/pkg/adapter/gemini/gemini_hooks.go
@@ -14,8 +14,13 @@ import (
 
 const antigravityHooksTarget = ".agents/hooks.json"
 
-func (a *Adapter) configuredHooks(cfg *config.HarnessConfig) []adapter.HookConfig {
-	hooks, _, _ := pkgcontent.GenerateProjectHookConfigs(cfg, adapterName, a.SupportsHooks())
+func (a *Adapter) configuredAntigravityHooks(cfg *config.HarnessConfig) []adapter.HookConfig {
+	hooks, _, _ := pkgcontent.GenerateProjectHookConfigs(cfg, "antigravity-cli", a.SupportsHooks())
+	return hooks
+}
+
+func (a *Adapter) configuredLegacyGeminiHooks(cfg *config.HarnessConfig) []adapter.HookConfig {
+	hooks, _, _ := pkgcontent.GenerateProjectHookConfigs(cfg, "gemini", a.SupportsHooks())
 	return hooks
 }
 
@@ -58,12 +63,17 @@ func buildAntigravityHookSpec(hooks []adapter.HookConfig) map[string]any {
 			handler["timeout"] = h.Timeout
 		}
 
-		entry := map[string]any{
-			"matcher": h.Matcher,
-			"hooks":   []map[string]any{handler},
-		}
 		entries, _ := spec[h.Event].([]any)
-		spec[h.Event] = append(entries, entry)
+		switch h.Event {
+		case "PreToolUse", "PostToolUse":
+			entry := map[string]any{
+				"matcher": h.Matcher,
+				"hooks":   []map[string]any{handler},
+			}
+			spec[h.Event] = append(entries, entry)
+		default:
+			spec[h.Event] = append(entries, handler)
+		}
 	}
 	return spec
 }

--- a/pkg/adapter/gemini/gemini_lifecycle.go
+++ b/pkg/adapter/gemini/gemini_lifecycle.go
@@ -87,6 +87,7 @@ func (a *Adapter) Clean(_ context.Context) error {
 		filepath.Join(a.root, ".gemini", "commands"),
 		filepath.Join(a.root, ".gemini", "rules"),
 		filepath.Join(a.root, ".gemini", "agents"),
+		filepath.Join(a.root, ".gemini", "hooks", "autopus"),
 		filepath.Join(a.root, ".agents", "skills"),
 		filepath.Join(a.root, antigravityPluginDir),
 	}

--- a/pkg/adapter/gemini/gemini_settings.go
+++ b/pkg/adapter/gemini/gemini_settings.go
@@ -65,7 +65,7 @@ func (a *Adapter) generateSettingsWithHooks(cfg *config.HarnessConfig) ([]adapte
 	if err := json.Unmarshal(files[0].Content, &settings); err != nil {
 		return nil, fmt.Errorf("gemini settings JSON 파싱 실패: %w", err)
 	}
-	applyGeminiHooksAndPermissions(settings, a.configuredHooks(cfg), content.DetectPermissions(a.root, cfg.Hooks.Permissions))
+	applyGeminiHooksAndPermissions(settings, a.configuredLegacyGeminiHooks(cfg), content.DetectPermissions(a.root, cfg.Hooks.Permissions))
 	return buildGeminiSettingsMapping(settings)
 }
 
@@ -111,6 +111,8 @@ func applyGeminiHooksAndPermissions(settings map[string]any, hooks []adapter.Hoo
 			"PostToolUse": true,
 			"BeforeTool":  true,
 			"AfterTool":   true,
+			"AfterAgent":  true,
+			"Stop":        true,
 		}
 		for _, h := range hooks {
 			managedEvents[h.Event] = true

--- a/pkg/adapter/gemini/gemini_update.go
+++ b/pkg/adapter/gemini/gemini_update.go
@@ -3,6 +3,7 @@ package gemini
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -31,8 +32,12 @@ func (a *Adapter) Update(ctx context.Context, cfg *config.HarnessConfig) (*adapt
 	}
 
 	plan, pf := a.buildUpdateTransactionPlan(oldManifest, newFiles)
-	if _, err := adapter.ApplyTransaction(a.root, adapterName, plan); err != nil {
+	rollbackHooks, err := applyGeminiManagedHookAssets(a.root, geminiManagedHookAssets(pf.Files))
+	if err != nil {
 		return nil, err
+	}
+	if _, err := adapter.ApplyTransaction(a.root, adapterName, plan); err != nil {
+		return nil, errors.Join(err, rollbackHooks())
 	}
 	a.installAntigravityPluginIfAvailable(ctx)
 
@@ -93,6 +98,12 @@ func (a *Adapter) prepareFiles(cfg *config.HarnessConfig) ([]adapter.FileMapping
 		files = append(files, agentMappings...)
 	}
 
+	completionHookAssets, err := prepareGeminiCompletionHookAssets()
+	if err != nil {
+		return nil, err
+	}
+	files = append(files, completionHookAssets...)
+
 	settingsMappings, err := a.generateSettingsWithHooks(cfg)
 	if err != nil {
 		return nil, err
@@ -111,7 +122,7 @@ func (a *Adapter) prepareFiles(cfg *config.HarnessConfig) ([]adapter.FileMapping
 	}
 	files = append(files, statusFiles...)
 
-	hookMappings, err := a.prepareAntigravityHooksJSON(a.configuredHooks(cfg))
+	hookMappings, err := a.prepareAntigravityHooksJSON(a.configuredAntigravityHooks(cfg))
 	if err != nil {
 		return nil, err
 	}
@@ -125,10 +136,18 @@ func (a *Adapter) buildUpdateTransactionPlan(
 	newFiles []adapter.FileMapping,
 ) (adapter.TransactionPlan, *adapter.PlatformFiles) {
 	finalFiles := make([]adapter.FileMapping, 0, len(newFiles))
+	writes := make([]adapter.TransactionWrite, 0, len(newFiles))
 	for _, file := range newFiles {
-		action := adapter.ResolveAction(a.root, file.TargetPath, file.OverwritePolicy, oldManifest)
-		if action == adapter.ActionSkip {
-			continue
+		if !isGeminiManagedHookAsset(file) {
+			action := adapter.ResolveAction(a.root, file.TargetPath, file.OverwritePolicy, oldManifest)
+			if action == adapter.ActionSkip {
+				continue
+			}
+			writes = append(writes, adapter.TransactionWrite{
+				Path:    file.TargetPath,
+				Content: file.Content,
+				Perm:    geminiFileMode(file.TargetPath),
+			})
 		}
 		finalFiles = append(finalFiles, file)
 	}
@@ -140,9 +159,19 @@ func (a *Adapter) buildUpdateTransactionPlan(
 	}
 
 	return adapter.TransactionPlan{
-		Writes:   adapter.TransactionWritesFromFiles(finalFiles, geminiFileMode),
+		Writes:   writes,
 		Manifest: adapter.ManifestFromFiles(adapterName, pf),
 	}, pf
+}
+
+func geminiManagedHookAssets(files []adapter.FileMapping) []adapter.FileMapping {
+	assets := make([]adapter.FileMapping, 0, len(files))
+	for _, file := range files {
+		if isGeminiManagedHookAsset(file) {
+			assets = append(assets, file)
+		}
+	}
+	return assets
 }
 
 func geminiFileMode(path string) os.FileMode {

--- a/pkg/adapter/gemini/gemini_update_symlink_test.go
+++ b/pkg/adapter/gemini/gemini_update_symlink_test.go
@@ -1,0 +1,88 @@
+package gemini
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/insajin/autopus-adk/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdate_RejectsSymlinkedCompletionHookParentWithoutExternalMutation(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	adapter := NewWithRoot(root, WithoutPluginInstall())
+	cfg := config.DefaultFullConfig("gemini-only")
+	_, err := adapter.Generate(context.Background(), cfg)
+	require.NoError(t, err)
+
+	manifestPath := filepath.Join(root, ".autopus", adapterName+"-manifest.json")
+	manifestBefore, err := os.ReadFile(manifestPath)
+	require.NoError(t, err)
+
+	hooksPath := filepath.Join(root, ".gemini", "hooks")
+	require.NoError(t, os.RemoveAll(hooksPath))
+	outside := t.TempDir()
+	outsideHook := filepath.Join(outside, "autopus", geminiCompletionHookAssetName)
+	require.NoError(t, os.MkdirAll(filepath.Dir(outsideHook), 0o755))
+	externalBefore := []byte("outside-owned\n")
+	require.NoError(t, os.WriteFile(outsideHook, externalBefore, 0o600))
+	if err := os.Symlink(outside, hooksPath); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	_, err = adapter.Update(context.Background(), cfg)
+	require.Error(t, err)
+
+	externalAfter, readErr := os.ReadFile(outsideHook)
+	require.NoError(t, readErr)
+	assert.Equal(t, externalBefore, externalAfter)
+	assert.NoFileExists(t, filepath.Join(outside, "autopus", "hook-gemini-stop.sh"))
+	manifestAfter, readErr := os.ReadFile(manifestPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, manifestBefore, manifestAfter)
+}
+
+func TestUpdate_RestoresManagedHooksWhenTransactionFails(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	geminiAdapter := NewWithRoot(root, WithoutPluginInstall())
+	cfg := config.DefaultFullConfig("gemini-only")
+	_, err := geminiAdapter.Generate(context.Background(), cfg)
+	require.NoError(t, err)
+
+	manifestPath := filepath.Join(root, ".autopus", adapterName+"-manifest.json")
+	manifestBefore, err := os.ReadFile(manifestPath)
+	require.NoError(t, err)
+	staleHooks := map[string][]byte{
+		testGeminiCompletionHookTarget: []byte("stale-after-agent\n"),
+		testGeminiStopHookTarget:       []byte("stale-stop\n"),
+	}
+	for target, content := range staleHooks {
+		path := filepath.Join(root, filepath.FromSlash(target))
+		require.NoError(t, os.WriteFile(path, content, 0o600))
+		require.NoError(t, os.Chmod(path, 0o600))
+	}
+
+	statuslinePath := filepath.Join(root, ".gemini", "statusline.sh")
+	require.NoError(t, os.Remove(statuslinePath))
+	require.NoError(t, os.Mkdir(statuslinePath, 0o755))
+
+	_, err = geminiAdapter.Update(context.Background(), cfg)
+	require.Error(t, err)
+	for target, expected := range staleHooks {
+		path := filepath.Join(root, filepath.FromSlash(target))
+		actual, readErr := os.ReadFile(path)
+		require.NoError(t, readErr)
+		assert.Equal(t, expected, actual)
+		info, statErr := os.Stat(path)
+		require.NoError(t, statErr)
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	}
+	manifestAfter, readErr := os.ReadFile(manifestPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, manifestBefore, manifestAfter)
+}

--- a/pkg/content/claude_hook_contract_test.go
+++ b/pkg/content/claude_hook_contract_test.go
@@ -1,0 +1,162 @@
+package content_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stopHookRun struct {
+	provider   string
+	sessionDir string
+	stdout     string
+}
+
+func TestClaudeStopHook_NextRoundInputUsesBlockJSON(t *testing.T) {
+	assertStopHookNextRoundContract(t, "claude", "hook-claude-stop.sh")
+}
+
+func TestClaudeStopHook_NonBlockingPathsEmitNoOutput(t *testing.T) {
+	assertStopHookNonBlockingContract(t, "claude", "hook-claude-stop.sh")
+}
+
+func assertStopHookNextRoundContract(t *testing.T, provider, scriptName string) {
+	t.Helper()
+	for _, tt := range []struct {
+		name   string
+		prompt string
+	}{
+		{name: "plain prompt", prompt: "Continue with round two."},
+		{
+			name:   "quotes newlines and control characters",
+			prompt: "quote: \"double\" and slash: \\\nline two\tcarriage\rcontrol:\x01 nul:\x00\n끝 🐙\n",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			run := runRoundStopHook(t, provider, scriptName, tt.prompt, false)
+			var decision struct {
+				Decision string `json:"decision"`
+				Reason   string `json:"reason"`
+			}
+			require.NoError(t, json.Unmarshal([]byte(run.stdout), &decision),
+				"stdout must contain one valid Stop JSON object only: %q", run.stdout)
+			assert.Equal(t, "block", decision.Decision)
+			assert.Equal(t, tt.prompt, decision.Reason)
+			assertRoundArtifacts(t, run)
+		})
+	}
+}
+
+func assertStopHookNonBlockingContract(t *testing.T, provider, scriptName string) {
+	t.Helper()
+	t.Run("abort", func(t *testing.T) {
+		run := runRoundStopHook(t, provider, scriptName, "must not be emitted", true)
+		assert.Empty(t, strings.TrimSpace(run.stdout), "abort must remain non-blocking")
+		assertRoundArtifacts(t, run)
+		assert.NoFileExists(t, filepath.Join(run.sessionDir, provider+"-round2-abort"))
+	})
+	t.Run("no next round", func(t *testing.T) {
+		run := runUnscopedStopHook(t, provider, scriptName)
+		assert.Empty(t, strings.TrimSpace(run.stdout), "an unscoped completion must not block Stop")
+		assert.FileExists(t, filepath.Join(run.sessionDir, provider+"-result.json"))
+		assert.FileExists(t, filepath.Join(run.sessionDir, provider+"-done"))
+	})
+}
+
+func runRoundStopHook(t *testing.T, provider, scriptName, prompt string, abort bool) stopHookRun {
+	t.Helper()
+	sessionDir := t.TempDir()
+	nextName := provider + "-round2-input.json"
+	if abort {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(sessionDir, provider+"-round2-abort"), nil, 0o600,
+		))
+	} else {
+		input, err := json.Marshal(map[string]any{
+			"provider": provider,
+			"round":    2,
+			"prompt":   prompt,
+		})
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(sessionDir, nextName), input, 0o600))
+	}
+
+	run := executeStopHook(t, provider, scriptName, sessionDir, "1")
+	assert.NoFileExists(t, filepath.Join(sessionDir, nextName))
+	assert.NoFileExists(t, filepath.Join(sessionDir, provider+"-round2-ready"))
+	return run
+}
+
+func runUnscopedStopHook(t *testing.T, provider, scriptName string) stopHookRun {
+	t.Helper()
+	return executeStopHook(t, provider, scriptName, t.TempDir(), "")
+}
+
+func executeStopHook(t *testing.T, provider, scriptName, sessionDir, round string) stopHookRun {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX hook contract")
+	}
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	script := filepath.Clean(filepath.Join(
+		filepath.Dir(thisFile), "..", "..", "content", "hooks", scriptName,
+	))
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command("sh", script)
+	cmd.Stdin = strings.NewReader(`{"last_assistant_message":"round one output"}`)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.Env = stopHookEnvironment(t, sessionDir, round)
+	require.NoError(t, cmd.Run(), "stderr: %s", stderr.String())
+	return stopHookRun{provider: provider, sessionDir: sessionDir, stdout: stdout.String()}
+}
+
+func stopHookEnvironment(t *testing.T, sessionDir, round string) []string {
+	t.Helper()
+	binDir := t.TempDir()
+	for _, name := range []string{"python3", "chmod", "rm"} {
+		path, err := exec.LookPath(name)
+		require.NoError(t, err)
+		require.NoError(t, os.Symlink(path, filepath.Join(binDir, name)))
+	}
+	env := make([]string, 0, len(os.Environ())+4)
+	for _, entry := range os.Environ() {
+		key := strings.SplitN(entry, "=", 2)[0]
+		switch key {
+		case "PATH", "AUTOPUS_SESSION_ID", "AUTOPUS_SESSION_DIR", "AUTOPUS_ROUND":
+			continue
+		}
+		env = append(env, entry)
+	}
+	return append(env,
+		"PATH="+binDir,
+		"AUTOPUS_SESSION_ID=stop-hook-contract",
+		"AUTOPUS_SESSION_DIR="+sessionDir,
+		"AUTOPUS_ROUND="+round,
+	)
+}
+
+func assertRoundArtifacts(t *testing.T, run stopHookRun) {
+	t.Helper()
+	resultData, err := os.ReadFile(filepath.Join(
+		run.sessionDir, run.provider+"-round1-result.json",
+	))
+	require.NoError(t, err)
+	var result struct {
+		Output   string `json:"output"`
+		ExitCode int    `json:"exit_code"`
+	}
+	require.NoError(t, json.Unmarshal(resultData, &result))
+	assert.Equal(t, "round one output", result.Output)
+	assert.Zero(t, result.ExitCode)
+	assert.FileExists(t, filepath.Join(run.sessionDir, run.provider+"-round1-done"))
+}

--- a/pkg/content/codex_hook_contract_test.go
+++ b/pkg/content/codex_hook_contract_test.go
@@ -230,3 +230,11 @@ func TestCodexStopHook_DoesNotFollowTranscriptSymlink(t *testing.T) {
 	assert.Empty(t, result.Output)
 	assert.FileExists(t, filepath.Join(sessionDir, "codex-done"))
 }
+
+func TestCodexStopHook_NextRoundInputUsesBlockJSON(t *testing.T) {
+	assertStopHookNextRoundContract(t, "codex", "hook-codex-stop.sh")
+}
+
+func TestCodexStopHook_NonBlockingPathsEmitNoOutput(t *testing.T) {
+	assertStopHookNonBlockingContract(t, "codex", "hook-codex-stop.sh")
+}

--- a/pkg/content/codex_hook_session_directory_test.go
+++ b/pkg/content/codex_hook_session_directory_test.go
@@ -1,0 +1,84 @@
+package content_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCodexHooks_RejectRelativeSessionDirectory(t *testing.T) {
+	for _, tc := range codexSessionDirectoryCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			relativeDir := "relative-session"
+			require.NoError(t, os.Mkdir(filepath.Join(root, relativeDir), 0o700))
+
+			result := runCodexSessionDirectoryHook(t, tc, root, "codex-relative", relativeDir)
+
+			assert.Empty(t, result.stdout)
+			assert.Empty(t, result.stderr)
+			assert.Empty(t, requireReadDir(t, filepath.Join(root, relativeDir)))
+		})
+	}
+}
+
+func TestCodexHooks_LegacyAbsoluteSessionFallback(t *testing.T) {
+	require.NoError(t, os.MkdirAll("/tmp/autopus", 0o700))
+	for _, tc := range codexSessionDirectoryCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			dir, err := os.MkdirTemp("/tmp/autopus", "codex-legacy-")
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+			result := runCodexSessionDirectoryHook(t, tc, "", filepath.Base(dir), "")
+
+			assert.Empty(t, result.stdout)
+			assert.Empty(t, result.stderr)
+			for _, artifact := range tc.artifacts {
+				assertRegularMode(t, filepath.Join(dir, artifact), 0o600)
+			}
+		})
+	}
+}
+
+type codexSessionDirectoryCase struct {
+	name      string
+	script    string
+	round     string
+	payload   string
+	artifacts []string
+}
+
+func codexSessionDirectoryCases() []codexSessionDirectoryCase {
+	return []codexSessionDirectoryCase{
+		{
+			name: "stop", script: "hook-codex-stop.sh", payload: `{"last_assistant_message":"legacy"}`,
+			artifacts: []string{"codex-result.json", "codex-done"},
+		},
+		{
+			name: "sessionstart", script: "hook-codex-sessionstart.sh", round: "0",
+			artifacts: []string{"codex-round0-ready"},
+		},
+	}
+}
+
+func runCodexSessionDirectoryHook(
+	t *testing.T,
+	tc codexSessionDirectoryCase,
+	workDir, sessionID, sessionDir string,
+) hookProcessResult {
+	t.Helper()
+	cmd := exec.Command("sh", hookContractScript(t, tc.script))
+	cmd.Dir = workDir
+	cmd.Stdin = bytes.NewBufferString(tc.payload)
+	cmd.Env = confinementHookEnvironment(sessionID, sessionDir, tc.round)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	require.NoError(t, cmd.Run(), "stderr: %s", stderr.String())
+	return hookProcessResult{stdout: stdout.String(), stderr: stderr.String()}
+}

--- a/pkg/content/gemini_stop_hook_contract_test.go
+++ b/pkg/content/gemini_stop_hook_contract_test.go
@@ -1,0 +1,104 @@
+package content_test
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAntigravityStopHook_NextRoundInputUsesContinueJSON(t *testing.T) {
+	run := runRoundStopHook(t, "gemini", "hook-gemini-stop.sh", "Continue in Antigravity.", false)
+	var decision struct {
+		Decision string `json:"decision"`
+		Reason   string `json:"reason"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(run.stdout), &decision))
+	assert.Equal(t, "continue", decision.Decision)
+	assert.Equal(t, "Continue in Antigravity.", decision.Reason)
+	assertRoundArtifacts(t, run)
+}
+
+func TestAntigravityStopHook_NonContinuingPathsEmitStopJSON(t *testing.T) {
+	t.Run("abort", func(t *testing.T) {
+		run := runRoundStopHook(t, "gemini", "hook-gemini-stop.sh", "ignored", true)
+		assertAntigravityStopDecision(t, run.stdout)
+		assertRoundArtifacts(t, run)
+	})
+	t.Run("unscoped completion", func(t *testing.T) {
+		run := runUnscopedStopHook(t, "gemini", "hook-gemini-stop.sh")
+		assertAntigravityStopDecision(t, run.stdout)
+	})
+	t.Run("unmanaged session", func(t *testing.T) {
+		cmd := exec.Command("sh", hookContractScript(t, "hook-gemini-stop.sh"))
+		cmd.Stdin = strings.NewReader(`{"last_assistant_message":"ignored"}`)
+		cmd.Env = append(os.Environ(), "AUTOPUS_SESSION_ID=", "AUTOPUS_SESSION_DIR=")
+		stdout, err := cmd.Output()
+		require.NoError(t, err)
+		assertAntigravityStopDecision(t, string(stdout))
+	})
+}
+
+func TestAntigravityStopHook_MalformedInputStillEmitsStopJSON(t *testing.T) {
+	sessionDir := t.TempDir()
+	cmd := exec.Command("sh", hookContractScript(t, "hook-gemini-stop.sh"))
+	cmd.Stdin = strings.NewReader(`{`)
+	cmd.Env = append(os.Environ(),
+		"AUTOPUS_SESSION_ID=malformed",
+		"AUTOPUS_SESSION_DIR="+sessionDir,
+		"AUTOPUS_ROUND=",
+	)
+	stdout, err := cmd.Output()
+	require.NoError(t, err)
+	assertAntigravityStopDecision(t, string(stdout))
+	assert.FileExists(t, filepath.Join(sessionDir, "gemini-result.json"))
+	assert.FileExists(t, filepath.Join(sessionDir, "gemini-done"))
+}
+
+func TestAntigravityStopHook_CollectsActualCamelCaseTranscriptPayload(t *testing.T) {
+	sessionDir := t.TempDir()
+	transcript := filepath.Join(t.TempDir(), "transcript.jsonl")
+	lines := strings.Join([]string{
+		`{"source":"MODEL","type":"VIEW_FILE","content":"tool output"}`,
+		`{"source":"MODEL","type":"PLANNER_RESPONSE","content":"final answer"}`,
+	}, "\n") + "\n"
+	require.NoError(t, os.WriteFile(transcript, []byte(lines), 0o600))
+	payload, err := json.Marshal(map[string]any{
+		"conversationId": "conversation",
+		"transcriptPath": transcript,
+		"fullyIdle":      true,
+	})
+	require.NoError(t, err)
+
+	cmd := exec.Command("sh", hookContractScript(t, "hook-gemini-stop.sh"))
+	cmd.Stdin = strings.NewReader(string(payload))
+	cmd.Env = stopHookEnvironment(t, sessionDir, "")
+	stdout, err := cmd.Output()
+	require.NoError(t, err)
+	assertAntigravityStopDecision(t, string(stdout))
+	result := requireReadFile(t, filepath.Join(sessionDir, "gemini-result.json"))
+	var completion struct {
+		Output string `json:"output"`
+	}
+	require.NoError(t, json.Unmarshal(result, &completion))
+	assert.Equal(t, "final answer", completion.Output)
+}
+
+func assertAntigravityStopDecision(t *testing.T, stdout string) {
+	t.Helper()
+	assert.Equal(t, `{"decision":"stop"}`, strings.TrimSpace(stdout))
+}
+
+func assertNoContinuation(t *testing.T, hook cursorHookCase, stdout string) {
+	t.Helper()
+	if hook.decision == "continue" {
+		assertAntigravityStopDecision(t, stdout)
+		return
+	}
+	assert.Empty(t, stdout)
+}

--- a/pkg/content/hook_confinement_contract_test.go
+++ b/pkg/content/hook_confinement_contract_test.go
@@ -1,0 +1,193 @@
+package content_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const hookInputLimit = 1024 * 1024
+
+func TestCompletionHooks_ArtifactSymlinksDoNotEscapeSession(t *testing.T) {
+	for _, hook := range confinementHookCases() {
+		t.Run(hook.provider, func(t *testing.T) {
+			session := newCursorHookSession(t, hook)
+			writeRoundInput(t, session.dir, hook.provider, 2, "confined continuation")
+			victimDir := t.TempDir()
+			names := []string{
+				hook.provider + "-round1-result.json",
+				hook.provider + "-round1-done",
+				hook.provider + "-round2-ready",
+				hook.provider + "-round-cursor",
+			}
+			victims := make(map[string]string, len(names))
+			for _, name := range names {
+				victim := filepath.Join(victimDir, name)
+				require.NoError(t, os.WriteFile(victim, []byte("preserve-"+name), 0o600))
+				require.NoError(t, os.Symlink(victim, filepath.Join(session.dir, name)))
+				victims[name] = victim
+			}
+
+			result := runConfinementHook(t, hook, session.id, session.dir, "1", "round one", "")
+
+			assertContinuation(t, hook, result.stdout, "confined continuation")
+			assert.Empty(t, result.stderr)
+			for name, victim := range victims {
+				assert.Equal(t, "preserve-"+name, string(requireReadFile(t, victim)))
+			}
+			assertRegularMode(t, filepath.Join(session.dir, names[0]), 0o600)
+			assertRegularMode(t, filepath.Join(session.dir, names[1]), 0o600)
+			assertRegularMode(t, filepath.Join(session.dir, names[3]), 0o600)
+			assert.NoFileExists(t, filepath.Join(session.dir, names[2]))
+		})
+	}
+}
+
+func TestCompletionHooks_InputSymlinkFailsClosed(t *testing.T) {
+	for _, hook := range confinementHookCases() {
+		t.Run(hook.provider, func(t *testing.T) {
+			session := newCursorHookSession(t, hook)
+			target := filepath.Join(t.TempDir(), "outside-input.json")
+			body := hookInputJSON(t, hook.provider, 2, "must not continue")
+			require.NoError(t, os.WriteFile(target, body, 0o600))
+			input := filepath.Join(session.dir, hook.provider+"-round2-input.json")
+			require.NoError(t, os.Symlink(target, input))
+
+			result := runConfinementHook(t, hook, session.id, session.dir, "1", "round one", "")
+
+			assertNoContinuation(t, hook, result.stdout)
+			assert.Empty(t, result.stderr)
+			assert.Equal(t, body, requireReadFile(t, target))
+			assert.NoFileExists(t, filepath.Join(session.dir, hook.provider+"-round-cursor"))
+		})
+	}
+}
+
+func TestCompletionHooks_OversizedInputFailsClosed(t *testing.T) {
+	for _, hook := range confinementHookCases() {
+		t.Run(hook.provider, func(t *testing.T) {
+			session := newCursorHookSession(t, hook)
+			input := filepath.Join(session.dir, hook.provider+"-round2-input.json")
+			body := hookInputJSON(t, hook.provider, 2, strings.Repeat("x", hookInputLimit+1))
+			require.NoError(t, os.WriteFile(input, body, 0o600))
+
+			result := runConfinementHook(t, hook, session.id, session.dir, "1", "round one", "")
+
+			assertNoContinuation(t, hook, result.stdout)
+			assert.Empty(t, result.stderr)
+			assert.NoFileExists(t, filepath.Join(session.dir, hook.provider+"-round-cursor"))
+		})
+	}
+}
+
+func TestCompletionHooks_ArtifactWriteFailureFailsClosed(t *testing.T) {
+	for _, hook := range confinementHookCases() {
+		t.Run(hook.provider, func(t *testing.T) {
+			for _, artifact := range []string{"result", "cursor"} {
+				t.Run(artifact, func(t *testing.T) {
+					session := newCursorHookSession(t, hook)
+					writeRoundInput(t, session.dir, hook.provider, 2, "must not continue")
+					blockedPath := roundResultPath(session.dir, hook.provider, 1)
+					if artifact == "cursor" {
+						blockedPath = filepath.Join(session.dir, hook.provider+"-round-cursor")
+					}
+					require.NoError(t, os.Mkdir(blockedPath, 0o700))
+
+					result := runConfinementHook(t, hook, session.id, session.dir, "1", "round one", "")
+
+					assertNoContinuation(t, hook, result.stdout)
+					assert.Empty(t, result.stderr)
+					assert.DirExists(t, blockedPath)
+				})
+			}
+		})
+	}
+}
+
+func confinementHookCases() []cursorHookCase {
+	all := cursorHookCases()
+	return []cursorHookCase{all[0], all[2], all[3], all[4]}
+}
+
+func hookInputJSON(t *testing.T, provider string, round int, prompt string) []byte {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{"provider": provider, "round": round, "prompt": prompt})
+	require.NoError(t, err)
+	return body
+}
+
+func runConfinementHook(
+	t *testing.T,
+	hook cursorHookCase,
+	sessionID, sessionDir, round, output, workDir string,
+) hookProcessResult {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("filesystem hook contract")
+	}
+	command := "sh"
+	if hook.runtime == "bun" {
+		var err error
+		command, err = exec.LookPath("bun")
+		if err != nil {
+			t.Skip("bun is required for the OpenCode hook contract test")
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, command, hookContractScript(t, hook.script))
+	cmd.Dir = workDir
+	payload, err := json.Marshal(map[string]string{hook.payloadKey: output})
+	require.NoError(t, err)
+	cmd.Stdin = bytes.NewReader(payload)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	cmd.Env = confinementHookEnvironment(sessionID, sessionDir, round)
+	err = cmd.Run()
+	require.NoError(t, ctx.Err(), "hook exceeded confinement test deadline")
+	require.NoError(t, err, "stderr: %s", stderr.String())
+	return hookProcessResult{stdout: stdout.String(), stderr: stderr.String()}
+}
+
+func confinementHookEnvironment(sessionID, sessionDir, round string) []string {
+	env := make([]string, 0, len(os.Environ())+4)
+	for _, entry := range os.Environ() {
+		key := strings.SplitN(entry, "=", 2)[0]
+		switch key {
+		case "PATH", "AUTOPUS_SESSION_ID", "AUTOPUS_SESSION_DIR", "AUTOPUS_ROUND":
+			continue
+		}
+		env = append(env, entry)
+	}
+	env = append(env, "PATH=/opt/homebrew/bin:/usr/bin:/bin", "AUTOPUS_SESSION_ID="+sessionID, "AUTOPUS_ROUND="+round)
+	if sessionDir != "" {
+		env = append(env, "AUTOPUS_SESSION_DIR="+sessionDir)
+	}
+	return env
+}
+
+func hookContractScript(t *testing.T, name string) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	return filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", "..", "content", "hooks", name))
+}
+
+func assertRegularMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Lstat(path)
+	require.NoError(t, err)
+	assert.True(t, info.Mode().IsRegular(), "%s must be a regular file", path)
+	assert.Zero(t, info.Mode()&os.ModeSymlink)
+	assert.Equal(t, want, info.Mode().Perm())
+}

--- a/pkg/content/hook_round_cursor_contract_test.go
+++ b/pkg/content/hook_round_cursor_contract_test.go
@@ -1,0 +1,281 @@
+package content_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type cursorHookCase struct {
+	provider   string
+	script     string
+	runtime    string
+	payloadKey string
+	decision   string
+}
+
+type cursorHookSession struct {
+	id  string
+	dir string
+}
+
+type hookProcessResult struct {
+	stdout string
+	stderr string
+}
+
+func TestCompletionHooks_SuppressCmuxNoise(t *testing.T) {
+	for _, hook := range cursorHookCases()[:3] {
+		t.Run(hook.provider, func(t *testing.T) {
+			session := newCursorHookSession(t, hook)
+			writeRoundInput(t, session.dir, hook.provider, 2, "continue safely")
+			result := runCursorHook(t, hook, session, "first output", true)
+			assertContinuation(t, hook, result.stdout, "continue safely")
+			assert.Empty(t, result.stderr, "cmux stderr must not escape the hook")
+			assert.FileExists(t, filepath.Join(session.dir, "fake-cmux-called"))
+		})
+	}
+}
+
+func TestCompletionHooks_RoundCursorSurvivesFixedParentRound(t *testing.T) {
+	for _, hook := range cursorHookCases() {
+		t.Run(hook.provider, func(t *testing.T) {
+			session := newCursorHookSession(t, hook)
+			writeRoundInput(t, session.dir, hook.provider, 2, "round two prompt")
+
+			first := runCursorHook(t, hook, session, "first output", false)
+			assertContinuation(t, hook, first.stdout, "round two prompt")
+			assert.Empty(t, first.stderr)
+			assertHookResult(t, session.dir, hook.provider, 1, "first output")
+			firstResult, err := os.ReadFile(roundResultPath(session.dir, hook.provider, 1))
+			require.NoError(t, err)
+			assert.FileExists(t, roundDonePath(session.dir, hook.provider, 1))
+
+			cursorPath := filepath.Join(session.dir, hook.provider+"-round-cursor")
+			assertCursor(t, cursorPath, 2)
+			// Readers must accept the canonical ASCII decimal with a trailing newline.
+			require.NoError(t, os.WriteFile(cursorPath, []byte("2\n"), 0o600))
+
+			abortPath := filepath.Join(session.dir, hook.provider+"-round3-abort")
+			require.NoError(t, os.WriteFile(abortPath, nil, 0o600))
+			second := runCursorHook(t, hook, session, "second output", false)
+			assertNoContinuation(t, hook, second.stdout)
+			assert.Empty(t, second.stderr)
+			assertHookResult(t, session.dir, hook.provider, 2, "second output")
+			assert.FileExists(t, roundDonePath(session.dir, hook.provider, 2))
+			assert.NoFileExists(t, abortPath)
+			assert.NoFileExists(t, filepath.Join(session.dir, hook.provider+"-round3-ready"))
+			assertCursor(t, cursorPath, 2)
+
+			gotFirstResult, err := os.ReadFile(roundResultPath(session.dir, hook.provider, 1))
+			require.NoError(t, err)
+			assert.Equal(t, firstResult, gotFirstResult, "round1 result must not be overwritten")
+		})
+	}
+}
+
+func TestCompletionHooks_EmptyPromptDoesNotAdvanceCursor(t *testing.T) {
+	for _, hook := range cursorHookCases() {
+		t.Run(hook.provider, func(t *testing.T) {
+			session := newCursorHookSession(t, hook)
+			writeRoundInput(t, session.dir, hook.provider, 2, "")
+			result := runCursorHook(t, hook, session, "first output", false)
+			assertNoContinuation(t, hook, result.stdout)
+			assert.Empty(t, result.stderr)
+			assert.NoFileExists(t, filepath.Join(session.dir, hook.provider+"-round-cursor"))
+		})
+	}
+}
+
+func TestCompletionHooks_UseEnvironmentWhenItIsAheadOfCursor(t *testing.T) {
+	for _, hook := range cursorHookCases() {
+		t.Run(hook.provider, func(t *testing.T) {
+			session := newCursorHookSession(t, hook)
+			cursor := filepath.Join(session.dir, hook.provider+"-round-cursor")
+			require.NoError(t, os.WriteFile(cursor, []byte("1\n"), 0o600))
+			abort := filepath.Join(session.dir, hook.provider+"-round4-abort")
+			require.NoError(t, os.WriteFile(abort, nil, 0o600))
+			result := runCursorHookAtRound(t, hook, session, "third output", false, "3")
+			assertNoContinuation(t, hook, result.stdout)
+			assert.Empty(t, result.stderr)
+			assertHookResult(t, session.dir, hook.provider, 3, "third output")
+			assert.NoFileExists(t, abort)
+			assertCursor(t, cursor, 1)
+		})
+	}
+}
+
+func cursorHookCases() []cursorHookCase {
+	return []cursorHookCase{
+		{provider: "claude", script: "hook-claude-stop.sh", runtime: "sh", payloadKey: "last_assistant_message", decision: "block"},
+		{provider: "codex", script: "hook-codex-stop.sh", runtime: "sh", payloadKey: "last_assistant_message", decision: "block"},
+		{provider: "gemini", script: "hook-gemini-afteragent.sh", runtime: "sh", payloadKey: "prompt_response", decision: "block"},
+		{provider: "gemini", script: "hook-gemini-stop.sh", runtime: "sh", payloadKey: "last_assistant_message", decision: "continue"},
+		{provider: "opencode", script: "hook-opencode-complete.ts", runtime: "bun", payloadKey: "text"},
+	}
+}
+
+func newCursorHookSession(t *testing.T, hook cursorHookCase) cursorHookSession {
+	t.Helper()
+	return cursorHookSession{id: "cursor-" + hook.provider, dir: t.TempDir()}
+}
+
+func writeRoundInput(t *testing.T, dir, provider string, round int, prompt string) {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{
+		"provider": provider,
+		"round":    round,
+		"prompt":   prompt,
+	})
+	require.NoError(t, err)
+	path := filepath.Join(dir, fmt.Sprintf("%s-round%d-input.json", provider, round))
+	require.NoError(t, os.WriteFile(path, body, 0o600))
+}
+
+func runCursorHook(
+	t *testing.T,
+	hook cursorHookCase,
+	session cursorHookSession,
+	output string,
+	noisyCmux bool,
+) hookProcessResult {
+	return runCursorHookAtRound(t, hook, session, output, noisyCmux, "1")
+}
+
+func runCursorHookAtRound(
+	t *testing.T,
+	hook cursorHookCase,
+	session cursorHookSession,
+	output string,
+	noisyCmux bool,
+	envRound string,
+) hookProcessResult {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX hook contract")
+	}
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	script := filepath.Clean(filepath.Join(
+		filepath.Dir(thisFile), "..", "..", "content", "hooks", hook.script,
+	))
+	command := "sh"
+	if hook.runtime == "bun" {
+		var err error
+		command, err = exec.LookPath("bun")
+		if err != nil {
+			t.Skip("bun is required for the OpenCode hook contract test")
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, command, script)
+	payload, err := json.Marshal(map[string]string{hook.payloadKey: output})
+	require.NoError(t, err)
+	cmd.Stdin = bytes.NewReader(payload)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.Env = cursorHookEnvironment(t, hook, session, noisyCmux, envRound)
+	err = cmd.Run()
+	if ctx.Err() != nil {
+		require.FailNow(t, "hook timed out", "%s did not find the effective next-round signal", hook.provider)
+	}
+	require.NoError(t, err, "stderr: %s", stderr.String())
+	return hookProcessResult{stdout: stdout.String(), stderr: stderr.String()}
+}
+
+func cursorHookEnvironment(
+	t *testing.T,
+	hook cursorHookCase,
+	session cursorHookSession,
+	noisyCmux bool,
+	envRound string,
+) []string {
+	t.Helper()
+	binDir := t.TempDir()
+	for _, name := range []string{"python3", "chmod", "rm"} {
+		path, err := exec.LookPath(name)
+		require.NoError(t, err)
+		require.NoError(t, os.Symlink(path, filepath.Join(binDir, name)))
+	}
+	if hook.runtime == "sh" {
+		body := "#!/bin/sh\n: > \"$FAKE_CMUX_MARKER\"\n"
+		if noisyCmux {
+			body += "printf 'OK\\n'\nprintf 'ERR\\n' >&2\n"
+		}
+		cmux := filepath.Join(binDir, "cmux")
+		require.NoError(t, os.WriteFile(cmux, []byte(body), 0o700))
+	}
+	env := make([]string, 0, len(os.Environ())+6)
+	for _, entry := range os.Environ() {
+		key := strings.SplitN(entry, "=", 2)[0]
+		switch key {
+		case "PATH", "AUTOPUS_SESSION_ID", "AUTOPUS_SESSION_DIR", "AUTOPUS_ROUND", "FAKE_CMUX_MARKER":
+			continue
+		}
+		env = append(env, entry)
+	}
+	return append(env,
+		"PATH="+binDir,
+		"AUTOPUS_SESSION_ID="+session.id,
+		"AUTOPUS_SESSION_DIR="+session.dir,
+		"AUTOPUS_ROUND="+envRound,
+		"FAKE_CMUX_MARKER="+filepath.Join(session.dir, "fake-cmux-called"),
+	)
+}
+
+func assertContinuation(t *testing.T, hook cursorHookCase, stdout, prompt string) {
+	t.Helper()
+	if hook.decision == "" {
+		assert.Equal(t, prompt, stdout)
+		return
+	}
+	var decision struct {
+		Decision string `json:"decision"`
+		Reason   string `json:"reason"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &decision), "stdout: %q", stdout)
+	assert.Equal(t, hook.decision, decision.Decision)
+	assert.Equal(t, prompt, decision.Reason)
+}
+
+func assertHookResult(t *testing.T, dir, provider string, round int, want string) {
+	t.Helper()
+	body, err := os.ReadFile(roundResultPath(dir, provider, round))
+	require.NoError(t, err)
+	var result struct {
+		Output string `json:"output"`
+	}
+	require.NoError(t, json.Unmarshal(body, &result))
+	assert.Equal(t, want, result.Output)
+}
+
+func assertCursor(t *testing.T, path string, want int) {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, fmt.Sprint(want), strings.TrimSpace(string(body)))
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func roundResultPath(dir, provider string, round int) string {
+	return filepath.Join(dir, fmt.Sprintf("%s-round%d-result.json", provider, round))
+}
+
+func roundDonePath(dir, provider string, round int) string {
+	return filepath.Join(dir, fmt.Sprintf("%s-round%d-done", provider, round))
+}

--- a/pkg/content/hook_session_directory_contract_test.go
+++ b/pkg/content/hook_session_directory_contract_test.go
@@ -1,0 +1,128 @@
+package content_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompletionHooks_RejectSymlinkAndRelativeSessionDirectories(t *testing.T) {
+	for _, hook := range confinementHookCases() {
+		t.Run(hook.provider, func(t *testing.T) {
+			t.Run("symlink", func(t *testing.T) {
+				realDir := t.TempDir()
+				linkedDir := filepath.Join(t.TempDir(), "session-link")
+				require.NoError(t, os.Symlink(realDir, linkedDir))
+
+				result := runConfinementHook(t, hook, "linked-session", linkedDir, "", "must not write", "")
+
+				assertNoContinuation(t, hook, result.stdout)
+				assert.Empty(t, result.stderr)
+				assert.Empty(t, requireReadDir(t, realDir))
+			})
+
+			t.Run("relative", func(t *testing.T) {
+				root := t.TempDir()
+				require.NoError(t, os.Mkdir(filepath.Join(root, "relative-session"), 0o700))
+
+				result := runConfinementHook(t, hook, "relative-session", "relative-session", "", "must not write", root)
+
+				assertNoContinuation(t, hook, result.stdout)
+				assert.Empty(t, result.stderr)
+				assert.Empty(t, requireReadDir(t, filepath.Join(root, "relative-session")))
+			})
+		})
+	}
+}
+
+func TestCompletionHooks_LegacySessionFallbackRemainsSupported(t *testing.T) {
+	require.NoError(t, os.MkdirAll("/tmp/autopus", 0o700))
+	for _, hook := range confinementHookCases() {
+		t.Run(hook.provider, func(t *testing.T) {
+			dir, err := os.MkdirTemp("/tmp/autopus", "confinement-"+hook.provider+"-")
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+			result := runConfinementHook(t, hook, filepath.Base(dir), "", "", "legacy output", "")
+
+			assertNoContinuation(t, hook, result.stdout)
+			assert.Empty(t, result.stderr)
+			assertRegularMode(t, filepath.Join(dir, hook.provider+"-result.json"), 0o600)
+			assertRegularMode(t, filepath.Join(dir, hook.provider+"-done"), 0o600)
+		})
+	}
+}
+
+func TestSessionStartHooks_ConfineReadyArtifact(t *testing.T) {
+	for _, tc := range []struct {
+		provider string
+		script   string
+	}{
+		{provider: "claude", script: "hook-claude-sessionstart.sh"},
+		{provider: "gemini", script: "hook-gemini-sessionstart.sh"},
+	} {
+		t.Run(tc.provider, func(t *testing.T) {
+			sessionDir := t.TempDir()
+			victim := filepath.Join(t.TempDir(), "ready-victim")
+			require.NoError(t, os.WriteFile(victim, []byte("preserve-ready"), 0o600))
+			ready := filepath.Join(sessionDir, tc.provider+"-round1-ready")
+			require.NoError(t, os.Symlink(victim, ready))
+
+			result := runSessionStartHook(t, tc.script, sessionDir, "1")
+
+			assert.Empty(t, result.stdout)
+			assert.Empty(t, result.stderr)
+			assert.Equal(t, "preserve-ready", string(requireReadFile(t, victim)))
+			assertRegularMode(t, ready, 0o600)
+		})
+	}
+}
+
+func TestSessionStartHooks_RejectSymlinkSessionDirectory(t *testing.T) {
+	for _, tc := range []struct {
+		provider string
+		script   string
+	}{
+		{provider: "claude", script: "hook-claude-sessionstart.sh"},
+		{provider: "gemini", script: "hook-gemini-sessionstart.sh"},
+	} {
+		t.Run(tc.provider, func(t *testing.T) {
+			realDir := t.TempDir()
+			linkedDir := filepath.Join(t.TempDir(), "session-link")
+			require.NoError(t, os.Symlink(realDir, linkedDir))
+
+			result := runSessionStartHook(t, tc.script, linkedDir, "1")
+
+			assert.Empty(t, result.stdout)
+			assert.Empty(t, result.stderr)
+			assert.Empty(t, requireReadDir(t, realDir))
+		})
+	}
+}
+
+func runSessionStartHook(t *testing.T, script, sessionDir, round string) hookProcessResult {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("filesystem hook contract")
+	}
+	cmd := exec.Command("sh", hookContractScript(t, script))
+	cmd.Env = confinementHookEnvironment("session-start", sessionDir, round)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	err := cmd.Run()
+	require.NoError(t, err, "stderr: %s", stderr.String())
+	return hookProcessResult{stdout: stdout.String(), stderr: stderr.String()}
+}
+
+func requireReadDir(t *testing.T, path string) []os.DirEntry {
+	t.Helper()
+	entries, err := os.ReadDir(path)
+	require.NoError(t, err)
+	return entries
+}

--- a/pkg/content/hooks_completion.go
+++ b/pkg/content/hooks_completion.go
@@ -21,6 +21,13 @@ const (
 	// regardless of the hook's spawn cwd. Hook commands run via `sh -c`, so the
 	// parameter expansion resolves at execution time.
 	claudeHookDirPrefix = `"${CLAUDE_PROJECT_DIR:-.}"/.claude/hooks/autopus/`
+	// Legacy Gemini CLI exposes GEMINI_PROJECT_DIR. Retain a git/cwd fallback for
+	// older clients while anchoring the managed asset on the project root.
+	geminiHookDirPrefix = `"${GEMINI_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"/.gemini/hooks/autopus/`
+	// Antigravity runs hooks from the directory containing .agents/hooks.json,
+	// so that directory's parent is the canonical project root. Do not consult
+	// Git here: the project may be nested below an unrelated repository root.
+	antigravityHookDirPrefix = `"$(cd .. && pwd)/.gemini/hooks/autopus/`
 	// Codex hooks may run with a subdirectory as cwd. Resolve the checked-out
 	// project root at hook execution time and use assets installed by the Codex
 	// adapter itself, so codex-only harnesses do not depend on Claude surfaces.
@@ -55,9 +62,11 @@ func generateCompletionHooks(platform string) []adapter.HookConfig {
 		// consumer that executes these settings without the variable.
 		completion = entry{"Stop", claudeHookDirPrefix + "hook-claude-stop.sh"}
 		ready = entry{"SessionStart", claudeHookDirPrefix + "hook-claude-sessionstart.sh"}
-	case "antigravity-cli", "gemini", "gemini-cli":
-		// AfterAgent is the Antigravity CLI event fired when the agent session ends.
-		completion = entry{"AfterAgent", ".claude/hooks/autopus/hook-gemini-afteragent.sh"}
+	case "antigravity-cli":
+		completion = entry{"Stop", antigravityHookDirPrefix + "hook-gemini-stop.sh\""}
+	case "gemini", "gemini-cli":
+		// Gemini CLI uses AfterAgent and blocks a stop with decision=block.
+		completion = entry{"AfterAgent", geminiHookDirPrefix + "hook-gemini-afteragent.sh"}
 	case "codex":
 		completion = entry{"Stop", codexHookDirPrefix + "hook-codex-stop.sh\""}
 		ready = entry{"SessionStart", codexHookDirPrefix + "hook-codex-sessionstart.sh\""}

--- a/pkg/content/hooks_stop_test.go
+++ b/pkg/content/hooks_stop_test.go
@@ -1,6 +1,6 @@
 // Package content_test verifies completion hook registration for the orchestra hook-IPC path.
 // S1: claude-code platform emits a Stop event hook pointing to hook-claude-stop.sh.
-// S2: antigravity-cli platform emits AfterAgent, codex platform emits Stop.
+// S2: antigravity-cli and codex emit Stop; legacy Gemini emits AfterAgent.
 package content_test
 
 import (
@@ -55,16 +55,33 @@ func TestGenerateCLIHooks_StopEvent(t *testing.T) {
 				typ:     "command",
 			},
 		},
-		// S2a: antigravity-cli AfterAgent hook
+		// S2a: Antigravity CLI uses its native flat Stop hook contract.
 		{
 			platform: "antigravity-cli",
 			want: wantHook{
-				event:   "AfterAgent",
-				command: ".claude/hooks/autopus/hook-gemini-afteragent.sh",
+				event:   "Stop",
+				command: `"$(cd .. && pwd)/.gemini/hooks/autopus/hook-gemini-stop.sh"`,
 				typ:     "command",
 			},
 		},
-		// S2b: codex Stop hook
+		// S2b: Legacy Gemini CLI keeps the AfterAgent contract.
+		{
+			platform: "gemini",
+			want: wantHook{
+				event:   "AfterAgent",
+				command: `"${GEMINI_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"/.gemini/hooks/autopus/hook-gemini-afteragent.sh`,
+				typ:     "command",
+			},
+		},
+		{
+			platform: "gemini-cli",
+			want: wantHook{
+				event:   "AfterAgent",
+				command: `"${GEMINI_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"/.gemini/hooks/autopus/hook-gemini-afteragent.sh`,
+				typ:     "command",
+			},
+		},
+		// S2c: codex Stop hook
 		{
 			platform: "codex",
 			want: wantHook{
@@ -143,7 +160,8 @@ func TestGenerateCLIHooks_CompletionHookTimeout(t *testing.T) {
 		readyEvent      string // "" when the platform has no SessionStart-equivalent ready hook
 	}{
 		{"claude-code", "Stop", "SessionStart"},
-		{"antigravity-cli", "AfterAgent", ""},
+		{"antigravity-cli", "Stop", ""},
+		{"gemini", "AfterAgent", ""},
 		{"codex", "Stop", "SessionStart"},
 	}
 

--- a/pkg/content/hooks_test.go
+++ b/pkg/content/hooks_test.go
@@ -142,13 +142,13 @@ func TestGenerateHookConfigs_AntigravityKeepsOfficialEventNames(t *testing.T) {
 	assert.Contains(t, eventNames, "PostToolUse")
 	assert.NotContains(t, eventNames, "BeforeTool")
 	assert.NotContains(t, eventNames, "AfterTool")
-	// AfterAgent is the completion hook — it must be present.
-	assert.Contains(t, eventNames, "AfterAgent")
+	// Stop is the completion hook in the Antigravity lifecycle.
+	assert.Contains(t, eventNames, "Stop")
 
 	// Tool-use hooks must be wrapped for Antigravity JSON stdout protocol;
-	// the completion AfterAgent hook is a plain command (not tool-use).
+	// the completion Stop hook is a plain command (not tool-use).
 	for _, h := range hooks {
-		if h.Event == "AfterAgent" {
+		if h.Event == "Stop" {
 			// Completion hook: plain command, no run_command matcher.
 			continue
 		}

--- a/pkg/content/opencode_hook_contract_test.go
+++ b/pkg/content/opencode_hook_contract_test.go
@@ -1,0 +1,87 @@
+package content_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenCodeCompletionHook_RejectsUnsafeExportedSessionDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("filesystem hook contract")
+	}
+	realDir := t.TempDir()
+	linkDir := filepath.Join(t.TempDir(), "session-link")
+	require.NoError(t, os.Symlink(realDir, linkDir))
+	notDir := filepath.Join(t.TempDir(), "session-file")
+	require.NoError(t, os.WriteFile(notDir, []byte("not a directory"), 0o600))
+	relativeRoot := t.TempDir()
+	relativeDir := "relative-session"
+	require.NoError(t, os.Mkdir(filepath.Join(relativeRoot, relativeDir), 0o700))
+
+	for _, unsafeDir := range []string{linkDir, notDir} {
+		runOpenCodeHook(t, "unsafe-opencode-session", unsafeDir, "")
+	}
+	runOpenCodeHook(t, "unsafe-opencode-session", relativeDir, relativeRoot)
+	assert.NoFileExists(t, filepath.Join(realDir, "opencode-result.json"))
+	assert.NoFileExists(t, filepath.Join(relativeRoot, relativeDir, "opencode-result.json"))
+	assert.Equal(t, "not a directory", string(requireReadFile(t, notDir)))
+}
+
+func TestOpenCodeCompletionHook_UsesLegacySessionFallback(t *testing.T) {
+	require.NoError(t, os.MkdirAll("/tmp/autopus", 0o700))
+	dir, err := os.MkdirTemp("/tmp/autopus", "opencode-fallback-")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	runOpenCodeHook(t, filepath.Base(dir), "", "")
+	result := requireReadFile(t, filepath.Join(dir, "opencode-result.json"))
+	assert.JSONEq(t, `{"output":"hook output","exit_code":0}`, string(result))
+	assert.FileExists(t, filepath.Join(dir, "opencode-done"))
+}
+
+func runOpenCodeHook(t *testing.T, sessionID, sessionDir, workDir string) {
+	t.Helper()
+	bun, err := exec.LookPath("bun")
+	if err != nil {
+		t.Skip("bun is required for the OpenCode hook contract test")
+	}
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	script := filepath.Clean(filepath.Join(
+		filepath.Dir(thisFile), "..", "..", "content", "hooks", "hook-opencode-complete.ts",
+	))
+	cmd := exec.Command(bun, script)
+	cmd.Dir = workDir
+	cmd.Stdin = bytes.NewBufferString(`{"text":"hook output"}`)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	env := make([]string, 0, len(os.Environ())+3)
+	for _, entry := range os.Environ() {
+		key := strings.SplitN(entry, "=", 2)[0]
+		if key != "AUTOPUS_SESSION_ID" && key != "AUTOPUS_SESSION_DIR" && key != "AUTOPUS_ROUND" {
+			env = append(env, entry)
+		}
+	}
+	cmd.Env = append(env, "AUTOPUS_SESSION_ID="+sessionID, "AUTOPUS_ROUND=")
+	if sessionDir != "" {
+		cmd.Env = append(cmd.Env, "AUTOPUS_SESSION_DIR="+sessionDir)
+	}
+	require.NoError(t, cmd.Run(), "stderr: %s", stderr.String())
+	assert.Empty(t, stdout.String())
+	assert.Empty(t, stderr.String())
+}
+
+func requireReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return body
+}

--- a/pkg/orchestra/codex_startup_fallback_integration_test.go
+++ b/pkg/orchestra/codex_startup_fallback_integration_test.go
@@ -1,0 +1,67 @@
+package orchestra
+
+import (
+	"context"
+	"os"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var codexFallbackResponsePath = regexp.MustCompile(`response file: ([^ ]+?\.md)`)
+
+type codexStartupFallbackTerminal struct {
+	*seqScreenMock
+}
+
+func (m *codexStartupFallbackTerminal) SendCommand(
+	ctx context.Context,
+	paneID terminal.PaneID,
+	command string,
+) error {
+	if err := m.seqScreenMock.SendCommand(ctx, paneID, command); err != nil {
+		return err
+	}
+	match := codexFallbackResponsePath.FindStringSubmatch(command)
+	if len(match) != 2 {
+		return nil
+	}
+	return os.WriteFile(match[1], []byte(markedResponse("codex response-only completion")), 0o600)
+}
+
+func TestInteractivePaneBackend_CodexUntrustedStartupSendsPromptAndCollectsResponse(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	term := &codexStartupFallbackTerminal{seqScreenMock: &seqScreenMock{
+		name: "cmux", screens: []string{codexStablePrompt},
+	}}
+	provider := ProviderConfig{
+		Name: "codex", Binary: "codex", StartupTimeout: 3 * time.Second,
+	}
+	backend := NewInteractivePaneBackend(OrchestraConfig{
+		Terminal: term, HookMode: true,
+		SessionID: "codex-startup-integration-" + NewSessionID(),
+		Providers: []ProviderConfig{provider}, WorkingDir: t.TempDir(),
+		InitialDelay: time.Millisecond,
+	})
+
+	response, err := backend.Execute(context.Background(), ProviderRequest{
+		Provider: provider.Name, Config: provider, Prompt: "prove prompt delivery",
+		Role: "reviewer", Timeout: 8 * time.Second,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	assert.Equal(t, "codex response-only completion", response.Output)
+	assert.False(t, response.TimedOut)
+	promptSent := false
+	for _, command := range term.commands {
+		if codexFallbackResponsePath.MatchString(command) {
+			promptSent = true
+		}
+	}
+	assert.True(t, promptSent, "the stable Codex prompt must receive the initial request")
+}

--- a/pkg/orchestra/completion_file_ipc.go
+++ b/pkg/orchestra/completion_file_ipc.go
@@ -39,7 +39,7 @@ func (d *FileIPCDetector) WaitForCompletion(ctx context.Context, pi paneInfo, _ 
 	}
 
 	timeout := fileIPCTimeout(ctx)
-	doneName := sanitizeProviderName(provider) + "-done"
+	doneName := sanitizeProviderName(providerArtifactIdentity(provider)) + "-done"
 	if round > 0 {
 		doneName = RoundSignalName(provider, round, "done")
 	}

--- a/pkg/orchestra/completion_file_ipc_test.go
+++ b/pkg/orchestra/completion_file_ipc_test.go
@@ -201,7 +201,7 @@ func TestNewCompletionDetectorWithConfig_FallbackPoll(t *testing.T) {
 }
 
 // TestFileIPCDetector_BoundedTimeout_S7 verifies S7: done-file never appears →
-// WaitForCompletion returns completed=false within explicit tolerance (200ms–1s).
+// WaitForCompletion returns completed=false within explicit tolerance.
 // This guards against infinite wait when the hook script never fires.
 func TestFileIPCDetector_BoundedTimeout_S7(t *testing.T) {
 	t.Parallel()
@@ -211,8 +211,10 @@ func TestFileIPCDetector_BoundedTimeout_S7(t *testing.T) {
 	// Use a provider name with no done file in the session dir.
 	pi := paneInfo{provider: ProviderConfig{Name: "codex-notarget"}}
 
-	// 200ms deadline — no done file will be created.
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	const timeout = 200 * time.Millisecond
+	const schedulingTolerance = 25 * time.Millisecond
+	// No done file will be created before the deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	start := time.Now()
@@ -221,8 +223,9 @@ func TestFileIPCDetector_BoundedTimeout_S7(t *testing.T) {
 
 	assert.NoError(t, err, "S7: WaitForCompletion must not return error on timeout")
 	assert.False(t, completed, "S7: completed must be false when done-file never appears")
-	// Explicit tolerance: must return between 200ms and 1s after context deadline.
-	assert.GreaterOrEqual(t, elapsed, 200*time.Millisecond, "S7: must not return before deadline")
+	// Keep a meaningful lower bound without requiring the timer and elapsed-time
+	// observations to land on the exact same scheduler tick under -race.
+	assert.GreaterOrEqual(t, elapsed, timeout-schedulingTolerance, "S7: must wait for the deadline")
 	assert.Less(t, elapsed, time.Second, "S7: must return within 1s of deadline (no infinite wait)")
 }
 

--- a/pkg/orchestra/hook_completion_handoff.go
+++ b/pkg/orchestra/hook_completion_handoff.go
@@ -1,0 +1,110 @@
+package orchestra
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/terminal"
+)
+
+const (
+	hookStableIdleFrames = 2
+)
+
+func needsHookCompletionHandoff(cfg OrchestraConfig, round int) bool {
+	if cfg.YieldRounds {
+		return true
+	}
+	rounds := cfg.DebateRounds
+	if rounds <= 0 {
+		rounds = 1
+	}
+	return round < rounds
+}
+
+// resolveHookCompletionHandoff classifies Codex's grace-based response-only
+// completion before another round or yield can interact with its Stop hook.
+// Only two stable provider-specific idle frames may deactivate the hook.
+// Response-file availability is not turn completion, so working and blocker
+// frames remain under observation until next-ready, stable idle, or the
+// provider deadline. I/O and timeout outcomes remain active by default.
+func resolveHookCompletionHandoff(
+	ctx context.Context,
+	cfg OrchestraConfig,
+	session *HookSession,
+	provider ProviderConfig,
+	pi paneInfo,
+	round int,
+) (hookCompletionProvenance, error) {
+	if !needsHookCompletionHandoff(cfg, round) || !isCodexInteractiveProvider(provider) {
+		return hookCompletionUnknown, nil
+	}
+	if provenance, err := session.completionArtifactProvenance(provider, round); err != nil ||
+		handoffArtifactResolved(provenance) {
+		return provenance, err
+	}
+	if cfg.Terminal == nil {
+		return hookCompletionUnknown, fmt.Errorf("completion handoff terminal is unavailable")
+	}
+
+	handoffCtx := ctx
+	cancel := func() {}
+	if _, bounded := ctx.Deadline(); !bounded {
+		handoffCtx, cancel = context.WithTimeout(ctx, fileIPCReadyTimeout)
+	}
+	defer cancel()
+	ticker := time.NewTicker(sessionReadyPollInterval)
+	defer ticker.Stop()
+	stableFrames := 0
+	patterns := SessionReadyPatterns()
+	for {
+		select {
+		case <-handoffCtx.Done():
+			provenance, err := session.completionArtifactProvenance(provider, round)
+			if err != nil || handoffArtifactResolved(provenance) {
+				return provenance, err
+			}
+			return hookCompletionUnknown, fmt.Errorf("completion handoff unresolved: %w", handoffCtx.Err())
+		case <-ticker.C:
+			provenance, err := session.completionArtifactProvenance(provider, round)
+			if err != nil || handoffArtifactResolved(provenance) {
+				return provenance, err
+			}
+			screen, err := readScreenBounded(handoffCtx, cfg.Terminal, pi.paneID, terminal.ReadScreenOpts{})
+			if err != nil {
+				provenance, artifactErr := session.completionArtifactProvenance(provider, round)
+				if artifactErr == nil && handoffArtifactResolved(provenance) {
+					return provenance, nil
+				}
+				if artifactErr != nil {
+					return hookCompletionUnknown, fmt.Errorf(
+						"read completion handoff screen: %v; recheck completion artifact: %w",
+						err, artifactErr,
+					)
+				}
+				return hookCompletionUnknown, fmt.Errorf("read completion handoff screen: %w", err)
+			}
+			if isSessionReadyBlocked(screen, provider.Name) {
+				stableFrames = 0
+				continue
+			}
+			if isProviderWorking(screen) || isProviderStillWorking(screen, provider.WorkingPatterns) {
+				stableFrames = 0
+				continue
+			}
+			if !isProviderSessionReady(screen, patterns, provider.Name) {
+				stableFrames = 0
+				continue
+			}
+			stableFrames++
+			if stableFrames >= hookStableIdleFrames {
+				return session.deactivateContinuationHook(provider, round)
+			}
+		}
+	}
+}
+
+func handoffArtifactResolved(provenance hookCompletionProvenance) bool {
+	return provenance == hookCompletionNextRoundReady
+}

--- a/pkg/orchestra/hook_completion_handoff_io_race_test.go
+++ b/pkg/orchestra/hook_completion_handoff_io_race_test.go
@@ -1,0 +1,45 @@
+package orchestra
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type readyThenReadErrorTerminal struct {
+	mockTerminal
+	session *HookSession
+}
+
+func (t *readyThenReadErrorTerminal) ReadScreen(_ context.Context, _ terminal.PaneID, _ terminal.ReadScreenOpts) (string, error) {
+	if err := t.session.writeArtifact(RoundSignalName("codex", 2, "ready"), nil, 0o600); err != nil {
+		return "", err
+	}
+	return "", errors.New("screen I/O failed after next-ready")
+}
+
+func TestResolveHookCompletionHandoff_NextReadyWinsReadErrorRace(t *testing.T) {
+	session, err := NewHookSession("handoff-read-error-race-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+	provider := ProviderConfig{Name: "codex", Binary: "codex"}
+	term := &readyThenReadErrorTerminal{
+		mockTerminal: mockTerminal{name: "cmux"}, session: session,
+	}
+	cfg := OrchestraConfig{Providers: []ProviderConfig{provider}, Terminal: term, DebateRounds: 2}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	provenance, err := resolveHookCompletionHandoff(
+		ctx, cfg, session, provider, paneInfo{provider: provider, paneID: "surface:1"}, 1,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, hookCompletionNextRoundReady, provenance)
+	assert.True(t, session.HasHook("codex"))
+}

--- a/pkg/orchestra/hook_completion_health.go
+++ b/pkg/orchestra/hook_completion_health.go
@@ -1,0 +1,101 @@
+package orchestra
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+)
+
+type hookCompletionProvenance string
+
+const (
+	hookCompletionUnknown          hookCompletionProvenance = "unknown"
+	hookCompletionDone             hookCompletionProvenance = "done"
+	hookCompletionNextRoundReady   hookCompletionProvenance = "next_round_ready"
+	hookCompletionResponseFileOnly hookCompletionProvenance = "response_file_without_done"
+)
+
+type hookCompletionObservation struct {
+	provenance hookCompletionProvenance
+	round      int
+}
+
+// hookCompletionHealth tracks completion hooks that were configured but did
+// not run in this orchestration. Its zero value is ready for concurrent use.
+type hookCompletionHealth struct {
+	mu       sync.RWMutex
+	inactive map[string]hookCompletionObservation
+}
+
+// HasHook reports whether a configured completion hook is still active in this run.
+func (s *HookSession) HasHook(provider string) bool {
+	identity := providerArtifactIdentity(provider)
+	s.hookHealth.mu.RLock()
+	defer s.hookHealth.mu.RUnlock()
+	_, inactive := s.hookHealth.inactive[identity]
+	return s.hookProviders[identity] && !inactive
+}
+
+// SetHookProviders replaces completion hook configuration and resets run health.
+func (s *HookSession) SetHookProviders(providers map[string]bool) {
+	s.hookHealth.mu.Lock()
+	defer s.hookHealth.mu.Unlock()
+	s.hookProviders = make(map[string]bool, len(providers))
+	for provider, enabled := range providers {
+		s.hookProviders[providerArtifactIdentity(provider)] = enabled
+	}
+	s.hookHealth.inactive = nil
+}
+
+// completionArtifactProvenance checks evidence that the configured hook is
+// active without mutating run health.
+func (s *HookSession) completionArtifactProvenance(provider ProviderConfig, round int) (hookCompletionProvenance, error) {
+	provenance, err := s.nextRoundReadyProvenance(provider, round)
+	if err != nil || provenance == hookCompletionNextRoundReady {
+		return provenance, err
+	}
+	doneName := RoundSignalName(provider.Name, round, "done")
+	if _, err := s.statArtifact(doneName); err == nil {
+		return hookCompletionDone, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return hookCompletionUnknown, fmt.Errorf("inspect completion artifact %s: %w", doneName, err)
+	}
+	return hookCompletionUnknown, nil
+}
+
+func (s *HookSession) nextRoundReadyProvenance(provider ProviderConfig, round int) (hookCompletionProvenance, error) {
+	if err := validateHookArtifactProvider(provider.Name); err != nil {
+		return hookCompletionUnknown, err
+	}
+	if !isCodexInteractiveProvider(provider) {
+		return hookCompletionUnknown, nil
+	}
+	readyName := RoundSignalName(provider.Name, round+1, "ready")
+	if _, err := s.statArtifact(readyName); err == nil {
+		return hookCompletionNextRoundReady, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return hookCompletionUnknown, fmt.Errorf("inspect completion artifact %s: %w", readyName, err)
+	}
+	return hookCompletionUnknown, nil
+}
+
+// deactivateContinuationHook records stable idle evidence after a final ready
+// check. A current done artifact proves execution, not a live next-round waiter.
+func (s *HookSession) deactivateContinuationHook(provider ProviderConfig, round int) (hookCompletionProvenance, error) {
+	provenance, err := s.nextRoundReadyProvenance(provider, round)
+	if err != nil || provenance == hookCompletionNextRoundReady {
+		return provenance, err
+	}
+	identity := providerArtifactIdentity(provider.Name)
+	s.hookHealth.mu.Lock()
+	if s.hookHealth.inactive == nil {
+		s.hookHealth.inactive = make(map[string]hookCompletionObservation)
+	}
+	s.hookHealth.inactive[identity] = hookCompletionObservation{
+		provenance: hookCompletionResponseFileOnly,
+		round:      round,
+	}
+	s.hookHealth.mu.Unlock()
+	return hookCompletionResponseFileOnly, nil
+}

--- a/pkg/orchestra/hook_ipc_integration_test.go
+++ b/pkg/orchestra/hook_ipc_integration_test.go
@@ -2,6 +2,7 @@ package orchestra
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,8 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestTryFileIPC_Success verifies that tryFileIPC returns true when
-// WaitForReady succeeds and WriteInputRound succeeds.
+// TestTryFileIPC_Success verifies the delivered outcome when ready and input writes succeed.
 func TestTryFileIPC_Success(t *testing.T) {
 	t.Parallel()
 
@@ -29,10 +29,11 @@ func TestTryFileIPC_Success(t *testing.T) {
 
 	// When: tryFileIPC is called
 	ctx := context.Background()
-	ok := tryFileIPC(ctx, sess, "claude", 2, "debate prompt")
+	outcome, ipcErr := tryFileIPC(ctx, sess, "claude", 2, "debate prompt")
 
-	// Then: returns true (file IPC succeeded)
-	assert.True(t, ok, "tryFileIPC must return true on success")
+	// Then: file IPC was delivered without falling back.
+	require.NoError(t, ipcErr)
+	assert.Equal(t, fileIPCDelivered, outcome)
 
 	// Then: input file was created
 	inputName := RoundSignalName("claude", 2, "input.json")
@@ -40,9 +41,9 @@ func TestTryFileIPC_Success(t *testing.T) {
 	assert.NoError(t, err, "input file must exist after successful IPC")
 }
 
-// TestTryFileIPC_ReadyTimeout_Fallback verifies that tryFileIPC returns false
-// when WaitForReady times out (provider not ready).
-func TestTryFileIPC_ReadyTimeout_Fallback(t *testing.T) {
+// TestTryFileIPC_ContextDeadlineReleaseFailure verifies that a cancelled caller
+// cannot authorize direct fallback without a release acknowledgement.
+func TestTryFileIPC_ContextDeadlineReleaseFailure(t *testing.T) {
 	t.Parallel()
 
 	sess, err := NewHookSession("test-try-file-ipc-timeout")
@@ -53,15 +54,17 @@ func TestTryFileIPC_ReadyTimeout_Fallback(t *testing.T) {
 	// Use a cancelled context to speed up the test
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
-	ok := tryFileIPC(ctx, sess, "claude", 1, "prompt")
+	outcome, ipcErr := tryFileIPC(ctx, sess, "claude", 1, "prompt")
 
-	// Then: returns false (fallback to SendLongText)
-	assert.False(t, ok, "tryFileIPC must return false on ready timeout")
+	// Then: cancellation prevents release acknowledgement and direct fallback.
+	assert.Equal(t, fileIPCReleaseFailure, outcome)
+	require.Error(t, ipcErr)
+	abortPath := filepath.Join(sess.Dir(), RoundSignalName("claude", 1, "abort"))
+	assert.FileExists(t, abortPath, "timeout fallback must release a late hook waiter")
 }
 
-// TestTryFileIPC_ContextCancelled_Fallback verifies that tryFileIPC returns false
-// when context is cancelled during WaitForReady.
-func TestTryFileIPC_ContextCancelled_Fallback(t *testing.T) {
+// TestTryFileIPC_ContextCancelledReleaseFailure covers cancellation before ready wait.
+func TestTryFileIPC_ContextCancelledReleaseFailure(t *testing.T) {
 	t.Parallel()
 
 	sess, err := NewHookSession("test-try-file-ipc-ctx-cancel")
@@ -73,10 +76,13 @@ func TestTryFileIPC_ContextCancelled_Fallback(t *testing.T) {
 	cancel()
 
 	// When: tryFileIPC is called
-	ok := tryFileIPC(ctx, sess, "claude", 1, "prompt")
+	outcome, ipcErr := tryFileIPC(ctx, sess, "claude", 1, "prompt")
 
-	// Then: returns false (fallback)
-	assert.False(t, ok, "tryFileIPC must return false on cancelled context")
+	// Then: direct fallback is not authorized on a cancelled context.
+	assert.Equal(t, fileIPCReleaseFailure, outcome)
+	assert.ErrorIs(t, ipcErr, context.Canceled)
+	assert.FileExists(t, filepath.Join(sess.Dir(), RoundSignalName("claude", 1, "abort")),
+		"cancelled fallback must release the hook waiter")
 }
 
 // TestTryFileIPC_WriteFailure_SendsAbort verifies R5-SAFETY: when WriteInputRound
@@ -92,21 +98,18 @@ func TestTryFileIPC_WriteFailure_SendsAbort(t *testing.T) {
 	readyName := RoundSignalName("claude", 1, "ready")
 	require.NoError(t, os.WriteFile(filepath.Join(sess.Dir(), readyName), []byte("1"), 0o644))
 
-	// Given: make the session dir read-only to cause WriteInputRound failure
-	require.NoError(t, os.Chmod(sess.Dir(), 0o555))
-	defer func() { _ = os.Chmod(sess.Dir(), 0o700) }()
+	// Given: collide with the atomic input temp file while leaving abort writes available.
+	inputName := RoundSignalName("claude", 1, "input.json")
+	require.NoError(t, os.Mkdir(filepath.Join(sess.Dir(), inputName+".tmp"), 0o700))
 
+	consumed := consumeFileIPCAbort(sess, "claude", 1, nil, nil)
 	// When: tryFileIPC is called
-	ok := tryFileIPC(context.Background(), sess, "claude", 1, "prompt")
+	outcome, ipcErr := tryFileIPC(context.Background(), sess, "claude", 1, "prompt")
 
-	// Then: returns false (fallback)
-	assert.False(t, ok, "tryFileIPC must return false on write failure")
-
-	// Restore permissions so we can check abort file and cleanup
-	_ = os.Chmod(sess.Dir(), 0o700)
-
-	// Note: abort signal write also fails due to permissions, but that's
-	// expected — the key behavior is the fallback return value.
+	// Then: fallback is safe only after the waiter consumes abort and ready.
+	assert.Equal(t, fileIPCSafeFallback, outcome)
+	assert.ErrorContains(t, ipcErr, "write input")
+	require.NoError(t, <-consumed)
 }
 
 // TestExecuteRound_FileIPC_Path verifies that executeRound uses file IPC
@@ -115,9 +118,9 @@ func TestExecuteRound_FileIPC_Path(t *testing.T) {
 	t.Parallel()
 
 	mock := newCmuxMock()
-	mock.readScreenOutput = "❯\n"
+	mock.readScreenOutput = "hook is waiting; no prompt is visible\n"
 
-	sess, err := NewHookSession("test-exec-round-fileipc")
+	sess, err := NewHookSession("test-exec-round-fileipc-" + NewSessionID())
 	require.NoError(t, err)
 	defer sess.Cleanup()
 
@@ -173,8 +176,60 @@ func TestExecuteRound_FileIPC_Path(t *testing.T) {
 
 	// Then: input file was created via file IPC (not SendLongText)
 	inputName := RoundSignalName("claude", 2, "input.json")
-	_, err = os.Stat(filepath.Join(sess.Dir(), inputName))
-	assert.NoError(t, err, "file IPC input file must exist")
+	inputData, err := os.ReadFile(filepath.Join(sess.Dir(), inputName))
+	require.NoError(t, err, "file IPC input file must exist")
+	var input HookInput
+	require.NoError(t, json.Unmarshal(inputData, &input))
+	assert.Contains(t, input.Prompt, responseBeginMarker,
+		"file IPC must carry the same response-file fallback contract as direct pane input")
+	assert.NotEmpty(t, panes[0].responseFile)
+}
+
+func TestExecuteRound_FileIPCFallbackPersistsRoundCursor(t *testing.T) {
+	t.Parallel()
+
+	mock := newCmuxMock()
+	mock.readScreenOutput = "❯\n"
+	session, err := NewHookSession("test-exec-round-cursor-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+	session.SetHookProviders(map[string]bool{"claude": true})
+
+	inputName := RoundSignalName("claude", 2, "input.json")
+	require.NoError(t, os.Mkdir(filepath.Join(session.Dir(), inputName+".tmp"), 0o700),
+		"the input temp-path collision forces direct pane fallback")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(session.Dir(), RoundSignalName("claude", 2, "ready")), nil, 0o600,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(session.Dir(), RoundSignalName("claude", 2, "result.json")),
+		[]byte(`{"output":"direct fallback response","exit_code":0}`), 0o600,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(session.Dir(), RoundSignalName("claude", 2, "done")), nil, 0o600,
+	))
+	consumed := consumeFileIPCAbort(session, "claude", 2, nil, nil)
+
+	provider := ProviderConfig{Name: "claude", Binary: "echo", InteractiveInput: "stdin"}
+	panes := []paneInfo{{provider: provider, paneID: "pane-1"}}
+	cfg := OrchestraConfig{
+		Providers: []ProviderConfig{provider}, Strategy: StrategyDebate,
+		Prompt: "round 2 fallback", TimeoutSeconds: 5, Terminal: mock,
+		Interactive: true, HookMode: true, InitialDelay: time.Millisecond,
+	}
+
+	responses := executeRound(
+		context.Background(), cfg, panes, session, 2,
+		[]ProviderResponse{{Provider: "claude", Output: "round 1"}},
+	)
+	require.NoError(t, <-consumed)
+
+	require.Len(t, responses, 1)
+	assert.Equal(t, "direct fallback response", responses[0].Output)
+	assert.NotEmpty(t, mock.sendLongTextCalls, "failed file IPC must fall back to pane input")
+	cursor, err := os.ReadFile(filepath.Join(session.Dir(), "claude-round-cursor"))
+	require.NoError(t, err)
+	assert.Equal(t, "2", string(cursor))
 }
 
 // TestWaitForDoneRoundCtx_ZeroRound_FallsBack verifies WaitForDoneRoundCtx

--- a/pkg/orchestra/hook_round_cursor.go
+++ b/pkg/orchestra/hook_round_cursor.go
@@ -1,0 +1,20 @@
+package orchestra
+
+import "fmt"
+
+func hookRoundCursorName(provider string) string {
+	return sanitizeProviderName(providerArtifactIdentity(provider)) + "-round-cursor"
+}
+
+// WriteRoundCursor persists the logical round inherited by the next hook
+// invocation. Provider CLIs keep their launch-time environment, so round 2+
+// cannot rely on AUTOPUS_ROUND changing inside the parent process.
+func (s *HookSession) WriteRoundCursor(provider string, round int) error {
+	if err := validateHookArtifactProvider(provider); err != nil {
+		return err
+	}
+	if round <= 0 {
+		return fmt.Errorf("hook round cursor must be positive: %d", round)
+	}
+	return s.writeJSONArtifact(hookRoundCursorName(provider), round)
+}

--- a/pkg/orchestra/hook_round_cursor_test.go
+++ b/pkg/orchestra/hook_round_cursor_test.go
@@ -1,0 +1,38 @@
+package orchestra
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHookSessionWriteRoundCursor(t *testing.T) {
+	t.Parallel()
+
+	session, err := NewHookSession("round-cursor-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+
+	require.NoError(t, session.WriteRoundCursor("claude", 2))
+	path := filepath.Join(session.Dir(), "claude-round-cursor")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "2", string(data))
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestHookSessionWriteRoundCursorRejectsUnsafeCoordinates(t *testing.T) {
+	t.Parallel()
+
+	session, err := NewHookSession("round-cursor-invalid-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+
+	assert.Error(t, session.WriteRoundCursor("../claude", 2))
+	assert.Error(t, session.WriteRoundCursor("claude", 0))
+}

--- a/pkg/orchestra/hook_signal.go
+++ b/pkg/orchestra/hook_signal.go
@@ -16,10 +16,13 @@ type HookResult struct {
 
 // HookSession manages the file-based signal protocol for hook result collection.
 type HookSession struct {
-	sessionID     string
-	sessionDir    string
-	hookProviders map[string]bool
-	storage       *hookSessionStorage
+	sessionID            string
+	sessionDir           string
+	hookProviders        map[string]bool
+	startupHookProviders map[string]bool
+	hookHealth           hookCompletionHealth
+	startupHealth        hookStartupHealth
+	storage              *hookSessionStorage
 }
 
 // defaultHookProviders lists providers that have hooks by default.
@@ -43,18 +46,18 @@ func NewHookSession(sessionID string) (*HookSession, error) {
 	}
 
 	return &HookSession{
-		sessionID:     sessionID,
-		sessionDir:    dir,
-		hookProviders: DefaultHookProviders(),
-		storage:       storage,
+		sessionID:            sessionID,
+		sessionDir:           dir,
+		hookProviders:        DefaultHookProviders(),
+		startupHookProviders: DefaultStartupHookProviders(),
+		storage:              storage,
 	}, nil
 }
 
-// ApplyProviderHooks derives the session's hook-capable provider set from the
-// per-provider ProviderConfig.HasHook overrides. When no provider sets an override
-// the resolved map equals DefaultHookProviders() (INV-003, backward-compatible).
+// ApplyProviderHooks resolves independent completion and startup overrides.
 func (s *HookSession) ApplyProviderHooks(providers []ProviderConfig) {
-	s.hookProviders = resolveHookProviders(providers)
+	s.SetHookProviders(resolveHookProviders(providers))
+	s.SetStartupHookProviders(resolveStartupHookProviders(providers))
 }
 
 // WaitForDone polls for the provider-specific "{provider}-done" file at 200ms intervals.
@@ -73,7 +76,7 @@ func (s *HookSession) WaitForDone(timeout time.Duration, providers ...string) er
 	// Use provider-specific done file if provider name is given (R1 protocol)
 	doneName := "done"
 	if len(providers) > 0 {
-		doneName = providers[0] + "-done"
+		doneName = providerArtifactIdentity(providers[0]) + "-done"
 	}
 
 	for {
@@ -142,7 +145,7 @@ func (s *HookSession) ReadResult(providers ...string) (*HookResult, error) {
 		if err := validateHookArtifactProvider(providers[0]); err != nil {
 			return nil, err
 		}
-		resultName = providers[0] + "-result.json"
+		resultName = providerArtifactIdentity(providers[0]) + "-result.json"
 	}
 	data, err := s.readArtifact(resultName)
 	if err != nil {
@@ -180,7 +183,7 @@ func (s *HookSession) ResetAttempt(provider string, round int) error {
 	if err := validateHookArtifactProvider(provider); err != nil {
 		return err
 	}
-	safeProvider := provider
+	safeProvider := providerArtifactIdentity(provider)
 	doneName := safeProvider + "-done"
 	resultName := safeProvider + "-result.json"
 	if round > 0 {
@@ -229,16 +232,6 @@ func (s *HookSession) Cleanup() {
 	}
 }
 
-// HasHook checks if a provider has hook configuration available.
-func (s *HookSession) HasHook(provider string) bool {
-	return s.hookProviders[provider]
-}
-
-// SetHookProviders overrides which providers have hooks configured.
-func (s *HookSession) SetHookProviders(providers map[string]bool) {
-	s.hookProviders = providers
-}
-
 // Dir returns the session directory path.
 func (s *HookSession) Dir() string {
 	return s.sessionDir
@@ -261,7 +254,7 @@ func (s *HookSession) WriteInputRound(provider string, round int, prompt string)
 		return err
 	}
 	filename := RoundSignalName(provider, round, "input.json")
-	input := HookInput{Provider: provider, Round: round, Prompt: prompt}
+	input := HookInput{Provider: providerArtifactIdentity(provider), Round: round, Prompt: prompt}
 	return s.writeJSONArtifact(filename, input)
 }
 

--- a/pkg/orchestra/hook_signal_round_test.go
+++ b/pkg/orchestra/hook_signal_round_test.go
@@ -220,8 +220,8 @@ func TestSendRoundEnvToPane(t *testing.T) {
 	assert.Equal(t, "export AUTOPUS_ROUND=3", mock.sendCommandCalls[0].Cmd)
 }
 
-// TestCollectRoundHookResults_ContextCancelled verifies early exit on
-// cancelled context (uses the new ctx.Err() check).
+// TestCollectRoundHookResults_ContextCancelled verifies that cancellation
+// preserves one unavailable result per hook provider without waiting.
 func TestCollectRoundHookResults_ContextCancelled(t *testing.T) {
 	t.Parallel()
 	sess, err := NewHookSession("test-collect-ctx-cancel")
@@ -237,8 +237,13 @@ func TestCollectRoundHookResults_ContextCancelled(t *testing.T) {
 	}
 
 	responses := collectRoundHookResults(ctx, cfg, sess, 1)
-	// Should return empty or partial — context cancelled before iteration.
-	assert.Empty(t, responses)
+	require.Len(t, responses, 2)
+	for _, response := range responses {
+		assert.True(t, response.TimedOut)
+		assert.True(t, response.EmptyOutput)
+		assert.Contains(t, response.Error, context.Canceled.Error())
+		assert.Equal(t, paneBackendName, response.ExecutedBackend)
+	}
 }
 
 // TestCollectRoundHookResults_DefaultTimeout verifies the 60s default timeout

--- a/pkg/orchestra/hook_startup_health.go
+++ b/pkg/orchestra/hook_startup_health.go
@@ -1,0 +1,66 @@
+package orchestra
+
+import "sync"
+
+type hookStartupObservation struct {
+	round int
+}
+
+// hookStartupHealth tracks startup hooks configured for this run that did not
+// emit a ready artifact. It is independent from completion-hook health and its
+// zero value is ready for concurrent use.
+type hookStartupHealth struct {
+	mu       sync.RWMutex
+	inactive map[string]hookStartupObservation
+}
+
+// HasStartupHook reports whether startup-ready artifacts are still trusted for
+// this run. Provider aliases share the generated artifact identity.
+func (s *HookSession) HasStartupHook(provider string) bool {
+	if s == nil {
+		return false
+	}
+	identity := providerArtifactIdentity(provider)
+	s.startupHealth.mu.RLock()
+	defer s.startupHealth.mu.RUnlock()
+	_, inactive := s.startupHealth.inactive[identity]
+	return s.startupHookProviders[identity] && !inactive
+}
+
+// SetStartupHookProviders replaces startup-hook configuration and resets its
+// run health without changing completion-hook configuration or health.
+func (s *HookSession) SetStartupHookProviders(providers map[string]bool) {
+	if s == nil {
+		return
+	}
+	s.startupHealth.mu.Lock()
+	defer s.startupHealth.mu.Unlock()
+	s.startupHookProviders = make(map[string]bool, len(providers))
+	for provider, enabled := range providers {
+		s.startupHookProviders[providerArtifactIdentity(provider)] = enabled
+	}
+	s.startupHealth.inactive = nil
+}
+
+// deactivateCodexStartupHook records that this run cannot trust Codex's
+// project-local SessionStart hook. Other providers remain fail-closed because
+// their startup contracts do not have Codex's project-hook trust boundary.
+func (s *HookSession) deactivateCodexStartupHook(provider string, round int) bool {
+	if s == nil {
+		return false
+	}
+	identity := providerArtifactIdentity(provider)
+	if identity != "codex" {
+		return false
+	}
+	s.startupHealth.mu.Lock()
+	defer s.startupHealth.mu.Unlock()
+	if !s.startupHookProviders[identity] {
+		return false
+	}
+	if s.startupHealth.inactive == nil {
+		s.startupHealth.inactive = make(map[string]hookStartupObservation)
+	}
+	s.startupHealth.inactive[identity] = hookStartupObservation{round: round}
+	return true
+}

--- a/pkg/orchestra/hook_startup_health_test.go
+++ b/pkg/orchestra/hook_startup_health_test.go
@@ -1,0 +1,209 @@
+package orchestra
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const codexStablePrompt = "› Summarize recent commits\n"
+
+func TestWaitForPaneReady_CodexMissingArtifactDeactivatesStartupHook(t *testing.T) {
+	session, err := NewHookSession("codex-startup-inactive-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+
+	term := &seqScreenMock{name: "cmux", screens: []string{codexStablePrompt}}
+	ready := waitForPaneReady(
+		context.Background(), term, "surface:codex-untrusted",
+		SessionReadyPatterns(), 3*time.Second, session, "CODEX", 0,
+	)
+
+	assert.True(t, ready, "a stable Codex prompt must survive an untrusted project startup hook")
+	assert.False(t, session.HasStartupHook("codex"),
+		"the missing Codex startup artifact must disable only startup trust for this run")
+	assert.True(t, session.HasHook("codex"),
+		"startup trust fallback must not disable the independent completion hook")
+	assert.GreaterOrEqual(t, term.readCalls, 2)
+}
+
+func TestWaitForPaneReady_NonCodexMissingArtifactRemainsFailClosed(t *testing.T) {
+	on := true
+	tests := []struct {
+		name     string
+		provider ProviderConfig
+		screen   string
+	}{
+		{
+			name: "claude",
+			provider: ProviderConfig{
+				Name: "claude", HasStartupHook: &on,
+			},
+			screen: "❯ Try \"write a test for <filepath>\"\n",
+		},
+		{
+			name: "gemini explicit startup",
+			provider: ProviderConfig{
+				Name: "gemini", HasStartupHook: &on,
+			},
+			screen: "> Type your message\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session, err := NewHookSession("non-codex-startup-" + sanitizeProviderName(tt.name) + "-" + NewSessionID())
+			require.NoError(t, err)
+			defer session.Cleanup()
+			session.ApplyProviderHooks([]ProviderConfig{tt.provider})
+			term := &seqScreenMock{name: "cmux", screens: []string{tt.screen}}
+
+			ready := waitForPaneReady(
+				context.Background(), term, "surface:non-codex",
+				SessionReadyPatterns(), 700*time.Millisecond,
+				session, tt.provider.Name, 0,
+			)
+
+			assert.False(t, ready)
+			assert.True(t, session.HasStartupHook(tt.provider.Name),
+				"non-Codex startup contracts must remain fail-closed")
+		})
+	}
+}
+
+func TestWaitForPaneReady_CodexBlockerDoesNotDeactivateStartupHook(t *testing.T) {
+	session, err := NewHookSession("codex-startup-blocker-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+	term := &seqScreenMock{name: "cmux", screens: []string{
+		codexStablePrompt + "PostCompact hooks\nTurn hooks on or off\nPress esc to go back\n",
+	}}
+
+	ready := waitForPaneReady(
+		context.Background(), term, "surface:codex-blocked",
+		SessionReadyPatterns(), 1300*time.Millisecond, session, "codex", 0,
+	)
+
+	assert.False(t, ready)
+	assert.True(t, session.HasStartupHook("codex"),
+		"a blocker screen is not evidence that only the startup hook is inactive")
+}
+
+func TestWaitForPaneReady_CodexWorkingScreenDoesNotDeactivateStartupHook(t *testing.T) {
+	session, err := NewHookSession("codex-startup-working-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+	term := &seqScreenMock{name: "cmux", screens: []string{
+		codexStablePrompt + "• Working (2s • esc to interrupt)\n",
+	}}
+
+	ready := waitForPaneReady(
+		context.Background(), term, "surface:codex-working",
+		SessionReadyPatterns(), 1300*time.Millisecond, session, "codex", 0,
+	)
+
+	assert.False(t, ready)
+	assert.True(t, session.HasStartupHook("codex"),
+		"an active Codex TUI must not be mistaken for an inactive startup hook")
+}
+
+func TestRecreatePane_CodexStartupInactiveUsesStableDirectReadiness(t *testing.T) {
+	term := newRecoveryLaunchTerminal()
+	term.readScreenOutput = codexStablePrompt
+	provider := ProviderConfig{
+		Name: "codex", Binary: "codex", StartupTimeout: 3 * time.Second,
+	}
+	cfg, session := newRecoveryHookConfig(
+		t, term, "recovery-codex-startup-inactive", provider,
+	)
+
+	ready := waitForPaneReady(
+		context.Background(), term, "surface:initial-codex",
+		SessionReadyPatterns(), provider.StartupTimeout, session, provider.Name, 0,
+	)
+	require.True(t, ready)
+	require.False(t, session.HasStartupHook(provider.Name))
+
+	old := paneInfo{paneID: "old-pane", provider: provider}
+	got, err := recreatePane(context.Background(), cfg, old, 2)
+
+	require.NoError(t, err)
+	assert.Equal(t, terminal.PaneID("pane-1"), got.paneID)
+	assert.Equal(t, 2, got.directPromptRound)
+	assert.Contains(t, term.closeCalls, "old-pane")
+	_, statErr := session.statArtifact(RoundSignalName(provider.Name, 2, "ready"))
+	assert.ErrorIs(t, statErr, os.ErrNotExist,
+		"recovery must not require a startup artifact after run-level Codex trust fallback")
+}
+
+func TestRecreatePane_CodexStartupInactiveRejectsWorkingScreen(t *testing.T) {
+	term := newRecoveryLaunchTerminal()
+	term.readScreenOutput = codexStablePrompt + "• Working (2s • esc to interrupt)\n"
+	provider := ProviderConfig{
+		Name: "codex", Binary: "codex", StartupTimeout: 700 * time.Millisecond,
+	}
+	cfg, session := newRecoveryHookConfig(
+		t, term, "recovery-codex-startup-working", provider,
+	)
+	require.True(t, session.deactivateCodexStartupHook(provider.Name, 0))
+	old := paneInfo{paneID: "old-pane", provider: provider}
+
+	got, err := recreatePane(context.Background(), cfg, old, 2)
+
+	require.Error(t, err)
+	assert.Equal(t, old, got)
+	assert.Contains(t, term.closeCalls, "pane-1")
+	assert.NotContains(t, term.closeCalls, "old-pane")
+}
+
+func TestHookSession_CompletionAndStartupHealthAreIndependent(t *testing.T) {
+	session, err := NewHookSession("hook-health-independent-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+
+	provenance, err := session.deactivateContinuationHook(
+		ProviderConfig{Name: "codex", Binary: "codex"}, 1,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, hookCompletionResponseFileOnly, provenance)
+	assert.False(t, session.HasHook("codex"))
+	assert.True(t, session.HasStartupHook("codex"),
+		"completion fallback must not mutate startup trust")
+}
+
+func TestHookSession_StartupHealthIsConcurrentAndZeroValueSafe(t *testing.T) {
+	var session HookSession
+	assert.False(t, session.HasStartupHook("codex"))
+	assert.False(t, session.deactivateCodexStartupHook("codex", 0))
+
+	var wg sync.WaitGroup
+	for i := 0; i < 24; i++ {
+		wg.Add(1)
+		go func(round int) {
+			defer wg.Done()
+			if round%3 == 0 {
+				session.SetStartupHookProviders(map[string]bool{"CODEX": true})
+				return
+			}
+			if round%3 == 1 {
+				_ = session.HasStartupHook("codex")
+				return
+			}
+			_ = session.deactivateCodexStartupHook("CODEX", round)
+		}(i)
+	}
+	wg.Wait()
+
+	session.SetStartupHookProviders(map[string]bool{"CODEX": true})
+	require.True(t, session.HasStartupHook("codex"))
+	require.True(t, session.deactivateCodexStartupHook("CODEX", 7))
+	assert.False(t, session.HasStartupHook("codex"),
+		"provider aliases must share one startup-health identity")
+}

--- a/pkg/orchestra/interactive.go
+++ b/pkg/orchestra/interactive.go
@@ -74,7 +74,7 @@ func RunInteractivePaneOrchestra(ctx context.Context, cfg OrchestraConfig) (*Orc
 
 	launchFailed := launchInteractiveSessions(timeoutCtx, cfg, panes)
 	failed = append(failed, launchFailed...)
-	readyFailed := waitForSessionReady(timeoutCtx, cfg.Terminal, panes)
+	readyFailed := waitForSessionReadyWithHook(timeoutCtx, cfg.Terminal, panes, hookSession, 0)
 	failed = append(failed, readyFailed...)
 	promptFailed := sendPrompts(timeoutCtx, cfg, panes)
 	failed = append(failed, promptFailed...)
@@ -84,16 +84,7 @@ func RunInteractivePaneOrchestra(ctx context.Context, cfg OrchestraConfig) (*Orc
 	time.Sleep(initialDelay)
 
 	patterns := DefaultCompletionPatterns()
-	var responses []ProviderResponse
-	if cfg.HookMode && hookSession != nil {
-		var hookErr error
-		responses, hookErr = WaitAndCollectHookResults(cfg, cfg.SessionID)
-		if hookErr != nil {
-			responses = waitAndCollectResults(timeoutCtx, cfg, panes, patterns, start, nil, hookSession, 0)
-		}
-	} else {
-		responses = waitAndCollectResults(timeoutCtx, cfg, panes, patterns, start, nil, hookSession, 0)
-	}
+	responses := waitAndCollectResults(timeoutCtx, cfg, panes, patterns, start, nil, hookSession, 0)
 	failed = append(failed, responseFailuresFromInteractivePanes(panes, responses, timeout, failed)...)
 
 	// Step 8: Merge by strategy (reuse existing mergeByStrategy)
@@ -128,6 +119,8 @@ func startPipeCapture(ctx context.Context, term terminal.Terminal, panes []paneI
 func launchInteractiveSessions(ctx context.Context, cfg OrchestraConfig, panes []paneInfo) []FailedProvider {
 	var wg sync.WaitGroup
 	failedCh := make(chan FailedProvider, len(panes)*2)
+	completionHookProviders := resolveHookProviders(cfg.Providers)
+	startupHookProviders := resolveStartupHookProviders(cfg.Providers)
 	for i := range panes {
 		wg.Add(1)
 		go func(i int) {
@@ -160,14 +153,34 @@ func launchInteractiveSessions(ctx context.Context, cfg OrchestraConfig, panes [
 			// (they are independent login shells). SendSessionEnvToPane mirrors the pattern
 			// used by SendRoundEnvToPane for AUTOPUS_ROUND. Without this, hook scripts that
 			// guard on AUTOPUS_SESSION_ID (e.g., hook-claude-stop.sh:8) exit 0 as a no-op.
-			if cfg.HookMode && cfg.SessionID != "" {
+			artifactProvider := providerArtifactIdentity(pi.provider.Name)
+			hasHookCapability := completionHookProviders[artifactProvider] || startupHookProviders[artifactProvider]
+			if cfg.HookMode && cfg.SessionID != "" && hasHookCapability {
 				envErr, enterErr := sendPaneInputAndEnterSerialized(ctx, cfg.Terminal, pi.paneID, 0, func() error {
 					return SendSessionEnvToPane(ctx, cfg.Terminal, pi.paneID, cfg.SessionID)
 				})
 				if envErr != nil {
-					log.Printf("[interactive] SendSessionEnvToPane for %s failed (non-fatal): %v", pi.provider.Name, envErr)
-				} else if enterErr != nil {
-					log.Printf("[interactive] session-env Enter for %s failed (non-fatal): %v", pi.provider.Name, enterErr)
+					recordFailure(fmt.Sprintf("export hook session failed: %v", envErr))
+					return
+				}
+				if enterErr != nil {
+					recordFailure(fmt.Sprintf("commit hook session export failed: %v", enterErr))
+					return
+				}
+				// Fastest keeps its unscoped round-0 hook contract. Debate collection
+				// is round-scoped, so the provider CLI must inherit round 1 at launch.
+				if cfg.Strategy == StrategyDebate {
+					roundErr, roundEnterErr := sendPaneInputAndEnterSerialized(ctx, cfg.Terminal, pi.paneID, 0, func() error {
+						return SendRoundEnvToPane(ctx, cfg.Terminal, pi.paneID, 1)
+					})
+					if roundErr != nil {
+						recordFailure(fmt.Sprintf("export hook round failed: %v", roundErr))
+						return
+					}
+					if roundEnterErr != nil {
+						recordFailure(fmt.Sprintf("commit hook round export failed: %v", roundEnterErr))
+						return
+					}
 				}
 			}
 

--- a/pkg/orchestra/interactive_collect.go
+++ b/pkg/orchestra/interactive_collect.go
@@ -23,6 +23,7 @@ func waitAndCollectResults(ctx context.Context, cfg OrchestraConfig, panes []pan
 
 	for _, pi := range panes {
 		if pi.skipWait {
+			mu.Lock()
 			responses = append(responses, unavailableResponse(ProviderResponse{
 				Provider:    pi.provider.Name,
 				Duration:    time.Since(start),
@@ -30,6 +31,7 @@ func waitAndCollectResults(ctx context.Context, cfg OrchestraConfig, panes []pan
 				EmptyOutput: true,
 				Error:       "provider was skipped before completion collection",
 			}, usageSourcePane, usageReasonPane))
+			mu.Unlock()
 			continue
 		}
 		wg.Add(1)
@@ -39,13 +41,23 @@ func waitAndCollectResults(ctx context.Context, cfg OrchestraConfig, panes []pan
 			if baselines != nil {
 				baseline = baselines[pi.provider.Name]
 			}
-			timedOut := !waitForCompletion(ctx, cfg, pi, patterns, baseline, hookSession, round)
+			completionConfirmed := waitForCompletion(ctx, cfg, pi, patterns, baseline, hookSession, round)
+			timedOut := !completionConfirmed
 			output, responseFileOK := readResponseFile(pi.responseFile)
 			if responseFileOK {
 				timedOut = false
 			}
+			hookResultOK := false
+			if !responseFileOK && hookSession != nil && hookSession.HasHook(pi.provider.Name) {
+				if result, err := hookSession.ReadResultRound(pi.provider.Name, round); err == nil && result != nil && result.Output != "" {
+					output = result.Output
+					hookResultOK = true
+					// A result without detector completion is partial evidence, not
+					// authority to turn a timeout or detector failure into success.
+				}
+			}
 
-			if !responseFileOK {
+			if !responseFileOK && !hookResultOK {
 				// Fresh context for final read — original ctx may be cancelled after timeout.
 				readCtx, readCancel := context.WithTimeout(context.Background(), 5*time.Second)
 				screen, _ := cfg.Terminal.ReadScreen(readCtx, pi.paneID, terminal.ReadScreenOpts{
@@ -88,6 +100,8 @@ func waitAndCollectResults(ctx context.Context, cfg OrchestraConfig, panes []pan
 				collectionMode := "poll"
 				if responseFileOK {
 					collectionMode = "response_file"
+				} else if hookResultOK {
+					collectionMode = "hook"
 				}
 				receipt := collectionReceipt(cfg.RunID, pi.provider.Name, collectionMode, collectionMode, status, errMsg, output, round, partial)
 				receiptPath = cfg.ReliabilityStore.recordCollection(receipt)

--- a/pkg/orchestra/interactive_collect_hook_test.go
+++ b/pkg/orchestra/interactive_collect_hook_test.go
@@ -1,0 +1,96 @@
+package orchestra
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitAndCollectResults_HookResultPrecedesScreenFallback(t *testing.T) {
+	t.Parallel()
+
+	session, err := NewHookSession("pane-hook-collect-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+	require.NoError(t, os.WriteFile(filepath.Join(session.Dir(), "claude-result.json"),
+		[]byte(`{"output":"hook output","exit_code":0}`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(session.Dir(), "claude-done"), nil, 0o600))
+
+	term := newCmuxMock()
+	term.readScreenOutput = "screen fallback must not win\n❯\n"
+	provider := ProviderConfig{Name: "claude"}
+	panes := []paneInfo{{provider: provider, paneID: "pane-hook"}}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	responses := waitAndCollectResults(ctx, OrchestraConfig{
+		Providers: []ProviderConfig{provider}, Terminal: term, HookMode: true,
+	}, panes, DefaultCompletionPatterns(), time.Now(), nil, session, 0)
+
+	require.Len(t, responses, 1)
+	assert.Equal(t, "hook output", responses[0].Output)
+	assert.False(t, responses[0].TimedOut)
+	assert.Zero(t, term.readScreenCalls)
+}
+
+func TestWaitAndCollectResults_ResultWithoutDone_RemainsTimedOut(t *testing.T) {
+	t.Parallel()
+
+	session, err := NewHookSession("pane-hook-orphan-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+	require.NoError(t, os.WriteFile(filepath.Join(session.Dir(), "claude-result.json"),
+		[]byte(`{"output":"orphan hook output","exit_code":0}`), 0o600))
+
+	term := newCmuxMock()
+	term.readScreenOutput = "bounded screen fallback"
+	provider := ProviderConfig{Name: "claude"}
+	ctx, cancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+
+	responses := waitAndCollectResults(ctx, OrchestraConfig{
+		Providers: []ProviderConfig{provider}, Terminal: term, HookMode: true,
+	}, []paneInfo{{provider: provider, paneID: "pane-orphan"}},
+		DefaultCompletionPatterns(), started, nil, session, 0)
+
+	require.Len(t, responses, 1)
+	assert.True(t, responses[0].TimedOut, "a result artifact cannot replace the missing done signal")
+	assert.Contains(t, responses[0].Error, "completion detector timed out")
+	assert.Equal(t, "orphan hook output", responses[0].Output, "partial result evidence may be preserved on a timeout")
+	assert.Zero(t, term.readScreenCalls, "available partial evidence must avoid an unbounded final screen read")
+	assert.Less(t, time.Since(started), time.Second, "collector must remain bounded by the caller context")
+}
+
+func TestWaitAndCollectResults_DetectorFailureDoesNotPromoteHookResult(t *testing.T) {
+	t.Parallel()
+
+	session, err := NewHookSession("pane-hook-detector-error-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+	require.NoError(t, os.WriteFile(filepath.Join(session.Dir(), "claude-result.json"),
+		[]byte(`{"output":"stale hook output","exit_code":0}`), 0o600))
+
+	term := newCmuxMock()
+	term.readScreenOutput = "detector failure screen fallback"
+	provider := ProviderConfig{Name: "claude"}
+	ctx, cancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
+	defer cancel()
+
+	responses := waitAndCollectResults(ctx, OrchestraConfig{
+		Providers: []ProviderConfig{provider}, Terminal: term, HookMode: true,
+		CompletionDetector: &stubCompletionDetector{err: errors.New("injected detector failure")},
+	}, []paneInfo{{provider: provider, paneID: "pane-detector-error"}},
+		DefaultCompletionPatterns(), time.Now(), nil, session, 0)
+
+	require.Len(t, responses, 1)
+	assert.True(t, responses[0].TimedOut)
+	assert.Equal(t, "stale hook output", responses[0].Output)
+	assert.Zero(t, term.readScreenCalls)
+}

--- a/pkg/orchestra/interactive_debate.go
+++ b/pkg/orchestra/interactive_debate.go
@@ -197,18 +197,22 @@ func runPaneDebate(ctx context.Context, cfg OrchestraConfig, rounds int, perRoun
 
 		roundHistory = append(roundHistory, roundResponses)
 
-		// R5: Yield mode — output JSON after Round 1 and keep panes alive.
 		if cfg.YieldRounds && round == 1 {
 			fmt.Fprintf(os.Stderr, "[Debate] yield after round 1/%d\n", rounds)
 			sessionID := NewSessionID()
-			session := buildYieldSession(sessionID, panes, roundResponses, time.Now())
+			session, sessionErr := buildYieldSession(sessionID, cfg.Terminal, panes, roundResponses, time.Now())
+			if sessionErr != nil {
+				return nil, fmt.Errorf("persist yield session context: %w", sessionErr)
+			}
 			if err := SaveSession(session); err != nil {
 				return nil, fmt.Errorf("persist yield session: %w", err)
 			}
+			handoffErr := handoffYieldPanes(sessionID, cfg.Terminal, panes)
 			ownsPanes = false
+			if handoffErr != nil {
+				return nil, handoffErr
+			}
 			output := BuildYieldOutput(cfg, panes, roundHistory, sessionID)
-			// surfMgr.Stop() removed — defer at line 115 handles cleanup.
-			// Explicit Stop here caused duplicate WarmPool.Close() calls.
 			result := buildDebateResult(cfg, roundResponses, roundHistory, start)
 			result.Yield = &output
 			result.FailedProviders = append(result.FailedProviders, launchFailed...)
@@ -258,37 +262,6 @@ func runPaneDebate(ctx context.Context, cfg OrchestraConfig, rounds int, perRoun
 		result.FailedProviders[i].CorrelationRunID = cfg.RunID
 	}
 	return finalizeDebateOutcome(result, cfg)
-}
-
-func buildYieldSession(sessionID string, panes []paneInfo, responses []ProviderResponse, createdAt time.Time) OrchestraSession {
-	session := OrchestraSession{
-		ID:        sessionID,
-		Panes:     make(map[string]string, len(panes)),
-		Providers: make([]SessionProviderConfig, 0, len(panes)),
-		Rounds:    make([][]SessionProviderResponse, 0, 1),
-		CreatedAt: createdAt,
-	}
-	for _, pi := range panes {
-		session.Panes[pi.provider.Name] = string(pi.paneID)
-		session.Providers = append(session.Providers, SessionProviderConfig{
-			Name:   pi.provider.Name,
-			Binary: pi.provider.Binary,
-		})
-	}
-
-	round := make([]SessionProviderResponse, 0, len(responses))
-	for _, response := range responses {
-		round = append(round, SessionProviderResponse{
-			Provider:        response.Provider,
-			Output:          response.Output,
-			DurationMs:      response.Duration.Milliseconds(),
-			TimedOut:        response.TimedOut,
-			Usage:           response.Usage,
-			UsageCapability: response.UsageCapability,
-		})
-	}
-	session.Rounds = append(session.Rounds, round)
-	return session
 }
 
 // executeRound is in interactive_debate_round.go.

--- a/pkg/orchestra/interactive_debate.go
+++ b/pkg/orchestra/interactive_debate.go
@@ -93,6 +93,7 @@ func runNonInteractiveDebate(ctx context.Context, cfg OrchestraConfig, rounds in
 
 // runPaneDebate executes the multi-turn debate loop using terminal panes.
 func runPaneDebate(ctx context.Context, cfg OrchestraConfig, rounds int, perRound time.Duration, start time.Time) (*OrchestraResult, error) {
+	cfg.DebateRounds = rounds
 	cfg.RunID = ensureRunID(&cfg)
 	if cfg.ReliabilityStore == nil {
 		store, err := newReliabilityStore(cfg.RunID)
@@ -150,9 +151,11 @@ func runPaneDebate(ctx context.Context, cfg OrchestraConfig, rounds int, perRoun
 	}
 
 	launchFailed := launchInteractiveSessions(ctx, cfg, panes)
-	if !cfg.HookMode || hookSession == nil {
-		launchFailed = append(launchFailed, waitForSessionReady(ctx, cfg.Terminal, panes)...)
-	}
+	// Startup cannot consume the whole orchestration deadline: a failed provider
+	// must still reach the round result as skipWait plus FailedProvider evidence.
+	readyCtx, cancelReady := context.WithTimeout(ctx, perRound)
+	launchFailed = append(launchFailed, waitForSessionReadyWithHook(readyCtx, cfg.Terminal, panes, hookSession, 1)...)
+	cancelReady()
 	if cfg.ReliabilityStore != nil {
 		for _, provider := range cfg.Providers {
 			_ = cfg.ReliabilityStore.recordPreflight(preflightReceipt(cfg.RunID, cfg, provider))
@@ -161,6 +164,7 @@ func runPaneDebate(ctx context.Context, cfg OrchestraConfig, rounds int, perRoun
 
 	// Create SurfaceManager for proactive health monitoring (R1).
 	surfMgr := NewSurfaceManager(cfg.Terminal)
+	surfMgr.setHookSession(hookSession)
 	surfMgr.Start(ctx, panes)
 	defer surfMgr.Stop()
 	cfg.SurfaceMgr = surfMgr
@@ -199,6 +203,11 @@ func runPaneDebate(ctx context.Context, cfg OrchestraConfig, rounds int, perRoun
 
 		if cfg.YieldRounds && round == 1 {
 			fmt.Fprintf(os.Stderr, "[Debate] yield after round 1/%d\n", rounds)
+			if err := releaseYieldHookWaiters(
+				ctx, hookSession, panes, round+1, yieldHookReleaseBudget(perRound),
+			); err != nil {
+				return nil, fmt.Errorf("release hook waiters before yield: %w", err)
+			}
 			sessionID := NewSessionID()
 			session, sessionErr := buildYieldSession(sessionID, cfg.Terminal, panes, roundResponses, time.Now())
 			if sessionErr != nil {

--- a/pkg/orchestra/interactive_debate_direct_prompt_test.go
+++ b/pkg/orchestra/interactive_debate_direct_prompt_test.go
@@ -1,0 +1,68 @@
+package orchestra
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecuteRound_RecoveredDirectPromptOnlySkipsCurrentRoundFileIPC(t *testing.T) {
+	t.Parallel()
+
+	session, err := NewHookSession("recovered-direct-round-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+	session.SetHookProviders(map[string]bool{"claude": true})
+	writeRoundIPCFixture(t, session, "claude", 2, "direct round response")
+
+	term := newCmuxMock()
+	term.readScreenOutput = "❯\n"
+	provider := ProviderConfig{Name: "claude", Binary: "echo", InteractiveInput: "stdin"}
+	panes := []paneInfo{{
+		provider: provider, paneID: "pane-recovered", directPromptRound: 2,
+	}}
+	cfg := OrchestraConfig{
+		Providers: []ProviderConfig{provider}, Strategy: StrategyDebate,
+		Prompt: "recovered prompt", TimeoutSeconds: 5, Terminal: term,
+		Interactive: true, HookMode: true, InitialDelay: time.Millisecond,
+		WorkingDir: t.TempDir(),
+	}
+
+	round2 := executeRound(context.Background(), cfg, panes, session, 2,
+		[]ProviderResponse{{Provider: "codex", Output: "round 1"}})
+
+	require.Len(t, round2, 1)
+	assert.Equal(t, "direct round response", round2[0].Output)
+	assert.NoFileExists(t, filepath.Join(session.Dir(), RoundSignalName("claude", 2, "input.json")))
+	require.NotEmpty(t, term.sendLongTextCalls, "recovered round must submit directly to its stable prompt")
+	directSendCount := len(term.sendLongTextCalls)
+	cursor, err := os.ReadFile(filepath.Join(session.Dir(), hookRoundCursorName("claude")))
+	require.NoError(t, err)
+	assert.Equal(t, "2", string(cursor))
+
+	writeRoundIPCFixture(t, session, "claude", 3, "next round IPC response")
+	round3 := executeRound(context.Background(), cfg, panes, session, 3, round2)
+
+	require.Len(t, round3, 1)
+	assert.Equal(t, "next round IPC response", round3[0].Output)
+	assert.FileExists(t, filepath.Join(session.Dir(), RoundSignalName("claude", 3, "input.json")),
+		"the round-scoped direct marker must not disable next-round file IPC")
+	assert.Len(t, term.sendLongTextCalls, directSendCount, "next round must return to file IPC")
+	for _, call := range term.sendCommandCalls {
+		assert.NotContains(t, call.Cmd, "AUTOPUS_ROUND", "active panes must never receive a shell export")
+	}
+}
+
+func writeRoundIPCFixture(t *testing.T, session *HookSession, provider string, round int, output string) {
+	t.Helper()
+	require.NoError(t, session.writeArtifact(RoundSignalName(provider, round, "ready"), nil, 0o600))
+	require.NoError(t, session.writeArtifact(RoundSignalName(provider, round, "done"), nil, 0o600))
+	require.NoError(t, session.writeJSONArtifact(RoundSignalName(provider, round, "result.json"), HookResult{
+		Output: output,
+	}))
+}

--- a/pkg/orchestra/interactive_debate_helpers.go
+++ b/pkg/orchestra/interactive_debate_helpers.go
@@ -5,101 +5,15 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"sync"
 	"time"
 )
 
-// collectRoundHookResults collects hook-based results for a specific round.
-// Each provider waits on its own execution timeout so one missing hook signal
-// does not consume the full round budget for every sibling provider.
-func collectRoundHookResults(ctx context.Context, cfg OrchestraConfig, session *HookSession, round int) []ProviderResponse {
-	if cfg.ReliabilityStore == nil && cfg.RunID != "" {
-		if store, err := newReliabilityStore(cfg.RunID); err == nil {
-			cfg.ReliabilityStore = store
-		}
-	}
-
-	var (
-		mu        sync.Mutex
-		responses []ProviderResponse
-		wg        sync.WaitGroup
-	)
-	for _, p := range cfg.Providers {
-		if ctx.Err() != nil {
-			continue
-		}
-		wg.Add(1)
-		go func(provider ProviderConfig) {
-			defer wg.Done()
-			if !session.HasHook(provider.Name) {
-				return
-			}
-
-			start := time.Now()
-			timeout := providerExecutionTimeout(provider, cfg.TimeoutSeconds)
-			err := session.WaitForDoneRoundCtx(ctx, timeout, provider.Name, round)
-			if err != nil {
-				receiptPath := ""
-				if cfg.ReliabilityStore != nil {
-					receipt := collectionReceipt(cfg.RunID, provider.Name, "hook", "hook", "timeout", err.Error(), "", round, true)
-					receiptPath = cfg.ReliabilityStore.recordCollection(receipt)
-					event := timeoutEvent(cfg.RunID, provider.Name, round, "retry with subprocess fallback")
-					_ = cfg.ReliabilityStore.recordEvent(event)
-					_ = cfg.ReliabilityStore.writeFailureBundle("hook collection timed out", "retry with subprocess fallback", true)
-				}
-				mu.Lock()
-				responses = append(responses, unavailableResponse(ProviderResponse{
-					Provider: provider.Name,
-					Duration: time.Since(start),
-					TimedOut: true,
-					Receipt:  receiptPath,
-				}, usageSourcePane, usageReasonPane))
-				mu.Unlock()
-				return
-			}
-
-			result, readErr := session.ReadResultRound(provider.Name, round)
-			output := ""
-			status := "pass"
-			errMsg := ""
-			partial := false
-			if readErr == nil && result != nil {
-				output = result.Output
-			} else if readErr != nil {
-				status = "read_failed"
-				errMsg = readErr.Error()
-				partial = true
-			}
-			receiptPath := ""
-			if cfg.ReliabilityStore != nil {
-				receipt := collectionReceipt(cfg.RunID, provider.Name, "hook", "hook", status, errMsg, output, round, partial)
-				receiptPath = cfg.ReliabilityStore.recordCollection(receipt)
-			}
-			mu.Lock()
-			responses = append(responses, unavailableResponse(ProviderResponse{
-				Provider: provider.Name,
-				Output:   output,
-				Duration: time.Since(start),
-				Receipt:  receiptPath,
-			}, usageSourcePane, usageReasonPane))
-			mu.Unlock()
-		}(p)
-	}
-	wg.Wait()
-	return responses
-}
-
-// runJudgeRound executes the judge verdict after all debate rounds through the
-// same pane-aware backend selection as the participant providers.
-// Uses a fresh context with 120s timeout since the parent context may be near expiry
-// after debate rounds consumed most of the allotted time.
-// The selected backend owns bounded completion detection; the context timeout
-// remains the outer safety bound and still respects parent cancellation.
+// runJudgeRound uses pane-aware backend selection with a bounded fresh context.
+// The parent context remains the outer cancellation bound.
 func runJudgeRound(ctx context.Context, cfg OrchestraConfig, _ []paneInfo, _ *HookSession, responses []ProviderResponse, round int) *ProviderResponse {
 	judgment := buildTypedJudgmentPrompt(cfg.Prompt, responses)
 	judgeCfg := findOrBuildJudgeConfig(cfg)
 
-	// Bound the judge with both the parent context and a local timeout.
 	judgeTimeout := time.Duration(cfg.TimeoutSeconds) * time.Second
 	if judgeTimeout < 60*time.Second {
 		judgeTimeout = 60 * time.Second
@@ -148,8 +62,6 @@ func runJudgeRound(ctx context.Context, cfg OrchestraConfig, _ []paneInfo, _ *Ho
 	return resp
 }
 
-// consensusReached checks if all responses are substantially similar.
-// REQ-7: Uses configurable threshold from OrchestraConfig (default 0.66).
 // @AX:NOTE [AUTO] REQ-7 magic constant 0.66 — default consensus threshold; configurable via ConsensusThreshold field
 func consensusReached(responses []ProviderResponse, cfg OrchestraConfig) bool {
 	if len(responses) < 2 {
@@ -163,7 +75,6 @@ func consensusReached(responses []ProviderResponse, cfg OrchestraConfig) bool {
 	return metrics != nil && metrics.TotalClaims > 0 && metrics.DissentClaims == 0
 }
 
-// countNonEmpty counts responses with non-empty output.
 func countNonEmpty(responses []ProviderResponse) int {
 	n := 0
 	for _, r := range responses {
@@ -174,10 +85,6 @@ func countNonEmpty(responses []ProviderResponse) int {
 	return n
 }
 
-// perRoundTimeout calculates the timeout for each debate round.
-// REQ-5: Enforces a 45-second minimum floor per round.
-// R1: Subtracts judge budget (min 60s) from total before dividing among debate rounds.
-// When noJudge is true, the judge budget is skipped entirely so all time goes to debate.
 // @AX:NOTE [AUTO] REQ-5 magic constant 45s — minimum floor per debate round; lowering risks premature timeout
 func perRoundTimeout(totalSeconds, rounds int, noJudge bool) time.Duration {
 	if totalSeconds <= 0 {
@@ -186,8 +93,7 @@ func perRoundTimeout(totalSeconds, rounds int, noJudge bool) time.Duration {
 	if rounds <= 0 {
 		rounds = 1
 	}
-	// Reserve judge budget (min 60s) from total before dividing among debate rounds.
-	// Skip reservation when --no-judge is set — no judge phase will run.
+	// Reserve the judge budget unless --no-judge is set.
 	judgeReserve := 60
 	if noJudge {
 		judgeReserve = 0
@@ -203,7 +109,6 @@ func perRoundTimeout(totalSeconds, rounds int, noJudge bool) time.Duration {
 	return time.Duration(perRound) * time.Second
 }
 
-// buildDebateResult constructs the final OrchestraResult from debate rounds.
 func buildDebateResult(cfg OrchestraConfig, responses []ProviderResponse, roundHistory [][]ProviderResponse, start time.Time) *OrchestraResult {
 	merged, summary := mergeByStrategy(cfg.Strategy, responses, cfg)
 	if merged == "" {

--- a/pkg/orchestra/interactive_debate_hook_cancel_test.go
+++ b/pkg/orchestra/interactive_debate_hook_cancel_test.go
@@ -1,0 +1,126 @@
+package orchestra
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectRoundHookResults_PreCancelledPreservesOwnedProviderCardinality(t *testing.T) {
+	session := newTestHookSession(t)
+	session.SetHookProviders(map[string]bool{"claude": true, "gemini": true})
+	store := &reliabilityStore{runID: "pre-cancel", dir: t.TempDir()}
+	providers := []ProviderConfig{
+		{Name: "claude", ExecutionTimeout: time.Second},
+		{Name: "opencode", ExecutionTimeout: time.Second},
+		{Name: "custom-skip", ExecutionTimeout: time.Second},
+		{Name: "gemini", ExecutionTimeout: time.Second},
+	}
+	panes := []paneInfo{
+		{provider: providers[0]},
+		{provider: providers[1]},
+		{provider: providers[2], skipWait: true},
+		{provider: providers[3]},
+	}
+	cfg := OrchestraConfig{Providers: providers, Strategy: StrategyDebate, RunID: "pre-cancel", ReliabilityStore: store}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	started := time.Now()
+	responses := collectRoundHookResults(ctx, cfg, session, 1, panes)
+	elapsed := time.Since(started)
+
+	byProvider := responsesByProvider(responses)
+	require.Len(t, responses, 3, "two hook providers plus the skipped pane belong to this collector")
+	assert.NotContains(t, byProvider, "opencode", "active hookless panes are collected by the poll path")
+	assertCancelledHookResponse(t, byProvider["claude"])
+	assertCancelledHookResponse(t, byProvider["gemini"])
+	assert.Equal(t, skippedHookCollectionError, byProvider["custom-skip"].Error)
+	assert.Less(t, elapsed, 250*time.Millisecond)
+	require.Len(t, store.collection, 2, "each cancelled hook provider needs collection evidence")
+	require.Len(t, store.events, 2, "each cancelled hook provider needs timeout evidence")
+
+	combined := append(responses, ProviderResponse{
+		Provider: "opencode", Output: "poll response", ExecutedBackend: paneBackendName,
+	})
+	result := buildDebateResult(
+		OrchestraConfig{Providers: providers, Strategy: StrategyDebate},
+		combined, [][]ProviderResponse{combined}, started,
+	)
+	assert.Len(t, result.Responses, 4)
+	assert.Len(t, result.FailedProviders, 3)
+	assert.Equal(t, 4, result.DispatchCount)
+	assert.Len(t, result.RunReceipt.ProviderReceipts, 4)
+}
+
+func TestCollectRoundHookResults_MidCancelPreservesSuccessAndFailure(t *testing.T) {
+	session := newTestHookSession(t)
+	session.SetHookProviders(map[string]bool{"claude": true, "codex": true})
+	store := &reliabilityStore{runID: "mid-cancel", dir: t.TempDir()}
+	providers := []ProviderConfig{
+		{Name: "claude", ExecutionTimeout: 2 * time.Second},
+		{Name: "codex", ExecutionTimeout: 2 * time.Second},
+	}
+	writeRoundHookResult(t, session, "claude", 1, "completed before cancellation")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelled := make(chan struct{})
+	go func() {
+		time.Sleep(40 * time.Millisecond)
+		cancel()
+		close(cancelled)
+	}()
+
+	started := time.Now()
+	responses := collectRoundHookResults(ctx, OrchestraConfig{
+		Providers: providers, RunID: "mid-cancel", ReliabilityStore: store,
+	}, session, 1, []paneInfo{{provider: providers[0]}, {provider: providers[1]}})
+	elapsed := time.Since(started)
+	<-cancelled
+
+	byProvider := responsesByProvider(responses)
+	require.Len(t, responses, 2)
+	assert.Equal(t, "completed before cancellation", byProvider["claude"].Output)
+	assert.False(t, byProvider["claude"].TimedOut)
+	assertCancelledHookResponse(t, byProvider["codex"])
+	assert.Less(t, elapsed, 250*time.Millisecond, "cancellation must unblock the waiting hook immediately")
+	require.Len(t, store.collection, 2)
+	require.Len(t, store.events, 1)
+	assert.Equal(t, "codex", store.events[0].Correlation.ProviderID)
+}
+
+func assertCancelledHookResponse(t *testing.T, response ProviderResponse) {
+	t.Helper()
+	assert.NotEmpty(t, response.Provider)
+	assert.True(t, response.TimedOut)
+	assert.True(t, response.EmptyOutput)
+	assert.Contains(t, response.Error, context.Canceled.Error())
+	assert.NotEmpty(t, response.Receipt)
+	assert.Equal(t, paneBackendName, response.ExecutedBackend)
+	assert.Equal(t, "participant", response.Role)
+}
+
+func responsesByProvider(responses []ProviderResponse) map[string]ProviderResponse {
+	indexed := make(map[string]ProviderResponse, len(responses))
+	for _, response := range responses {
+		indexed[response.Provider] = response
+	}
+	return indexed
+}
+
+func writeRoundHookResult(t *testing.T, session *HookSession, provider string, round int, output string) {
+	t.Helper()
+	data, err := json.Marshal(HookResult{Output: output})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(session.Dir(), RoundSignalName(provider, round, "result.json")), data, 0o600,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(session.Dir(), RoundSignalName(provider, round, "done")), nil, 0o600,
+	))
+}

--- a/pkg/orchestra/interactive_debate_hook_collect.go
+++ b/pkg/orchestra/interactive_debate_hook_collect.go
@@ -1,0 +1,207 @@
+package orchestra
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	hookResponseSettleBudget       = 200 * time.Millisecond
+	hookResponseSettlePollInterval = 10 * time.Millisecond
+	skippedHookCollectionError     = "provider was skipped before hook completion collection"
+)
+
+// collectRoundHookResults isolates each hook provider behind its execution
+// timeout while preserving an unavailable result for panes skipped before send.
+func collectRoundHookResults(ctx context.Context, cfg OrchestraConfig, session *HookSession, round int, paneGroups ...[]paneInfo) []ProviderResponse {
+	paneByProvider := hookPanesByProvider(paneGroups)
+	reliabilityStoreResolved := cfg.ReliabilityStore != nil || cfg.RunID == ""
+	var mu sync.Mutex
+	var responses []ProviderResponse
+	var wg sync.WaitGroup
+	for _, provider := range cfg.Providers {
+		pi, found := paneByProvider[provider.Name]
+		if found && pi.skipWait {
+			mu.Lock()
+			responses = append(responses, skippedHookResponse(provider))
+			mu.Unlock()
+			continue
+		}
+		if !session.HasHook(provider.Name) {
+			continue
+		}
+		if !reliabilityStoreResolved {
+			if store, err := newReliabilityStore(cfg.RunID); err == nil {
+				cfg.ReliabilityStore = store
+			}
+			reliabilityStoreResolved = true
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			response := hookTimeoutResponse(cfg, provider, round, time.Now(), ctxErr)
+			mu.Lock()
+			responses = append(responses, response)
+			mu.Unlock()
+			continue
+		}
+		if !found {
+			pi.provider = provider
+		}
+		wg.Add(1)
+		go func(provider ProviderConfig, pi paneInfo) {
+			defer wg.Done()
+			response := collectRoundHookProvider(ctx, cfg, session, provider, pi, round)
+			mu.Lock()
+			responses = append(responses, response)
+			mu.Unlock()
+		}(provider, pi)
+	}
+	wg.Wait()
+	return responses
+}
+
+func hookPanesByProvider(paneGroups [][]paneInfo) map[string]paneInfo {
+	panes := make(map[string]paneInfo)
+	if len(paneGroups) == 0 {
+		return panes
+	}
+	for _, pi := range paneGroups[0] {
+		panes[pi.provider.Name] = pi
+	}
+	return panes
+}
+
+func skippedHookResponse(provider ProviderConfig) ProviderResponse {
+	return unavailableResponse(ProviderResponse{
+		Provider:        provider.Name,
+		ModelFamily:     provider.ModelFamily,
+		ExecutedBackend: paneBackendName,
+		Role:            "participant",
+		TimedOut:        true,
+		EmptyOutput:     true,
+		Error:           skippedHookCollectionError,
+	}, usageSourcePane, usageReasonPane)
+}
+
+func collectRoundHookProvider(ctx context.Context, cfg OrchestraConfig, session *HookSession, provider ProviderConfig, pi paneInfo, round int) ProviderResponse {
+	start := time.Now()
+	providerCtx, cancel := context.WithTimeout(ctx, providerExecutionTimeout(provider, cfg.TimeoutSeconds))
+	defer cancel()
+
+	completed, detectorErr := (&FileIPCDetector{session: session}).WaitForCompletion(providerCtx, pi, nil, "", round)
+	if !completed {
+		return hookTimeoutResponse(cfg, provider, round, start, completionWaitError(providerCtx, detectorErr))
+	}
+
+	output, responseFileOK := waitForMarkedHookResponse(providerCtx, pi.responseFile)
+	if responseFileOK {
+		provenance, provenanceErr := resolveHookCompletionHandoff(
+			providerCtx, cfg, session, provider, pi, round,
+		)
+		if provenanceErr != nil {
+			log.Printf("[Round %d] %s completion handoff failed closed; retaining hook: %v", round, provider.Name, provenanceErr)
+			return hookTimeoutResponse(
+				cfg, provider, round, start, fmt.Errorf("completion handoff: %w", provenanceErr),
+			)
+		} else if provenance == hookCompletionResponseFileOnly {
+			log.Printf("[Round %d] %s completion hook inactive after stable response-only handoff", round, provider.Name)
+		}
+	}
+	status, errMsg := "pass", ""
+	partial := false
+	if !responseFileOK {
+		result, readErr := session.ReadResultRound(provider.Name, round)
+		if readErr == nil && result != nil {
+			output = result.Output
+		} else if readErr != nil {
+			status = "read_failed"
+			errMsg = readErr.Error()
+			partial = true
+		}
+	}
+
+	receiptPath := ""
+	if cfg.ReliabilityStore != nil {
+		mode := "hook"
+		if responseFileOK {
+			mode = "response_file"
+		}
+		receipt := collectionReceipt(cfg.RunID, provider.Name, mode, mode, status, errMsg, output, round, partial)
+		receiptPath = cfg.ReliabilityStore.recordCollection(receipt)
+	}
+	return unavailableResponse(ProviderResponse{
+		Provider:        provider.Name,
+		ModelFamily:     provider.ModelFamily,
+		ExecutedBackend: paneBackendName,
+		Output:          output,
+		Duration:        time.Since(start),
+		Receipt:         receiptPath,
+	}, usageSourcePane, usageReasonPane)
+}
+
+func completionWaitError(ctx context.Context, detectorErr error) error {
+	if detectorErr != nil {
+		return detectorErr
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return context.DeadlineExceeded
+}
+
+func hookTimeoutResponse(cfg OrchestraConfig, provider ProviderConfig, round int, start time.Time, waitErr error) ProviderResponse {
+	errMsg := "hook completion timeout before a done signal was collected"
+	if waitErr != nil {
+		errMsg = fmt.Sprintf("%s: %v", errMsg, waitErr)
+	}
+	receiptPath := ""
+	if cfg.ReliabilityStore != nil {
+		receipt := collectionReceipt(cfg.RunID, provider.Name, "hook", "hook", "timeout", errMsg, "", round, true)
+		receiptPath = cfg.ReliabilityStore.recordCollection(receipt)
+		event := timeoutEvent(cfg.RunID, provider.Name, round, "retry with subprocess fallback")
+		_ = cfg.ReliabilityStore.recordEvent(event)
+		_ = cfg.ReliabilityStore.writeFailureBundle("hook collection timed out", "retry with subprocess fallback", true)
+	}
+	return unavailableResponse(ProviderResponse{
+		Provider:        provider.Name,
+		ModelFamily:     provider.ModelFamily,
+		ExecutedBackend: paneBackendName,
+		Role:            "participant",
+		Duration:        time.Since(start),
+		TimedOut:        true,
+		EmptyOutput:     true,
+		Error:           errMsg,
+		Receipt:         receiptPath,
+	}, usageSourcePane, usageReasonPane)
+}
+
+// waitForMarkedHookResponse gives a response file that follows done a small,
+// explicit settle window. The provider/parent context always remains the outer
+// bound, and a final read at either boundary closes the write-vs-timeout race.
+func waitForMarkedHookResponse(ctx context.Context, path string) (string, bool) {
+	if strings.TrimSpace(path) == "" {
+		return "", false
+	}
+	if output, ok := readResponseFile(path); ok {
+		return output, true
+	}
+	settle := time.NewTimer(hookResponseSettleBudget)
+	defer settle.Stop()
+	ticker := time.NewTicker(hookResponseSettlePollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return readResponseFile(path)
+		case <-settle.C:
+			return readResponseFile(path)
+		case <-ticker.C:
+			if output, ok := readResponseFile(path); ok {
+				return output, true
+			}
+		}
+	}
+}

--- a/pkg/orchestra/interactive_debate_hook_response_test.go
+++ b/pkg/orchestra/interactive_debate_hook_response_test.go
@@ -1,0 +1,230 @@
+package orchestra
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectRoundHookResults_ClaudeResponseFileCompletesWithoutDone(t *testing.T) {
+	session, err := NewHookSession("debate-hook-claude-response")
+	require.NoError(t, err)
+	defer session.Cleanup()
+	provider := ProviderConfig{Name: "claude", ExecutionTimeout: 500 * time.Millisecond}
+	responsePath := filepath.Join(t.TempDir(), "claude-response.md")
+	writeMarkedResponse(t, responsePath, "claude file response")
+	panes := []paneInfo{{provider: provider, responseFile: responsePath}}
+
+	started := time.Now()
+	responses := collectRoundHookResults(
+		context.Background(), OrchestraConfig{Providers: []ProviderConfig{provider}}, session, 1, panes,
+	)
+
+	require.Len(t, responses, 1)
+	assert.Equal(t, "claude file response", responses[0].Output)
+	assert.False(t, responses[0].TimedOut)
+	assert.Less(t, time.Since(started), 250*time.Millisecond)
+}
+
+func TestCollectRoundHookResults_CodexResponseFileCompletesAfterGraceWithoutDone(t *testing.T) {
+	session, err := NewHookSession("debate-hook-codex-response")
+	require.NoError(t, err)
+	defer session.Cleanup()
+	provider := ProviderConfig{Name: "codex", ExecutionTimeout: 2 * time.Second}
+	responsePath := filepath.Join(t.TempDir(), "codex-response.md")
+	writeMarkedResponse(t, responsePath, "codex file response")
+	panes := []paneInfo{{provider: provider, responseFile: responsePath}}
+
+	started := time.Now()
+	responses := collectRoundHookResults(
+		context.Background(), OrchestraConfig{Providers: []ProviderConfig{provider}}, session, 1, panes,
+	)
+	elapsed := time.Since(started)
+
+	require.Len(t, responses, 1)
+	assert.Equal(t, "codex file response", responses[0].Output)
+	assert.False(t, responses[0].TimedOut)
+	assert.GreaterOrEqual(t, elapsed, 900*time.Millisecond)
+	assert.Less(t, elapsed, 1500*time.Millisecond)
+}
+
+func TestCollectRoundHookResults_ResponseFileWinsOverInvalidHookResult(t *testing.T) {
+	for _, hookResult := range []struct {
+		name string
+		data []byte
+	}{
+		{name: "missing"},
+		{name: "malformed", data: []byte("{bad json")},
+	} {
+		t.Run(hookResult.name, func(t *testing.T) {
+			session, err := NewHookSession("debate-hook-response-priority-" + hookResult.name)
+			require.NoError(t, err)
+			defer session.Cleanup()
+			provider := ProviderConfig{Name: "claude", ExecutionTimeout: time.Second}
+			responsePath := filepath.Join(t.TempDir(), "response.md")
+			writeMarkedResponse(t, responsePath, "authoritative response file")
+			panes := []paneInfo{{provider: provider, responseFile: responsePath}}
+			donePath := filepath.Join(session.Dir(), RoundSignalName("claude", 1, "done"))
+			require.NoError(t, os.WriteFile(donePath, []byte("1"), 0o600))
+			if hookResult.data != nil {
+				resultPath := filepath.Join(session.Dir(), RoundSignalName("claude", 1, "result.json"))
+				require.NoError(t, os.WriteFile(resultPath, hookResult.data, 0o600))
+			}
+
+			responses := collectRoundHookResults(
+				context.Background(), OrchestraConfig{Providers: []ProviderConfig{provider}}, session, 1, panes,
+			)
+
+			require.Len(t, responses, 1)
+			assert.Equal(t, "authoritative response file", responses[0].Output)
+			assert.False(t, responses[0].TimedOut)
+		})
+	}
+}
+
+func TestCollectRoundHookResults_SkippedPaneReturnsUnavailableImmediately(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider ProviderConfig
+	}{
+		{name: "hook provider", provider: ProviderConfig{Name: "claude", ExecutionTimeout: 600 * time.Millisecond}},
+		{name: "provider without hook", provider: ProviderConfig{Name: "custom", ExecutionTimeout: 600 * time.Millisecond}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session := newTestHookSession(t)
+			store := &reliabilityStore{runID: "skip-wait", dir: t.TempDir()}
+			panes := []paneInfo{{provider: tt.provider, skipWait: true}}
+			cfg := OrchestraConfig{
+				Providers:        []ProviderConfig{tt.provider},
+				ReliabilityStore: store,
+				RunID:            "skip-wait",
+			}
+
+			started := time.Now()
+			responses := collectRoundHookResults(context.Background(), cfg, session, 1, panes)
+			elapsed := time.Since(started)
+
+			require.Len(t, responses, 1)
+			assert.True(t, responses[0].TimedOut)
+			assert.True(t, responses[0].EmptyOutput)
+			assert.Equal(t, "provider was skipped before hook completion collection", responses[0].Error)
+			assert.Empty(t, responses[0].Receipt)
+			assert.Less(t, elapsed, 200*time.Millisecond)
+			assert.Empty(t, store.collection, "a skipped pane must not create a timeout receipt")
+			assert.Empty(t, store.events, "a skipped pane must not create a timeout event")
+			assert.NoFileExists(t, filepath.Join(store.dir, "failure-bundle.json"))
+		})
+	}
+}
+
+func TestCollectRoundHookResults_CodexResponseBeforeGraceKeepsTimeout(t *testing.T) {
+	session := newTestHookSession(t)
+	store := &reliabilityStore{runID: "codex-grace-timeout", dir: t.TempDir()}
+	provider := ProviderConfig{Name: "codex", ExecutionTimeout: 300 * time.Millisecond}
+	responsePath := filepath.Join(t.TempDir(), "codex-response.md")
+	writeMarkedResponse(t, responsePath, "response written before hook completion")
+	panes := []paneInfo{{provider: provider, responseFile: responsePath}}
+	cfg := OrchestraConfig{
+		Providers:        []ProviderConfig{provider},
+		ReliabilityStore: store,
+		RunID:            "codex-grace-timeout",
+	}
+
+	started := time.Now()
+	responses := collectRoundHookResults(context.Background(), cfg, session, 1, panes)
+	elapsed := time.Since(started)
+
+	require.Len(t, responses, 1)
+	assert.True(t, responses[0].TimedOut)
+	assert.True(t, responses[0].EmptyOutput)
+	assert.Empty(t, responses[0].Output, "an incomplete detector must not be salvaged by a response file")
+	assert.Contains(t, responses[0].Error, "timeout")
+	assert.GreaterOrEqual(t, elapsed, 250*time.Millisecond)
+	assert.Less(t, elapsed, time.Second)
+	require.Len(t, store.collection, 1)
+	assert.Equal(t, "timeout", store.collection[0].Status)
+	assert.Equal(t, "hook", store.collection[0].CollectionMode)
+	require.Len(t, store.events, 1)
+	assert.Equal(t, "hook_timeout", store.events[0].Kind)
+}
+
+func TestCollectRoundHookResults_DoneThenDelayedResponsePrefersResponseFile(t *testing.T) {
+	session := newTestHookSession(t)
+	provider := ProviderConfig{Name: "codex", ExecutionTimeout: time.Second}
+	responsePath := filepath.Join(t.TempDir(), "codex-response.md")
+	panes := []paneInfo{{provider: provider, responseFile: responsePath}}
+	donePath := filepath.Join(session.Dir(), RoundSignalName("codex", 1, "done"))
+	require.NoError(t, os.WriteFile(donePath, []byte("1"), 0o600))
+	writeErr := make(chan error, 1)
+	go func() {
+		time.Sleep(75 * time.Millisecond)
+		writeErr <- os.WriteFile(responsePath, []byte(markedResponse("response after done")), 0o600)
+	}()
+
+	started := time.Now()
+	responses := collectRoundHookResults(
+		context.Background(), OrchestraConfig{Providers: []ProviderConfig{provider}}, session, 1, panes,
+	)
+	elapsed := time.Since(started)
+	require.NoError(t, <-writeErr)
+
+	require.Len(t, responses, 1)
+	assert.Equal(t, "response after done", responses[0].Output)
+	assert.False(t, responses[0].TimedOut)
+	assert.GreaterOrEqual(t, elapsed, 50*time.Millisecond)
+	assert.Less(t, elapsed, 500*time.Millisecond)
+}
+
+func TestCollectRoundHookResults_DoneResponseSettleRespectsContext(t *testing.T) {
+	session := newTestHookSession(t)
+	provider := ProviderConfig{Name: "codex", ExecutionTimeout: time.Second}
+	responsePath := filepath.Join(t.TempDir(), "missing-response.md")
+	panes := []paneInfo{{provider: provider, responseFile: responsePath}}
+	donePath := filepath.Join(session.Dir(), RoundSignalName("codex", 1, "done"))
+	require.NoError(t, os.WriteFile(donePath, []byte("1"), 0o600))
+	ctx, cancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
+	defer cancel()
+
+	started := time.Now()
+	responses := collectRoundHookResults(ctx, OrchestraConfig{Providers: []ProviderConfig{provider}}, session, 1, panes)
+	elapsed := time.Since(started)
+
+	require.Len(t, responses, 1)
+	assert.Empty(t, responses[0].Output)
+	assert.GreaterOrEqual(t, elapsed, 50*time.Millisecond)
+	assert.Less(t, elapsed, 250*time.Millisecond)
+}
+
+func TestCollectRoundHookResults_ResponseThenDelayedDoneKeepsEarlyDoneContract(t *testing.T) {
+	session := newTestHookSession(t)
+	provider := ProviderConfig{Name: "codex", ExecutionTimeout: 2 * time.Second}
+	responsePath := filepath.Join(t.TempDir(), "codex-response.md")
+	writeMarkedResponse(t, responsePath, "response before done")
+	panes := []paneInfo{{provider: provider, responseFile: responsePath}}
+	writeErr := make(chan error, 1)
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		donePath := filepath.Join(session.Dir(), RoundSignalName("codex", 1, "done"))
+		writeErr <- os.WriteFile(donePath, []byte("1"), 0o600)
+	}()
+
+	started := time.Now()
+	responses := collectRoundHookResults(
+		context.Background(), OrchestraConfig{Providers: []ProviderConfig{provider}}, session, 1, panes,
+	)
+	elapsed := time.Since(started)
+	require.NoError(t, <-writeErr)
+
+	require.Len(t, responses, 1)
+	assert.Equal(t, "response before done", responses[0].Output)
+	assert.False(t, responses[0].TimedOut)
+	assert.GreaterOrEqual(t, elapsed, 250*time.Millisecond)
+	assert.Less(t, elapsed, 900*time.Millisecond)
+}

--- a/pkg/orchestra/interactive_debate_ipc.go
+++ b/pkg/orchestra/interactive_debate_ipc.go
@@ -2,6 +2,7 @@ package orchestra
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"time"
 )
@@ -10,21 +11,66 @@ import (
 // @AX:NOTE [AUTO] magic constant 30s — must be less than per-round timeout; increase if providers are slow to signal ready
 const fileIPCReadyTimeout = 30 * time.Second
 
+type fileIPCOutcome uint8
+
+const (
+	fileIPCDelivered fileIPCOutcome = iota
+	fileIPCSafeFallback
+	fileIPCReleaseFailure
+)
+
 // tryFileIPC attempts to deliver a prompt via file IPC for hook-capable providers.
-// Returns true if file IPC succeeded and SendLongText should be skipped.
-// Returns false if SendLongText fallback is needed.
-// R5-SAFETY: On write failure after ready, sends abort signal to prevent hook deadlock.
-func tryFileIPC(ctx context.Context, hookSession *HookSession, provider string, round int, prompt string) bool {
-	if err := hookSession.WaitForReadyCtx(ctx, fileIPCReadyTimeout, provider, round); err != nil {
-		log.Printf("[Round %d] %s WaitForReady failed: %v — falling back to SendLongText", round, provider, err)
-		return false
+// Safe fallback is returned only after the hook acknowledges abort by removing
+// both ready and abort artifacts. Release failures must never reach pane input.
+func tryFileIPC(ctx context.Context, hookSession *HookSession, provider string, round int, prompt string) (fileIPCOutcome, error) {
+	return tryFileIPCWithTimeouts(
+		ctx, hookSession, provider, round, prompt, fileIPCReadyTimeout, defaultHookReleaseTimeout,
+	)
+}
+
+func tryFileIPCWithTimeouts(
+	ctx context.Context,
+	hookSession *HookSession,
+	provider string,
+	round int,
+	prompt string,
+	readyTimeout time.Duration,
+	releaseTimeout time.Duration,
+) (fileIPCOutcome, error) {
+	if err := hookSession.WaitForReadyCtx(ctx, readyTimeout, provider, round); err != nil {
+		return releaseFileIPCFallback(
+			ctx, hookSession, provider, round, fmt.Errorf("wait for ready: %w", err), releaseTimeout,
+		)
 	}
 
 	if err := hookSession.WriteInputRound(provider, round, prompt); err != nil {
-		log.Printf("[Round %d] %s WriteInputRound failed: %v — falling back to SendLongText", round, provider, err)
-		_ = hookSession.WriteAbortSignal(provider, round)
-		return false
+		return releaseFileIPCFallback(
+			ctx, hookSession, provider, round, fmt.Errorf("write input: %w", err), releaseTimeout,
+		)
 	}
 
-	return true
+	return fileIPCDelivered, nil
+}
+
+func releaseFileIPCFallback(
+	ctx context.Context,
+	hookSession *HookSession,
+	provider string,
+	round int,
+	cause error,
+	timeout time.Duration,
+) (fileIPCOutcome, error) {
+	if err := hookSession.WriteAbortSignal(provider, round); err != nil {
+		releaseErr := fmt.Errorf("file IPC failed (%v); write abort: %w", cause, err)
+		log.Printf("[Round %d] %s release failed: %v", round, provider, releaseErr)
+		return fileIPCReleaseFailure, releaseErr
+	}
+	targets := []hookReleaseTarget{newHookReleaseTarget(provider, round)}
+	if err := waitForHookReleaseAcknowledgement(ctx, hookSession, targets, round, timeout); err != nil {
+		releaseErr := fmt.Errorf("file IPC failed (%v); acknowledge hook release: %w", cause, err)
+		log.Printf("[Round %d] %s release failed: %v", round, provider, releaseErr)
+		return fileIPCReleaseFailure, releaseErr
+	}
+	log.Printf("[Round %d] %s %v — falling back to direct pane input", round, provider, cause)
+	return fileIPCSafeFallback, cause
 }

--- a/pkg/orchestra/interactive_debate_ipc_release_test.go
+++ b/pkg/orchestra/interactive_debate_ipc_release_test.go
@@ -1,0 +1,215 @@
+package orchestra
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTryFileIPC_ReadyTimeoutLateWaiterAllowsSafeFallback(t *testing.T) {
+	session, err := NewHookSession("ipc-late-waiter-" + NewSessionID())
+	require.NoError(t, err)
+	t.Cleanup(session.Cleanup)
+
+	consumed := make(chan error, 1)
+	go func() {
+		abort := RoundSignalName("claude", 2, "abort")
+		if err := waitForFileIPCArtifact(session, abort, time.Second); err != nil {
+			consumed <- err
+			return
+		}
+		ready := RoundSignalName("claude", 2, "ready")
+		if err := session.writeArtifact(ready, nil, 0o600); err != nil {
+			consumed <- err
+			return
+		}
+		consumed <- removeFileIPCReleaseArtifacts(session, "claude", 2)
+	}()
+
+	outcome, ipcErr := tryFileIPCWithTimeouts(
+		context.Background(), session, "claude", 2, "prompt", 30*time.Millisecond, time.Second,
+	)
+
+	assert.Equal(t, fileIPCSafeFallback, outcome)
+	assert.ErrorContains(t, ipcErr, "wait for ready")
+	require.NoError(t, <-consumed)
+}
+
+func TestTryFileIPC_AcknowledgementTimeoutIsReleaseFailure(t *testing.T) {
+	session, err := NewHookSession("ipc-ack-timeout-" + NewSessionID())
+	require.NoError(t, err)
+	t.Cleanup(session.Cleanup)
+	require.NoError(t, session.writeArtifact(RoundSignalName("claude", 2, "ready"), nil, 0o600))
+	require.NoError(t, os.Mkdir(
+		filepath.Join(session.Dir(), RoundSignalName("claude", 2, "input.json")+".tmp"), 0o700,
+	))
+
+	outcome, ipcErr := tryFileIPCWithTimeouts(
+		context.Background(), session, "claude", 2, "prompt", time.Second, 40*time.Millisecond,
+	)
+
+	assert.Equal(t, fileIPCReleaseFailure, outcome)
+	assert.ErrorIs(t, ipcErr, context.DeadlineExceeded)
+	assert.ErrorContains(t, ipcErr, "abort consumption")
+}
+
+func TestExecuteRound_FileIPCFallbackWaitsForAbortAcknowledgement(t *testing.T) {
+	fixture := newFileIPCReleaseRoundFixture(t, false)
+	published := make(chan struct{})
+	release := make(chan struct{})
+	consumed := consumeFileIPCAbort(fixture.session, "claude", 2, published, release)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	responses := make(chan []ProviderResponse, 1)
+	go func() {
+		responses <- executeRound(ctx, fixture.cfg, fixture.panes, fixture.session, 2, fixture.previous)
+	}()
+
+	select {
+	case <-published:
+	case <-ctx.Done():
+		t.Fatal("abort was not published")
+	}
+	time.Sleep(350 * time.Millisecond)
+	longCalls, commandCalls := fileIPCDirectCallCounts(fixture.terminal)
+	assert.Zero(t, longCalls+commandCalls, "direct input must wait for abort acknowledgement")
+	close(release)
+	require.NoError(t, <-consumed)
+
+	select {
+	case got := <-responses:
+		require.Len(t, got, 1)
+		assert.Equal(t, "fallback response", got[0].Output)
+	case <-ctx.Done():
+		t.Fatal("round did not resume after abort acknowledgement")
+	}
+	longCalls, _ = fileIPCDirectCallCounts(fixture.terminal)
+	assert.Positive(t, longCalls)
+	assert.Contains(t, fileIPCPromptFailure(fixture.store), "write input")
+}
+
+func TestExecuteRound_AbortWriteFailureSkipsDirectInput(t *testing.T) {
+	fixture := newFileIPCReleaseRoundFixture(t, true)
+
+	responses := executeRound(
+		context.Background(), fixture.cfg, fixture.panes, fixture.session, 2, fixture.previous,
+	)
+
+	require.Len(t, responses, 1)
+	assert.Equal(t, skippedHookCollectionError, responses[0].Error)
+	longCalls, commandCalls := fileIPCDirectCallCounts(fixture.terminal)
+	assert.Zero(t, longCalls+commandCalls)
+	assert.Contains(t, fileIPCPromptFailure(fixture.store), "write abort")
+}
+
+type fileIPCReleaseRoundFixture struct {
+	session  *HookSession
+	terminal *mockTerminal
+	store    *reliabilityStore
+	cfg      OrchestraConfig
+	panes    []paneInfo
+	previous []ProviderResponse
+}
+
+func newFileIPCReleaseRoundFixture(t *testing.T, blockAbort bool) fileIPCReleaseRoundFixture {
+	t.Helper()
+	session, err := NewHookSession("ipc-release-round-" + NewSessionID())
+	require.NoError(t, err)
+	t.Cleanup(session.Cleanup)
+	session.SetHookProviders(map[string]bool{"claude": true})
+	require.NoError(t, session.writeArtifact(RoundSignalName("claude", 2, "ready"), nil, 0o600))
+	require.NoError(t, os.Mkdir(
+		filepath.Join(session.Dir(), RoundSignalName("claude", 2, "input.json")+".tmp"), 0o700,
+	))
+	if blockAbort {
+		require.NoError(t, os.Mkdir(
+			filepath.Join(session.Dir(), RoundSignalName("claude", 2, "abort")), 0o700,
+		))
+	} else {
+		require.NoError(t, session.writeJSONArtifact(
+			RoundSignalName("claude", 2, "result.json"), HookResult{Output: "fallback response"},
+		))
+		require.NoError(t, session.writeArtifact(RoundSignalName("claude", 2, "done"), nil, 0o600))
+	}
+	provider := ProviderConfig{Name: "claude", Binary: "echo", InteractiveInput: "stdin"}
+	terminal := newCmuxMock()
+	terminal.readScreenOutput = "❯\n"
+	store := &reliabilityStore{runID: "ipc-release", dir: t.TempDir()}
+	return fileIPCReleaseRoundFixture{
+		session: session, terminal: terminal, store: store,
+		cfg: OrchestraConfig{
+			Providers: []ProviderConfig{provider}, Strategy: StrategyDebate, Prompt: "fallback",
+			TimeoutSeconds: 1, Terminal: terminal, Interactive: true, HookMode: true,
+			InitialDelay: time.Millisecond, RunID: "ipc-release", ReliabilityStore: store,
+		},
+		panes:    []paneInfo{{provider: provider, paneID: "pane-1"}},
+		previous: []ProviderResponse{{Provider: "codex", Output: "round one"}},
+	}
+}
+
+func consumeFileIPCAbort(
+	session *HookSession,
+	provider string,
+	round int,
+	published chan<- struct{},
+	release <-chan struct{},
+) <-chan error {
+	done := make(chan error, 1)
+	go func() {
+		if err := waitForFileIPCArtifact(session, RoundSignalName(provider, round, "abort"), time.Second); err != nil {
+			done <- err
+			return
+		}
+		if published != nil {
+			close(published)
+		}
+		if release != nil {
+			<-release
+		}
+		done <- removeFileIPCReleaseArtifacts(session, provider, round)
+	}()
+	return done
+}
+
+func removeFileIPCReleaseArtifacts(session *HookSession, provider string, round int) error {
+	for _, suffix := range []string{"ready", "abort"} {
+		if err := session.removeArtifact(RoundSignalName(provider, round, suffix)); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	return nil
+}
+
+func waitForFileIPCArtifact(session *HookSession, name string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := session.statArtifact(name); err == nil {
+			return nil
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return context.DeadlineExceeded
+}
+
+func fileIPCDirectCallCounts(terminal *mockTerminal) (int, int) {
+	terminal.mu.Lock()
+	defer terminal.mu.Unlock()
+	return len(terminal.sendLongTextCalls), len(terminal.sendCommandCalls)
+}
+
+func fileIPCPromptFailure(store *reliabilityStore) string {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	for _, receipt := range store.prompt {
+		if receipt.TransportMode == "file_ipc" && receipt.Status == "failed" {
+			return receipt.Mismatch
+		}
+	}
+	return ""
+}

--- a/pkg/orchestra/interactive_debate_round.go
+++ b/pkg/orchestra/interactive_debate_round.go
@@ -80,27 +80,6 @@ func executeRound(ctx context.Context, cfg OrchestraConfig, panes []paneInfo, ho
 			}
 			prompt = isolation + buildRebuttalPrompt(cfg.Prompt, others, round)
 		}
-		if round > 1 {
-			// Only send round env to shell-based providers (args mode).
-			if pi.provider.InteractiveInput == "args" {
-				roundErr, roundEnterErr := sendPaneInputAndEnterSerialized(ctx, cfg.Terminal, pi.paneID, 0, func() error {
-					return SendRoundEnvToPane(ctx, cfg.Terminal, pi.paneID, round)
-				})
-				if roundErr != nil || roundEnterErr != nil {
-					log.Printf("[Round %d] %s SendRoundEnvToPane failed: send=%v enter=%v", round, pi.provider.Name, roundErr, roundEnterErr)
-				}
-			}
-			if !pollUntilPrompt(ctx, cfg.Terminal, pi.paneID, patterns, round2PollTimeout) {
-				log.Printf("[Round %d] %s prompt not ready within timeout -- skipping", round, pi.provider.Name)
-				panes[i].skipWait = true
-				if cfg.ReliabilityStore != nil {
-					receipt := promptReceipt(cfg.RunID, pi.provider.Name, "prompt_ready", prompt, round, "failed", "prompt not ready before round submission")
-					_ = cfg.ReliabilityStore.recordPrompt(receipt)
-				}
-				continue
-			}
-		}
-
 		// Skip direct prompt send for providers that received the prompt at launch (round 1 only).
 		if promptDeliveredAtLaunch(pi.provider) && round == 1 {
 			if cfg.ReliabilityStore != nil {
@@ -110,27 +89,67 @@ func executeRound(ctx context.Context, cfg OrchestraConfig, panes []paneInfo, ho
 			continue
 		}
 
-		// File IPC for Round 2+ when hook is available (SPEC-ORCH-017 R4)
-		if round > 1 && hookSession != nil && hookSession.HasHook(pi.provider.Name) {
-			if tryFileIPC(ctx, hookSession, pi.provider.Name, round, prompt) {
-				if cfg.ReliabilityStore != nil {
-					receipt := promptReceipt(cfg.RunID, pi.provider.Name, "file_ipc", prompt, round, "pass", "")
-					_ = cfg.ReliabilityStore.recordPrompt(receipt)
-				}
-				continue
-			}
-			if cfg.ReliabilityStore != nil {
-				receipt := promptReceipt(cfg.RunID, pi.provider.Name, "file_ipc", prompt, round, "failed", "file IPC fallback activated before completion wait")
-				_ = cfg.ReliabilityStore.recordPrompt(receipt)
-			}
-		}
-
 		sendPrompt, promptFile, responseFile := panePromptText(cfg, pi.provider, round, prompt)
 		if promptFile != "" {
 			roundPromptFiles = append(roundPromptFiles, promptFile)
 		}
 		if responseFile != "" {
 			roundResponseFiles = append(roundResponseFiles, responseFile)
+		}
+
+		// A recovered pane already received its current-round coordinates before
+		// launch. Submit that one round directly, then restore file IPC next round.
+		directPromptRound := pi.directPromptRound == round
+		// File IPC for Round 2+ when hook is available (SPEC-ORCH-017 R4).
+		if round > 1 && !directPromptRound && hookSession != nil && hookSession.HasHook(pi.provider.Name) {
+			ipcOutcome, ipcErr := tryFileIPC(ctx, hookSession, pi.provider.Name, round, sendPrompt)
+			if ipcOutcome == fileIPCDelivered {
+				if promptFile != "" {
+					pi.promptFiles = append(pi.promptFiles, promptFile)
+					panes[i].promptFiles = pi.promptFiles
+				}
+				if responseFile != "" {
+					pi.responseFile = responseFile
+					panes[i].responseFile = responseFile
+				}
+				if cfg.ReliabilityStore != nil {
+					receipt := promptReceipt(cfg.RunID, pi.provider.Name, "file_ipc", prompt, round, "pass", "")
+					_ = cfg.ReliabilityStore.recordPrompt(receipt)
+				}
+				continue
+			}
+			failureReason := "file IPC fallback activated before completion wait"
+			if ipcErr != nil {
+				failureReason = ipcErr.Error()
+			}
+			if cfg.ReliabilityStore != nil {
+				receipt := promptReceipt(cfg.RunID, pi.provider.Name, "file_ipc", prompt, round, "failed", failureReason)
+				_ = cfg.ReliabilityStore.recordPrompt(receipt)
+			}
+			if ipcOutcome != fileIPCSafeFallback {
+				log.Printf("[Round %d] %s file IPC release failed: %s -- skipping", round, pi.provider.Name, failureReason)
+				panes[i].skipWait = true
+				continue
+			}
+		}
+
+		if round > 1 {
+			if !pollUntilPrompt(ctx, cfg.Terminal, pi.paneID, patterns, round2PollTimeout) {
+				log.Printf("[Round %d] %s prompt not ready within timeout -- skipping", round, pi.provider.Name)
+				panes[i].skipWait = true
+				if cfg.ReliabilityStore != nil {
+					receipt := promptReceipt(cfg.RunID, pi.provider.Name, "prompt_ready", prompt, round, "failed", "prompt not ready before round submission")
+					_ = cfg.ReliabilityStore.recordPrompt(receipt)
+				}
+				continue
+			}
+			if hookSession != nil && hookSession.HasHook(pi.provider.Name) {
+				if err := hookSession.WriteRoundCursor(pi.provider.Name, round); err != nil {
+					log.Printf("[Round %d] %s round cursor failed: %v -- skipping", round, pi.provider.Name, err)
+					panes[i].skipWait = true
+					continue
+				}
+			}
 		}
 
 		// Sendkeys mode: use SendCommand (cmux send) instead of paste-buffer.
@@ -229,7 +248,6 @@ func executeRound(ctx context.Context, cfg OrchestraConfig, panes []paneInfo, ho
 
 	var responses []ProviderResponse
 	if cfg.HookMode && hookSession != nil {
-		responses = collectRoundHookResults(pollCtx, cfg, hookSession, round)
 		var pollPanes []paneInfo
 		for _, pi := range panes {
 			if pi.skipWait || hookSession.HasHook(pi.provider.Name) {
@@ -237,6 +255,10 @@ func executeRound(ctx context.Context, cfg OrchestraConfig, panes []paneInfo, ho
 			}
 			pollPanes = append(pollPanes, pi)
 		}
+		// Snapshot poll ownership before hook collection. Response-file-only
+		// provenance can disable a hook during collection, but the provider must
+		// not be collected a second time until the next round.
+		responses = collectRoundHookResults(pollCtx, cfg, hookSession, round, panes)
 		if len(pollPanes) > 0 {
 			responses = append(responses, waitAndCollectResults(pollCtx, cfg, pollPanes, patterns, time.Now(), baselines, nil, round)...)
 		}

--- a/pkg/orchestra/interactive_debate_salvage_test.go
+++ b/pkg/orchestra/interactive_debate_salvage_test.go
@@ -3,8 +3,10 @@ package orchestra
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 	"time"
 
@@ -19,6 +21,19 @@ type yieldSaveFailureTerminal struct {
 	setTempDir     func(string)
 }
 
+func (m *yieldSaveFailureTerminal) SplitPane(_ context.Context, dir terminal.Direction) (terminal.PaneID, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.splitPaneCalls = append(m.splitPaneCalls, dir)
+	if m.splitPaneErr != nil {
+		return "", m.splitPaneErr
+	}
+	m.nextPaneID++
+	id := terminal.PaneID(fmt.Sprintf("surface:%d", m.nextPaneID))
+	m.createdPanes = append(m.createdPanes, id)
+	return id, nil
+}
+
 func (m *yieldSaveFailureTerminal) SendLongText(_ context.Context, _ terminal.PaneID, _ string) error {
 	return errors.New("force provider launch failure after pane provisioning")
 }
@@ -26,6 +41,14 @@ func (m *yieldSaveFailureTerminal) SendLongText(_ context.Context, _ terminal.Pa
 func (m *yieldSaveFailureTerminal) FocusPane(_ context.Context, _ terminal.PaneID) error {
 	m.setTempDir(m.invalidTempDir)
 	return nil
+}
+
+func (m *yieldSaveFailureTerminal) WorkspaceRef() (string, error) {
+	return "workspace:1", nil
+}
+
+func (m *yieldSaveFailureTerminal) WithWorkspaceRef(string) (terminal.Terminal, error) {
+	return m, nil
 }
 
 func TestRunPaneDebate_YieldSaveFailureCleansOwnedPanes(t *testing.T) {
@@ -57,10 +80,53 @@ func TestRunPaneDebate_YieldSaveFailureCleansOwnedPanes(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, result)
 	assert.ErrorContains(t, err, "persist yield session")
-	assert.Equal(t, []string{"pane-1"}, term.closeCalls,
+	assert.Equal(t, []string{"surface:1"}, term.closeCalls,
 		"the pane stays locally owned and must close when persistence fails")
-	assert.NotContains(t, readTrackerRefs(surfaceTrackerFile(os.Getpid())), "pane-1",
+	assert.NotContains(t, readTrackerRefs(surfaceTrackerFile(os.Getpid())), "surface:1",
 		"a successfully closed pane must be untracked")
+}
+
+func TestRunPaneDebate_YieldHandoffFailureKeepsDurableSessionAndPanes(t *testing.T) {
+	isolateSurfaceTracker(t)
+	t.Setenv("TMPDIR", t.TempDir())
+	term := &yieldSaveFailureTerminal{
+		mockTerminal: mockTerminal{name: "cmux"},
+		setTempDir:   func(string) {},
+	}
+	originalUntracker := yieldSurfaceUntracker
+	yieldSurfaceUntracker = func(terminal.Terminal, string) error {
+		return errors.New("injected tracker handoff failure")
+	}
+	t.Cleanup(func() { yieldSurfaceUntracker = originalUntracker })
+	cfg := OrchestraConfig{
+		Providers:      []ProviderConfig{echoProvider("claude")},
+		Strategy:       StrategyDebate,
+		Prompt:         "keep the durable recovery handle",
+		TimeoutSeconds: 1,
+		Terminal:       term,
+		Interactive:    true,
+		YieldRounds:    true,
+		NoJudge:        true,
+		InitialDelay:   time.Millisecond,
+		WorkingDir:     t.TempDir(),
+	}
+
+	result, err := runPaneDebate(context.Background(), cfg, 1, time.Second, time.Now())
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Empty(t, term.closeCalls,
+		"a durable yield session owns the panes even when tracker handoff reports an error")
+	assert.Contains(t, readTrackerRefs(surfaceTrackerFile(os.Getpid())), "surface:1",
+		"the tracker recovery handle must remain when handoff persistence fails")
+	match := regexp.MustCompile(`yield session (orch-[0-9a-f]+)`).FindStringSubmatch(err.Error())
+	require.Len(t, match, 2)
+	sessionID := match[1]
+	t.Cleanup(func() { _ = RemoveSession(sessionID) })
+	assert.ErrorContains(t, err, "auto orchestra cleanup --session-id "+sessionID)
+	loaded, loadErr := LoadSession(sessionID)
+	require.NoError(t, loadErr)
+	assert.Equal(t, map[string]string{"claude": "surface:1"}, loaded.Panes)
 }
 
 func TestExecuteRound_OrdersResponsesAtDebateBoundary(t *testing.T) {

--- a/pkg/orchestra/interactive_hook_done_handoff_test.go
+++ b/pkg/orchestra/interactive_hook_done_handoff_test.go
@@ -1,0 +1,103 @@
+package orchestra
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunPaneDebate_DoneOnlyStableIdleFallsBackToDirectPolling(t *testing.T) {
+	isolateSurfaceTracker(t)
+	t.Setenv("TMPDIR", t.TempDir())
+	term := newResponseOnlyHookTerminal()
+	cfg := responseOnlyHookDebateConfig(t, term, false)
+	doneWritten := publishDoneAfterFirstResponse(term, cfg.SessionID)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result, err := runPaneDebate(ctx, cfg, 2, 5*time.Second, time.Now())
+
+	require.NoError(t, <-doneWritten)
+	require.NoError(t, err)
+	require.Len(t, result.RoundHistory, 2)
+	require.Len(t, result.RoundHistory[1], 1)
+	assert.Equal(t, "response-only round 2", result.RoundHistory[1][0].Output)
+	assert.Equal(t, 2, term.writes(), "done without next-ready must fall back to direct input")
+}
+
+func TestRunPaneDebate_DoneOnlyStableIdleYieldsWithoutAbortWaiter(t *testing.T) {
+	isolateSurfaceTracker(t)
+	t.Setenv("TMPDIR", t.TempDir())
+	term := newResponseOnlyHookTerminal()
+	cfg := responseOnlyHookDebateConfig(t, term, true)
+	doneWritten := publishDoneAfterFirstResponse(term, cfg.SessionID)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result, err := runPaneDebate(ctx, cfg, 2, 5*time.Second, time.Now())
+
+	require.NoError(t, <-doneWritten)
+	require.NoError(t, err)
+	require.NotNil(t, result.Yield)
+	t.Cleanup(func() { _ = RemoveSession(result.Yield.SessionID) })
+	assert.Equal(t, 1, term.writes())
+}
+
+func publishDoneAfterFirstResponse(term *responseOnlyHookTerminal, sessionID string) <-chan error {
+	done := make(chan error, 1)
+	term.afterResponse = func(writeNumber int) {
+		if writeNumber != 1 {
+			return
+		}
+		path := filepath.Join(os.TempDir(), hookBaseDirectoryName, sessionID,
+			RoundSignalName("codex", 1, "done"))
+		done <- os.WriteFile(path, nil, 0o600)
+	}
+	return done
+}
+
+type readyDuringStableFrameTerminal struct {
+	mockTerminal
+	session *HookSession
+	reads   int
+}
+
+func (t *readyDuringStableFrameTerminal) ReadScreen(_ context.Context, _ terminal.PaneID, _ terminal.ReadScreenOpts) (string, error) {
+	t.mu.Lock()
+	t.reads++
+	reads := t.reads
+	t.mu.Unlock()
+	if reads == hookStableIdleFrames {
+		if err := t.session.writeArtifact(RoundSignalName("codex", 2, "ready"), nil, 0o600); err != nil {
+			return "", err
+		}
+	}
+	return "codex>\n", nil
+}
+
+func TestResolveHookCompletionHandoff_ReadyWinsFinalIdleRace(t *testing.T) {
+	session, err := NewHookSession("handoff-ready-race-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+	require.NoError(t, session.writeArtifact(RoundSignalName("codex", 1, "done"), nil, 0o600))
+	term := &readyDuringStableFrameTerminal{
+		mockTerminal: mockTerminal{name: "cmux"}, session: session,
+	}
+	provider := ProviderConfig{Name: "codex", Binary: "codex"}
+	cfg := OrchestraConfig{Providers: []ProviderConfig{provider}, Terminal: term, DebateRounds: 2}
+
+	provenance, err := resolveHookCompletionHandoff(
+		context.Background(), cfg, session, provider,
+		paneInfo{provider: provider, paneID: "surface:1"}, 1,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, hookCompletionNextRoundReady, provenance)
+	assert.True(t, session.HasHook("codex"))
+}

--- a/pkg/orchestra/interactive_hook_handoff_test.go
+++ b/pkg/orchestra/interactive_hook_handoff_test.go
@@ -1,0 +1,284 @@
+package orchestra
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunPaneDebate_DelayedNextReadyKeepsHookFileIPC(t *testing.T) {
+	isolateSurfaceTracker(t)
+	t.Setenv("TMPDIR", t.TempDir())
+	term := newResponseOnlyHookTerminal()
+	term.maxResponses = 1
+	cfg := responseOnlyHookDebateConfig(t, term, false)
+	producerDone := make(chan error, 1)
+	term.afterResponse = func(writeNumber int) {
+		if writeNumber != 1 {
+			return
+		}
+		term.mu.Lock()
+		term.readScreenOutput = "codex>\n• Running Stop hook (1s • esc to interrupt)\n"
+		term.mu.Unlock()
+		go publishDelayedRoundTwo(cfg.SessionID, term, producerDone)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+	defer cancel()
+
+	result, err := runPaneDebate(ctx, cfg, 2, 5*time.Second, time.Now())
+
+	require.NoError(t, <-producerDone)
+	require.NoError(t, err)
+	require.Len(t, result.RoundHistory, 2)
+	require.Len(t, result.RoundHistory[1], 1)
+	assert.Equal(t, "delayed hook round 2", result.RoundHistory[1][0].Output)
+	assert.Equal(t, 1, term.writes(), "round 2 must remain on file IPC")
+}
+
+func TestRunPaneDebate_DelayedNextReadyYieldsAfterAbortAck(t *testing.T) {
+	isolateSurfaceTracker(t)
+	t.Setenv("TMPDIR", t.TempDir())
+	term := newResponseOnlyHookTerminal()
+	term.maxResponses = 1
+	cfg := responseOnlyHookDebateConfig(t, term, true)
+	producerDone := make(chan error, 1)
+	term.afterResponse = func(writeNumber int) {
+		if writeNumber != 1 {
+			return
+		}
+		term.mu.Lock()
+		term.readScreenOutput = "codex>\n• Running Stop hook (1s • esc to interrupt)\n"
+		term.mu.Unlock()
+		go publishDelayedYieldReady(cfg.SessionID, term, producerDone)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+	defer cancel()
+
+	result, err := runPaneDebate(ctx, cfg, 2, 5*time.Second, time.Now())
+
+	require.NoError(t, <-producerDone)
+	require.NoError(t, err)
+	require.NotNil(t, result.Yield)
+	t.Cleanup(func() { _ = RemoveSession(result.Yield.SessionID) })
+	assert.Equal(t, 1, term.writes())
+}
+
+func TestCollectRoundHookResults_PermanentWorkingHandoffIsUnusable(t *testing.T) {
+	session, err := NewHookSession("working-handoff-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+	provider := ProviderConfig{Name: "codex", ExecutionTimeout: 2 * time.Second}
+	responsePath := filepath.Join(t.TempDir(), "response.md")
+	writeMarkedResponse(t, responsePath, "response while Stop hook runs")
+	term := newResponseOnlyHookTerminal()
+	term.readScreenOutput = "codex>\n• Running Stop hook (1s • esc to interrupt)\n"
+	store := &reliabilityStore{runID: "working-handoff", dir: t.TempDir()}
+	cfg := OrchestraConfig{
+		Providers: []ProviderConfig{provider}, Terminal: term, DebateRounds: 2,
+		RunID: "working-handoff", ReliabilityStore: store,
+	}
+
+	responses := collectRoundHookResults(context.Background(), cfg, session, 1, []paneInfo{{
+		provider: provider, paneID: "surface:1", responseFile: responsePath,
+	}})
+
+	require.Len(t, responses, 1)
+	assert.True(t, responses[0].TimedOut)
+	assert.True(t, responses[0].EmptyOutput)
+	assert.Empty(t, responses[0].Output)
+	assert.Contains(t, responses[0].Error, "completion handoff")
+	assert.True(t, session.HasHook("codex"), "working evidence must fail closed")
+	require.Len(t, store.collection, 1)
+	assert.Equal(t, "timeout", store.collection[0].Status)
+	require.Len(t, store.events, 1)
+	assert.Equal(t, "hook_timeout", store.events[0].Kind)
+	assert.FileExists(t, filepath.Join(store.dir, "failure-bundle.json"))
+}
+
+func TestResolveHookCompletionHandoff_GenericWorkingThenIdleDeactivatesHook(t *testing.T) {
+	session, err := NewHookSession("working-idle-handoff-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+	provider := ProviderConfig{Name: "codex", Binary: "codex"}
+	term := newTransitionResponseTerminal(1)
+	cfg := OrchestraConfig{Providers: []ProviderConfig{provider}, Terminal: term, DebateRounds: 2}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	provenance, err := resolveHookCompletionHandoff(
+		ctx, cfg, session, provider, paneInfo{provider: provider, paneID: "surface:1"}, 1,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, hookCompletionResponseFileOnly, provenance)
+	assert.False(t, session.HasHook("codex"))
+	assert.GreaterOrEqual(t, term.transitionReadCount(), 3)
+}
+
+func TestRunPaneDebate_GenericWorkingThenIdleUsesDirectRoundTwo(t *testing.T) {
+	isolateSurfaceTracker(t)
+	t.Setenv("TMPDIR", t.TempDir())
+	term := newTransitionResponseTerminal(0)
+	term.afterResponse = func(writeNumber int) {
+		if writeNumber == 1 {
+			term.setWorkingReads(6)
+		}
+	}
+	cfg := responseOnlyHookDebateConfig(t, term, false)
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+	defer cancel()
+
+	result, err := runPaneDebate(ctx, cfg, 2, 5*time.Second, time.Now())
+
+	require.NoError(t, err)
+	require.Len(t, result.RoundHistory, 2)
+	require.Len(t, result.RoundHistory[1], 1)
+	assert.Equal(t, "response-only round 2", result.RoundHistory[1][0].Output)
+	assert.Equal(t, 2, term.writes(), "round 2 must use direct input after stable idle")
+}
+
+type transitionResponseTerminal struct {
+	*responseOnlyHookTerminal
+	workingReads    int
+	transitionReads int
+}
+
+func newTransitionResponseTerminal(workingReads int) *transitionResponseTerminal {
+	return &transitionResponseTerminal{
+		responseOnlyHookTerminal: newResponseOnlyHookTerminal(),
+		workingReads:             workingReads,
+	}
+}
+
+func (t *transitionResponseTerminal) ReadScreen(_ context.Context, _ terminal.PaneID, _ terminal.ReadScreenOpts) (string, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.transitionReads++
+	if t.workingReads != 0 {
+		if t.workingReads > 0 {
+			t.workingReads--
+		}
+		return "codex>\n• Preparing... (1s • esc to interrupt)\n", nil
+	}
+	return "codex>\n", nil
+}
+
+func (t *transitionResponseTerminal) setWorkingReads(reads int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.workingReads = reads
+}
+
+func (t *transitionResponseTerminal) transitionReadCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.transitionReads
+}
+
+func TestCollectRoundHookResults_FinalRoundDoesNotMutateHookHealth(t *testing.T) {
+	session, err := NewHookSession("final-round-health-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+	provider := ProviderConfig{Name: "codex", ExecutionTimeout: 2 * time.Second}
+	responsePath := filepath.Join(t.TempDir(), "response.md")
+	writeMarkedResponse(t, responsePath, "final response")
+	term := newResponseOnlyHookTerminal()
+	cfg := OrchestraConfig{
+		Providers: []ProviderConfig{provider}, Terminal: term, DebateRounds: 1,
+	}
+
+	responses := collectRoundHookResults(context.Background(), cfg, session, 1, []paneInfo{{
+		provider: provider, paneID: "surface:1", responseFile: responsePath,
+	}})
+
+	require.Len(t, responses, 1)
+	assert.Equal(t, "final response", responses[0].Output)
+	assert.True(t, session.HasHook("codex"))
+	assert.Zero(t, term.readScreenCalls, "a final round needs no handoff probe")
+}
+
+func TestCompletionArtifactProvenance_NextReadyWinsOverCurrentDone(t *testing.T) {
+	session, err := NewHookSession("handoff-priority-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+	provider := ProviderConfig{Name: "codex", Binary: "codex"}
+	require.NoError(t, session.writeArtifact(RoundSignalName("codex", 1, "done"), nil, 0o600))
+
+	provenance, err := session.completionArtifactProvenance(provider, 1)
+	require.NoError(t, err)
+	assert.Equal(t, hookCompletionDone, provenance)
+	require.NoError(t, session.writeArtifact(RoundSignalName("codex", 2, "ready"), nil, 0o600))
+
+	provenance, err = session.completionArtifactProvenance(provider, 1)
+	require.NoError(t, err)
+	assert.Equal(t, hookCompletionNextRoundReady, provenance)
+}
+
+func publishDelayedRoundTwo(sessionID string, term *responseOnlyHookTerminal, done chan<- error) {
+	dir := filepath.Join(os.TempDir(), hookBaseDirectoryName, sessionID)
+	currentDone := filepath.Join(dir, RoundSignalName("codex", 1, "done"))
+	if err := os.WriteFile(currentDone, nil, 0o600); err != nil {
+		done <- err
+		return
+	}
+	time.Sleep(1500 * time.Millisecond)
+	ready := filepath.Join(dir, RoundSignalName("codex", 2, "ready"))
+	if err := os.WriteFile(ready, nil, 0o600); err != nil {
+		done <- err
+		return
+	}
+	term.mu.Lock()
+	term.readScreenOutput = "codex>\n"
+	term.mu.Unlock()
+	input := filepath.Join(dir, RoundSignalName("codex", 2, "input.json"))
+	if err := waitForPath(input, 3*time.Second); err != nil {
+		done <- err
+		return
+	}
+	result := filepath.Join(dir, RoundSignalName("codex", 2, "result.json"))
+	if err := os.WriteFile(result, []byte(`{"output":"delayed hook round 2","exit_code":0}`), 0o600); err != nil {
+		done <- err
+		return
+	}
+	donePath := filepath.Join(dir, RoundSignalName("codex", 2, "done"))
+	done <- os.WriteFile(donePath, nil, 0o600)
+}
+
+func publishDelayedYieldReady(sessionID string, term *responseOnlyHookTerminal, done chan<- error) {
+	dir := filepath.Join(os.TempDir(), hookBaseDirectoryName, sessionID)
+	currentDone := filepath.Join(dir, RoundSignalName("codex", 1, "done"))
+	if err := os.WriteFile(currentDone, nil, 0o600); err != nil {
+		done <- err
+		return
+	}
+	time.Sleep(1500 * time.Millisecond)
+	ready := filepath.Join(dir, RoundSignalName("codex", 2, "ready"))
+	abort := filepath.Join(dir, RoundSignalName("codex", 2, "abort"))
+	if _, err := os.Stat(abort); err == nil {
+		_ = os.Remove(abort)
+		done <- assert.AnError
+		return
+	}
+	if err := os.WriteFile(ready, nil, 0o600); err != nil {
+		done <- err
+		return
+	}
+	term.mu.Lock()
+	term.readScreenOutput = "codex>\n"
+	term.mu.Unlock()
+	if err := waitForPath(abort, 3*time.Second); err != nil {
+		done <- err
+		return
+	}
+	if err := os.Remove(ready); err != nil {
+		done <- err
+		return
+	}
+	done <- os.Remove(abort)
+}

--- a/pkg/orchestra/interactive_hook_inactive_fallback_test.go
+++ b/pkg/orchestra/interactive_hook_inactive_fallback_test.go
@@ -1,0 +1,193 @@
+package orchestra
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var responseOnlyPathPattern = regexp.MustCompile(`response file: ([^ ]+?\.md)`)
+
+type responseOnlyHookTerminal struct {
+	mockTerminal
+	responseMu     sync.Mutex
+	responseWrites int
+	maxResponses   int
+	afterResponse  func(int)
+}
+
+func newResponseOnlyHookTerminal() *responseOnlyHookTerminal {
+	return &responseOnlyHookTerminal{mockTerminal: mockTerminal{
+		name: "cmux", readScreenOutput: "codex>\n",
+	}}
+}
+
+func (t *responseOnlyHookTerminal) SplitPane(_ context.Context, dir terminal.Direction) (terminal.PaneID, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.splitPaneCalls = append(t.splitPaneCalls, dir)
+	t.nextPaneID++
+	id := terminal.PaneID(fmt.Sprintf("surface:%d", t.nextPaneID))
+	t.createdPanes = append(t.createdPanes, id)
+	return id, nil
+}
+
+func (t *responseOnlyHookTerminal) SendCommand(ctx context.Context, paneID terminal.PaneID, cmd string) error {
+	if err := t.mockTerminal.SendCommand(ctx, paneID, cmd); err != nil {
+		return err
+	}
+	return t.writeResponseOnly(cmd)
+}
+
+func (t *responseOnlyHookTerminal) SendLongText(ctx context.Context, paneID terminal.PaneID, text string) error {
+	if err := t.mockTerminal.SendLongText(ctx, paneID, text); err != nil {
+		return err
+	}
+	return t.writeResponseOnly(text)
+}
+
+func (t *responseOnlyHookTerminal) WorkspaceRef() (string, error) {
+	return "workspace:1", nil
+}
+
+func (t *responseOnlyHookTerminal) WithWorkspaceRef(string) (terminal.Terminal, error) {
+	return t, nil
+}
+
+func (t *responseOnlyHookTerminal) writeResponseOnly(text string) error {
+	match := responseOnlyPathPattern.FindStringSubmatch(text)
+	if len(match) != 2 {
+		return nil
+	}
+	t.responseMu.Lock()
+	if t.maxResponses > 0 && t.responseWrites >= t.maxResponses {
+		t.responseMu.Unlock()
+		return nil
+	}
+	t.responseWrites++
+	writeNumber := t.responseWrites
+	afterResponse := t.afterResponse
+	t.responseMu.Unlock()
+	output := fmt.Sprintf("response-only round %d", writeNumber)
+	if err := os.WriteFile(match[1], []byte(markedResponse(output)), 0o600); err != nil {
+		return err
+	}
+	if afterResponse != nil {
+		afterResponse(writeNumber)
+	}
+	return nil
+}
+
+func (t *responseOnlyHookTerminal) writes() int {
+	t.responseMu.Lock()
+	defer t.responseMu.Unlock()
+	return t.responseWrites
+}
+
+func TestRunPaneDebate_ResponseOnlyHookFallsBackToDirectPolling(t *testing.T) {
+	isolateSurfaceTracker(t)
+	t.Setenv("TMPDIR", t.TempDir())
+	term := newResponseOnlyHookTerminal()
+	cfg := responseOnlyHookDebateConfig(t, term, false)
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+	defer cancel()
+
+	result, err := runPaneDebate(ctx, cfg, 2, 5*time.Second, time.Now())
+
+	require.NoError(t, err)
+	require.Len(t, result.RoundHistory, 2)
+	require.Len(t, result.RoundHistory[0], 1)
+	require.Len(t, result.RoundHistory[1], 1)
+	assert.Equal(t, "response-only round 1", result.RoundHistory[0][0].Output)
+	assert.Equal(t, "response-only round 2", result.RoundHistory[1][0].Output)
+	assert.Equal(t, 2, term.writes(), "round 2 must be delivered directly to the stable prompt")
+}
+
+func TestRunPaneDebate_ResponseOnlyHookYieldsWithoutAbortWaiter(t *testing.T) {
+	isolateSurfaceTracker(t)
+	t.Setenv("TMPDIR", t.TempDir())
+	term := newResponseOnlyHookTerminal()
+	cfg := responseOnlyHookDebateConfig(t, term, true)
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	result, err := runPaneDebate(ctx, cfg, 2, 3*time.Second, time.Now())
+
+	require.NoError(t, err)
+	require.NotNil(t, result.Yield)
+	t.Cleanup(func() { _ = RemoveSession(result.Yield.SessionID) })
+	assert.Equal(t, "response-only round 1", result.RoundHistory[0][0].Output)
+	assert.Equal(t, 1, term.writes())
+	assert.Empty(t, term.closeCalls, "the durable yield session must own the pane")
+}
+
+func TestCollectRoundHookResults_DoneProvenanceKeepsHookActive(t *testing.T) {
+	session, err := NewHookSession("hook-done-health-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+	provider := ProviderConfig{Name: "codex", ExecutionTimeout: time.Second}
+	responsePath := t.TempDir() + "/response.md"
+	writeMarkedResponse(t, responsePath, "normal hook response")
+	require.NoError(t, session.writeArtifact(RoundSignalName("codex", 1, "done"), nil, 0o600))
+
+	responses := collectRoundHookResults(
+		context.Background(), OrchestraConfig{Providers: []ProviderConfig{provider}},
+		session, 1, []paneInfo{{provider: provider, responseFile: responsePath}},
+	)
+
+	require.Len(t, responses, 1)
+	assert.Equal(t, "normal hook response", responses[0].Output)
+	assert.True(t, session.HasHook("codex"), "done provenance must retain the normal hook contract")
+}
+
+func TestCollectRoundHookResults_NonCodexResponseBeforeDoneKeepsHookActive(t *testing.T) {
+	for _, providerName := range []string{"claude", "gemini"} {
+		t.Run(providerName, func(t *testing.T) {
+			session, err := NewHookSession("non-codex-health-" + providerName + "-" + NewSessionID())
+			require.NoError(t, err)
+			defer session.Cleanup()
+			provider := ProviderConfig{Name: providerName, ExecutionTimeout: time.Second}
+			responsePath := t.TempDir() + "/response.md"
+			writeMarkedResponse(t, responsePath, "response before done")
+			doneWritten := make(chan error, 1)
+			go func() {
+				time.Sleep(75 * time.Millisecond)
+				doneWritten <- session.writeArtifact(RoundSignalName(providerName, 1, "done"), nil, 0o600)
+			}()
+
+			responses := collectRoundHookResults(
+				context.Background(), OrchestraConfig{Providers: []ProviderConfig{provider}},
+				session, 1, []paneInfo{{provider: provider, responseFile: responsePath}},
+			)
+
+			require.NoError(t, <-doneWritten)
+			require.Len(t, responses, 1)
+			assert.Equal(t, "response before done", responses[0].Output)
+			assert.True(t, session.HasHook(providerName),
+				"non-Codex response-first ordering must retain the normal hook contract")
+		})
+	}
+}
+
+func responseOnlyHookDebateConfig(t *testing.T, term terminal.Terminal, yield bool) OrchestraConfig {
+	t.Helper()
+	provider := ProviderConfig{
+		Name: "codex", Binary: "codex", InteractiveInput: "args", PromptViaArgs: true,
+		ExecutionTimeout: 3 * time.Second,
+	}
+	return OrchestraConfig{
+		Providers: []ProviderConfig{provider}, Strategy: StrategyDebate,
+		Prompt: "prove response-only hook fallback", TimeoutSeconds: 4,
+		Terminal: term, Interactive: true, HookMode: true,
+		SessionID: "response-only-" + NewSessionID(), YieldRounds: yield,
+		NoJudge: true, InitialDelay: time.Millisecond, WorkingDir: t.TempDir(),
+	}
+}

--- a/pkg/orchestra/interactive_judge_pane_test.go
+++ b/pkg/orchestra/interactive_judge_pane_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestRunJudgeRound_PaneCapableTerminalDoesNotExecuteSubprocess(t *testing.T) {
-	provider, marker := newPaneBoundaryMarkerProvider(t, "judge-fixture", "")
+	provider, marker := newPaneBoundaryMarkerProvider(t, "claude", "")
 	term := &paneCommitTerminal{
 		screen: `{"recommendation":"keep the judge in a pane"}` + "\n❯\n",
 	}

--- a/pkg/orchestra/interactive_launch.go
+++ b/pkg/orchestra/interactive_launch.go
@@ -17,6 +17,8 @@ const launchScriptsDir = ".autopus/orchestra/launch"
 // surface close before giving up and leaving the ref tracked for orphan reaping.
 const closePaneSurfaceAttempts = 3
 
+var closeSurfaceUntracker = untrackSurfaceForTerminal
+
 // buildInteractiveLaunchCmd constructs the launch command for interactive mode.
 // Uses the binary name plus model/variant flags from PaneArgs, excluding print/pipe flags.
 // When the provider supports launch-time input, prompt is a short instruction
@@ -173,11 +175,14 @@ func cleanupInteractivePanes(term terminal.Terminal, panes []paneInfo) {
 // expires (issue #61: a completed provider pane intermittently lingers). A
 // swallowed close failure silently leaks the surface for the rest of the live
 // session — the orphan reaper only reclaims surfaces of dead processes on a
-// later run, never this process's own refs. Two guarantees keep the leak
+// later run, never this process's own refs. Three guarantees keep the leak
 // recoverable:
 //   - The surface ref is untracked ONLY on a successful close. Untracking after a
 //     failed close (the previous behavior) discarded the ref so even the
 //     next-run orphan reaper could never reclaim it — a permanent leak.
+//   - Tracker removal uses the exact terminal/workspace/server identity. A
+//     tracker persistence failure is logged but does not turn a successful pane
+//     close into a cleanup failure; the stale record remains a recovery handle.
 //   - A persistent failure is logged with the surface ref so the leak is
 //     observable instead of silent.
 func closePaneSurface(term terminal.Terminal, paneID terminal.PaneID) bool {
@@ -189,7 +194,9 @@ func closePaneSurface(term terminal.Terminal, paneID terminal.PaneID) bool {
 	var lastErr error
 	for attempt := 0; attempt < closePaneSurfaceAttempts; attempt++ {
 		if lastErr = term.Close(ctx, ref); lastErr == nil {
-			untrackSurface(ref)
+			if err := closeSurfaceUntracker(term, ref); err != nil {
+				log.Printf("[cleanup] surface %q closed but tracker handoff failed; recovery handle retained: %v", ref, err)
+			}
 			return true
 		}
 	}

--- a/pkg/orchestra/interactive_launch.go
+++ b/pkg/orchestra/interactive_launch.go
@@ -68,7 +68,7 @@ func buildInteractiveLaunchCmdWithCWD(p ProviderConfig, prompt, workingDir strin
 }
 
 func interactiveLaunchArgs(p ProviderConfig) []string {
-	if p.Name == "gemini" && p.Binary == "agy" && len(p.PaneArgs) == 0 && p.InteractiveInput != "args" {
+	if usesAntigravityPromptInteractive(p) && len(p.PaneArgs) == 0 && p.InteractiveInput != "args" {
 		return p.PaneArgs
 	}
 	return paneArgs(p)
@@ -82,8 +82,7 @@ func usesAntigravityPromptInteractive(p ProviderConfig) bool {
 	if p.Binary != "agy" && !strings.HasSuffix(p.Binary, "/agy") {
 		return false
 	}
-	name := strings.TrimSpace(p.Name)
-	return name == "gemini" || name == "antigravity" || name == "antigravity-cli"
+	return providerArtifactIdentity(p.Name) == "gemini"
 }
 
 func shellQuoteCommandArg(s string) string {

--- a/pkg/orchestra/interactive_launch_alias_test.go
+++ b/pkg/orchestra/interactive_launch_alias_test.go
@@ -1,0 +1,115 @@
+package orchestra
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInteractiveLaunchArgs_GeminiArtifactAliasesSuppressPrintArgs(t *testing.T) {
+	t.Parallel()
+
+	geminiProvider := func(name, binary string) ProviderConfig {
+		return ProviderConfig{
+			Name: name, Binary: binary, Args: []string{"--print", ""},
+			PromptViaArgs: true, InteractiveInput: "stdin",
+		}
+	}
+	tests := []struct {
+		name     string
+		provider ProviderConfig
+		want     []string
+		wantCmd  string
+	}{
+		{name: "gemini", provider: geminiProvider("gemini", "agy"), wantCmd: "agy --dangerously-skip-permissions --prompt-interactive 'test prompt'"},
+		{name: "antigravity", provider: geminiProvider("antigravity", "agy"), wantCmd: "agy --dangerously-skip-permissions --prompt-interactive 'test prompt'"},
+		{name: "antigravity cli", provider: geminiProvider("antigravity-cli", "agy"), wantCmd: "agy --dangerously-skip-permissions --prompt-interactive 'test prompt'"},
+		{name: "gemini cli", provider: geminiProvider("gemini-cli", "agy"), wantCmd: "agy --dangerously-skip-permissions --prompt-interactive 'test prompt'"},
+		{name: "agy", provider: geminiProvider("agy", "agy"), wantCmd: "agy --dangerously-skip-permissions --prompt-interactive 'test prompt'"},
+		{
+			name:     "agy path",
+			provider: geminiProvider("gemini-cli", "/opt/autopus/bin/agy"),
+			wantCmd:  "/opt/autopus/bin/agy --dangerously-skip-permissions --prompt-interactive 'test prompt'",
+		},
+		{
+			name:     "custom provider keeps its print args",
+			provider: geminiProvider("custom", "agy"),
+			want:     []string{"--print", ""},
+			wantCmd:  "agy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, interactiveLaunchArgs(tt.provider))
+			assert.Equal(t, tt.wantCmd, buildInteractiveLaunchCmd(tt.provider, "test prompt"))
+		})
+	}
+}
+
+func TestPromptDeliveredAtLaunch_GeminiArtifactAliases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		provider ProviderConfig
+		want     bool
+	}{
+		{name: "gemini", provider: ProviderConfig{Name: "gemini", Binary: "agy"}, want: true},
+		{name: "antigravity", provider: ProviderConfig{Name: "antigravity", Binary: "agy"}, want: true},
+		{name: "antigravity cli", provider: ProviderConfig{Name: "antigravity-cli", Binary: "agy"}, want: true},
+		{name: "gemini cli", provider: ProviderConfig{Name: "gemini-cli", Binary: "agy"}, want: true},
+		{name: "agy", provider: ProviderConfig{Name: "agy", Binary: "agy"}, want: true},
+		{name: "custom agy binary", provider: ProviderConfig{Name: "custom", Binary: "agy"}, want: false},
+		{name: "gemini other binary", provider: ProviderConfig{Name: "gemini", Binary: "gemini"}, want: false},
+		{
+			name:     "custom args mode",
+			provider: ProviderConfig{Name: "custom", Binary: "custom", InteractiveInput: "args"},
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, promptDeliveredAtLaunch(tt.provider))
+		})
+	}
+}
+
+func TestResolveHookProviders_GeminiArtifactAliasesOwnCanonicalHook(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		provider             ProviderConfig
+		wantGeminiHook       bool
+		wantProviderMapEntry bool
+	}{
+		{
+			name: "gemini", provider: ProviderConfig{Name: "gemini", Binary: "agy"},
+			wantProviderMapEntry: true,
+		},
+		{name: "antigravity", provider: ProviderConfig{Name: "antigravity", Binary: "agy"}},
+		{name: "antigravity cli", provider: ProviderConfig{Name: "antigravity-cli", Binary: "agy"}},
+		{name: "gemini cli", provider: ProviderConfig{Name: "gemini-cli", Binary: "agy"}},
+		{name: "agy", provider: ProviderConfig{Name: "agy", Binary: "agy"}},
+		{
+			name:           "custom agy binary",
+			provider:       ProviderConfig{Name: "custom", Binary: "agy"},
+			wantGeminiHook: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := resolveHookProviders([]ProviderConfig{tt.provider})
+			assert.Equal(t, tt.wantGeminiHook, got["gemini"])
+			_, hasProviderEntry := got[tt.provider.Name]
+			assert.Equal(t, tt.wantProviderMapEntry, hasProviderEntry,
+				"hook capability must be owned by the canonical artifact identity")
+		})
+	}
+}

--- a/pkg/orchestra/interactive_launch_hook_test.go
+++ b/pkg/orchestra/interactive_launch_hook_test.go
@@ -1,0 +1,187 @@
+package orchestra
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/insajin/autopus-adk/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type launchOrderEvent struct {
+	kind  string
+	value string
+}
+
+type launchOrderTerminal struct {
+	*seqScreenMock
+	events []launchOrderEvent
+}
+
+func (m *launchOrderTerminal) SendCommand(_ context.Context, _ terminal.PaneID, cmd string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, launchOrderEvent{kind: "command", value: cmd})
+	return nil
+}
+
+func (m *launchOrderTerminal) SendLongText(_ context.Context, _ terminal.PaneID, text string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, launchOrderEvent{kind: "long_text", value: text})
+	return nil
+}
+
+func (m *launchOrderTerminal) eventsSnapshot() []launchOrderEvent {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]launchOrderEvent(nil), m.events...)
+}
+
+func TestLaunchInteractiveSessions_DebateExportsRoundBeforeLaunch(t *testing.T) {
+	t.Parallel()
+
+	term := &launchOrderTerminal{seqScreenMock: &seqScreenMock{name: "cmux"}}
+	provider := ProviderConfig{Name: "claude", Binary: "claude"}
+	panes := []paneInfo{{provider: provider, paneID: terminal.PaneID("surface:debate-launch")}}
+	cfg := OrchestraConfig{
+		Providers: []ProviderConfig{provider},
+		Strategy:  StrategyDebate,
+		Terminal:  term,
+		HookMode:  true,
+		SessionID: "orch-debate-launch-order",
+	}
+
+	failed := launchInteractiveSessions(context.Background(), cfg, panes)
+
+	assert.Empty(t, failed)
+	events := term.eventsSnapshot()
+	sessionIndex, roundIndex, launchIndex := -1, -1, -1
+	for i, event := range events {
+		switch {
+		case event.kind == "command" && event.value == "export AUTOPUS_ROUND=1":
+			roundIndex = i
+		case event.kind == "command" && strings.Contains(event.value, "export AUTOPUS_SESSION_ID=orch-debate-launch-order"):
+			sessionIndex = i
+		case event.kind == "long_text":
+			launchIndex = i
+		}
+	}
+	require.NotEqual(t, -1, sessionIndex, "session export must be sent")
+	require.NotEqual(t, -1, roundIndex, "debate round export must be sent")
+	require.NotEqual(t, -1, launchIndex, "provider launch must be sent")
+	assert.Less(t, sessionIndex, roundIndex)
+	assert.Less(t, roundIndex, launchIndex, "round 1 must be inherited by the provider CLI")
+}
+
+func TestLaunchInteractiveSessions_FastestKeepsUnscopedHookRound(t *testing.T) {
+	t.Parallel()
+
+	term := &launchOrderTerminal{seqScreenMock: &seqScreenMock{name: "cmux"}}
+	provider := ProviderConfig{Name: "claude", Binary: "claude"}
+	panes := []paneInfo{{provider: provider, paneID: terminal.PaneID("surface:fastest-launch")}}
+	cfg := OrchestraConfig{
+		Providers: []ProviderConfig{provider},
+		Strategy:  StrategyFastest,
+		Terminal:  term,
+		HookMode:  true,
+		SessionID: "orch-fastest-launch-order",
+	}
+
+	failed := launchInteractiveSessions(context.Background(), cfg, panes)
+
+	assert.Empty(t, failed)
+	events := term.eventsSnapshot()
+	sessionExported := false
+	for _, event := range events {
+		if event.kind != "command" {
+			continue
+		}
+		if strings.Contains(event.value, "export AUTOPUS_SESSION_ID=orch-fastest-launch-order") {
+			sessionExported = true
+		}
+		assert.NotContains(t, event.value, "AUTOPUS_ROUND=",
+			"fastest completion still consumes unscoped hook artifacts")
+	}
+	assert.True(t, sessionExported)
+}
+
+func TestLaunchInteractiveSessions_ExportsForCompletionOrStartupCapability(t *testing.T) {
+	t.Parallel()
+	on, off := true, false
+	tests := []struct {
+		name     string
+		provider ProviderConfig
+	}{
+		{name: "gemini completion default", provider: ProviderConfig{Name: "gemini", Binary: "gemini"}},
+		{name: "claude alias defaults", provider: ProviderConfig{Name: "claude-code", Binary: "claude"}},
+		{name: "gemini cli alias discovered", provider: ProviderConfig{Name: "gemini-cli", Binary: "gemini", HasHook: &on}},
+		{name: "antigravity alias discovered", provider: ProviderConfig{Name: "antigravity-cli", Binary: "agy", HasHook: &on}},
+		{name: "agy alias discovered", provider: ProviderConfig{Name: "agy", Binary: "agy", HasHook: &on}},
+		{name: "opencode completion override", provider: ProviderConfig{Name: "opencode", Binary: "opencode", HasHook: &on}},
+		{name: "claude startup default", provider: ProviderConfig{Name: "claude", Binary: "claude", HasHook: &off}},
+		{name: "custom startup override", provider: ProviderConfig{Name: "custom", Binary: "custom", HasHook: &off, HasStartupHook: &on}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			term := &launchOrderTerminal{seqScreenMock: &seqScreenMock{name: "cmux"}}
+			panes := []paneInfo{{provider: tt.provider, paneID: "surface:capability-export"}}
+			cfg := OrchestraConfig{
+				Providers: []ProviderConfig{tt.provider}, Strategy: StrategyFastest,
+				Terminal: term, HookMode: true, SessionID: "orch-capability-export",
+			}
+
+			failed := launchInteractiveSessions(context.Background(), cfg, panes)
+
+			assert.Empty(t, failed)
+			exported := false
+			for _, event := range term.eventsSnapshot() {
+				if event.kind == "command" && strings.Contains(event.value, "export AUTOPUS_SESSION_ID=orch-capability-export") {
+					exported = true
+				}
+			}
+			assert.True(t, exported, "either completion or startup hooks require the pane session environment")
+		})
+	}
+}
+
+func TestLaunchInteractiveSessions_HookExportFailureSkipsLaunch(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name          string
+		successBefore int
+		wantError     string
+	}{
+		{name: "session send", successBefore: 0, wantError: "export hook session failed"},
+		{name: "session enter", successBefore: 1, wantError: "commit hook session export failed"},
+		{name: "round send", successBefore: 2, wantError: "export hook round failed"},
+		{name: "round enter", successBefore: 3, wantError: "commit hook round export failed"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			term := newCmuxMock()
+			term.sendCommandErr = errors.New("injected transport failure")
+			term.sendCommandErrAfter = tt.successBefore
+			provider := ProviderConfig{Name: "claude", Binary: "claude"}
+			panes := []paneInfo{{provider: provider, paneID: "surface:hook-export"}}
+			cfg := OrchestraConfig{
+				Providers: []ProviderConfig{provider}, Strategy: StrategyDebate,
+				Terminal: term, HookMode: true, SessionID: "orch-hook-export-failure",
+			}
+
+			failed := launchInteractiveSessions(context.Background(), cfg, panes)
+
+			require.Len(t, failed, 1)
+			assert.ErrorContains(t, errors.New(failed[0].Error), tt.wantError)
+			assert.True(t, panes[0].skipWait)
+			assert.Empty(t, term.sendLongTextCalls, "a provider must not launch without its mandatory hook environment")
+		})
+	}
+}

--- a/pkg/orchestra/interactive_pane_debate_test.go
+++ b/pkg/orchestra/interactive_pane_debate_test.go
@@ -86,6 +86,10 @@ func TestRunPaneDebate_WithJudge(t *testing.T) {
 	mock := &countingScreenMock{
 		mockTerminal: mockTerminal{name: "cmux"},
 		outputs: []string{
+			"❯\n", // Claude startup frame 1
+			"❯\n", // Claude startup frame 2
+			">\n", // Gemini startup frame 1
+			">\n", // Gemini startup frame 2
 			"loading...\n",
 			"loading...\n",
 			"loading...\n",
@@ -106,7 +110,7 @@ func TestRunPaneDebate_WithJudge(t *testing.T) {
 		Interactive:    true,
 		InitialDelay:   time.Millisecond,
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 7*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
 	result, err := runPaneDebate(ctx, cfg, 1, 45*time.Second, time.Now())

--- a/pkg/orchestra/interactive_pane_ready_test.go
+++ b/pkg/orchestra/interactive_pane_ready_test.go
@@ -1,0 +1,201 @@
+package orchestra
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type cancelAfterReadsTerminal struct {
+	*seqScreenMock
+	cancel    context.CancelFunc
+	stopAfter int
+}
+
+func (m *cancelAfterReadsTerminal) ReadScreen(ctx context.Context, paneID terminal.PaneID, opts terminal.ReadScreenOpts) (string, error) {
+	screen, err := m.seqScreenMock.ReadScreen(ctx, paneID, opts)
+	if m.readCalls >= m.stopAfter {
+		m.cancel()
+	}
+	return screen, err
+}
+
+func TestWaitForPaneReady_EarlyHookReadyWithoutInputPrompt_ReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	session, err := NewHookSession("pane-ready-early-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(session.Dir(), RoundSignalName("codex", 1, "ready")),
+		[]byte("1"), 0o600,
+	))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	term := &cancelAfterReadsTerminal{
+		seqScreenMock: &seqScreenMock{name: "cmux", screens: []string{"starting codex...\n"}},
+		cancel:        cancel,
+		stopAfter:     1,
+	}
+	ready := waitForPaneReady(
+		ctx, term, terminal.PaneID("surface:1"),
+		SessionReadyPatterns(), time.Second, session, "codex", 1,
+	)
+
+	assert.False(t, ready, "hook startup alone must not prove the TUI can receive input")
+	assert.Equal(t, 1, term.readCalls, "the gate must inspect the provider screen")
+}
+
+func TestWaitForPaneReady_EarlyHookReadyWaitsForInputPrompt(t *testing.T) {
+	t.Parallel()
+
+	session, err := NewHookSession("pane-ready-prompt-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(session.Dir(), RoundSignalName("codex", 1, "ready")),
+		[]byte("1"), 0o600,
+	))
+
+	term := &seqScreenMock{name: "cmux", screens: []string{
+		"starting codex...\n",
+		"PostCompact hooks\nTurn hooks on or off\nNo hooks installed for this event.\nPress esc to go back\n",
+		"› Find and fix a bug in @filename\n",
+		"› Find and fix a bug in @filename\n",
+	}}
+	ready := waitForPaneReady(
+		context.Background(), term, terminal.PaneID("surface:2"),
+		SessionReadyPatterns(), time.Second, session, "codex", 1,
+	)
+
+	assert.True(t, ready)
+	assert.Equal(t, 4, term.readCalls, "the hook signal must not bypass stable screen readiness")
+}
+
+func TestIsSessionReady_CodexHooksModal_ReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	screen := "› Summarize recent commits\nPostCompact hooks\nTurn hooks on or off\nNo hooks installed for this event.\nPress esc to go back\n"
+	assert.False(t, isSessionReady(screen, SessionReadyPatterns()))
+}
+
+func TestWaitForPaneReady_TransientPromptFrame_ReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	session, err := NewHookSession("pane-ready-transient-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(session.Dir(), RoundSignalName("codex", 1, "ready")),
+		[]byte("1"), 0o600,
+	))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	term := &cancelAfterReadsTerminal{
+		seqScreenMock: &seqScreenMock{name: "cmux", screens: []string{
+			"starting codex...\n",
+			"› Summarize recent commits\n",
+			"loading extensions...\n",
+		}},
+		cancel: cancel, stopAfter: 3,
+	}
+
+	ready := waitForPaneReady(ctx, term, terminal.PaneID("surface:3"),
+		SessionReadyPatterns(), time.Second, session, "codex", 1)
+
+	assert.False(t, ready, "one transient prompt frame must not open the input gate")
+	assert.Equal(t, 3, term.readCalls)
+}
+
+func TestWaitForPaneReady_OtherProviderPrompt_ReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	session, err := NewHookSession("pane-ready-other-provider-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(session.Dir(), RoundSignalName("codex", 1, "ready")),
+		[]byte("1"), 0o600,
+	))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	term := &cancelAfterReadsTerminal{
+		seqScreenMock: &seqScreenMock{name: "cmux", screens: []string{"❯\n", "❯\n"}},
+		cancel:        cancel, stopAfter: 2,
+	}
+
+	ready := waitForPaneReady(ctx, term, terminal.PaneID("surface:4"),
+		SessionReadyPatterns(), time.Second, session, "codex", 1)
+
+	assert.False(t, ready, "a Claude prompt must not make a Codex pane ready")
+}
+
+func TestWaitForPaneReady_HookProviderRequiresMatchingRoundSignal(t *testing.T) {
+	t.Parallel()
+
+	session, err := NewHookSession("pane-ready-wrong-round-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(session.Dir(), RoundSignalName("codex", 1, "ready")),
+		[]byte("1"), 0o600,
+	))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	term := &cancelAfterReadsTerminal{
+		seqScreenMock: &seqScreenMock{name: "cmux", screens: []string{
+			"› Summarize recent commits\n", "› Summarize recent commits\n",
+		}},
+		cancel: cancel, stopAfter: 2,
+	}
+
+	ready := waitForPaneReady(ctx, term, terminal.PaneID("surface:5"),
+		SessionReadyPatterns(), time.Second, session, "codex", 2)
+
+	assert.False(t, ready, "a ready signal from another round must not open the gate")
+}
+
+func TestWaitForPaneReady_HooklessProviderUsesStableScreen(t *testing.T) {
+	t.Parallel()
+
+	session, err := NewHookSession("pane-ready-hookless-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+
+	term := &seqScreenMock{name: "cmux", screens: []string{"Ask anything\n", "Ask anything\n"}}
+	ready := waitForPaneReady(context.Background(), term, terminal.PaneID("surface:6"),
+		SessionReadyPatterns(), time.Second, session, "opencode", 1)
+
+	assert.True(t, ready, "a hookless provider must retain provider-specific screen fallback")
+	assert.Equal(t, 2, term.readCalls)
+}
+
+func TestWaitForPaneReady_ClaudeANSIAndNBSPPrompt_IsStableReady(t *testing.T) {
+	t.Parallel()
+
+	session, err := NewHookSession("pane-ready-claude-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(session.Dir(), RoundSignalName("claude", 1, "ready")),
+		[]byte("1"), 0o600,
+	))
+
+	const screen = "\x1b[32m❯\x1b[0m\u00a0Try \"write a test for <filepath>\"\n"
+	term := &seqScreenMock{name: "cmux", screens: []string{screen, screen}}
+	ready := waitForPaneReady(context.Background(), term, terminal.PaneID("surface:7"),
+		SessionReadyPatterns(), time.Second, session, "claude", 1)
+
+	assert.True(t, ready)
+	assert.Equal(t, 2, term.readCalls, "Claude prompt must be stable across two frames")
+}

--- a/pkg/orchestra/interactive_pane_ready_test.go
+++ b/pkg/orchestra/interactive_pane_ready_test.go
@@ -86,6 +86,15 @@ func TestIsSessionReady_CodexHooksModal_ReturnsFalse(t *testing.T) {
 	assert.False(t, isSessionReady(screen, SessionReadyPatterns()))
 }
 
+func TestIsProviderSessionReady_CustomProviderUsesGenericCLIPrompt(t *testing.T) {
+	t.Parallel()
+
+	patterns := SessionReadyPatterns()
+	assert.True(t, isProviderSessionReady("❯\n", patterns, "custom-provider"))
+	assert.False(t, isProviderSessionReady("❯\n", patterns, "codex"),
+		"a known provider must not accept another provider's prompt")
+}
+
 func TestWaitForPaneReady_TransientPromptFrame_ReturnsFalse(t *testing.T) {
 	t.Parallel()
 
@@ -198,4 +207,77 @@ func TestWaitForPaneReady_ClaudeANSIAndNBSPPrompt_IsStableReady(t *testing.T) {
 
 	assert.True(t, ready)
 	assert.Equal(t, 2, term.readCalls, "Claude prompt must be stable across two frames")
+}
+
+func TestWaitForSessionReady_RequiresProviderSpecificStableFrames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		screens []string
+	}{
+		{
+			name:    "other provider prompt",
+			screens: []string{"❯\n", "❯\n"},
+		},
+		{
+			name:    "transient provider prompt",
+			screens: []string{"› Summarize recent commits\n", "loading extensions...\n"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			term := &cancelAfterReadsTerminal{
+				seqScreenMock: &seqScreenMock{name: "cmux", screens: tt.screens},
+				cancel:        cancel,
+				stopAfter:     len(tt.screens),
+			}
+			panes := []paneInfo{{
+				provider: ProviderConfig{Name: "codex", StartupTimeout: time.Second},
+				paneID:   terminal.PaneID("surface:stable-gate"),
+			}}
+
+			failed := waitForSessionReady(ctx, term, panes)
+
+			require.Len(t, failed, 1)
+			assert.Equal(t, "codex", failed[0].Name)
+			assert.True(t, panes[0].skipWait)
+		})
+	}
+}
+
+func TestWaitForSessionReadyWithHook_MissingReadySignalSkipsPrompt(t *testing.T) {
+	t.Parallel()
+
+	session, err := NewHookSession("pane-ready-wrapper-hook-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	const screen = "❯ Try \"write a test for <filepath>\"\n"
+	term := &cancelAfterReadsTerminal{
+		seqScreenMock: &seqScreenMock{name: "cmux", screens: []string{screen, screen}},
+		cancel:        cancel,
+		stopAfter:     2,
+	}
+	panes := []paneInfo{{
+		provider: ProviderConfig{Name: "claude", StartupTimeout: time.Second},
+		paneID:   terminal.PaneID("surface:hook-gate"),
+	}}
+
+	failed := waitForSessionReadyWithHook(ctx, term, panes, session, 0)
+	promptFailed := sendPrompts(ctx, OrchestraConfig{Terminal: term, Prompt: "must not send"}, panes)
+
+	require.Len(t, failed, 1)
+	assert.Equal(t, "claude", failed[0].Name)
+	assert.True(t, panes[0].skipWait)
+	assert.Empty(t, promptFailed)
+	assert.Empty(t, term.longTextsSnapshot(), "a readiness failure must block prompt delivery")
 }

--- a/pkg/orchestra/interactive_poll.go
+++ b/pkg/orchestra/interactive_poll.go
@@ -3,25 +3,24 @@ package orchestra
 import (
 	"context"
 	"log"
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/insajin/autopus-adk/pkg/terminal"
 )
 
-// waitForPaneReady waits until the provider session is ready to receive a prompt,
-// watching two signals in one loop (SPEC-ORCH-022): the SessionStart hook ready
-// file (when a hook session is present) and the screen prompt pattern. Either
-// signal returns ready. The file signal is deterministic and avoids the ANSI /
-// prompt screen-scraping flakiness that made the CLAUDECODE pane path fall back
-// to subprocess before reaching hook-IPC; screen scraping remains the fallback
-// for providers without an installed session-start hook.
+// waitForPaneReady waits for provider startup evidence and a stable input prompt.
+// Hook-ready proves only process startup, so hook-capable providers also require
+// two consecutive provider-specific ready frames. Hookless providers use the
+// same stable screen gate without waiting for an unavailable hook artifact.
 func waitForPaneReady(ctx context.Context, term terminal.Terminal, paneID terminal.PaneID, patterns []CompletionPattern, timeout time.Duration, hookSession *HookSession, provider string, round int) bool {
-	readyPath := ""
-	if hookSession != nil {
-		readyPath = filepath.Join(hookSession.Dir(), RoundSignalName(provider, round, "ready"))
+	hookRequired := hookSession != nil && hookSession.HasHook(provider)
+	hookStarted := !hookRequired
+	readyName := ""
+	if hookRequired {
+		readyName = RoundSignalName(provider, round, "ready")
 	}
+	const stableReadyFrames = 2
+	readyFrames := 0
 	deadline := time.After(timeout)
 	ticker := time.NewTicker(sessionReadyPollInterval)
 	defer ticker.Stop()
@@ -32,13 +31,18 @@ func waitForPaneReady(ctx context.Context, term terminal.Terminal, paneID termin
 		case <-deadline:
 			return false
 		case <-ticker.C:
-			if readyPath != "" {
-				if _, err := os.Stat(readyPath); err == nil {
-					return true
+			if !hookStarted {
+				if _, err := hookSession.statArtifact(readyName); err == nil {
+					hookStarted = true
 				}
 			}
 			screen, err := readScreenBounded(ctx, term, paneID, terminal.ReadScreenOpts{})
-			if err == nil && isSessionReady(screen, patterns) {
+			if err != nil || !isProviderSessionReady(screen, patterns, provider) {
+				readyFrames = 0
+				continue
+			}
+			readyFrames++
+			if hookStarted && readyFrames >= stableReadyFrames {
 				return true
 			}
 		}

--- a/pkg/orchestra/interactive_poll.go
+++ b/pkg/orchestra/interactive_poll.go
@@ -2,18 +2,22 @@ package orchestra
 
 import (
 	"context"
+	"errors"
 	"log"
+	"os"
 	"time"
 
 	"github.com/insajin/autopus-adk/pkg/terminal"
 )
 
+const codexStartupArtifactGrace = time.Second
+
 // waitForPaneReady waits for provider startup evidence and a stable input prompt.
-// Hook-ready proves only process startup, so hook-capable providers also require
-// two consecutive provider-specific ready frames. Hookless providers use the
-// same stable screen gate without waiting for an unavailable hook artifact.
+// Hook-ready proves only process startup, so providers with startup hook wiring
+// also require two consecutive provider-specific ready frames. Other providers
+// use the stable screen gate without waiting for an unavailable artifact.
 func waitForPaneReady(ctx context.Context, term terminal.Terminal, paneID terminal.PaneID, patterns []CompletionPattern, timeout time.Duration, hookSession *HookSession, provider string, round int) bool {
-	hookRequired := hookSession != nil && hookSession.HasHook(provider)
+	hookRequired := hookSession != nil && hookSession.HasStartupHook(provider)
 	hookStarted := !hookRequired
 	readyName := ""
 	if hookRequired {
@@ -21,6 +25,8 @@ func waitForPaneReady(ctx context.Context, term terminal.Terminal, paneID termin
 	}
 	const stableReadyFrames = 2
 	readyFrames := 0
+	var stableSince time.Time
+	var artifactMissingSince time.Time
 	deadline := time.After(timeout)
 	ticker := time.NewTicker(sessionReadyPollInterval)
 	defer ticker.Stop()
@@ -31,19 +37,50 @@ func waitForPaneReady(ctx context.Context, term terminal.Terminal, paneID termin
 		case <-deadline:
 			return false
 		case <-ticker.C:
+			now := time.Now()
+			if hookRequired && !hookSession.HasStartupHook(provider) {
+				hookRequired = false
+				hookStarted = true
+			}
 			if !hookStarted {
-				if _, err := hookSession.statArtifact(readyName); err == nil {
+				_, err := hookSession.statArtifact(readyName)
+				switch {
+				case err == nil:
 					hookStarted = true
+					artifactMissingSince = time.Time{}
+				case errors.Is(err, os.ErrNotExist):
+					if artifactMissingSince.IsZero() {
+						artifactMissingSince = now
+					}
+				default:
+					artifactMissingSince = time.Time{}
 				}
 			}
 			screen, err := readScreenBounded(ctx, term, paneID, terminal.ReadScreenOpts{})
 			if err != nil || !isProviderSessionReady(screen, patterns, provider) {
 				readyFrames = 0
+				stableSince = time.Time{}
 				continue
+			}
+			if readyFrames == 0 {
+				stableSince = now
 			}
 			readyFrames++
 			if hookStarted && readyFrames >= stableReadyFrames {
 				return true
+			}
+			if hookRequired && readyFrames >= stableReadyFrames &&
+				providerArtifactIdentity(provider) == "codex" &&
+				!artifactMissingSince.IsZero() {
+				graceStart := stableSince
+				if artifactMissingSince.After(graceStart) {
+					graceStart = artifactMissingSince
+				}
+				if now.Sub(graceStart) >= codexStartupArtifactGrace &&
+					hookSession.deactivateCodexStartupHook(provider, round) {
+					log.Printf("[startup] %s ready artifact inactive after stable prompt grace; using direct readiness for this run", provider)
+					return true
+				}
 			}
 		}
 	}
@@ -105,11 +142,15 @@ func pollUntilSessionReady(ctx context.Context, term terminal.Terminal, paneID t
 	}
 }
 
-// waitForSessionReady polls ReadScreen until a CLI-specific prompt is visible or timeout.
-// Uses SessionReadyPatterns (no shell $ / # patterns) to avoid false positives.
-// Providers that never become ready are marked skipWait so prompts are not sent
-// into a shell or half-launched TUI.
+// waitForSessionReady preserves the hookless startup-gate helper contract.
 func waitForSessionReady(ctx context.Context, term terminal.Terminal, panes []paneInfo) []FailedProvider {
+	return waitForSessionReadyWithHook(ctx, term, panes, nil, 0)
+}
+
+// waitForSessionReadyWithHook requires provider-specific, stable screen readiness.
+// Providers with startup hook wiring must also emit their ready artifact. Those
+// that never become ready are marked skipWait so their prompt is never sent.
+func waitForSessionReadyWithHook(ctx context.Context, term terminal.Terminal, panes []paneInfo, hookSession *HookSession, round int) []FailedProvider {
 	patterns := SessionReadyPatterns()
 	var failed []FailedProvider
 	for i, pi := range panes {
@@ -120,7 +161,7 @@ func waitForSessionReady(ctx context.Context, term terminal.Terminal, panes []pa
 			continue
 		}
 		timeout := startupTimeoutFor(pi.provider)
-		if pollUntilSessionReady(ctx, term, pi.paneID, patterns, timeout) {
+		if waitForPaneReady(ctx, term, pi.paneID, patterns, timeout, hookSession, pi.provider.Name, round) {
 			continue
 		}
 		panes[i].skipWait = true

--- a/pkg/orchestra/interactive_session_ready.go
+++ b/pkg/orchestra/interactive_session_ready.go
@@ -48,22 +48,29 @@ func isSessionReady(screen string, patterns []CompletionPattern) bool {
 // gate when multiple providers launch concurrently.
 func isProviderSessionReady(screen string, patterns []CompletionPattern, provider string) bool {
 	screen = stripANSI(screen)
-	if isSessionReadyBlocked(screen, provider) {
+	identity := providerArtifactIdentity(provider)
+	if isProviderWorking(screen) || isSessionReadyBlocked(screen, identity) {
 		return false
 	}
+	providerPatternFound := false
 	for _, cp := range patterns {
-		if !strings.EqualFold(strings.TrimSpace(cp.Provider), strings.TrimSpace(provider)) {
+		patternIdentity := providerArtifactIdentity(cp.Provider)
+		if !strings.EqualFold(strings.TrimSpace(patternIdentity), strings.TrimSpace(identity)) {
 			continue
 		}
+		providerPatternFound = true
 		if cp.Pattern != nil && cp.Pattern.MatchString(screen) {
 			return true
 		}
 	}
-	return false
+	// Custom providers have no built-in signature. Keep them extensible by
+	// accepting any known CLI prompt while named providers remain strictly bound
+	// to their own prompt pattern.
+	return !providerPatternFound && isSessionReady(screen, patterns)
 }
 
 func isSessionReadyBlocked(screen, provider string) bool {
-	return strings.EqualFold(strings.TrimSpace(provider), "codex") && codexReadyBlockerPattern.MatchString(screen)
+	return providerArtifactIdentity(provider) == "codex" && codexReadyBlockerPattern.MatchString(screen)
 }
 
 // startupTimeoutFor returns the per-provider startup timeout.
@@ -71,7 +78,7 @@ func startupTimeoutFor(provider ProviderConfig) time.Duration {
 	if provider.StartupTimeout > 0 {
 		return provider.StartupTimeout
 	}
-	switch provider.Name {
+	switch providerArtifactIdentity(provider.Name) {
 	case "claude":
 		return 15 * time.Second
 	case "gemini":

--- a/pkg/orchestra/interactive_session_ready.go
+++ b/pkg/orchestra/interactive_session_ready.go
@@ -2,26 +2,22 @@ package orchestra
 
 import (
 	"regexp"
+	"strings"
 	"time"
 )
 
-// sessionReadyPromptPatterns matches CLI-specific prompts WITHOUT shell patterns ($ and #).
-// Used by waitForSessionReady to avoid premature detection on bare shell prompts.
-var sessionReadyPromptPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`(?m)^❯(?:\s|\x{00a0})*(?:Try\b.*)?$`), // claude code prompt, including startup suggestion text
-	regexp.MustCompile(`(?m)^\s*>\s*(Type your|@|\s*$)`),      // gemini TUI prompt (> Type your..., > @, bare >)
-	regexp.MustCompile(`(?im)^codex>\s*$`),                    // codex prompt (case-insensitive)
-	regexp.MustCompile(codexSuggestionPromptPattern),          // codex v0.135+ TUI suggestion prompt
-	regexp.MustCompile(`(?im)^Ask anything\s*$`),              // opencode TUI prompt
-	// NOTE: no shell $ or # patterns — this is the key difference from defaultPromptPatterns
-}
+const claudeReadyPromptPattern = `(?m)^[\t ]*❯[ \t\x{00a0}]*(?:Try\b[^\r\n]*)?[ \t\x{00a0}]*$`
+
+var codexReadyBlockerPattern = regexp.MustCompile(
+	`(?im)^\s*(?:PostCompact hooks|Turn hooks on or off.*|Press esc to go back)\s*$`,
+)
 
 // SessionReadyPatterns returns completion patterns for CLI session readiness detection.
 // Unlike DefaultCompletionPatterns, this excludes shell prompts ($ and #) to prevent
 // false positives when detecting whether a CLI tool has finished launching.
 func SessionReadyPatterns() []CompletionPattern {
 	return []CompletionPattern{
-		{Provider: "claude", Pattern: regexp.MustCompile(`(?m)^❯(?:\s|\x{00a0})*(?:Try\b.*)?$`)},
+		{Provider: "claude", Pattern: regexp.MustCompile(claudeReadyPromptPattern)},
 		{Provider: "codex", Pattern: regexp.MustCompile(codexReadyPromptPattern)},
 		{Provider: "gemini", Pattern: regexp.MustCompile(`(?m)^\s*>\s*(Type your|@|\s*$)`)},
 		{Provider: "opencode", Pattern: regexp.MustCompile(`(?im)^Ask anything\s*$`)},
@@ -32,18 +28,42 @@ func SessionReadyPatterns() []CompletionPattern {
 // indicating the provider session has fully launched. Unlike isPromptVisible, this does
 // NOT match shell prompts ($ and #) to avoid false positives during startup.
 func isSessionReady(screen string, patterns []CompletionPattern) bool {
+	if len(patterns) == 0 {
+		patterns = SessionReadyPatterns()
+	}
 	screen = stripANSI(screen)
 	for _, cp := range patterns {
-		if cp.Pattern.MatchString(screen) {
-			return true
+		if isSessionReadyBlocked(screen, cp.Provider) {
+			continue
 		}
-	}
-	for _, p := range sessionReadyPromptPatterns {
-		if p.MatchString(screen) {
+		if cp.Pattern != nil && cp.Pattern.MatchString(screen) {
 			return true
 		}
 	}
 	return false
+}
+
+// isProviderSessionReady matches only the requested provider's input prompt.
+// This prevents one pane's startup chrome from satisfying another provider's
+// gate when multiple providers launch concurrently.
+func isProviderSessionReady(screen string, patterns []CompletionPattern, provider string) bool {
+	screen = stripANSI(screen)
+	if isSessionReadyBlocked(screen, provider) {
+		return false
+	}
+	for _, cp := range patterns {
+		if !strings.EqualFold(strings.TrimSpace(cp.Provider), strings.TrimSpace(provider)) {
+			continue
+		}
+		if cp.Pattern != nil && cp.Pattern.MatchString(screen) {
+			return true
+		}
+	}
+	return false
+}
+
+func isSessionReadyBlocked(screen, provider string) bool {
+	return strings.EqualFold(strings.TrimSpace(provider), "codex") && codexReadyBlockerPattern.MatchString(screen)
 }
 
 // startupTimeoutFor returns the per-provider startup timeout.

--- a/pkg/orchestra/interactive_spec015_test.go
+++ b/pkg/orchestra/interactive_spec015_test.go
@@ -66,6 +66,37 @@ func TestWaitAndCollectResults_SkippedPaneTimedOut(t *testing.T) {
 	assert.Equal(t, "failed-provider", responses[0].Provider)
 }
 
+func TestWaitAndCollectResults_MixedSkippedAndLiveRaceSafe(t *testing.T) {
+	t.Parallel()
+
+	responsePath := filepath.Join(t.TempDir(), "response.md")
+	content := responseBeginMarker + "\nlive output\n" + responseEndMarker + "\n"
+	require.NoError(t, os.WriteFile(responsePath, []byte(content), 0o600))
+
+	panes := make([]paneInfo, 0, 128)
+	for range 64 {
+		panes = append(panes,
+			paneInfo{
+				provider:     ProviderConfig{Name: "live-provider"},
+				paneID:       "live-pane",
+				responseFile: responsePath,
+			},
+			paneInfo{
+				provider: ProviderConfig{Name: "skipped-provider"},
+				paneID:   "skipped-pane",
+				skipWait: true,
+			},
+		)
+	}
+
+	responses := waitAndCollectResults(
+		context.Background(), OrchestraConfig{Terminal: newCmuxMock()}, panes,
+		DefaultCompletionPatterns(), time.Now(), nil, nil, 0,
+	)
+
+	require.Len(t, responses, len(panes))
+}
+
 func TestWaitAndCollectResults_PrefersResponseFile(t *testing.T) {
 	t.Parallel()
 
@@ -199,9 +230,9 @@ func TestSendRoundEnv_SkippedForTUIProvider(t *testing.T) {
 	}
 }
 
-// TestSendRoundEnv_SentForArgsProvider verifies that SendRoundEnvToPane IS called
-// for args-based providers (InteractiveInput == "args").
-func TestSendRoundEnv_SentForArgsProvider(t *testing.T) {
+// TestSendRoundEnv_SkippedForActiveArgsProvider verifies an already-running
+// args provider does not receive a shell export as TUI input in later rounds.
+func TestSendRoundEnv_SkippedForActiveArgsProvider(t *testing.T) {
 	t.Parallel()
 
 	mock := newCmuxMock()
@@ -227,15 +258,8 @@ func TestSendRoundEnv_SentForArgsProvider(t *testing.T) {
 	}
 	_ = executeRound(ctx, cfg, panes, nil, 2, prevResponses)
 
-	// Verify that the export is immediately committed with Enter before any
-	// prompt input can be attached to the shell line.
-	foundCommittedExport := false
-	for i, call := range mock.sendCommandCalls {
-		if call.Cmd == "export AUTOPUS_ROUND=2" && i+1 < len(mock.sendCommandCalls) {
-			next := mock.sendCommandCalls[i+1]
-			foundCommittedExport = next.PaneID == call.PaneID && next.Cmd == "\n"
-			break
-		}
+	for _, call := range mock.sendCommandCalls {
+		assert.NotContains(t, call.Cmd, "AUTOPUS_ROUND",
+			"round cursor and file IPC own active-pane round identity")
 	}
-	assert.True(t, foundCommittedExport, "args provider round env must be committed with an adjacent Enter")
 }

--- a/pkg/orchestra/interactive_surface.go
+++ b/pkg/orchestra/interactive_surface.go
@@ -34,6 +34,9 @@ func validateSurface(ctx context.Context, term terminal.Terminal, paneID termina
 // success. (R2, R3, R4)
 func recreatePane(ctx context.Context, cfg OrchestraConfig, pi paneInfo, round int) (paneInfo, error) {
 	oldPaneID := pi.paneID
+	if _, err := recoveryHookSession(cfg); err != nil {
+		return pi, fmt.Errorf("recreatePane %s: %w", pi.provider.Name, err)
+	}
 
 	// Prepare a replacement while the old pane remains available. The old pane
 	// is retired only after the new CLI session reaches the commit point.
@@ -79,38 +82,16 @@ func recreatePane(ctx context.Context, cfg OrchestraConfig, pi paneInfo, round i
 		outputPath = ""
 	}
 
-	// Set round env on new pane before launching CLI.
-	if round > 1 && pi.provider.InteractiveInput == "args" {
-		roundErr, roundEnterErr := sendPaneInputAndEnterSerialized(ctx, cfg.Terminal, newPaneID, 0, func() error {
-			return SendRoundEnvToPane(ctx, cfg.Terminal, newPaneID, round)
-		})
-		if roundErr != nil || roundEnterErr != nil {
-			log.Printf("[recreatePane] %s round env failed (non-fatal): send=%v enter=%v", pi.provider.Name, roundErr, roundEnterErr)
-		}
-	}
-
-	// Relaunch CLI session. For args providers in round > 1, launch in REPL
-	// mode without the original prompt — the round prompt will be sent via
-	// SendLongText later by the caller.
-	cmd := buildInteractiveLaunchCmdWithCWD(pi.provider, "", cfg.WorkingDir)
-	launchErr, launchEnterErr := sendPaneInputAndEnterSerialized(ctx, cfg.Terminal, newPaneID, promptRegisterDelay, func() error {
-		return cfg.Terminal.SendLongText(ctx, newPaneID, cmd)
-	})
-	if launchErr != nil {
+	// A fresh shell must receive all hook coordinates before the provider starts.
+	if err := launchRecoveryProvider(ctx, cfg, newPaneID, pi.provider, round); err != nil {
 		closePaneSurface(cfg.Terminal, newPaneID)
 		_ = os.Remove(tmpFile.Name())
-		return pi, fmt.Errorf("recreatePane launch for %s: %w", pi.provider.Name, launchErr)
-	}
-	if launchEnterErr != nil {
-		closePaneSurface(cfg.Terminal, newPaneID)
-		_ = os.Remove(tmpFile.Name())
-		return pi, fmt.Errorf("recreatePane launch enter for %s: %w", pi.provider.Name, launchEnterErr)
+		return pi, fmt.Errorf("recreatePane %s: %w", pi.provider.Name, err)
 	}
 
-	// Wait for session readiness.
-	patterns := SessionReadyPatterns()
+	// Commit only after two consecutive provider-specific ready frames.
 	timeout := startupTimeoutFor(pi.provider)
-	if !pollUntilSessionReady(ctx, cfg.Terminal, newPaneID, patterns, timeout) {
+	if !waitForRecoveredProviderReady(ctx, cfg, newPaneID, pi.provider, round) {
 		closePaneSurface(cfg.Terminal, newPaneID)
 		_ = os.Remove(tmpFile.Name())
 		return pi, fmt.Errorf("recreatePane session for %s did not become ready after %s", pi.provider.Name, timeout)
@@ -127,10 +108,11 @@ func recreatePane(ctx context.Context, cfg OrchestraConfig, pi paneInfo, round i
 	log.Printf("[Surface] %s pane recreated: %s → %s", pi.provider.Name, oldPaneID, newPaneID)
 
 	return paneInfo{
-		paneID:     newPaneID,
-		outputFile: outputPath,
-		provider:   pi.provider,
-		skipWait:   false,
+		paneID:            newPaneID,
+		outputFile:        outputPath,
+		provider:          pi.provider,
+		skipWait:          false,
+		directPromptRound: round,
 	}, nil
 }
 

--- a/pkg/orchestra/interactive_surface_test.go
+++ b/pkg/orchestra/interactive_surface_test.go
@@ -106,6 +106,9 @@ func TestRecreatePane_Success(t *testing.T) {
 	if newPI.provider.Name != "opencode" {
 		t.Errorf("expected provider opencode, got %s", newPI.provider.Name)
 	}
+	if newPI.directPromptRound != 1 {
+		t.Errorf("expected directPromptRound=1, got %d", newPI.directPromptRound)
+	}
 	// Verify cleanup of old pane was called.
 	if len(mock.closeCalls) < 1 {
 		t.Error("expected Close call for old pane")
@@ -196,21 +199,34 @@ func containsString(values []string, want string) bool {
 	return false
 }
 
-// TestRecreatePane_RoundEnvSet verifies that SendRoundEnvToPane is called with
-// the correct round number when recreating an args-mode provider in round > 1.
-func TestRecreatePane_RoundEnvSet(t *testing.T) {
+// TestRecreatePane_HookRoundEnvSet verifies that a hook-capable replacement
+// inherits the current round before its provider process starts.
+func TestRecreatePane_HookRoundEnvSet(t *testing.T) {
 	ctx := context.Background()
 	mock := newCmuxMock()
 	mock.readScreenOutput = "Ask anything"
+	hasHook := true
 
 	pi := paneInfo{
 		paneID:     "old-pane",
 		outputFile: t.TempDir() + "/old-output.txt",
-		provider:   ProviderConfig{Name: "opencode", Binary: "opencode", InteractiveInput: "args"},
+		provider: ProviderConfig{
+			Name: "opencode", Binary: "opencode", InteractiveInput: "args", HasHook: &hasHook,
+		},
 	}
 
-	cfg := OrchestraConfig{Terminal: mock, Prompt: "test prompt"}
-	_, err := recreatePane(ctx, cfg, pi, 3)
+	cfg := OrchestraConfig{
+		Terminal: mock, Prompt: "test prompt", HookMode: true, SessionID: "recreate-round-env",
+	}
+	session, err := NewHookSession(cfg.SessionID)
+	if err != nil {
+		t.Fatalf("NewHookSession failed: %v", err)
+	}
+	defer session.Cleanup()
+	session.ApplyProviderHooks([]ProviderConfig{pi.provider})
+	cfg.SurfaceMgr = NewSurfaceManager(mock)
+	cfg.SurfaceMgr.setHookSession(session)
+	_, err = recreatePane(ctx, cfg, pi, 3)
 	if err != nil {
 		t.Fatalf("recreatePane failed: %v", err)
 	}

--- a/pkg/orchestra/interactive_test.go
+++ b/pkg/orchestra/interactive_test.go
@@ -155,7 +155,7 @@ func TestInteractive_SessionTimeout_ProducesPartialResult(t *testing.T) {
 // TestInteractive_SessionTimeout_PartialOutputPreserved verifies partial output is kept.
 func TestInteractive_SessionTimeout_PartialOutputPreserved(t *testing.T) {
 	mock := newCmuxMock()
-	mock.readScreenOutputs = append([]string{"❯\n"}, strings.Split(strings.Repeat("partial output before timeout\n", 20), "\n")[:20]...)
+	mock.readScreenOutputs = append([]string{"❯\n", "❯\n"}, strings.Split(strings.Repeat("partial output before timeout\n", 20), "\n")[:20]...)
 	cfg := OrchestraConfig{
 		Providers:      []ProviderConfig{echoProvider("slow")},
 		Strategy:       StrategyConsensus,

--- a/pkg/orchestra/interactive_yield_hook.go
+++ b/pkg/orchestra/interactive_yield_hook.go
@@ -1,0 +1,152 @@
+package orchestra
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"time"
+)
+
+const (
+	defaultHookReleaseTimeout = 3 * time.Second
+	hookReleasePollInterval   = 20 * time.Millisecond
+)
+
+type hookReleaseTarget struct {
+	provider  string
+	abortName string
+	readyName string
+}
+
+// releaseYieldHookWaiters returns hook-capable panes to an interactive prompt
+// before their ownership is transferred to a durable yield session. All aborts
+// are published first, then observed under one shared deadline so a slow hook
+// cannot multiply the handoff timeout by the provider count.
+func releaseYieldHookWaiters(ctx context.Context, session *HookSession, panes []paneInfo, nextRound int, timeout time.Duration) error {
+	if session == nil {
+		return nil
+	}
+	targets, err := yieldHookReleaseTargets(session, panes, nextRound)
+	if err != nil {
+		return fmt.Errorf("resolve yield hook release targets: %w", err)
+	}
+	if len(targets) == 0 {
+		return nil
+	}
+	if timeout <= 0 {
+		return fmt.Errorf("yield hook release timeout must be positive")
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("release yield hooks: %w", err)
+	}
+	for _, target := range targets {
+		if err := session.WriteAbortSignal(target.provider, nextRound); err != nil {
+			return fmt.Errorf("write abort for %s round %d: %w", target.provider, nextRound, err)
+		}
+	}
+	return waitForHookReleaseAcknowledgement(ctx, session, targets, nextRound, timeout)
+}
+
+func waitForHookReleaseAcknowledgement(
+	ctx context.Context,
+	session *HookSession,
+	targets []hookReleaseTarget,
+	round int,
+	timeout time.Duration,
+) error {
+	if timeout <= 0 {
+		return fmt.Errorf("hook release timeout must be positive")
+	}
+	releaseCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	if err := releaseCtx.Err(); err != nil {
+		return fmt.Errorf("wait for hook abort consumption in round %d: %w", round, err)
+	}
+
+	pending := make(map[string]hookReleaseTarget, len(targets))
+	for _, target := range targets {
+		pending[target.provider] = target
+	}
+	ticker := time.NewTicker(hookReleasePollInterval)
+	defer ticker.Stop()
+	for len(pending) > 0 {
+		for provider, target := range pending {
+			removed, err := hookReleaseArtifactsRemoved(session, target)
+			if err != nil {
+				return fmt.Errorf("inspect hook release for %s round %d: %w", provider, round, err)
+			}
+			if removed {
+				delete(pending, provider)
+			}
+		}
+		if len(pending) == 0 {
+			return nil
+		}
+		select {
+		case <-releaseCtx.Done():
+			providers := make([]string, 0, len(pending))
+			for provider := range pending {
+				providers = append(providers, provider)
+			}
+			sort.Strings(providers)
+			return fmt.Errorf("wait for hook abort consumption by %v in round %d: %w", providers, round, releaseCtx.Err())
+		case <-ticker.C:
+		}
+	}
+	return nil
+}
+
+func yieldHookReleaseTargets(session *HookSession, panes []paneInfo, nextRound int) ([]hookReleaseTarget, error) {
+	seen := make(map[string]bool, len(panes))
+	targets := make([]hookReleaseTarget, 0, len(panes))
+	for _, pane := range panes {
+		provider := pane.provider.Name
+		if seen[provider] || !session.HasHook(provider) {
+			continue
+		}
+		seen[provider] = true
+		target := newHookReleaseTarget(provider, nextRound)
+		if pane.skipWait {
+			info, err := session.statArtifact(target.readyName)
+			switch {
+			case err == nil && info.Mode().IsRegular():
+			case err == nil:
+				return nil, fmt.Errorf("inspect skipped hook ready for %s round %d: artifact is not a regular file", provider, nextRound)
+			case errors.Is(err, os.ErrNotExist):
+				continue
+			default:
+				return nil, fmt.Errorf("inspect skipped hook ready for %s round %d: %w", provider, nextRound, err)
+			}
+		}
+		targets = append(targets, target)
+	}
+	return targets, nil
+}
+
+func newHookReleaseTarget(provider string, round int) hookReleaseTarget {
+	return hookReleaseTarget{
+		provider:  provider,
+		abortName: RoundSignalName(provider, round, "abort"),
+		readyName: RoundSignalName(provider, round, "ready"),
+	}
+}
+
+func hookReleaseArtifactsRemoved(session *HookSession, target hookReleaseTarget) (bool, error) {
+	for _, name := range []string{target.abortName, target.readyName} {
+		if _, err := session.statArtifact(name); err == nil {
+			return false, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+func yieldHookReleaseBudget(perRound time.Duration) time.Duration {
+	if perRound > 0 && perRound < defaultHookReleaseTimeout {
+		return perRound
+	}
+	return defaultHookReleaseTimeout
+}

--- a/pkg/orchestra/interactive_yield_hook_test.go
+++ b/pkg/orchestra/interactive_yield_hook_test.go
@@ -1,0 +1,242 @@
+package orchestra
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type yieldHookTerminal struct {
+	mockTerminal
+}
+
+func (t *yieldHookTerminal) SplitPane(_ context.Context, dir terminal.Direction) (terminal.PaneID, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.splitPaneCalls = append(t.splitPaneCalls, dir)
+	t.nextPaneID++
+	id := terminal.PaneID("surface:1")
+	t.createdPanes = append(t.createdPanes, id)
+	return id, nil
+}
+
+func (t *yieldHookTerminal) WorkspaceRef() (string, error) {
+	return "workspace:1", nil
+}
+
+func (t *yieldHookTerminal) WithWorkspaceRef(string) (terminal.Terminal, error) {
+	return t, nil
+}
+
+func TestReleaseYieldHookWaiters_WritesAllAbortsAndWaitsForConsumption(t *testing.T) {
+	session, err := NewHookSession("yield-release-success-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+	session.SetHookProviders(map[string]bool{"claude": true, "codex": true})
+	panes := []paneInfo{
+		{provider: ProviderConfig{Name: "claude"}},
+		{provider: ProviderConfig{Name: "codex"}},
+	}
+	for _, provider := range []string{"claude", "codex"} {
+		require.NoError(t, session.writeArtifact(RoundSignalName(provider, 2, "ready"), nil, 0o600))
+	}
+
+	consumed := consumeYieldAborts(session, []string{"claude", "codex"}, 2)
+	err = releaseYieldHookWaiters(context.Background(), session, panes, 2, time.Second)
+
+	require.NoError(t, err)
+	require.NoError(t, <-consumed)
+	for _, provider := range []string{"claude", "codex"} {
+		_, abortErr := session.statArtifact(RoundSignalName(provider, 2, "abort"))
+		assert.True(t, errors.Is(abortErr, os.ErrNotExist))
+	}
+}
+
+func TestReleaseYieldHookWaiters_Failures(t *testing.T) {
+	t.Run("write", func(t *testing.T) {
+		session, err := NewHookSession("yield-release-write-" + NewSessionID())
+		require.NoError(t, err)
+		defer session.Cleanup()
+		session.SetHookProviders(map[string]bool{"../unsafe": true})
+
+		err = releaseYieldHookWaiters(context.Background(), session, []paneInfo{{
+			provider: ProviderConfig{Name: "../unsafe"},
+		}}, 2, time.Second)
+
+		assert.ErrorContains(t, err, "write abort")
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		session, err := NewHookSession("yield-release-timeout-" + NewSessionID())
+		require.NoError(t, err)
+		defer session.Cleanup()
+		session.SetHookProviders(map[string]bool{"claude": true})
+
+		err = releaseYieldHookWaiters(context.Background(), session, []paneInfo{{
+			provider: ProviderConfig{Name: "claude"},
+		}}, 2, 40*time.Millisecond)
+
+		assert.ErrorContains(t, err, "wait for hook abort consumption")
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+
+	t.Run("context", func(t *testing.T) {
+		session, err := NewHookSession("yield-release-context-" + NewSessionID())
+		require.NoError(t, err)
+		defer session.Cleanup()
+		session.SetHookProviders(map[string]bool{"claude": true})
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err = releaseYieldHookWaiters(ctx, session, []paneInfo{{
+			provider: ProviderConfig{Name: "claude"},
+		}}, 2, time.Second)
+
+		assert.ErrorIs(t, err, context.Canceled)
+		_, statErr := session.statArtifact(RoundSignalName("claude", 2, "abort"))
+		assert.True(t, errors.Is(statErr, os.ErrNotExist))
+	})
+}
+
+func TestReleaseYieldHookWaiters_IgnoresHooklessAndSkippedPanes(t *testing.T) {
+	session, err := NewHookSession("yield-release-ignore-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+	session.SetHookProviders(map[string]bool{"claude": true})
+
+	err = releaseYieldHookWaiters(context.Background(), session, []paneInfo{
+		{provider: ProviderConfig{Name: "claude"}, skipWait: true},
+		{provider: ProviderConfig{Name: "opencode"}},
+	}, 2, 40*time.Millisecond)
+
+	require.NoError(t, err)
+	_, statErr := session.statArtifact(RoundSignalName("claude", 2, "abort"))
+	assert.True(t, errors.Is(statErr, os.ErrNotExist))
+}
+
+func TestRunPaneDebate_YieldReleasesHookBeforeSavingSession(t *testing.T) {
+	isolateSurfaceTracker(t)
+	t.Setenv("TMPDIR", t.TempDir())
+	term := &yieldHookTerminal{mockTerminal: mockTerminal{name: "cmux"}}
+	cfg := yieldHookDebateConfig(t, term, "yield-release-order")
+	beforeSave := make(chan bool, 1)
+	producer := publishYieldRoundOne(cfg.SessionID, true, beforeSave)
+
+	result, err := runPaneDebate(context.Background(), cfg, 2, 700*time.Millisecond, time.Now())
+
+	require.NoError(t, err)
+	require.NoError(t, <-producer)
+	assert.True(t, <-beforeSave, "abort must be consumed before SaveSession creates its directory")
+	require.NotNil(t, result.Yield)
+	t.Cleanup(func() { _ = RemoveSession(result.Yield.SessionID) })
+	_, loadErr := LoadSession(result.Yield.SessionID)
+	require.NoError(t, loadErr)
+	assert.Empty(t, term.closeCalls, "durable yield owns the pane")
+}
+
+func TestRunPaneDebate_YieldReleaseFailureKeepsPaneOwnership(t *testing.T) {
+	isolateSurfaceTracker(t)
+	t.Setenv("TMPDIR", t.TempDir())
+	term := &yieldHookTerminal{mockTerminal: mockTerminal{name: "cmux"}}
+	cfg := yieldHookDebateConfig(t, term, "yield-release-failure")
+	producer := publishYieldRoundOne(cfg.SessionID, false, nil)
+
+	result, err := runPaneDebate(context.Background(), cfg, 2, 500*time.Millisecond, time.Now())
+
+	require.Error(t, err)
+	require.NoError(t, <-producer)
+	assert.Nil(t, result)
+	assert.ErrorContains(t, err, "release hook waiters before yield")
+	assert.Equal(t, []string{"surface:1"}, term.closeCalls)
+	_, statErr := os.Stat(sessionDirectoryPath())
+	assert.True(t, errors.Is(statErr, os.ErrNotExist), "release failure must not create a yield session")
+}
+
+func yieldHookDebateConfig(t *testing.T, term terminal.Terminal, sessionID string) OrchestraConfig {
+	t.Helper()
+	provider := echoProvider("claude")
+	provider.InteractiveInput = "args"
+	provider.PromptViaArgs = true
+	return OrchestraConfig{
+		Providers: []ProviderConfig{provider}, Strategy: StrategyDebate,
+		Prompt: "yield after a hook round", TimeoutSeconds: 1,
+		Terminal: term, Interactive: true, HookMode: true, SessionID: sessionID,
+		YieldRounds: true, NoJudge: true, InitialDelay: time.Millisecond,
+		WorkingDir: t.TempDir(),
+	}
+}
+
+func publishYieldRoundOne(sessionID string, consumeAbort bool, beforeSave chan<- bool) <-chan error {
+	done := make(chan error, 1)
+	go func() {
+		dir := filepath.Join(os.TempDir(), hookBaseDirectoryName, sessionID)
+		if err := waitForPath(filepath.Join(dir, "."), time.Second); err != nil {
+			done <- err
+			return
+		}
+		if err := os.WriteFile(filepath.Join(dir, RoundSignalName("claude", 1, "result.json")), []byte(`{"output":"round one","exit_code":0}`), 0o600); err != nil {
+			done <- err
+			return
+		}
+		if err := os.WriteFile(filepath.Join(dir, RoundSignalName("claude", 1, "done")), nil, 0o600); err != nil {
+			done <- err
+			return
+		}
+		ready := filepath.Join(dir, RoundSignalName("claude", 2, "ready"))
+		if err := os.WriteFile(ready, nil, 0o600); err != nil {
+			done <- err
+			return
+		}
+		if consumeAbort {
+			abort := filepath.Join(dir, RoundSignalName("claude", 2, "abort"))
+			if err := waitForPath(abort, 2*time.Second); err != nil {
+				done <- err
+				return
+			}
+			if beforeSave != nil {
+				_, err := os.Stat(sessionDirectoryPath())
+				beforeSave <- errors.Is(err, os.ErrNotExist)
+			}
+			_ = os.Remove(ready)
+			_ = os.Remove(abort)
+		}
+		done <- nil
+	}()
+	return done
+}
+
+func consumeYieldAborts(session *HookSession, providers []string, round int) <-chan error {
+	done := make(chan error, 1)
+	go func() {
+		for _, provider := range providers {
+			if err := waitForPath(filepath.Join(session.Dir(), RoundSignalName(provider, round, "abort")), time.Second); err != nil {
+				done <- err
+				return
+			}
+		}
+		for _, provider := range providers {
+			_ = session.removeArtifact(RoundSignalName(provider, round, "ready"))
+			_ = session.removeArtifact(RoundSignalName(provider, round, "abort"))
+		}
+		done <- nil
+	}()
+	return done
+}
+
+func waitForPath(path string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return nil
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return context.DeadlineExceeded
+}

--- a/pkg/orchestra/interactive_yield_skipped_hook_test.go
+++ b/pkg/orchestra/interactive_yield_skipped_hook_test.go
@@ -1,0 +1,58 @@
+package orchestra
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReleaseYieldHookWaiters_SkippedReadyConsumesAbort(t *testing.T) {
+	session, err := NewHookSession("yield-skipped-ready-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+	session.SetHookProviders(map[string]bool{"codex": true})
+	require.NoError(t, session.writeArtifact(RoundSignalName("codex", 2, "ready"), nil, 0o600))
+	panes := []paneInfo{{provider: ProviderConfig{Name: "codex"}, skipWait: true}}
+	consumed := consumeYieldAborts(session, []string{"codex"}, 2)
+
+	err = releaseYieldHookWaiters(context.Background(), session, panes, 2, time.Second)
+
+	require.NoError(t, err)
+	require.NoError(t, <-consumed)
+	_, abortErr := session.statArtifact(RoundSignalName("codex", 2, "abort"))
+	assert.True(t, errors.Is(abortErr, os.ErrNotExist))
+}
+
+func TestReleaseYieldHookWaiters_SkippedWithoutReadyIsIgnored(t *testing.T) {
+	session, err := NewHookSession("yield-skipped-no-ready-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+	session.SetHookProviders(map[string]bool{"codex": true})
+	panes := []paneInfo{{provider: ProviderConfig{Name: "codex"}, skipWait: true}}
+
+	err = releaseYieldHookWaiters(context.Background(), session, panes, 2, 40*time.Millisecond)
+
+	require.NoError(t, err)
+	_, abortErr := session.statArtifact(RoundSignalName("codex", 2, "abort"))
+	assert.True(t, errors.Is(abortErr, os.ErrNotExist))
+}
+
+func TestReleaseYieldHookWaiters_SkippedReadyStatErrorFailsClosed(t *testing.T) {
+	root := t.TempDir()
+	notDirectory := filepath.Join(root, "not-a-directory")
+	require.NoError(t, os.WriteFile(notDirectory, []byte("x"), 0o600))
+	session := &HookSession{sessionDir: notDirectory}
+	session.SetHookProviders(map[string]bool{"codex": true})
+	panes := []paneInfo{{provider: ProviderConfig{Name: "codex"}, skipWait: true}}
+
+	err := releaseYieldHookWaiters(context.Background(), session, panes, 2, time.Second)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "inspect skipped hook ready")
+}

--- a/pkg/orchestra/pane_backend.go
+++ b/pkg/orchestra/pane_backend.go
@@ -70,7 +70,6 @@ func (b *InteractivePaneBackend) Execute(ctx context.Context, req ProviderReques
 		return paneProvisioningFallback(ctx, b.cfg, req, "interactive pane execution failed: SplitPane returned an empty pane ID")
 	}
 	if err != nil {
-		closePaneSurface(term, paneID)
 		return paneExecutionFailure(req, "interactive pane execution failed after SplitPane committed pane "+string(paneID)+": "+err.Error())
 	}
 	pi := paneInfo{paneID: paneID, provider: req.Config, role: req.Role}
@@ -98,27 +97,32 @@ func (b *InteractivePaneBackend) Execute(ctx context.Context, req ProviderReques
 	// os.Setenv alone is invisible to it. The structured spec review / orchestra
 	// run paths drive Execute directly (not RunInteractivePaneOrchestra), so the
 	// env injection that path performs in launchInteractiveSessions must be
-	// mirrored here. Non-fatal: a send failure degrades to screen-poll completion.
-	if b.cfg.HookMode && b.cfg.SessionID != "" {
+	// mirrored here. Once hook completion is selected, launch without its session
+	// coordinates would strand the collector, so every export step is fatal.
+	hasHookCapability := hookSession != nil &&
+		(hookSession.HasHook(req.Config.Name) || hookSession.HasStartupHook(req.Config.Name))
+	if b.cfg.HookMode && b.cfg.SessionID != "" && hasHookCapability {
 		envErr, enterErr := sendPaneInputAndEnterSerialized(ctx, term, paneID, 0, func() error {
 			return SendSessionEnvToPane(ctx, term, paneID, b.cfg.SessionID)
 		})
 		if envErr != nil {
-			log.Printf("pane_backend: SendSessionEnvToPane failed for %s (non-fatal): %v", req.Provider, envErr)
-		} else {
-			if enterErr != nil {
-				log.Printf("pane_backend: session-env Enter failed for %s (non-fatal): %v", req.Provider, enterErr)
-			}
-			if req.Round > 0 {
-				roundErr, roundEnterErr := sendPaneInputAndEnterSerialized(ctx, term, paneID, 0, func() error {
-					return SendRoundEnvToPane(ctx, term, paneID, req.Round)
-				})
-				if roundErr != nil || roundEnterErr != nil {
-					log.Printf("pane_backend: round env failed for %s (non-fatal): send=%v enter=%v", req.Provider, roundErr, roundEnterErr)
-				}
-			}
-			time.Sleep(promptRegisterDelay)
+			return paneExecutionFailure(req, "interactive pane execution failed: export hook session failed: "+envErr.Error())
 		}
+		if enterErr != nil {
+			return paneExecutionFailure(req, "interactive pane execution failed: commit hook session export failed: "+enterErr.Error())
+		}
+		if req.Round > 0 {
+			roundErr, roundEnterErr := sendPaneInputAndEnterSerialized(ctx, term, paneID, 0, func() error {
+				return SendRoundEnvToPane(ctx, term, paneID, req.Round)
+			})
+			if roundErr != nil {
+				return paneExecutionFailure(req, "interactive pane execution failed: export hook round failed: "+roundErr.Error())
+			}
+			if roundEnterErr != nil {
+				return paneExecutionFailure(req, "interactive pane execution failed: commit hook round export failed: "+roundEnterErr.Error())
+			}
+		}
+		time.Sleep(promptRegisterDelay)
 	}
 
 	// Launch the provider CLI. For args-based providers the prompt rides on the

--- a/pkg/orchestra/pane_backend_env_test.go
+++ b/pkg/orchestra/pane_backend_env_test.go
@@ -2,14 +2,55 @@ package orchestra
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/insajin/autopus-adk/pkg/terminal"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type backendHookExportTerminal struct {
+	*seqScreenMock
+	mu            sync.Mutex
+	events        []backendHookExportEvent
+	commandCalls  int
+	failCommandAt int
+}
+
+type backendHookExportEvent struct {
+	kind  string
+	value string
+}
+
+func (m *backendHookExportTerminal) SendCommand(_ context.Context, _ terminal.PaneID, cmd string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.commandCalls++
+	m.events = append(m.events, backendHookExportEvent{kind: "command", value: cmd})
+	if m.commandCalls == m.failCommandAt {
+		return errors.New("injected hook export failure")
+	}
+	return nil
+}
+
+func (m *backendHookExportTerminal) SendLongText(ctx context.Context, paneID terminal.PaneID, text string) error {
+	m.mu.Lock()
+	m.events = append(m.events, backendHookExportEvent{kind: "long_text", value: text})
+	m.mu.Unlock()
+	return m.seqScreenMock.SendLongText(ctx, paneID, text)
+}
+
+func (m *backendHookExportTerminal) eventsSnapshot() []backendHookExportEvent {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]backendHookExportEvent(nil), m.events...)
+}
 
 // TestExecute_ExportsSessionEnvWhenHookMode verifies SPEC-ORCH-022: the
 // structured spec-review / orchestra-run paths drive InteractivePaneBackend.Execute
@@ -53,19 +94,98 @@ func TestExecute_ExportsSessionEnvWhenHookMode(t *testing.T) {
 func TestExecute_NoSessionEnvWhenHookModeOff(t *testing.T) {
 	t.Parallel()
 	mock := &seqScreenMock{name: "cmux", screens: []string{"❯ "}}
-	b := NewInteractivePaneBackend(OrchestraConfig{Terminal: mock})
+	provider := ProviderConfig{Name: "claude", Binary: "claude", InteractiveInput: "args"}
+	b := NewInteractivePaneBackend(OrchestraConfig{
+		Terminal: mock, WorkingDir: t.TempDir(), InitialDelay: time.Millisecond,
+		CompletionDetector: &stubCompletionDetector{completed: true},
+	})
 	req := ProviderRequest{
 		Provider: "claude",
-		Config:   ProviderConfig{Name: "claude", Binary: "claude"},
+		Config:   provider,
 		Prompt:   "review this",
-		Timeout:  1 * time.Second,
+		Timeout:  3 * time.Second,
 	}
-	_, _ = b.Execute(context.Background(), req)
+	resp, err := b.Execute(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotEmpty(t, mock.longTextsSnapshot(), "non-hook execution must still launch the provider")
 
 	for _, c := range mock.commands {
 		require.NotContains(t, c, "export AUTOPUS_SESSION_ID=",
 			"Execute must not export AUTOPUS_SESSION_ID when HookMode is off")
 	}
+}
+
+func TestInteractivePaneBackendExecute_HookExportFailure_ReturnsBeforeLaunchAndCollection(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+
+	tests := []struct {
+		name          string
+		failCommandAt int
+		wantError     string
+	}{
+		{name: "session send", failCommandAt: 1, wantError: "export hook session failed"},
+		{name: "session enter", failCommandAt: 2, wantError: "commit hook session export failed"},
+		{name: "round send", failCommandAt: 3, wantError: "export hook round failed"},
+		{name: "round enter", failCommandAt: 4, wantError: "commit hook round export failed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sessionID := "pane-backend-export-" + NewSessionID()
+			term := &backendHookExportTerminal{
+				seqScreenMock: &seqScreenMock{name: "cmux", screens: []string{readyScreen}},
+				failCommandAt: tt.failCommandAt,
+			}
+			provider := ProviderConfig{Name: "claude", Binary: "claude", InteractiveInput: "args"}
+			backend := NewInteractivePaneBackend(OrchestraConfig{
+				Terminal: term, HookMode: true, SessionID: sessionID,
+				Providers: []ProviderConfig{provider}, InitialDelay: time.Millisecond,
+				CompletionDetector: &stubCompletionDetector{completed: true},
+			})
+
+			resp, err := backend.Execute(context.Background(), ProviderRequest{
+				Provider: "claude", Config: provider, Prompt: "review this", Round: 2,
+			})
+
+			require.Error(t, err)
+			require.NotNil(t, resp)
+			assert.ErrorContains(t, err, tt.wantError)
+			assert.Contains(t, resp.Error, tt.wantError)
+			assert.Equal(t, paneBackendName, resp.ExecutedBackend)
+			assert.Empty(t, term.longTextsSnapshot(), "provider launch must not run after hook export failure")
+			assert.Zero(t, term.readCalls, "collector and readiness polling must not run after hook export failure")
+		})
+	}
+}
+
+func TestInteractivePaneBackendExecute_HookExports_PrecedeProviderLaunch(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	sessionID := "pane-backend-order-" + NewSessionID()
+	term := &backendHookExportTerminal{
+		seqScreenMock: &seqScreenMock{name: "cmux", screens: []string{readyScreen}},
+	}
+	provider := ProviderConfig{Name: "claude", Binary: "claude", InteractiveInput: "args"}
+	backend := NewInteractivePaneBackend(OrchestraConfig{
+		Terminal: term, HookMode: true, SessionID: sessionID,
+		Providers: []ProviderConfig{provider}, InitialDelay: time.Millisecond,
+		CompletionDetector: &stubCompletionDetector{completed: true},
+	})
+
+	resp, err := backend.Execute(context.Background(), ProviderRequest{
+		Provider: "claude", Config: provider, Prompt: "review this", Round: 2,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	events := term.eventsSnapshot()
+	require.GreaterOrEqual(t, len(events), 5)
+	assert.Equal(t, "command", events[0].kind)
+	assert.Contains(t, events[0].value, "export AUTOPUS_SESSION_ID="+sessionID)
+	assert.Equal(t, backendHookExportEvent{kind: "command", value: "\n"}, events[1])
+	assert.Equal(t, backendHookExportEvent{kind: "command", value: "export AUTOPUS_ROUND=2"}, events[2])
+	assert.Equal(t, backendHookExportEvent{kind: "command", value: "\n"}, events[3])
+	assert.Equal(t, "long_text", events[4].kind, "provider launch must follow both committed hook exports")
 }
 
 func TestExecute_DoesNotCleanupSharedHookSession(t *testing.T) {

--- a/pkg/orchestra/pane_backend_env_test.go
+++ b/pkg/orchestra/pane_backend_env_test.go
@@ -69,39 +69,47 @@ func TestExecute_NoSessionEnvWhenHookModeOff(t *testing.T) {
 }
 
 func TestExecute_DoesNotCleanupSharedHookSession(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
 	const sid = "orch-test-shared-hook-owner"
-	sessionDir := filepath.Join(os.TempDir(), "autopus", sid)
-	require.NoError(t, os.RemoveAll(sessionDir))
-	defer func() { _ = os.RemoveAll(sessionDir) }()
+	owner, err := NewHookSession(sid)
+	require.NoError(t, err)
+	defer owner.Cleanup()
+	sentinel := filepath.Join(owner.Dir(), "sibling-owner-active")
+	require.NoError(t, os.WriteFile(sentinel, []byte("active"), 0o600))
 
-	provider := ProviderConfig{Name: "gemini", Binary: "agy"}
+	provider := ProviderConfig{Name: "claude", Binary: "claude", InteractiveInput: "args"}
 	mock := &seqScreenMock{name: "cmux", screens: []string{readyScreen}}
 	b := NewInteractivePaneBackend(OrchestraConfig{
-		Terminal:   mock,
-		HookMode:   true,
-		SessionID:  sid,
-		WorkingDir: t.TempDir(),
-		Providers:  []ProviderConfig{provider},
+		Terminal:           mock,
+		HookMode:           true,
+		SessionID:          sid,
+		WorkingDir:         t.TempDir(),
+		Providers:          []ProviderConfig{provider},
+		InitialDelay:       time.Millisecond,
+		CompletionDetector: &stubCompletionDetector{completed: true},
 	})
 	req := ProviderRequest{
-		Provider: "gemini",
+		Provider: "claude",
 		Config:   provider,
 		Prompt:   "review this",
 		Role:     "reviewer",
-		Timeout:  time.Second,
+		Timeout:  5 * time.Second,
 	}
 
 	resp, err := b.Execute(context.Background(), req)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
-	require.DirExists(t, sessionDir,
+	require.DirExists(t, owner.Dir(),
 		"provider-level Execute must not remove the shared hook session while sibling providers may still be running")
+	require.FileExists(t, sentinel, "provider-level Execute must preserve sibling-owned artifacts")
+	require.NoError(t, owner.WriteInputRound("claude", 2, "sibling still active"),
+		"the outer owner must remain usable after provider-level Execute returns")
 }
 
 func TestExecute_CodexPromptUsesSendkeysAfterReady(t *testing.T) {
 	t.Parallel()
 
-	mock := &seqScreenMock{name: "cmux", screens: []string{readyScreen}}
+	mock := &seqScreenMock{name: "cmux", screens: []string{"› Summarize recent commits\n"}}
 	provider := ProviderConfig{Name: "codex", Binary: "codex", PaneArgs: []string{"-m", "gpt-5.4"}}
 	b := NewInteractivePaneBackend(OrchestraConfig{
 		Terminal:     mock,

--- a/pkg/orchestra/pane_backend_hookless_env_test.go
+++ b/pkg/orchestra/pane_backend_hookless_env_test.go
@@ -1,0 +1,55 @@
+package orchestra
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type hooklessExportRejectTerminal struct {
+	*backendHookExportTerminal
+}
+
+func (t *hooklessExportRejectTerminal) SendCommand(ctx context.Context, paneID terminal.PaneID, command string) error {
+	if strings.Contains(command, "AUTOPUS_") {
+		return errors.New("unexpected hook environment export")
+	}
+	return t.backendHookExportTerminal.SendCommand(ctx, paneID, command)
+}
+
+func TestInteractivePaneBackendExecute_HooklessProviderSkipsHookEnvExport(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	off := false
+	provider := ProviderConfig{
+		Name: "opencode", Binary: "opencode", InteractiveInput: "args",
+		HasHook: &off, HasStartupHook: &off,
+	}
+	term := &hooklessExportRejectTerminal{backendHookExportTerminal: &backendHookExportTerminal{
+		seqScreenMock: &seqScreenMock{name: "cmux", screens: []string{readyScreen}},
+	}}
+	backend := NewInteractivePaneBackend(OrchestraConfig{
+		Terminal: term, HookMode: true, SessionID: "hookless-backend-" + NewSessionID(),
+		Providers: []ProviderConfig{provider}, InitialDelay: time.Millisecond,
+		CompletionDetector: &stubCompletionDetector{completed: true},
+	})
+
+	resp, err := backend.Execute(context.Background(), ProviderRequest{
+		Provider: provider.Name, Config: provider, Prompt: "review this", Timeout: 500 * time.Millisecond,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, term.longTextsSnapshot(), "hookless provider must still launch")
+	for _, event := range term.eventsSnapshot() {
+		assert.False(t,
+			event.kind == "command" && strings.Contains(event.value, "AUTOPUS_"),
+			"hookless provider must not receive hook environment exports: %+v", event,
+		)
+	}
+}

--- a/pkg/orchestra/pane_backend_reliability_test.go
+++ b/pkg/orchestra/pane_backend_reliability_test.go
@@ -213,14 +213,23 @@ func TestExecute_S13_NonHookDetector(t *testing.T) {
 	_, isPoll := resolved.detector.(*ScreenPollDetector)
 	assert.True(t, isPoll, "non-hook mode resolves to ScreenPollDetector")
 
-	// Execution still completes/returns without erroring on the missing hook.
-	mock := &seqScreenMock{name: "cmux", screens: []string{readyScreen}}
-	b := NewInteractivePaneBackend(OrchestraConfig{Terminal: mock, HookMode: false})
+	// Execution still completes through screen polling without a hook. The
+	// sequence separates the post-prompt baseline from the final stable prompt.
+	mock := &seqScreenMock{name: "cmux", screens: []string{
+		readyScreen, readyScreen, readyScreen,
+		"AI is thinking...\n",
+		"answer complete\n❯\n", "answer complete\n❯\n",
+	}}
+	b := NewInteractivePaneBackend(OrchestraConfig{
+		Terminal: mock, HookMode: false, InitialDelay: time.Millisecond,
+	})
 	resp, err := b.Execute(context.Background(), ProviderRequest{
-		Provider: "claude", Prompt: "hi", Timeout: 2 * time.Second, Config: fastStartupClaude(),
+		Provider: "claude", Prompt: "hi", Timeout: 10 * time.Second, Config: fastStartupClaude(),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, resp)
+	assert.False(t, resp.TimedOut, "screen polling must complete before the expanded race-safe budget")
+	assert.Equal(t, paneBackendName, resp.ExecutedBackend)
 }
 
 // TestExecute_S14_BothBackendsFail asserts that when the pane fails (SplitPane

--- a/pkg/orchestra/pane_cleanup_close_test.go
+++ b/pkg/orchestra/pane_cleanup_close_test.go
@@ -2,6 +2,7 @@ package orchestra
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -26,8 +27,21 @@ func isolateSurfaceTracker(t *testing.T) {
 // It records every Close attempt so tests can assert the retry count.
 type flakyCloseTerminal struct {
 	mockTerminal
+	workspaceRef string
 	failUntil    int // number of leading Close calls that return an error
 	closeAttempt int // total Close attempts observed
+}
+
+func (m *flakyCloseTerminal) WorkspaceRef() (string, error) {
+	if m.workspaceRef == "" {
+		return "workspace:13", nil
+	}
+	return m.workspaceRef, nil
+}
+
+func (m *flakyCloseTerminal) WithWorkspaceRef(ref string) (terminal.Terminal, error) {
+	m.workspaceRef = ref
+	return m, nil
 }
 
 func (m *flakyCloseTerminal) Close(_ context.Context, name string) error {
@@ -46,7 +60,7 @@ func (m *flakyCloseTerminal) Close(_ context.Context, name string) error {
 func TestClosePaneSurface_RetriesTransientFailure(t *testing.T) {
 	isolateSurfaceTracker(t)
 
-	term := &flakyCloseTerminal{failUntil: 1}
+	term := &flakyCloseTerminal{mockTerminal: mockTerminal{name: "cmux"}, failUntil: 1}
 	ok := closePaneSurface(term, terminal.PaneID("surface:7"))
 
 	assert.True(t, ok, "surface must be closed after a transient failure is retried")
@@ -58,7 +72,7 @@ func TestClosePaneSurface_RetriesTransientFailure(t *testing.T) {
 func TestClosePaneSurface_SucceedsFirstTry(t *testing.T) {
 	isolateSurfaceTracker(t)
 
-	term := &flakyCloseTerminal{failUntil: 0}
+	term := &flakyCloseTerminal{mockTerminal: mockTerminal{name: "cmux"}}
 	ok := closePaneSurface(term, terminal.PaneID("surface:3"))
 
 	assert.True(t, ok)
@@ -73,9 +87,11 @@ func TestClosePaneSurface_PersistentFailureKeepsRefTracked(t *testing.T) {
 	isolateSurfaceTracker(t)
 
 	ref := "surface:9"
-	trackSurface(ref)
-
-	term := &flakyCloseTerminal{failUntil: closePaneSurfaceAttempts + 1}
+	term := &flakyCloseTerminal{
+		mockTerminal: mockTerminal{name: "cmux"},
+		failUntil:    closePaneSurfaceAttempts + 1,
+	}
+	trackSurfaceForTerminal(term, ref)
 	ok := closePaneSurface(term, terminal.PaneID(ref))
 
 	assert.False(t, ok, "a surface that never closes must report failure")
@@ -91,13 +107,30 @@ func TestClosePaneSurface_SuccessUntracksRef(t *testing.T) {
 	isolateSurfaceTracker(t)
 
 	ref := "surface:11"
-	trackSurface(ref)
-
-	term := &flakyCloseTerminal{failUntil: 0}
+	term := &flakyCloseTerminal{mockTerminal: mockTerminal{name: "cmux"}}
+	trackSurfaceForTerminal(term, ref)
 	assert.True(t, closePaneSurface(term, terminal.PaneID(ref)))
 
 	refs := readTrackerRefs(surfaceTrackerFile(os.Getpid()))
 	assert.NotContains(t, refs, ref, "a successfully closed surface must be untracked")
+}
+
+func TestClosePaneSurface_UntrackFailureKeepsRecoveryHandleWithoutFailingCleanup(t *testing.T) {
+	isolateSurfaceTracker(t)
+
+	ref := "surface:12"
+	term := &flakyCloseTerminal{mockTerminal: mockTerminal{name: "cmux"}}
+	trackSurfaceForTerminal(term, ref)
+	originalUntracker := closeSurfaceUntracker
+	closeSurfaceUntracker = func(terminal.Terminal, string) error {
+		return errors.New("injected tracker persistence failure")
+	}
+	t.Cleanup(func() { closeSurfaceUntracker = originalUntracker })
+
+	assert.True(t, closePaneSurface(term, terminal.PaneID(ref)),
+		"tracker persistence must not turn a successful pane close into cleanup failure")
+	assert.Contains(t, readTrackerRefs(surfaceTrackerFile(os.Getpid())), ref,
+		"failed tracker persistence must retain the recovery handle for a later reap")
 }
 
 // TestClosePaneSurface_EmptyRefNoop guards the idempotency edge: an empty pane id
@@ -115,7 +148,7 @@ func TestClosePaneSurface_EmptyRefNoop(t *testing.T) {
 func TestCleanupInteractivePanes_ClosesEverySurface(t *testing.T) {
 	isolateSurfaceTracker(t)
 
-	term := &flakyCloseTerminal{failUntil: 1}
+	term := &flakyCloseTerminal{mockTerminal: mockTerminal{name: "cmux"}, failUntil: 1}
 	panes := []paneInfo{
 		{paneID: "surface:1"},
 		{paneID: "surface:2"},

--- a/pkg/orchestra/pane_fallback_commit_test.go
+++ b/pkg/orchestra/pane_fallback_commit_test.go
@@ -3,6 +3,7 @@ package orchestra
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -15,6 +16,7 @@ import (
 )
 
 const committedPaneID terminal.PaneID = "pane-committed"
+const paneCommitWorkspaceRef = "workspace:13"
 
 // paneCommitTerminal models a pane that was provisioned successfully and then
 // fails at a selected post-provisioning I/O boundary.
@@ -30,9 +32,64 @@ type paneCommitTerminal struct {
 	readErr           error
 	closeErr          error
 	closed            []string
+	workspaceRef      string
 }
 
 func (m *paneCommitTerminal) Name() string { return "cmux" }
+
+func (m *paneCommitTerminal) WorkspaceRef() (string, error) {
+	ref := m.workspaceRef
+	if ref == "" {
+		ref = paneCommitWorkspaceRef
+	}
+	if err := validatePaneCommitWorkspaceRef(ref); err != nil {
+		return "", err
+	}
+	return ref, nil
+}
+
+func (m *paneCommitTerminal) WithWorkspaceRef(ref string) (terminal.Terminal, error) {
+	if err := validatePaneCommitWorkspaceRef(ref); err != nil {
+		return nil, err
+	}
+	clone := *m
+	clone.workspaceRef = ref
+	clone.closed = append([]string(nil), m.closed...)
+	return &clone, nil
+}
+
+func validatePaneCommitWorkspaceRef(ref string) error {
+	if _, err := terminal.NewCmuxAdapterWithWorkspace(ref); err != nil {
+		return fmt.Errorf("invalid pane fixture workspace: %w", err)
+	}
+	if ref != paneCommitWorkspaceRef {
+		return fmt.Errorf("pane fixture workspace %q is not %q", ref, paneCommitWorkspaceRef)
+	}
+	return nil
+}
+
+func TestPaneCommitTerminalWorkspaceContext_ValidatedClone(t *testing.T) {
+	original := &paneCommitTerminal{closed: []string{"surface:1"}}
+
+	workspaceRef, err := original.WorkspaceRef()
+	require.NoError(t, err)
+	assert.Equal(t, paneCommitWorkspaceRef, workspaceRef)
+
+	restored, err := original.WithWorkspaceRef(paneCommitWorkspaceRef)
+	require.NoError(t, err)
+	clone, ok := restored.(*paneCommitTerminal)
+	require.True(t, ok)
+	assert.NotSame(t, original, clone)
+	assert.Empty(t, original.workspaceRef)
+	assert.Equal(t, paneCommitWorkspaceRef, clone.workspaceRef)
+	clone.closed[0] = "surface:2"
+	assert.Equal(t, []string{"surface:1"}, original.closed)
+
+	_, err = original.WithWorkspaceRef("workspace:14")
+	assert.Error(t, err)
+	_, err = original.WithWorkspaceRef("../unsafe")
+	assert.Error(t, err)
+}
 
 func (m *paneCommitTerminal) CreateWorkspace(context.Context, string) error { return nil }
 

--- a/pkg/orchestra/pane_provisioning_boundary_test.go
+++ b/pkg/orchestra/pane_provisioning_boundary_test.go
@@ -11,8 +11,9 @@ import (
 
 func TestRunPaneOrchestra_PostSplitTempFailureDoesNotFallbackToSubprocess(t *testing.T) {
 	isolateSurfaceTracker(t)
+	const committedSurfaceRef = "surface:9101"
 	provider, marker := newPaneBoundaryMarkerProvider(t, strings.Repeat("provider", 80), "")
-	term := &paneCommitTerminal{screen: readyScreen}
+	term := &paneCommitTerminal{splitID: committedSurfaceRef, screen: readyScreen}
 	cfg := OrchestraConfig{
 		Providers:      []ProviderConfig{provider},
 		Strategy:       StrategyConsensus,
@@ -25,9 +26,9 @@ func TestRunPaneOrchestra_PostSplitTempFailureDoesNotFallbackToSubprocess(t *tes
 
 	assert.Error(t, err, "a failure after SplitPane commits must remain a pane-path error")
 	assert.Equal(t, 1, term.splitCalls)
-	assert.Contains(t, term.closed, string(committedPaneID), "the split pane must be cleaned up")
+	assert.Contains(t, term.closed, committedSurfaceRef, "the split pane must be cleaned up")
 	_, statErr := os.Stat(marker)
 	assert.ErrorIs(t, statErr, os.ErrNotExist, "post-split temp-file failure must not execute subprocess")
 	refs := readTrackerRefs(surfaceTrackerFile(os.Getpid()))
-	assert.NotContains(t, refs, string(committedPaneID), "successful cleanup must remove the tracker ref")
+	assert.NotContains(t, refs, committedSurfaceRef, "successful cleanup must remove the tracker ref")
 }

--- a/pkg/orchestra/pane_runner.go
+++ b/pkg/orchestra/pane_runner.go
@@ -17,14 +17,15 @@ const sentinel = "__AUTOPUS_DONE__"
 
 // paneInfo tracks a provider's pane and output file.
 type paneInfo struct {
-	paneID       terminal.PaneID
-	outputFile   string
-	provider     ProviderConfig
-	role         string
-	skipWait     bool // true when SendCommand failed — skip sentinel wait
-	promptFiles  []string
-	responseFile string
-	launchFiles  []string
+	paneID            terminal.PaneID
+	outputFile        string
+	provider          ProviderConfig
+	role              string
+	skipWait          bool // true when SendCommand failed — skip sentinel wait
+	promptFiles       []string
+	responseFile      string
+	launchFiles       []string
+	directPromptRound int
 }
 
 // RunPaneOrchestra runs orchestration using terminal panes when available.
@@ -122,7 +123,6 @@ func splitProviderPanes(ctx context.Context, cfg OrchestraConfig) ([]paneInfo, [
 			return nil, nil, newPaneProvisioningError(fmt.Errorf("SplitPane for %s returned an empty pane ID", p.Name), partial)
 		}
 		if err != nil {
-			closePaneSurface(cfg.Terminal, paneID)
 			cleanupPanes(cfg.Terminal, panes)
 			return nil, nil, fmt.Errorf("SplitPane for %s committed pane %s and then failed: %w", p.Name, paneID, err)
 		}

--- a/pkg/orchestra/provider_artifact_identity.go
+++ b/pkg/orchestra/provider_artifact_identity.go
@@ -1,0 +1,20 @@
+package orchestra
+
+import "strings"
+
+// providerArtifactIdentity returns the stable provider name used by generated
+// hook scripts. Custom provider identities remain unchanged.
+func providerArtifactIdentity(provider string) string {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "claude", "claude-code":
+		return "claude"
+	case "gemini", "antigravity", "antigravity-cli", "gemini-cli", "agy":
+		return "gemini"
+	case "codex":
+		return "codex"
+	case "opencode":
+		return "opencode"
+	default:
+		return provider
+	}
+}

--- a/pkg/orchestra/provider_artifact_identity_test.go
+++ b/pkg/orchestra/provider_artifact_identity_test.go
@@ -1,0 +1,93 @@
+package orchestra
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProviderArtifactIdentity_CanonicalizesKnownAliasesOnly(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"claude":            "claude",
+		"claude-code":       "claude",
+		"antigravity":       "gemini",
+		"antigravity-cli":   "gemini",
+		"gemini-cli":        "gemini",
+		"agy":               "gemini",
+		"CustomProvider_01": "CustomProvider_01",
+	}
+	for provider, want := range tests {
+		provider, want := provider, want
+		t.Run(provider, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, want, providerArtifactIdentity(provider))
+		})
+	}
+}
+
+func TestHookSession_AliasUsesCanonicalArtifactsAndPayload(t *testing.T) {
+	t.Parallel()
+
+	session, err := NewHookSession("provider-alias-artifacts")
+	require.NoError(t, err)
+	t.Cleanup(session.Cleanup)
+
+	require.NoError(t, session.WriteInputRound("claude-code", 2, "review this"))
+	data, err := session.readArtifact("claude-round2-input.json")
+	require.NoError(t, err)
+	var input HookInput
+	require.NoError(t, json.Unmarshal(data, &input))
+	assert.Equal(t, "claude", input.Provider)
+	assert.Equal(t, "review this", input.Prompt)
+	_, err = session.statArtifact("claude-code-round2-input.json")
+	assert.Error(t, err)
+
+	require.NoError(t, session.WriteRoundCursor("claude-code", 2))
+	_, err = session.statArtifact("claude-round-cursor")
+	assert.NoError(t, err)
+}
+
+func TestHookSession_AliasCapabilityOverridesCanonicalProvider(t *testing.T) {
+	t.Parallel()
+
+	on, off := true, false
+	session, err := NewHookSession("provider-alias-capabilities")
+	require.NoError(t, err)
+	t.Cleanup(session.Cleanup)
+	session.ApplyProviderHooks([]ProviderConfig{
+		{Name: "claude-code", HasHook: &off, HasStartupHook: &off},
+		{Name: "agy", HasHook: &on, HasStartupHook: &on},
+	})
+
+	assert.False(t, session.HasHook("claude"))
+	assert.False(t, session.HasHook("claude-code"))
+	assert.True(t, session.HasHook("gemini"))
+	assert.True(t, session.HasHook("antigravity-cli"))
+	assert.True(t, session.HasStartupHook("gemini-cli"))
+	assert.Equal(t, "done-gemini-round2", buildSignalName("agy", 2))
+}
+
+func TestHookSession_AliasReadsAndResetsCanonicalLegacyArtifacts(t *testing.T) {
+	t.Parallel()
+
+	session, err := NewHookSession("provider-alias-legacy-artifacts")
+	require.NoError(t, err)
+	t.Cleanup(session.Cleanup)
+	require.NoError(t, session.writeJSONArtifact("gemini-result.json", HookResult{Output: "ok"}))
+	require.NoError(t, session.writeArtifact("gemini-done", nil, 0o600))
+
+	require.NoError(t, session.WaitForDone(500*time.Millisecond, "agy"))
+	result, err := session.ReadResult("gemini-cli")
+	require.NoError(t, err)
+	assert.Equal(t, "ok", result.Output)
+	require.NoError(t, session.ResetAttempt("antigravity", 0))
+	_, err = session.statArtifact("gemini-done")
+	assert.Error(t, err)
+	_, err = session.statArtifact("gemini-result.json")
+	assert.Error(t, err)
+}

--- a/pkg/orchestra/provider_patterns.go
+++ b/pkg/orchestra/provider_patterns.go
@@ -5,6 +5,11 @@ import (
 	"strings"
 )
 
+var defaultStartupHookProviders = map[string]bool{
+	"claude": true,
+	"codex":  true,
+}
+
 // provider_patterns.go is the single declarative source for provider pattern
 // defaults (fast-fail rules, hook-capable providers, prompt patterns). The defaults
 // here are exact copies of the previously hardcoded values; when a ProviderConfig
@@ -71,12 +76,35 @@ func DefaultHookProviders() map[string]bool {
 func resolveHookProviders(providers []ProviderConfig) map[string]bool {
 	out := DefaultHookProviders()
 	for _, p := range providers {
+		identity := providerArtifactIdentity(p.Name)
 		if p.HasHook != nil {
-			out[p.Name] = *p.HasHook
+			out[identity] = *p.HasHook
 			continue
 		}
 		if usesAntigravityPromptInteractive(p) {
-			out[p.Name] = false
+			out[identity] = false
+		}
+	}
+	return out
+}
+
+// DefaultStartupHookProviders returns providers whose generated wiring emits a
+// startup-ready artifact. Completion-only hooks are intentionally excluded.
+func DefaultStartupHookProviders() map[string]bool {
+	out := make(map[string]bool, len(defaultStartupHookProviders))
+	for name, has := range defaultStartupHookProviders {
+		out[name] = has
+	}
+	return out
+}
+
+// resolveStartupHookProviders applies startup-specific overrides without
+// inferring startup capability from completion hook configuration.
+func resolveStartupHookProviders(providers []ProviderConfig) map[string]bool {
+	out := DefaultStartupHookProviders()
+	for _, provider := range providers {
+		if provider.HasStartupHook != nil {
+			out[providerArtifactIdentity(provider.Name)] = *provider.HasStartupHook
 		}
 	}
 	return out

--- a/pkg/orchestra/provider_patterns_test.go
+++ b/pkg/orchestra/provider_patterns_test.go
@@ -76,6 +76,47 @@ func TestResolveHookProviders_OverrideBehavior(t *testing.T) {
 	}
 }
 
+func TestDefaultStartupHookProviders_MatchesGeneratedWiring(t *testing.T) {
+	got := DefaultStartupHookProviders()
+	for _, provider := range []string{"claude", "codex"} {
+		if !got[provider] {
+			t.Fatalf("expected %s startup hook to be enabled, got %v", provider, got)
+		}
+	}
+	for _, provider := range []string{"gemini", "opencode", "custom"} {
+		if got[provider] {
+			t.Fatalf("expected %s startup hook to be disabled, got %v", provider, got)
+		}
+	}
+}
+
+func TestResolveStartupHookProviders_OverridesAreIndependentFromCompletionHooks(t *testing.T) {
+	on, off := true, false
+	got := resolveStartupHookProviders([]ProviderConfig{
+		{Name: "claude", HasHook: &off},
+		{Name: "codex", HasStartupHook: &off},
+		{Name: "gemini", HasHook: &on},
+		{Name: "opencode", HasHook: &on},
+		{Name: "custom", HasHook: &on},
+		{Name: "custom-ready", HasStartupHook: &on},
+	})
+
+	if !got["claude"] {
+		t.Fatal("completion override must not erase Claude's independent startup wiring")
+	}
+	if got["codex"] {
+		t.Fatal("explicit startup override must disable Codex startup readiness")
+	}
+	for _, provider := range []string{"gemini", "opencode", "custom"} {
+		if got[provider] {
+			t.Fatalf("completion hook override must not create phantom startup hook for %s", provider)
+		}
+	}
+	if !got["custom-ready"] {
+		t.Fatal("explicit startup override must enable custom startup readiness")
+	}
+}
+
 // S4: DefaultPromptPatterns() exposes exactly the hardcoded defaultPromptPatterns set.
 func TestDefaultPromptPatterns_CountMatchesHardcoded(t *testing.T) {
 	if len(DefaultPromptPatterns()) != len(defaultPromptPatterns) {

--- a/pkg/orchestra/provider_session_ready_alias_test.go
+++ b/pkg/orchestra/provider_session_ready_alias_test.go
@@ -1,0 +1,65 @@
+package orchestra
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsProviderSessionReady_KnownAliasesRemainProviderSpecific(t *testing.T) {
+	tests := []struct {
+		provider    string
+		ownPrompt   string
+		otherPrompt string
+	}{
+		{
+			provider: "claude-code", ownPrompt: "❯ Try \"write a test for <filepath>\"\n",
+			otherPrompt: codexStablePrompt,
+		},
+		{
+			provider: "gemini-cli", ownPrompt: "> Type your message\n",
+			otherPrompt: "❯\n",
+		},
+		{
+			provider: "antigravity-cli", ownPrompt: "> Type your message\n",
+			otherPrompt: codexStablePrompt,
+		},
+		{
+			provider: "agy", ownPrompt: "> Type your message\n",
+			otherPrompt: "Ask anything\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.provider, func(t *testing.T) {
+			patterns := SessionReadyPatterns()
+			assert.True(t, isProviderSessionReady(tt.ownPrompt, patterns, tt.provider))
+			assert.False(t, isProviderSessionReady(tt.otherPrompt, patterns, tt.provider),
+				"a known alias must not use the custom-provider generic fallback")
+		})
+	}
+}
+
+func TestIsProviderSessionReady_TrulyCustomProviderKeepsGenericFallback(t *testing.T) {
+	assert.True(t, isProviderSessionReady("Ask anything\n", SessionReadyPatterns(), "my-provider"))
+}
+
+func TestStartupTimeoutFor_KnownAliasesUseCanonicalDefaults(t *testing.T) {
+	tests := []struct {
+		provider string
+		want     time.Duration
+	}{
+		{provider: "claude-code", want: 15 * time.Second},
+		{provider: "gemini-cli", want: 10 * time.Second},
+		{provider: "antigravity", want: 10 * time.Second},
+		{provider: "antigravity-cli", want: 10 * time.Second},
+		{provider: "agy", want: 10 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.provider, func(t *testing.T) {
+			assert.Equal(t, tt.want, startupTimeoutFor(ProviderConfig{Name: tt.provider}))
+		})
+	}
+}

--- a/pkg/orchestra/provider_validation.go
+++ b/pkg/orchestra/provider_validation.go
@@ -26,7 +26,7 @@ func validateHookSessionID(sessionID string) error {
 }
 
 func providerCanonicalName(name string) string {
-	return strings.ToLower(name)
+	return strings.ToLower(providerArtifactIdentity(strings.TrimSpace(name)))
 }
 
 func validateProviderConfigs(providers []ProviderConfig) error {

--- a/pkg/orchestra/provider_validation_test.go
+++ b/pkg/orchestra/provider_validation_test.go
@@ -21,6 +21,8 @@ func TestValidateProviderConfigs_RejectsUnsafeAndDuplicateNames(t *testing.T) {
 		{name: "unsafe", providers: []ProviderConfig{{Name: "../claude"}}, want: "unsafe"},
 		{name: "raw duplicate", providers: []ProviderConfig{{Name: "claude"}, {Name: "claude"}}, want: "duplicate raw"},
 		{name: "canonical duplicate", providers: []ProviderConfig{{Name: "claude"}, {Name: "Claude"}}, want: "duplicate canonical"},
+		{name: "claude artifact alias", providers: []ProviderConfig{{Name: "claude"}, {Name: "claude-code"}}, want: "duplicate canonical"},
+		{name: "gemini artifact alias", providers: []ProviderConfig{{Name: "gemini"}, {Name: "agy"}}, want: "duplicate canonical"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -36,6 +38,7 @@ func TestValidateProviderConfigs_SingleUppercaseCustomNameIsAllowed(t *testing.T
 	t.Parallel()
 
 	assert.NoError(t, validateProviderConfigs([]ProviderConfig{{Name: "CustomAI"}}))
+	assert.NoError(t, validateProviderConfigs([]ProviderConfig{{Name: "CustomAI"}, {Name: "OtherAI"}}))
 }
 
 func TestValidateHookSessionID_RequiresCanonicalLowercase(t *testing.T) {

--- a/pkg/orchestra/recovery_hook_launch.go
+++ b/pkg/orchestra/recovery_hook_launch.go
@@ -1,0 +1,116 @@
+package orchestra
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/insajin/autopus-adk/pkg/terminal"
+)
+
+func recoveryHookSession(cfg OrchestraConfig) (*HookSession, error) {
+	if !cfg.HookMode {
+		return nil, nil
+	}
+	if cfg.SessionID == "" {
+		return nil, fmt.Errorf("hook recovery requires a session ID")
+	}
+	if cfg.SurfaceMgr == nil || cfg.SurfaceMgr.hookSession == nil {
+		return nil, fmt.Errorf("hook recovery requires the active hook session")
+	}
+	session := cfg.SurfaceMgr.hookSession
+	if session.SessionID() != cfg.SessionID {
+		return nil, fmt.Errorf(
+			"active hook session %q does not match config session %q",
+			session.SessionID(), cfg.SessionID,
+		)
+	}
+	return session, nil
+}
+
+// launchRecoveryProvider installs fresh-pane hook coordinates before launching
+// the provider. A partially installed hook environment is fatal because the
+// provider would otherwise run without a usable completion protocol.
+func launchRecoveryProvider(
+	ctx context.Context,
+	cfg OrchestraConfig,
+	paneID terminal.PaneID,
+	provider ProviderConfig,
+	round int,
+) error {
+	hookSession, err := recoveryHookSession(cfg)
+	if err != nil {
+		return err
+	}
+	hasHookCapability := hookSession != nil &&
+		(hookSession.HasHook(provider.Name) || hookSession.HasStartupHook(provider.Name))
+	if hasHookCapability {
+		if err := hookSession.ResetAttempt(provider.Name, round); err != nil {
+			return fmt.Errorf("reset hook attempt for %s: %w", provider.Name, err)
+		}
+		sendErr, enterErr := sendPaneInputAndEnterSerialized(ctx, cfg.Terminal, paneID, 0, func() error {
+			return SendSessionEnvToPane(ctx, cfg.Terminal, paneID, cfg.SessionID)
+		})
+		if sendErr != nil {
+			return fmt.Errorf("export hook session failed: %w", sendErr)
+		}
+		if enterErr != nil {
+			return fmt.Errorf("commit hook session export failed: %w", enterErr)
+		}
+
+		roundErr, roundEnterErr := sendPaneInputAndEnterSerialized(ctx, cfg.Terminal, paneID, 0, func() error {
+			return SendRoundEnvToPane(ctx, cfg.Terminal, paneID, round)
+		})
+		if roundErr != nil {
+			return fmt.Errorf("export hook round failed: %w", roundErr)
+		}
+		if roundEnterErr != nil {
+			return fmt.Errorf("commit hook round export failed: %w", roundEnterErr)
+		}
+	}
+
+	cmd := buildInteractiveLaunchCmdWithCWD(provider, "", cfg.WorkingDir)
+	launchErr, launchEnterErr := sendPaneInputAndEnterSerialized(ctx, cfg.Terminal, paneID, promptRegisterDelay, func() error {
+		return cfg.Terminal.SendLongText(ctx, paneID, cmd)
+	})
+	if launchErr != nil {
+		return fmt.Errorf("launch for %s failed: %w", provider.Name, launchErr)
+	}
+	if launchEnterErr != nil {
+		return fmt.Errorf("launch enter for %s failed: %w", provider.Name, launchEnterErr)
+	}
+	return nil
+}
+
+func waitForRecoveredProviderReady(
+	ctx context.Context,
+	cfg OrchestraConfig,
+	paneID terminal.PaneID,
+	provider ProviderConfig,
+	round int,
+) bool {
+	hookSession, err := recoveryHookSession(cfg)
+	if err != nil {
+		return false
+	}
+	if !waitForPaneReady(
+		ctx,
+		cfg.Terminal,
+		paneID,
+		SessionReadyPatterns(),
+		startupTimeoutFor(provider),
+		hookSession,
+		provider.Name,
+		round,
+	) {
+		return false
+	}
+	if hookSession == nil || !hookSession.HasStartupHook(provider.Name) {
+		return true
+	}
+	readyName := RoundSignalName(provider.Name, round, "ready")
+	if err := hookSession.removeArtifact(readyName); err != nil && !os.IsNotExist(err) {
+		return false
+	}
+	return true
+}

--- a/pkg/orchestra/recovery_hook_launch_test.go
+++ b/pkg/orchestra/recovery_hook_launch_test.go
@@ -1,0 +1,225 @@
+package orchestra
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recoveryLaunchEvent struct {
+	kind  string
+	value string
+	pane  terminal.PaneID
+}
+
+type recoveryLaunchTerminal struct {
+	mockTerminal
+	eventsMu      sync.Mutex
+	events        []recoveryLaunchEvent
+	commandCalls  int
+	failCommandAt int
+	stalePanes    map[terminal.PaneID]bool
+	screens       map[terminal.PaneID][]string
+	screenIndexes map[terminal.PaneID]int
+	onLaunch      func(terminal.PaneID)
+}
+
+func newRecoveryLaunchTerminal() *recoveryLaunchTerminal {
+	return &recoveryLaunchTerminal{mockTerminal: mockTerminal{name: "tmux", readScreenOutput: "❯\n"}}
+}
+
+func (m *recoveryLaunchTerminal) SendCommand(_ context.Context, paneID terminal.PaneID, command string) error {
+	m.eventsMu.Lock()
+	defer m.eventsMu.Unlock()
+	m.commandCalls++
+	m.events = append(m.events, recoveryLaunchEvent{kind: "command", value: command, pane: paneID})
+	if m.commandCalls == m.failCommandAt {
+		return errors.New("injected recovery command failure")
+	}
+	return nil
+}
+
+func (m *recoveryLaunchTerminal) SendLongText(_ context.Context, paneID terminal.PaneID, text string) error {
+	m.eventsMu.Lock()
+	m.events = append(m.events, recoveryLaunchEvent{kind: "long_text", value: text, pane: paneID})
+	onLaunch := m.onLaunch
+	m.eventsMu.Unlock()
+	if onLaunch != nil {
+		onLaunch(paneID)
+	}
+	return nil
+}
+
+func (m *recoveryLaunchTerminal) ReadScreen(_ context.Context, paneID terminal.PaneID, _ terminal.ReadScreenOpts) (string, error) {
+	m.eventsMu.Lock()
+	defer m.eventsMu.Unlock()
+	if m.stalePanes[paneID] {
+		return "", errors.New("stale pane")
+	}
+	if sequence := m.screens[paneID]; len(sequence) > 0 {
+		if m.screenIndexes == nil {
+			m.screenIndexes = make(map[terminal.PaneID]int)
+		}
+		index := m.screenIndexes[paneID] % len(sequence)
+		m.screenIndexes[paneID]++
+		return sequence[index], nil
+	}
+	return m.readScreenOutput, nil
+}
+
+func (m *recoveryLaunchTerminal) eventsSnapshot() []recoveryLaunchEvent {
+	m.eventsMu.Lock()
+	defer m.eventsMu.Unlock()
+	return append([]recoveryLaunchEvent(nil), m.events...)
+}
+
+func TestLaunchRecoveryProvider_ExportsForCompletionOrStartupCapability(t *testing.T) {
+	t.Parallel()
+	on, off := true, false
+	tests := []struct {
+		name       string
+		provider   ProviderConfig
+		wantExport bool
+	}{
+		{name: "completion default", provider: ProviderConfig{Name: "gemini", Binary: "gemini"}, wantExport: true},
+		{name: "startup default", provider: ProviderConfig{Name: "claude", Binary: "claude", HasHook: &off}, wantExport: true},
+		{name: "startup override", provider: ProviderConfig{Name: "custom", Binary: "custom", HasHook: &off, HasStartupHook: &on}, wantExport: true},
+		{name: "hookless", provider: ProviderConfig{Name: "custom", Binary: "custom", HasHook: &off, HasStartupHook: &off}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			term := newRecoveryLaunchTerminal()
+			sessionID := "recovery-capability-" + sanitizeProviderName(tt.name)
+			cfg, _ := newRecoveryHookConfig(t, term, sessionID, tt.provider)
+
+			err := launchRecoveryProvider(context.Background(), cfg, "replacement", tt.provider, 4)
+
+			require.NoError(t, err)
+			events := term.eventsSnapshot()
+			exports := make([]string, 0, 2)
+			launchIndex := -1
+			for i, event := range events {
+				if event.kind == "command" && strings.Contains(event.value, "AUTOPUS_") {
+					exports = append(exports, event.value)
+				}
+				if event.kind == "long_text" {
+					launchIndex = i
+				}
+			}
+			require.NotEqual(t, -1, launchIndex)
+			if !tt.wantExport {
+				assert.Empty(t, exports)
+				return
+			}
+			require.Len(t, exports, 2)
+			assert.Contains(t, exports[0], "AUTOPUS_SESSION_ID="+sessionID)
+			assert.Equal(t, "export AUTOPUS_ROUND=4", exports[1])
+			assert.Equal(t, "\n", events[1].value)
+			assert.Equal(t, "\n", events[3].value)
+			assert.Greater(t, launchIndex, 3)
+		})
+	}
+}
+
+func TestLaunchRecoveryProvider_HookExportFailureSkipsLaunch(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name          string
+		failCommandAt int
+		wantError     string
+	}{
+		{name: "session send", failCommandAt: 1, wantError: "export hook session failed"},
+		{name: "session enter", failCommandAt: 2, wantError: "commit hook session export failed"},
+		{name: "round send", failCommandAt: 3, wantError: "export hook round failed"},
+		{name: "round enter", failCommandAt: 4, wantError: "commit hook round export failed"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			term := newRecoveryLaunchTerminal()
+			term.failCommandAt = tt.failCommandAt
+			provider := ProviderConfig{Name: "claude", Binary: "claude"}
+			cfg, _ := newRecoveryHookConfig(
+				t, term, "recovery-failure-"+sanitizeProviderName(tt.name), provider,
+			)
+
+			err := launchRecoveryProvider(context.Background(), cfg, "replacement", provider, 3)
+
+			require.ErrorContains(t, err, tt.wantError)
+			for _, event := range term.eventsSnapshot() {
+				assert.NotEqual(t, "long_text", event.kind, "provider must not launch after hook export failure")
+			}
+		})
+	}
+}
+
+func TestRecreatePane_HookExportFailureCleansReplacement(t *testing.T) {
+	term := newRecoveryLaunchTerminal()
+	term.failCommandAt = 1
+	old := paneInfo{paneID: "old-pane", provider: ProviderConfig{Name: "claude", Binary: "claude"}}
+	cfg, _ := newRecoveryHookConfig(t, term, "recovery-cold-cleanup", old.provider)
+
+	got, err := recreatePane(context.Background(), cfg, old, 2)
+
+	require.ErrorContains(t, err, "export hook session failed")
+	assert.Equal(t, old, got)
+	assert.Contains(t, term.closeCalls, "pane-1")
+	assert.NotContains(t, term.closeCalls, "old-pane")
+	assert.Empty(t, term.createdPanes[1:], "hook export failure must not launch a second replacement")
+}
+
+func TestSurfaceManager_WarmHookExportFailureFallsBackToColdRecovery(t *testing.T) {
+	term := newRecoveryLaunchTerminal()
+	term.failCommandAt = 1
+	term.stalePanes = map[terminal.PaneID]bool{"old-pane": true}
+	term.name = "cmux"
+	sm := NewSurfaceManager(term)
+	sm.warmPool = &WarmPool{term: term, pool: []warmPane{{paneID: "warm-pane"}}}
+	old := paneInfo{paneID: "old-pane", provider: ProviderConfig{Name: "claude", Binary: "claude"}}
+	cfg, session := newRecoveryHookConfig(t, term, "recovery-warm-cleanup", old.provider)
+	sm.setHookSession(session)
+	cfg.SurfaceMgr = sm
+	term.onLaunch = func(terminal.PaneID) {
+		require.NoError(t, session.writeArtifact(
+			RoundSignalName(old.provider.Name, 2, "ready"), nil, 0o600,
+		))
+	}
+
+	got, recovered, err := sm.ValidateAndRecover(context.Background(), cfg, old, 2)
+
+	require.NoError(t, err)
+	assert.True(t, recovered)
+	assert.Equal(t, terminal.PaneID("pane-1"), got.paneID)
+	assert.Equal(t, 2, got.directPromptRound)
+	assert.Contains(t, term.closeCalls, "warm-pane")
+	assert.Contains(t, term.closeCalls, "old-pane", "old pane retires only after cold recovery succeeds")
+	assert.Equal(t, []terminal.PaneID{"pane-1"}, term.createdPanes)
+	for _, event := range term.eventsSnapshot() {
+		assert.False(t, event.kind == "long_text" && event.pane == "warm-pane",
+			"warm provider must not launch after its hook export fails")
+	}
+}
+
+func TestRecreatePane_RequiresStableProviderReadyBeforeRetiringOld(t *testing.T) {
+	term := newRecoveryLaunchTerminal()
+	term.screens = map[terminal.PaneID][]string{"pane-1": {"❯\n", "$ \n"}}
+	old := paneInfo{
+		paneID:   "old-pane",
+		provider: ProviderConfig{Name: "claude", Binary: "claude", StartupTimeout: 450 * time.Millisecond},
+	}
+
+	got, err := recreatePane(context.Background(), OrchestraConfig{Terminal: term}, old, 2)
+
+	require.Error(t, err)
+	assert.Equal(t, old, got)
+	assert.Contains(t, term.closeCalls, "pane-1")
+	assert.NotContains(t, term.closeCalls, "old-pane")
+}

--- a/pkg/orchestra/recovery_startup_artifact_test.go
+++ b/pkg/orchestra/recovery_startup_artifact_test.go
@@ -1,0 +1,147 @@
+package orchestra
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newRecoveryHookConfig(
+	t *testing.T,
+	term terminal.Terminal,
+	sessionID string,
+	providers ...ProviderConfig,
+) (OrchestraConfig, *HookSession) {
+	t.Helper()
+	session, err := NewHookSession(sessionID)
+	require.NoError(t, err)
+	t.Cleanup(session.Cleanup)
+	session.ApplyProviderHooks(providers)
+	manager := NewSurfaceManager(term)
+	manager.setHookSession(session)
+	return OrchestraConfig{
+		Terminal: term, HookMode: true, SessionID: sessionID, SurfaceMgr: manager,
+	}, session
+}
+
+func TestRecreatePane_StaleStartupArtifactCannotCommitReplacement(t *testing.T) {
+	term := newRecoveryLaunchTerminal()
+	provider := ProviderConfig{
+		Name: "claude-code", Binary: "claude", StartupTimeout: 450 * time.Millisecond,
+	}
+	cfg, session := newRecoveryHookConfig(t, term, "recovery-stale-ready", provider)
+	require.NoError(t, session.writeArtifact("claude-round2-ready", nil, 0o600))
+	old := paneInfo{paneID: "old-pane", provider: provider}
+
+	got, err := recreatePane(context.Background(), cfg, old, 2)
+
+	require.Error(t, err)
+	assert.Equal(t, old, got)
+	assert.Contains(t, term.closeCalls, "pane-1")
+	assert.NotContains(t, term.closeCalls, "old-pane")
+}
+
+func TestRecreatePane_FreshStartupArtifactAndStableFramesCommit(t *testing.T) {
+	term := newRecoveryLaunchTerminal()
+	provider := ProviderConfig{
+		Name: "claude-code", Binary: "claude", StartupTimeout: time.Second,
+	}
+	cfg, session := newRecoveryHookConfig(t, term, "recovery-fresh-ready", provider)
+	readyName := "claude-round2-ready"
+	require.NoError(t, session.writeArtifact(readyName, nil, 0o600))
+	staleWasReset := false
+	term.onLaunch = func(terminal.PaneID) {
+		_, staleErr := session.statArtifact(readyName)
+		staleWasReset = os.IsNotExist(staleErr)
+		require.NoError(t, session.writeArtifact(readyName, nil, 0o600))
+	}
+	old := paneInfo{paneID: "old-pane", provider: provider}
+
+	got, err := recreatePane(context.Background(), cfg, old, 2)
+
+	require.NoError(t, err)
+	assert.True(t, staleWasReset, "stale ready must be removed before provider launch")
+	assert.Equal(t, terminal.PaneID("pane-1"), got.paneID)
+	assert.Equal(t, 2, got.directPromptRound)
+	assert.Contains(t, term.closeCalls, "old-pane")
+	_, statErr := session.statArtifact(readyName)
+	assert.Error(t, statErr, "SessionStart ready must be consumed before direct prompt completion wait")
+}
+
+func TestRecreatePane_StartupArtifactConsumeFailureDoesNotCommit(t *testing.T) {
+	term := newRecoveryLaunchTerminal()
+	provider := ProviderConfig{
+		Name: "claude", Binary: "claude", StartupTimeout: time.Second,
+	}
+	cfg, session := newRecoveryHookConfig(t, term, "recovery-ready-consume", provider)
+	readyName := RoundSignalName(provider.Name, 2, "ready")
+	term.onLaunch = func(terminal.PaneID) {
+		readyDir := filepath.Join(session.Dir(), readyName)
+		require.NoError(t, os.Mkdir(readyDir, 0o700))
+		require.NoError(t, os.WriteFile(filepath.Join(readyDir, "keep"), nil, 0o600))
+	}
+	old := paneInfo{paneID: "old-pane", provider: provider}
+
+	got, err := recreatePane(context.Background(), cfg, old, 2)
+
+	require.Error(t, err)
+	assert.Equal(t, old, got)
+	assert.Contains(t, term.closeCalls, "pane-1")
+	assert.NotContains(t, term.closeCalls, "old-pane")
+}
+
+func TestSurfaceManager_WarmReplacementRequiresFreshStartupArtifact(t *testing.T) {
+	term := newRecoveryLaunchTerminal()
+	term.name = "cmux"
+	term.stalePanes = map[terminal.PaneID]bool{"old-pane": true}
+	provider := ProviderConfig{
+		Name: "claude-code", Binary: "claude", StartupTimeout: time.Second,
+	}
+	cfg, session := newRecoveryHookConfig(t, term, "recovery-warm-fresh-ready", provider)
+	manager := cfg.SurfaceMgr
+	manager.warmPool = &WarmPool{
+		term: term, pool: []warmPane{{paneID: "warm-pane"}},
+	}
+	readyName := RoundSignalName(provider.Name, 2, "ready")
+	require.NoError(t, session.writeArtifact(readyName, nil, 0o600))
+	staleWasReset := false
+	term.onLaunch = func(paneID terminal.PaneID) {
+		assert.Equal(t, terminal.PaneID("warm-pane"), paneID)
+		_, staleErr := session.statArtifact(readyName)
+		staleWasReset = os.IsNotExist(staleErr)
+		require.NoError(t, session.writeArtifact(readyName, nil, 0o600))
+	}
+	old := paneInfo{paneID: "old-pane", provider: provider}
+
+	got, recovered, err := manager.ValidateAndRecover(context.Background(), cfg, old, 2)
+
+	require.NoError(t, err)
+	assert.True(t, recovered)
+	assert.True(t, staleWasReset)
+	assert.Equal(t, terminal.PaneID("warm-pane"), got.paneID)
+	assert.Contains(t, term.closeCalls, "old-pane")
+	_, statErr := session.statArtifact(readyName)
+	assert.Error(t, statErr)
+}
+
+func TestRecreatePane_HookModeWithoutActiveSessionFailsClosed(t *testing.T) {
+	term := newRecoveryLaunchTerminal()
+	old := paneInfo{
+		paneID: "old-pane", provider: ProviderConfig{Name: "claude", Binary: "claude"},
+	}
+
+	got, err := recreatePane(context.Background(), OrchestraConfig{
+		Terminal: term, HookMode: true, SessionID: "missing-active-session",
+	}, old, 2)
+
+	require.ErrorContains(t, err, "active hook session")
+	assert.Equal(t, old, got)
+	assert.Empty(t, term.createdPanes)
+	assert.NotContains(t, term.closeCalls, "old-pane")
+}

--- a/pkg/orchestra/round_signal.go
+++ b/pkg/orchestra/round_signal.go
@@ -12,7 +12,7 @@ import (
 // RoundSignalName generates a round-scoped signal filename.
 // Format: "{provider}-round{N}-{suffix}" (e.g., "claude-round2-done").
 func RoundSignalName(provider string, round int, suffix string) string {
-	return fmt.Sprintf("%s-round%d-%s", sanitizeProviderName(provider), round, suffix)
+	return fmt.Sprintf("%s-round%d-%s", sanitizeProviderName(providerArtifactIdentity(provider)), round, suffix)
 }
 
 // CleanRoundSignals removes signal files for the given round,

--- a/pkg/orchestra/session.go
+++ b/pkg/orchestra/session.go
@@ -32,11 +32,14 @@ type sessionWritableFile interface {
 
 // OrchestraSession holds state for a yield-rounds orchestra session.
 type OrchestraSession struct {
-	ID        string                      `json:"id"`
-	Panes     map[string]string           `json:"panes"` // provider name -> pane ID
-	Providers []SessionProviderConfig     `json:"providers"`
-	Rounds    [][]SessionProviderResponse `json:"rounds"`
-	CreatedAt time.Time                   `json:"created_at"`
+	ID            string                      `json:"id"`
+	TerminalKind  string                      `json:"terminal_kind,omitempty"`
+	WorkspaceRef  string                      `json:"workspace_ref,omitempty"`
+	TmuxServerRef string                      `json:"tmux_server_ref,omitempty"`
+	Panes         map[string]string           `json:"panes"` // provider name -> pane ID
+	Providers     []SessionProviderConfig     `json:"providers"`
+	Rounds        [][]SessionProviderResponse `json:"rounds"`
+	CreatedAt     time.Time                   `json:"created_at"`
 }
 
 // SessionProviderConfig is a serializable subset of ProviderConfig.
@@ -199,4 +202,47 @@ func rollbackCreatedSession(root *os.Root, name string, created fs.FileInfo) {
 	if err == nil && current.Mode().IsRegular() && os.SameFile(created, current) {
 		_ = root.Remove(name)
 	}
+}
+
+type sessionCommitFunc func(root *os.Root, temporary, target string) error
+
+// UpdateSession atomically replaces an existing private or legacy session. It
+// never removes the target before the fully synced replacement is ready, so a
+// failed update leaves the previous cleanup handle available for retry.
+func UpdateSession(session OrchestraSession) error {
+	return updateSessionWithCommit(session, func(root *os.Root, temporary, target string) error {
+		return root.Rename(temporary, target)
+	})
+}
+
+func updateSessionWithCommit(session OrchestraSession, commit sessionCommitFunc) error {
+	data, err := json.MarshalIndent(session, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal session update: %w", err)
+	}
+	root, name, originalInfo, err := openSessionUpdateTarget(session.ID)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
+	temporary := name + "." + NewSessionID() + ".tmp"
+	file, err := root.OpenFile(temporary, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create session update: %w", err)
+	}
+	if err := persistCreatedSession(root, temporary, file, data); err != nil {
+		return fmt.Errorf("persist session update: %w", err)
+	}
+	defer func() { _ = root.Remove(temporary) }()
+	currentInfo, err := root.Lstat(name)
+	if err != nil || !currentInfo.Mode().IsRegular() || !os.SameFile(originalInfo, currentInfo) {
+		return errors.New("session entry changed before update")
+	}
+	if commit == nil {
+		return errors.New("nil session update commit")
+	}
+	if err := commit(root, temporary, name); err != nil {
+		return fmt.Errorf("commit session update: %w", err)
+	}
+	return nil
 }

--- a/pkg/orchestra/session_legacy.go
+++ b/pkg/orchestra/session_legacy.go
@@ -154,3 +154,38 @@ func RemoveSession(id string) error {
 	}
 	return nil
 }
+
+func openSessionUpdateTarget(id string) (*os.Root, string, fs.FileInfo, error) {
+	name, err := sessionFilename(id)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	root, err := openSessionRoot(false)
+	if err == nil {
+		_, info, readErr := readSessionEntry(root, name, id)
+		if readErr == nil {
+			return root, name, info, nil
+		}
+		_ = root.Close()
+		if !errors.Is(readErr, fs.ErrNotExist) {
+			return nil, "", nil, fmt.Errorf("read session before update: %w", readErr)
+		}
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return nil, "", nil, fmt.Errorf("open session update root: %w", err)
+	}
+
+	legacyName, err := legacySessionFilename(id)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	legacyRoot, err := openLegacySessionRoot()
+	if err != nil {
+		return nil, "", nil, err
+	}
+	_, info, err := readSessionEntry(legacyRoot, legacyName, id)
+	if err != nil {
+		_ = legacyRoot.Close()
+		return nil, "", nil, fmt.Errorf("read legacy session before update: %w", err)
+	}
+	return legacyRoot, legacyName, info, nil
+}

--- a/pkg/orchestra/session_terminal.go
+++ b/pkg/orchestra/session_terminal.go
@@ -1,0 +1,183 @@
+package orchestra
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/insajin/autopus-adk/pkg/terminal"
+)
+
+// ResolveSessionTerminal restores the terminal context persisted with a yield
+// session. Legacy cmux sessions fail closed because surface refs are only
+// meaningful inside their original workspace. Legacy tmux panes are accepted
+// only from an actively detected tmux context.
+func ResolveSessionTerminal(session *OrchestraSession, detected terminal.Terminal) (terminal.Terminal, error) {
+	if session == nil {
+		return nil, errors.New("nil orchestra session")
+	}
+	if len(session.Panes) == 0 {
+		return detected, nil
+	}
+	switch session.TerminalKind {
+	case "":
+		if hasOnlyGlobalTmuxPanes(session.Panes) {
+			if detected == nil || detected.Name() != "tmux" {
+				return nil, errors.New("legacy tmux session requires an active tmux context")
+			}
+			return detected, nil
+		}
+		return nil, errors.New("legacy session has no proven terminal workspace context")
+	case "cmux":
+		return resolveCmuxSessionTerminal(session, detected)
+	case "tmux":
+		return resolveTmuxSessionTerminal(session, detected)
+	case "plain":
+		return nil, errors.New("plain terminal cannot operate persisted panes")
+	default:
+		return nil, fmt.Errorf("unsupported persisted terminal kind %q", session.TerminalKind)
+	}
+}
+
+// ResolveSessionTerminalWithWorkspace applies an explicit recovery capability
+// only to metadata-less cmux sessions created before workspace persistence.
+func ResolveSessionTerminalWithWorkspace(session *OrchestraSession, detected terminal.Terminal, workspaceRef string) (terminal.Terminal, error) {
+	if workspaceRef == "" {
+		return ResolveSessionTerminal(session, detected)
+	}
+	if session == nil {
+		return nil, errors.New("nil orchestra session")
+	}
+	if session.TerminalKind != "" || session.WorkspaceRef != "" || session.TmuxServerRef != "" {
+		return nil, errors.New("workspace override is only valid for a legacy cmux session")
+	}
+	if len(session.Panes) == 0 {
+		return terminal.NewCmuxAdapterWithWorkspace(workspaceRef)
+	}
+	if !hasOnlyCmuxPanes(session.Panes) {
+		return nil, errors.New("workspace override requires legacy cmux pane references")
+	}
+	legacy := *session
+	legacy.TerminalKind = "cmux"
+	legacy.WorkspaceRef = workspaceRef
+	term, err := resolveCmuxSessionTerminal(&legacy, detected)
+	if err != nil {
+		return nil, fmt.Errorf("invalid workspace override: %w", err)
+	}
+	return term, nil
+}
+
+func resolveCmuxSessionTerminal(session *OrchestraSession, detected terminal.Terminal) (terminal.Terminal, error) {
+	if session.TmuxServerRef != "" {
+		return nil, errors.New("cmux session contains conflicting tmux server context")
+	}
+	if !hasOnlyCmuxPanes(session.Panes) {
+		return nil, errors.New("cmux session contains an incompatible pane reference")
+	}
+	if session.WorkspaceRef == "" {
+		return nil, errors.New("cmux session has no persisted workspace context")
+	}
+	if _, err := terminal.NewCmuxAdapterWithWorkspace(session.WorkspaceRef); err != nil {
+		return nil, fmt.Errorf("invalid persisted cmux workspace context: %w", err)
+	}
+	if detected != nil && detected.Name() == "cmux" {
+		provider, ok := detected.(terminal.WorkspaceContextProvider)
+		if !ok {
+			return nil, errors.New("cmux terminal cannot restore persisted workspace context")
+		}
+		return provider.WithWorkspaceRef(session.WorkspaceRef)
+	}
+	return terminal.NewCmuxAdapterWithWorkspace(session.WorkspaceRef)
+}
+
+func resolveTmuxSessionTerminal(session *OrchestraSession, detected terminal.Terminal) (terminal.Terminal, error) {
+	if !hasOnlyGlobalTmuxPanes(session.Panes) {
+		return nil, errors.New("tmux session contains an incompatible pane reference")
+	}
+	if session.WorkspaceRef != "" {
+		return nil, errors.New("tmux session contains conflicting cmux workspace context")
+	}
+	if detected == nil || detected.Name() != "tmux" {
+		return nil, errors.New("persisted tmux session requires an active tmux context")
+	}
+	currentRef, ok := currentTmuxServerRef()
+	if !ok || session.TmuxServerRef == "" {
+		return nil, errors.New("tmux server identity cannot be proven")
+	}
+	if !validTmuxServerRef.MatchString(session.TmuxServerRef) {
+		return nil, errors.New("persisted tmux server identity is invalid")
+	}
+	if currentRef != session.TmuxServerRef {
+		return nil, errors.New("tmux server identity does not match persisted session")
+	}
+	return detected, nil
+}
+
+func hasOnlyCmuxPanes(panes map[string]string) bool {
+	if len(panes) == 0 {
+		return false
+	}
+	for _, ref := range panes {
+		prefix := "surface:"
+		if strings.HasPrefix(ref, "pane:") {
+			prefix = "pane:"
+		}
+		if !strings.HasPrefix(ref, prefix) || !hasOnlyDecimalDigits(ref[len(prefix):]) {
+			return false
+		}
+	}
+	return true
+}
+
+func hasOnlyGlobalTmuxPanes(panes map[string]string) bool {
+	if len(panes) == 0 {
+		return false
+	}
+	for _, ref := range panes {
+		if len(ref) < 2 || ref[0] != '%' || !hasOnlyDecimalDigits(ref[1:]) {
+			return false
+		}
+	}
+	return true
+}
+
+func hasOnlyDecimalDigits(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, char := range value {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func sessionTerminalContext(term terminal.Terminal) (string, string, string, error) {
+	if term == nil || term.Name() == "plain" {
+		return "", "", "", errors.New("yield session requires a pane-capable terminal")
+	}
+	kind := term.Name()
+	if kind == "tmux" {
+		serverRef, ok := currentTmuxServerRef()
+		if !ok {
+			return "", "", "", errors.New("cannot persist tmux server identity")
+		}
+		return kind, "", serverRef, nil
+	}
+	if kind != "cmux" {
+		return "", "", "", fmt.Errorf("unsupported yield terminal kind %q", kind)
+	}
+	provider, ok := term.(terminal.WorkspaceContextProvider)
+	if !ok {
+		return "", "", "", errors.New("cmux terminal cannot persist workspace context")
+	}
+	workspaceRef, err := provider.WorkspaceRef()
+	if err != nil {
+		return "", "", "", fmt.Errorf("resolve cmux workspace context: %w", err)
+	}
+	if _, err := terminal.NewCmuxAdapterWithWorkspace(workspaceRef); err != nil {
+		return "", "", "", fmt.Errorf("validate cmux workspace context: %w", err)
+	}
+	return kind, workspaceRef, "", nil
+}

--- a/pkg/orchestra/session_test.go
+++ b/pkg/orchestra/session_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/insajin/autopus-adk/pkg/terminal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -29,8 +30,10 @@ func TestSaveAndLoadSession(t *testing.T) {
 	t.Parallel()
 
 	session := OrchestraSession{
-		ID:    "test-save-load-" + NewSessionID(),
-		Panes: map[string]string{"claude": "surface:1", "gemini": "surface:2"},
+		ID:           "test-save-load-" + NewSessionID(),
+		TerminalKind: "cmux",
+		WorkspaceRef: "workspace:17",
+		Panes:        map[string]string{"claude": "surface:1", "gemini": "surface:2"},
 		Providers: []SessionProviderConfig{
 			{Name: "claude", Binary: "claude"},
 			{Name: "gemini", Binary: "gemini"},
@@ -52,12 +55,172 @@ func TestSaveAndLoadSession(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, session.ID, loaded.ID)
+	assert.Equal(t, "cmux", loaded.TerminalKind)
+	assert.Equal(t, "workspace:17", loaded.WorkspaceRef)
 	assert.Equal(t, session.Panes, loaded.Panes)
 	assert.Len(t, loaded.Providers, 2)
 	assert.Equal(t, "claude", loaded.Providers[0].Name)
 	assert.Len(t, loaded.Rounds, 1)
 	assert.Len(t, loaded.Rounds[0], 2)
 	assert.Equal(t, "hello", loaded.Rounds[0][0].Output)
+}
+
+type sessionContextTerminal struct {
+	*mockTerminal
+	workspaceRef string
+}
+
+func (t *sessionContextTerminal) WorkspaceRef() (string, error) {
+	return t.workspaceRef, nil
+}
+
+func (t *sessionContextTerminal) WithWorkspaceRef(ref string) (terminal.Terminal, error) {
+	return &sessionContextTerminal{mockTerminal: t.mockTerminal, workspaceRef: ref}, nil
+}
+
+func TestResolveSessionTerminal_CmuxContext_RestoresPersistedWorkspace(t *testing.T) {
+	detected := &sessionContextTerminal{
+		mockTerminal: &mockTerminal{name: "cmux"},
+		workspaceRef: "workspace:99",
+	}
+	session := &OrchestraSession{
+		ID:           "context-restore",
+		TerminalKind: "cmux",
+		WorkspaceRef: "workspace:13",
+		Panes:        map[string]string{"claude": "surface:1"},
+	}
+
+	resolved, err := ResolveSessionTerminal(session, detected)
+	require.NoError(t, err)
+	contextual, ok := resolved.(interface{ WorkspaceRef() (string, error) })
+	require.True(t, ok)
+	got, err := contextual.WorkspaceRef()
+	require.NoError(t, err)
+	assert.Equal(t, "workspace:13", got)
+	assert.Equal(t, "workspace:99", detected.workspaceRef,
+		"restoring a session must not mutate the caller's terminal context")
+}
+
+func TestResolveSessionTerminal_LegacyCmuxWithoutWorkspace_FailsClosed(t *testing.T) {
+	detected := &sessionContextTerminal{
+		mockTerminal: &mockTerminal{name: "cmux"},
+		workspaceRef: "workspace:unproven",
+	}
+	session := &OrchestraSession{
+		ID:    "legacy-cmux",
+		Panes: map[string]string{"claude": "surface:1"},
+	}
+
+	_, err := ResolveSessionTerminal(session, detected)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "legacy session")
+	assert.ErrorContains(t, err, "workspace")
+}
+
+func TestResolveSessionTerminal_LegacyGlobalTmuxPanes_UsesExplicitSafeCapability(t *testing.T) {
+	detected := &mockTerminal{name: "tmux"}
+	session := &OrchestraSession{
+		ID:    "legacy-tmux",
+		Panes: map[string]string{"claude": "%42"},
+	}
+
+	resolved, err := ResolveSessionTerminal(session, detected)
+
+	require.NoError(t, err)
+	assert.Same(t, detected, resolved)
+}
+
+func TestResolveSessionTerminal_LegacyGlobalTmuxPanes_FromPlainShellFailsClosed(t *testing.T) {
+	session := &OrchestraSession{
+		ID:    "legacy-tmux-detached",
+		Panes: map[string]string{"claude": "%42"},
+	}
+
+	_, err := ResolveSessionTerminal(session, &terminal.PlainAdapter{})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "active tmux")
+}
+
+func TestResolveSessionTerminal_PersistedCmuxFromPlainShell_ReconstructsBackend(t *testing.T) {
+	session := &OrchestraSession{
+		ID:           "detached-cmux",
+		TerminalKind: "cmux",
+		WorkspaceRef: "workspace:13",
+		Panes:        map[string]string{"claude": "surface:1414"},
+	}
+
+	resolved, err := ResolveSessionTerminal(session, &terminal.PlainAdapter{})
+
+	require.NoError(t, err)
+	assert.Equal(t, "cmux", resolved.Name())
+	contextual, ok := resolved.(terminal.WorkspaceContextProvider)
+	require.True(t, ok)
+	workspaceRef, err := contextual.WorkspaceRef()
+	require.NoError(t, err)
+	assert.Equal(t, "workspace:13", workspaceRef)
+}
+
+func TestResolveSessionTerminal_PersistedTmux_DoesNotDowngradeToDetectedCmux(t *testing.T) {
+	detected := &sessionContextTerminal{
+		mockTerminal: &mockTerminal{name: "cmux"},
+		workspaceRef: "workspace:13",
+	}
+	session := &OrchestraSession{
+		ID:           "detached-tmux",
+		TerminalKind: "tmux",
+		Panes:        map[string]string{"claude": "%42"},
+	}
+
+	_, err := ResolveSessionTerminal(session, detected)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "active tmux")
+}
+
+func TestResolveSessionTerminal_IncompatiblePaneReferences_FailBeforeBackendUse(t *testing.T) {
+	tests := []struct {
+		name    string
+		session *OrchestraSession
+	}{
+		{
+			name: "cmux with tmux pane",
+			session: &OrchestraSession{
+				TerminalKind: "cmux", WorkspaceRef: "workspace:13",
+				Panes: map[string]string{"claude": "%42"},
+			},
+		},
+		{
+			name: "tmux with cmux surface",
+			session: &OrchestraSession{
+				TerminalKind: "tmux", Panes: map[string]string{"claude": "surface:1414"},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := ResolveSessionTerminal(test.session, &terminal.PlainAdapter{})
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "incompatible pane reference")
+		})
+	}
+}
+
+func TestResolveSessionTerminal_InvalidCmuxWorkspace_FailsBeforeClone(t *testing.T) {
+	detected := &sessionContextTerminal{
+		mockTerminal: &mockTerminal{name: "cmux"}, workspaceRef: "workspace:13",
+	}
+	session := &OrchestraSession{
+		TerminalKind: "cmux", WorkspaceRef: "../wrong-workspace",
+		Panes: map[string]string{"claude": "surface:1414"},
+	}
+
+	_, err := ResolveSessionTerminal(session, detected)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "invalid persisted cmux workspace")
+	assert.Equal(t, "workspace:13", detected.workspaceRef)
 }
 
 func TestLoadSession_NotFound(t *testing.T) {

--- a/pkg/orchestra/session_tmux_server_test.go
+++ b/pkg/orchestra/session_tmux_server_test.go
@@ -1,0 +1,100 @@
+package orchestra
+
+import (
+	"testing"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setTmuxServerForTest(t *testing.T, value string) string {
+	t.Helper()
+	t.Setenv("TMUX", value)
+	serverRef, ok := currentTmuxServerRef()
+	require.True(t, ok)
+	require.NotEmpty(t, serverRef)
+	return serverRef
+}
+
+func TestResolveSessionTerminal_TmuxMatchingServer_UsesDetectedTerminal(t *testing.T) {
+	serverRef := setTmuxServerForTest(t, "/tmp/tmux-501/default,12345,0")
+	detected := &mockTerminal{name: "tmux"}
+	session := &OrchestraSession{
+		TerminalKind: "tmux", TmuxServerRef: serverRef,
+		Panes: map[string]string{"claude": "%42"},
+	}
+
+	resolved, err := ResolveSessionTerminal(session, detected)
+
+	require.NoError(t, err)
+	assert.Same(t, detected, resolved)
+}
+
+func TestResolveSessionTerminal_TmuxDifferentServer_FailsClosed(t *testing.T) {
+	persistedRef := setTmuxServerForTest(t, "/tmp/tmux-501/default,12345,0")
+	setTmuxServerForTest(t, "/tmp/tmux-501/other,77777,0")
+	session := &OrchestraSession{
+		TerminalKind: "tmux", TmuxServerRef: persistedRef,
+		Panes: map[string]string{"claude": "%42"},
+	}
+
+	_, err := ResolveSessionTerminal(session, &mockTerminal{name: "tmux"})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "tmux server")
+}
+
+func TestResolveSessionTerminal_TmuxFromNonTmuxContext_FailsClosed(t *testing.T) {
+	serverRef := setTmuxServerForTest(t, "/tmp/tmux-501/default,12345,0")
+	session := &OrchestraSession{
+		TerminalKind: "tmux", TmuxServerRef: serverRef,
+		Panes: map[string]string{"claude": "%42"},
+	}
+
+	_, err := ResolveSessionTerminal(session, &terminal.PlainAdapter{})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "active tmux")
+}
+
+func TestResolveSessionTerminal_LegacyTmuxFromCmuxContext_FailsClosed(t *testing.T) {
+	setTmuxServerForTest(t, "/tmp/tmux-501/default,12345,0")
+	session := &OrchestraSession{Panes: map[string]string{"claude": "%42"}}
+
+	_, err := ResolveSessionTerminal(session, &mockTerminal{name: "cmux"})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "legacy tmux")
+}
+
+func TestBuildYieldSession_Tmux_PersistsServerIdentity(t *testing.T) {
+	serverRef := setTmuxServerForTest(t, "/tmp/tmux-501/default,12345,0")
+	panes := []paneInfo{{paneID: "%42", provider: ProviderConfig{Name: "claude", Binary: "claude"}}}
+
+	session, err := buildYieldSession(
+		"orch-tmux", &mockTerminal{name: "tmux"}, panes, nil,
+		time.Date(2026, time.July, 22, 0, 0, 0, 0, time.UTC),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "tmux", session.TerminalKind)
+	assert.Equal(t, serverRef, session.TmuxServerRef)
+}
+
+func TestSaveAndLoadSession_TmuxServerIdentity_RoundTrips(t *testing.T) {
+	serverRef := setTmuxServerForTest(t, "/tmp/tmux-501/default,12345,0")
+	session := OrchestraSession{
+		ID: "tmux-roundtrip-" + NewSessionID(), TerminalKind: "tmux",
+		TmuxServerRef: serverRef, Panes: map[string]string{"claude": "%42"},
+		CreatedAt: time.Now(),
+	}
+	require.NoError(t, SaveSession(session))
+	t.Cleanup(func() { _ = RemoveSession(session.ID) })
+
+	loaded, err := LoadSession(session.ID)
+
+	require.NoError(t, err)
+	assert.Equal(t, serverRef, loaded.TmuxServerRef)
+}

--- a/pkg/orchestra/session_update_test.go
+++ b/pkg/orchestra/session_update_test.go
@@ -1,0 +1,93 @@
+package orchestra
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateSession_ReplacesPaneSetAtomicallyAndPreservesPermissions(t *testing.T) {
+	session := OrchestraSession{
+		ID:           "update-panes-" + NewSessionID(),
+		TerminalKind: "cmux",
+		WorkspaceRef: "workspace:13",
+		Panes: map[string]string{
+			"claude": "surface:1414",
+			"codex":  "surface:1415",
+		},
+		CreatedAt: time.Now(),
+	}
+	require.NoError(t, SaveSession(session))
+	t.Cleanup(func() { _ = RemoveSession(session.ID) })
+	session.Panes = map[string]string{"codex": "surface:1415"}
+
+	require.NoError(t, UpdateSession(session))
+
+	loaded, err := LoadSession(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, session.Panes, loaded.Panes)
+	info, err := os.Stat(sessionFilePath(session.ID))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestUpdateSession_CommitFailurePreservesOriginalRetryHandle(t *testing.T) {
+	session := OrchestraSession{
+		ID:           "update-failure-" + NewSessionID(),
+		TerminalKind: "cmux",
+		WorkspaceRef: "workspace:13",
+		Panes:        map[string]string{"claude": "surface:1414", "codex": "surface:1415"},
+		CreatedAt:    time.Now(),
+	}
+	require.NoError(t, SaveSession(session))
+	t.Cleanup(func() { _ = RemoveSession(session.ID) })
+	updated := session
+	updated.Panes = map[string]string{"codex": "surface:1415"}
+	injected := errors.New("injected atomic rename failure")
+
+	err := updateSessionWithCommit(updated, func(*os.Root, string, string) error {
+		return injected
+	})
+
+	require.ErrorIs(t, err, injected)
+	loaded, loadErr := LoadSession(session.ID)
+	require.NoError(t, loadErr)
+	assert.Equal(t, session.Panes, loaded.Panes,
+		"a failed replacement must leave the original retry handle intact")
+}
+
+func TestUpdateSession_MissingTargetDoesNotCreateSession(t *testing.T) {
+	session := OrchestraSession{
+		ID:    "update-missing-" + NewSessionID(),
+		Panes: map[string]string{"claude": "surface:1"},
+	}
+
+	err := UpdateSession(session)
+
+	require.Error(t, err)
+	_, loadErr := LoadSession(session.ID)
+	assert.Error(t, loadErr)
+}
+
+func TestUpdateSession_LegacySession_ReplacesRetrySetInPlace(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	session := OrchestraSession{
+		ID:    "legacy-update",
+		Panes: map[string]string{"claude": "%41", "codex": "%42"},
+	}
+	path := writeLegacySessionForTest(t, session)
+	session.Panes = map[string]string{"codex": "%42"}
+
+	require.NoError(t, UpdateSession(session))
+
+	loaded, err := LoadSession(session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, session.Panes, loaded.Panes)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}

--- a/pkg/orchestra/session_workspace_override_test.go
+++ b/pkg/orchestra/session_workspace_override_test.go
@@ -1,0 +1,54 @@
+package orchestra
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveSessionTerminalWithWorkspace_LegacyCmux_UsesExplicitOverride(t *testing.T) {
+	detected := &sessionContextTerminal{
+		mockTerminal: &mockTerminal{name: "cmux"}, workspaceRef: "workspace:99",
+	}
+	session := &OrchestraSession{Panes: map[string]string{"claude": "surface:1414"}}
+
+	resolved, err := ResolveSessionTerminalWithWorkspace(session, detected, "workspace:13")
+
+	require.NoError(t, err)
+	contextual, ok := resolved.(interface{ WorkspaceRef() (string, error) })
+	require.True(t, ok)
+	workspaceRef, err := contextual.WorkspaceRef()
+	require.NoError(t, err)
+	assert.Equal(t, "workspace:13", workspaceRef)
+}
+
+func TestResolveSessionTerminalWithWorkspace_InvalidOverride_FailsClosed(t *testing.T) {
+	session := &OrchestraSession{Panes: map[string]string{"claude": "surface:1414"}}
+
+	_, err := ResolveSessionTerminalWithWorkspace(session, &mockTerminal{name: "cmux"}, "../unsafe")
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "workspace override")
+}
+
+func TestResolveSessionTerminalWithWorkspace_StructuredSessionRejectsConflict(t *testing.T) {
+	session := &OrchestraSession{
+		TerminalKind: "cmux", WorkspaceRef: "workspace:13",
+		Panes: map[string]string{"claude": "surface:1414"},
+	}
+
+	_, err := ResolveSessionTerminalWithWorkspace(session, &mockTerminal{name: "cmux"}, "workspace:21")
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "legacy cmux")
+}
+
+func TestResolveSessionTerminalWithWorkspace_LegacyTmuxRejectsCmuxOverride(t *testing.T) {
+	session := &OrchestraSession{Panes: map[string]string{"claude": "%42"}}
+
+	_, err := ResolveSessionTerminalWithWorkspace(session, &mockTerminal{name: "tmux"}, "workspace:13")
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "cmux pane")
+}

--- a/pkg/orchestra/signal_emitter.go
+++ b/pkg/orchestra/signal_emitter.go
@@ -132,7 +132,7 @@ func (e *SignalEmitter) pollAndEmit(ctx context.Context, pi paneInfo, patterns [
 
 // buildSignalName returns the cmux signal name for a provider/round.
 func buildSignalName(providerName string, round int) string {
-	safe := sanitizeProviderName(providerName)
+	safe := sanitizeProviderName(providerArtifactIdentity(providerName))
 	if round > 1 {
 		return fmt.Sprintf("done-%s-round%d", safe, round)
 	}

--- a/pkg/orchestra/startup_hook_capability_test.go
+++ b/pkg/orchestra/startup_hook_capability_test.go
@@ -1,0 +1,94 @@
+package orchestra
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHookSession_HasStartupHook_UsesIndependentDefaultsAndOverrides(t *testing.T) {
+	t.Parallel()
+
+	session, err := NewHookSession("startup-capability-" + NewSessionID())
+	require.NoError(t, err)
+	defer session.Cleanup()
+
+	assert.True(t, session.HasStartupHook("claude"))
+	assert.True(t, session.HasStartupHook("codex"))
+	assert.False(t, session.HasStartupHook("gemini"))
+	assert.False(t, session.HasStartupHook("opencode"))
+
+	on, off := true, false
+	session.ApplyProviderHooks([]ProviderConfig{
+		{Name: "codex", HasStartupHook: &off},
+		{Name: "opencode", HasHook: &on},
+		{Name: "custom-ready", HasStartupHook: &on},
+	})
+	assert.False(t, session.HasStartupHook("codex"))
+	assert.True(t, session.HasHook("opencode"))
+	assert.False(t, session.HasStartupHook("opencode"))
+	assert.True(t, session.HasStartupHook("custom-ready"))
+}
+
+func TestWaitForPaneReady_CompletionOnlyHooks_UseStableScreen(t *testing.T) {
+	t.Parallel()
+	on := true
+	tests := []struct {
+		name     string
+		provider ProviderConfig
+		screen   string
+	}{
+		{name: "gemini default", provider: ProviderConfig{Name: "gemini"}, screen: "> Type your message\n"},
+		{name: "opencode completion override", provider: ProviderConfig{Name: "opencode", HasHook: &on}, screen: "Ask anything\n"},
+		{name: "custom completion override", provider: ProviderConfig{Name: "custom", HasHook: &on}, screen: "Ask anything\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			session, err := NewHookSession("completion-only-ready-" + NewSessionID())
+			require.NoError(t, err)
+			defer session.Cleanup()
+			session.ApplyProviderHooks([]ProviderConfig{tt.provider})
+			term := &seqScreenMock{name: "cmux", screens: []string{tt.screen, tt.screen}}
+
+			ready := waitForPaneReady(context.Background(), term, "surface:completion-only",
+				SessionReadyPatterns(), time.Second, session, tt.provider.Name, 0)
+
+			assert.True(t, session.HasHook(tt.provider.Name))
+			assert.False(t, session.HasStartupHook(tt.provider.Name))
+			assert.True(t, ready)
+			assert.Equal(t, 2, term.readCalls)
+		})
+	}
+}
+
+func TestWaitForPaneReady_DefaultStartupHooks_MissingSignalFails(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		provider string
+		screen   string
+	}{
+		{provider: "claude", screen: "❯ Try \"write a test for <filepath>\"\n"},
+		{provider: "codex", screen: "› Summarize recent commits\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.provider, func(t *testing.T) {
+			t.Parallel()
+			session, err := NewHookSession("startup-signal-required-" + NewSessionID())
+			require.NoError(t, err)
+			defer session.Cleanup()
+			term := &seqScreenMock{name: "cmux", screens: []string{tt.screen, tt.screen}}
+
+			ready := waitForPaneReady(context.Background(), term, "surface:startup-required",
+				SessionReadyPatterns(), 450*time.Millisecond, session, tt.provider, 0)
+
+			assert.True(t, session.HasStartupHook(tt.provider))
+			assert.False(t, ready, "stable screen cannot replace a required startup artifact")
+		})
+	}
+}

--- a/pkg/orchestra/surface_manager.go
+++ b/pkg/orchestra/surface_manager.go
@@ -16,15 +16,20 @@ var samePaneRetryBackoffs = []time.Duration{200 * time.Millisecond, 400 * time.M
 // proactive stale detection. Replaces the reactive validateSurface() approach.
 // @AX:ANCHOR [AUTO] coordinator — owns background goroutine, health cache, warm pool, and pane recovery; used by runPaneDebate and executeRound
 type SurfaceManager struct {
-	term     terminal.Terminal
-	signal   terminal.SignalCapable // nil if terminal doesn't support signals
-	interval time.Duration          // health check interval (default 5s)
+	term        terminal.Terminal
+	signal      terminal.SignalCapable // nil if terminal doesn't support signals
+	interval    time.Duration          // health check interval (default 5s)
+	hookSession *HookSession
 
 	mu     sync.RWMutex
 	health map[string]terminal.SurfaceStatus // paneID -> last known health
 	cancel context.CancelFunc
 
 	warmPool *WarmPool // pre-created spare panes for instant recovery
+}
+
+func (sm *SurfaceManager) setHookSession(session *HookSession) {
+	sm.hookSession = session
 }
 
 // NewSurfaceManager creates a SurfaceManager. If the terminal supports
@@ -128,35 +133,30 @@ func (sm *SurfaceManager) ValidateAndRecover(ctx context.Context, cfg OrchestraC
 		}
 		return pi, false, nil // No recovery needed
 	}
+	cfg.SurfaceMgr = sm
+	if _, err := recoveryHookSession(cfg); err != nil {
+		return pi, false, err
+	}
 
 	// Surface is stale — try warm pool first for instant recovery.
 	if w := sm.acquireWarm(); w != nil {
 		log.Printf("[SurfaceManager] using warm spare pane for %s (%s -> %s)", pi.provider.Name, pi.paneID, w.paneID)
 
 		newPI := paneInfo{
-			paneID:     w.paneID,
-			outputFile: w.outputFile,
-			provider:   pi.provider,
-			skipWait:   false,
+			paneID:            w.paneID,
+			outputFile:        w.outputFile,
+			provider:          pi.provider,
+			skipWait:          false,
+			directPromptRound: round,
 		}
 
-		// Launch CLI session on the warm pane
-		cmd := buildInteractiveLaunchCmdWithCWD(pi.provider, "", cfg.WorkingDir)
-		sendErr, enterErr := sendPaneInputAndEnterSerialized(ctx, cfg.Terminal, w.paneID, promptRegisterDelay, func() error {
-			return cfg.Terminal.SendLongText(ctx, w.paneID, cmd)
-		})
-		if sendErr != nil {
-			log.Printf("[SurfaceManager] warm pane CLI launch failed, falling back to recreatePane: %v", sendErr)
+		if err := launchRecoveryProvider(ctx, cfg, w.paneID, pi.provider, round); err != nil {
+			log.Printf("[SurfaceManager] warm pane launch preparation failed, falling back to recreatePane: %v", err)
 			sm.warmPool.cleanupPane(ctx, *w)
 			goto coldRecovery
 		}
-		if enterErr != nil {
-			log.Printf("[SurfaceManager] warm pane CLI submit failed, falling back to recreatePane: %v", enterErr)
-			sm.warmPool.cleanupPane(ctx, *w)
-			goto coldRecovery
-		}
-		if !pollUntilSessionReady(ctx, cfg.Terminal, w.paneID, SessionReadyPatterns(), startupTimeoutFor(pi.provider)) {
-			log.Printf("[SurfaceManager] warm pane CLI session did not become ready, falling back to recreatePane")
+		if !waitForRecoveredProviderReady(ctx, cfg, w.paneID, pi.provider, round) {
+			log.Printf("[SurfaceManager] warm pane session did not become stably ready, falling back to recreatePane")
 			sm.warmPool.cleanupPane(ctx, *w)
 			goto coldRecovery
 		}

--- a/pkg/orchestra/surface_manager_test.go
+++ b/pkg/orchestra/surface_manager_test.go
@@ -185,7 +185,7 @@ func TestSurfaceManager_ValidateAndRecover_Healthy(t *testing.T) {
 	newPI, recovered, err := sm.ValidateAndRecover(context.Background(), cfg, pi, 1)
 	require.NoError(t, err)
 	assert.False(t, recovered)
-	assert.Equal(t, pi.paneID, newPI.paneID)
+	assert.Equal(t, pi, newPI, "an existing healthy pane must remain unchanged")
 }
 
 // TestSurfaceManager_ValidateAndRecover_StaleReadScreen verifies recovery when
@@ -208,6 +208,7 @@ func TestSurfaceManager_ValidateAndRecover_StaleReadScreen(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, recovered, "recovery should occur when ReadScreen fails")
 	assert.NotEqual(t, pi.paneID, newPI.paneID, "new pane should have different ID")
+	assert.Equal(t, 1, newPI.directPromptRound)
 }
 
 // TestSurfaceManager_ValidateAndRecover_CachedUnhealthyLiveHealthy preserves a
@@ -290,6 +291,7 @@ func TestSurfaceManager_ValidateAndRecover_WarmReplacementCommitsBeforeOldClose(
 	require.NoError(t, err)
 	assert.True(t, recovered)
 	assert.Equal(t, terminal.PaneID("warm-pane"), newPI.paneID)
+	assert.Equal(t, 1, newPI.directPromptRound)
 	launchIndex := term.eventIndex("launch:warm-pane")
 	closeIndex := term.eventIndex("close:old-pane")
 	require.NotEqual(t, -1, launchIndex)

--- a/pkg/orchestra/surface_tracker.go
+++ b/pkg/orchestra/surface_tracker.go
@@ -58,14 +58,17 @@ func surfaceTrackerFile(pid int) string {
 	return filepath.Join(surfaceTrackerBase, strconv.Itoa(pid)+".surfaces")
 }
 
-// splitTrackedPane splits a pane via the terminal and records the resulting
-// surface ref for orphan reaping. On the first call in this process it also reaps
-// surfaces left behind by orchestrator processes that are no longer alive.
+// splitTrackedPane owns tracking and cleanup for every non-empty SplitPane
+// result, including a pane ID returned together with an error. On the first call
+// it also reaps surfaces whose orchestrator processes are no longer alive.
 func splitTrackedPane(ctx context.Context, term terminal.Terminal, dir terminal.Direction) (terminal.PaneID, error) {
 	reapOrphanSurfacesOnce.Do(func() { ReapOrphanSurfaces(term) })
 	paneID, err := term.SplitPane(ctx, dir)
-	if err == nil && paneID != "" {
+	if paneID != "" {
 		trackSurfaceForTerminal(term, string(paneID))
+		if err != nil {
+			closePaneSurface(term, paneID)
+		}
 	}
 	return paneID, err
 }

--- a/pkg/orchestra/surface_tracker.go
+++ b/pkg/orchestra/surface_tracker.go
@@ -3,6 +3,7 @@ package orchestra
 import (
 	"context"
 	"errors"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
@@ -38,17 +39,9 @@ var surfaceTrackerLegacyBase = filepath.Join(os.TempDir(), "autopus", "surfaces"
 // validSurfaceRef matches safe cmux and tmux surface reference formats.
 var validSurfaceRef = regexp.MustCompile(`^([A-Za-z]+:[0-9]+|%[0-9]+)$`)
 
-func surfaceRefCompatible(backend, ref string) bool {
-	if backend == "tmux" {
-		return strings.HasPrefix(ref, "%")
-	}
-	return backend == "cmux" && !strings.HasPrefix(ref, "%")
-}
-
 // surfaceTrackerRoot returns the preferred base directory for surface tracking
 // files. It prefers ~/.autopus/surfaces and falls back to TempDir when the home
-// directory is unavailable. Callers (trackSurface) are responsible for creating
-// the directory with MkdirAll and verifying ownership/mode before writing.
+// directory is unavailable.
 func surfaceTrackerRoot() string {
 	home, err := os.UserHomeDir()
 	if err == nil && home != "" {
@@ -72,33 +65,51 @@ func splitTrackedPane(ctx context.Context, term terminal.Terminal, dir terminal.
 	reapOrphanSurfacesOnce.Do(func() { ReapOrphanSurfaces(term) })
 	paneID, err := term.SplitPane(ctx, dir)
 	if err == nil && paneID != "" {
-		trackSurface(string(paneID))
+		trackSurfaceForTerminal(term, string(paneID))
 	}
 	return paneID, err
 }
 
-// trackSurface appends a surface ref to this process's tracking file (best-effort;
-// tracking failures must never block pane creation). Before writing, it verifies
-// that the tracking directory is owned by the current user with mode 0700 (no
-// group/other bits). A mismatch indicates a privilege or symlink-swap attack and
-// causes the write to be silently skipped (REQ-007).
+// trackSurface records a legacy surface ref using an atomic replacement. It is
+// best-effort because tracking failures must never block pane creation.
 func trackSurface(ref string) {
-	if ref == "" {
-		return
-	}
-	if err := os.MkdirAll(surfaceTrackerBase, 0o700); err != nil {
-		return
-	}
-	// Security: verify ownership and mode before writing (platform-specific).
-	if !surfaceDirSecure(surfaceTrackerBase) {
-		return
-	}
-	f, err := os.OpenFile(surfaceTrackerFile(os.Getpid()), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	trackSurfaceRecord(trackedSurface{Ref: ref})
+}
+
+func trackSurfaceForTerminal(term terminal.Terminal, ref string) {
+	tracked, err := trackedSurfaceForTerminal(term, ref)
 	if err != nil {
+		if term == nil || term.Name() == "plain" {
+			return
+		}
+		log.Printf("[surface-tracker] recording unresolved %s ref %q: %v", term.Name(), ref, err)
+		tracked = trackedSurface{Ref: ref, TerminalKind: term.Name()}
+	}
+	trackSurfaceRecord(tracked)
+}
+
+func trackSurfaceRecord(tracked trackedSurface) {
+	if tracked.Ref == "" {
 		return
 	}
-	defer func() { _ = f.Close() }()
-	_, _ = f.WriteString(ref + "\n")
+	surfaceTrackerMu.Lock()
+	defer surfaceTrackerMu.Unlock()
+	root, err := openSecureTrackerRoot(surfaceTrackerBase, true)
+	if err != nil {
+		log.Printf("[surface-tracker] refusing tracker write: %v", err)
+		return
+	}
+	defer func() { _ = root.Close() }()
+	name := filepath.Base(surfaceTrackerFile(os.Getpid()))
+	current, _, readErr := readTrackedSurfacesFromRoot(root, name)
+	if readErr != nil && !errors.Is(readErr, fs.ErrNotExist) {
+		log.Printf("[surface-tracker] refusing tracker update: %v", readErr)
+		return
+	}
+	current = append(current, tracked)
+	if err := writeTrackedSurfacesToRoot(root, name, current, nil); err != nil {
+		log.Printf("[surface-tracker] tracker write failed: %v", err)
+	}
 }
 
 // untrackSurface removes a closed surface ref from this process's tracking file.
@@ -108,32 +119,95 @@ func untrackSurface(ref string) {
 	if ref == "" {
 		return
 	}
-	path := surfaceTrackerFile(os.Getpid())
-	refs := readTrackerRefs(path)
-	if len(refs) == 0 {
-		return
+	if err := untrackSurfaceWithoutTerminal(ref); err != nil {
+		log.Printf("[surface-tracker] untrack ref %q failed: %v", ref, err)
 	}
-	kept := refs[:0]
-	for _, r := range refs {
-		if r != ref {
-			kept = append(kept, r)
+}
+
+// untrackSurfaceForTerminal removes only the exact backend/workspace/server
+// tuple. It returns persistence failures so ownership handoff can fail closed.
+func untrackSurfaceForTerminal(term terminal.Terminal, ref string) error {
+	target, err := trackedSurfaceForTerminal(term, ref)
+	if err != nil {
+		return err
+	}
+	return mutateCurrentTracker(func(item trackedSurface) (bool, error) {
+		return sameTrackedSurface(item, target), nil
+	})
+}
+
+func untrackSurfaceWithoutTerminal(ref string) error {
+	return mutateCurrentTracker(func(item trackedSurface) (bool, error) {
+		return item.Ref == ref, nil
+	})
+}
+
+func mutateCurrentTracker(match func(trackedSurface) (bool, error)) error {
+	surfaceTrackerMu.Lock()
+	defer surfaceTrackerMu.Unlock()
+	root, err := openSecureTrackerRoot(surfaceTrackerBase, false)
+	if errors.Is(err, fs.ErrNotExist) || os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
+	name := filepath.Base(surfaceTrackerFile(os.Getpid()))
+	tracked, _, err := readTrackedSurfacesFromRoot(root, name)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	matched := make([]bool, len(tracked))
+	identities := make(map[surfaceIdentity]struct{})
+	legacyMatches := 0
+	matchCount := 0
+	for index, item := range tracked {
+		matched[index], err = match(item)
+		if err != nil {
+			return err
+		}
+		if !matched[index] {
+			continue
+		}
+		matchCount++
+		identity, identityErr := trackedSurfaceIdentity(item)
+		if identityErr != nil {
+			legacyMatches++
+			continue
+		}
+		identities[identity] = struct{}{}
+	}
+	if len(identities)+legacyMatches > 1 {
+		return errors.New("surface ref is ambiguous across tracker identities")
+	}
+	if matchCount == 0 {
+		return nil
+	}
+	kept := make([]trackedSurface, 0, len(tracked))
+	for index, item := range tracked {
+		if !matched[index] {
+			kept = append(kept, item)
 		}
 	}
-	writeTrackerRefs(path, kept)
+	return writeTrackedSurfacesToRoot(root, name, kept, nil)
 }
 
 // ReapOrphanSurfaces closes surfaces recorded by orchestrator processes that are
 // no longer alive and removes their tracking files. It never touches the current
 // process's surfaces or those of a live process, so it is safe to run while a
-// concurrent orchestra holds its own panes. It is a no-op for terminals that
-// cannot host surfaces (plain) so cmux tracking files are not discarded without
-// actually closing their surfaces.
+// concurrent orchestra holds its own panes. Structured cmux records can restore
+// their persisted workspace; tmux records require the active server identity to
+// match. Legacy cmux refs remain untouched because their workspace is unknown.
 //
 // Each ref is validated against validSurfaceRef before being passed to Close;
 // refs that fail validation are logged and skipped (REQ-007). The legacy
-// TempDir-based path is also reaped read-only (no MkdirAll).
+// TempDir-based path is also inspected without creating it.
 func ReapOrphanSurfaces(term terminal.Terminal) {
-	if term == nil || term.Name() == "plain" {
+	if term == nil {
 		return
 	}
 	reapOrphanSurfacesFromDir(surfaceTrackerBase, term)
@@ -144,9 +218,16 @@ func ReapOrphanSurfaces(term terminal.Terminal) {
 
 // reapOrphanSurfacesFromDir reaps compatible refs and retains retryable refs.
 func reapOrphanSurfacesFromDir(dir string, term terminal.Terminal) {
-	entries, err := os.ReadDir(dir)
+	surfaceTrackerMu.Lock()
+	defer surfaceTrackerMu.Unlock()
+	root, err := openSecureTrackerRoot(dir, false)
 	if err != nil {
-		return // dir absent or unreadable — silent no-op
+		return
+	}
+	defer func() { _ = root.Close() }()
+	entries, err := fs.ReadDir(root.FS(), ".")
+	if err != nil {
+		return
 	}
 	self := os.Getpid()
 	for _, e := range entries {
@@ -157,48 +238,41 @@ func reapOrphanSurfacesFromDir(dir string, term terminal.Terminal) {
 		if perr != nil || pid == self || processAlive(pid) {
 			continue
 		}
+		// Refresh claims only after the owner is known to be dead. A yielding
+		// process saves its durable session before it exits, so this ordering
+		// closes the snapshot race between session persistence and process exit.
+		claims := loadPersistedSessionSurfaceClaims()
 		path := filepath.Join(dir, e.Name())
-		refs := readTrackerRefs(path)
-		kept := refs[:0]
-		for _, ref := range refs {
+		tracked, _, readErr := readTrackedSurfacesFromRoot(root, e.Name())
+		if readErr != nil {
+			log.Printf("[surface-tracker] refusing entry %s: %v", path, readErr)
+			continue
+		}
+		kept := tracked[:0]
+		for _, item := range tracked {
+			ref := item.Ref
 			if !validSurfaceRef.MatchString(ref) {
-				log.Printf("[surface-tracker] skipping invalid ref %q from %s", ref, path)
+				log.Printf("[surface-tracker] retaining invalid or malformed ref %q from %s", ref, path)
+				kept = append(kept, item)
 				continue
 			}
-			if !surfaceRefCompatible(term.Name(), ref) {
-				kept = append(kept, ref)
+			if claims.owns(item, term) {
 				continue
 			}
-			if err := term.Close(context.Background(), ref); err != nil {
-				kept = append(kept, ref)
+			closeTerminal, resolveErr := resolveTrackedSurfaceTerminal(term, item)
+			if resolveErr != nil {
+				log.Printf("[surface-tracker] retaining ref %q from %s: %v", ref, path, resolveErr)
+				kept = append(kept, item)
+				continue
+			}
+			if err := closeTerminal.Close(context.Background(), ref); err != nil {
+				kept = append(kept, item)
 			}
 		}
-		writeTrackerRefs(path, kept)
-	}
-}
-
-// readTrackerRefs returns the non-empty surface refs recorded in a tracking file.
-func readTrackerRefs(path string) []string {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil
-	}
-	var refs []string
-	for _, line := range strings.Split(string(data), "\n") {
-		if line = strings.TrimSpace(line); line != "" {
-			refs = append(refs, line)
+		if err := writeTrackedSurfacesToRoot(root, e.Name(), kept, nil); err != nil {
+			log.Printf("[surface-tracker] preserving old tracker %s after update failure: %v", path, err)
 		}
 	}
-	return refs
-}
-
-// writeTrackerRefs rewrites a tracking file, removing it entirely when empty.
-func writeTrackerRefs(path string, refs []string) {
-	if len(refs) == 0 {
-		_ = os.Remove(path)
-		return
-	}
-	_ = os.WriteFile(path, []byte(strings.Join(refs, "\n")+"\n"), 0o600)
 }
 
 // processAlive reports whether a process with the given PID currently exists.

--- a/pkg/orchestra/surface_tracker_atomic_test.go
+++ b/pkg/orchestra/surface_tracker_atomic_test.go
@@ -1,0 +1,150 @@
+package orchestra
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type trackerWriteStub struct {
+	info       fs.FileInfo
+	writeCount int
+	writeErr   error
+	syncErr    error
+	closeErr   error
+	closed     bool
+}
+
+func (s *trackerWriteStub) Stat() (fs.FileInfo, error) { return s.info, nil }
+func (s *trackerWriteStub) Chmod(os.FileMode) error    { return nil }
+func (s *trackerWriteStub) Write(data []byte) (int, error) {
+	if s.writeCount > 0 {
+		return s.writeCount, s.writeErr
+	}
+	return len(data), s.writeErr
+}
+func (s *trackerWriteStub) Sync() error {
+	return s.syncErr
+}
+func (s *trackerWriteStub) Close() error {
+	s.closed = true
+	return s.closeErr
+}
+
+func TestPersistTrackerReplacement_ShortWriteDoesNotCommit(t *testing.T) {
+	dir := secureTrackerTestDir(t)
+	temporary := filepath.Join(dir, "record.tmp")
+	require.NoError(t, os.WriteFile(temporary, nil, 0o600))
+	info, err := os.Stat(temporary)
+	require.NoError(t, err)
+	root, err := os.OpenRoot(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = root.Close() })
+	commitCalled := false
+	file := &trackerWriteStub{info: info, writeCount: 3}
+
+	err = persistTrackerReplacement(root, "record.tmp", "record.surfaces", file, []byte("complete"),
+		func(*os.Root, string, string) error {
+			commitCalled = true
+			return nil
+		})
+
+	require.ErrorIs(t, err, io.ErrShortWrite)
+	assert.False(t, commitCalled)
+	assert.True(t, file.closed)
+}
+
+func TestWriteTrackedSurfaces_RenameFailurePreservesOldHandle(t *testing.T) {
+	dir := secureTrackerTestDir(t)
+	path := filepath.Join(dir, "2147480110.surfaces")
+	old := `{"surface_ref":"surface:1","terminal_kind":"cmux","workspace_ref":"workspace:13"}` + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(old), 0o600))
+	injected := errors.New("rename failed")
+
+	err := writeTrackedSurfacesWithCommit(path, trackedCmuxSurfaces("workspace:13", "surface:2"),
+		func(*os.Root, string, string) error { return injected })
+
+	require.ErrorIs(t, err, injected)
+	data, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	assert.Equal(t, old, string(data))
+}
+
+func TestPersistTrackerReplacement_SyncFailureDoesNotCommit(t *testing.T) {
+	dir := secureTrackerTestDir(t)
+	root, err := os.OpenRoot(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = root.Close() })
+	target := "2147480111.surfaces"
+	temporary := target + ".tmp"
+	old := []byte("surface:1\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, target), old, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, temporary), nil, 0o600))
+	info, err := os.Stat(filepath.Join(dir, temporary))
+	require.NoError(t, err)
+	injected := errors.New("sync failed")
+	file := &trackerWriteStub{info: info, syncErr: injected}
+	commitCalled := false
+
+	err = persistTrackerReplacement(root, temporary, target, file, []byte("surface:2\n"),
+		func(*os.Root, string, string) error {
+			commitCalled = true
+			return nil
+		})
+
+	require.ErrorIs(t, err, injected)
+	assert.False(t, commitCalled)
+	data, readErr := os.ReadFile(filepath.Join(dir, target))
+	require.NoError(t, readErr)
+	assert.Equal(t, old, data)
+}
+
+func TestTrackSurfaceRecord_ConcurrentRMWPreservesEveryHandle(t *testing.T) {
+	original := surfaceTrackerBase
+	surfaceTrackerBase = filepath.Join(secureTrackerTestDir(t), "surfaces")
+	t.Cleanup(func() { surfaceTrackerBase = original })
+	const count = 32
+	var wg sync.WaitGroup
+	wg.Add(count)
+	for index := 0; index < count; index++ {
+		index := index
+		go func() {
+			defer wg.Done()
+			trackSurfaceRecord(trackedSurface{
+				Ref: "surface:" + decimalString(index+1), TerminalKind: "cmux", WorkspaceRef: "workspace:13",
+			})
+		}()
+	}
+
+	wg.Wait()
+
+	tracked := readTrackedSurfaces(surfaceTrackerFile(os.Getpid()))
+	require.Len(t, tracked, count)
+	seen := make(map[string]struct{}, count)
+	for _, item := range tracked {
+		seen[item.Ref] = struct{}{}
+	}
+	assert.Len(t, seen, count)
+}
+
+func decimalString(value int) string {
+	const digits = "0123456789"
+	if value == 0 {
+		return "0"
+	}
+	var raw [20]byte
+	index := len(raw)
+	for value > 0 {
+		index--
+		raw[index] = digits[value%10]
+		value /= 10
+	}
+	return string(raw[index:])
+}

--- a/pkg/orchestra/surface_tracker_context.go
+++ b/pkg/orchestra/surface_tracker_context.go
@@ -1,0 +1,62 @@
+package orchestra
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/insajin/autopus-adk/pkg/terminal"
+)
+
+var newTrackedCmuxTerminal = func(workspaceRef string) (terminal.Terminal, error) {
+	return terminal.NewCmuxAdapterWithWorkspace(workspaceRef)
+}
+
+func resolveTrackedSurfaceTerminal(current terminal.Terminal, tracked trackedSurface) (terminal.Terminal, error) {
+	if current == nil {
+		return nil, errors.New("no terminal context available")
+	}
+	if tracked.TerminalKind == "" {
+		if strings.HasPrefix(tracked.Ref, "%") {
+			if current.Name() != "tmux" {
+				return nil, errors.New("legacy tmux surface requires an active tmux context")
+			}
+			if _, ok := currentTmuxServerRef(); !ok {
+				return nil, errors.New("active tmux server identity is unavailable")
+			}
+			return current, nil
+		}
+		return nil, errors.New("legacy surface has no proven workspace context")
+	}
+	if tracked.TerminalKind == "tmux" {
+		identity, err := trackedSurfaceIdentity(tracked)
+		if err != nil {
+			return nil, err
+		}
+		if current.Name() != "tmux" {
+			return nil, errors.New("tracked tmux surface requires an active tmux context")
+		}
+		currentRef, ok := currentTmuxServerRef()
+		if !ok {
+			return nil, errors.New("active tmux server identity is unavailable")
+		}
+		if currentRef != identity.TmuxServerRef {
+			return nil, errors.New("tracked tmux surface belongs to a different server")
+		}
+		return current, nil
+	}
+	if tracked.TerminalKind != "cmux" {
+		return nil, errors.New("unsupported tracked terminal backend")
+	}
+	identity, err := trackedSurfaceIdentity(tracked)
+	if err != nil {
+		return nil, err
+	}
+	if current.Name() == "cmux" {
+		provider, ok := current.(terminal.WorkspaceContextProvider)
+		if !ok {
+			return nil, errors.New("cmux terminal cannot restore tracked workspace context")
+		}
+		return provider.WithWorkspaceRef(identity.WorkspaceRef)
+	}
+	return newTrackedCmuxTerminal(identity.WorkspaceRef)
+}

--- a/pkg/orchestra/surface_tracker_context_test.go
+++ b/pkg/orchestra/surface_tracker_context_test.go
@@ -1,0 +1,119 @@
+package orchestra
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/insajin/autopus-adk/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+)
+
+type trackerTerminalState struct {
+	closeCalls      []string
+	closeWorkspaces []string
+	closeErr        error
+}
+
+type trackerContextTerminal struct {
+	*mockTerminal
+	workspaceRef string
+	state        *trackerTerminalState
+}
+
+func newTrackerContextTerminal(workspaceRef string) *trackerContextTerminal {
+	return &trackerContextTerminal{
+		mockTerminal: &mockTerminal{name: "cmux"},
+		workspaceRef: workspaceRef,
+		state:        &trackerTerminalState{},
+	}
+}
+
+func (t *trackerContextTerminal) WorkspaceRef() (string, error) {
+	return t.workspaceRef, nil
+}
+
+func (t *trackerContextTerminal) WithWorkspaceRef(ref string) (terminal.Terminal, error) {
+	return &trackerContextTerminal{
+		mockTerminal: t.mockTerminal, workspaceRef: ref, state: t.state,
+	}, nil
+}
+
+func (t *trackerContextTerminal) Close(_ context.Context, ref string) error {
+	t.state.closeCalls = append(t.state.closeCalls, ref)
+	t.state.closeWorkspaces = append(t.state.closeWorkspaces, t.workspaceRef)
+	return t.state.closeErr
+}
+
+func trackedCmuxSurfaces(workspace string, refs ...string) []trackedSurface {
+	tracked := make([]trackedSurface, 0, len(refs))
+	for _, ref := range refs {
+		tracked = append(tracked, trackedSurface{
+			Ref: ref, TerminalKind: "cmux", WorkspaceRef: workspace,
+		})
+	}
+	return tracked
+}
+
+func TestTrackSurfaceForTerminal_PersistsBackendAndWorkspace(t *testing.T) {
+	orig := surfaceTrackerBase
+	surfaceTrackerBase = filepath.Join(secureTrackerTestDir(t), "surfaces")
+	defer func() { surfaceTrackerBase = orig }()
+	term := newTrackerContextTerminal("workspace:13")
+
+	trackSurfaceForTerminal(term, "surface:1414")
+
+	assert.Equal(t, []trackedSurface{{
+		Ref: "surface:1414", TerminalKind: "cmux", WorkspaceRef: "workspace:13",
+	}}, readTrackedSurfaces(surfaceTrackerFile(os.Getpid())))
+}
+
+func TestReapOrphanSurfaces_LegacyTmuxGlobalPane_RequiresActiveTmux(t *testing.T) {
+	orig := surfaceTrackerBase
+	surfaceTrackerBase = secureTrackerTestDir(t)
+	defer func() { surfaceTrackerBase = orig }()
+	trackerFile := surfaceTrackerFile(2147480006)
+	writeTrackerRefs(trackerFile, []string{"%42"})
+
+	term := newTrackerContextTerminal("workspace:13")
+	ReapOrphanSurfaces(term)
+
+	assert.Empty(t, term.state.closeCalls)
+	assert.Equal(t, []string{"%42"}, readTrackerRefs(trackerFile))
+}
+
+func TestReapOrphanSurfaces_LegacyCmuxRecordWithoutWorkspace_FailsClosed(t *testing.T) {
+	orig := surfaceTrackerBase
+	surfaceTrackerBase = secureTrackerTestDir(t)
+	defer func() { surfaceTrackerBase = orig }()
+	trackerFile := surfaceTrackerFile(2147480008)
+	writeTrackerRefs(trackerFile, []string{"surface:88"})
+	term := newTrackerContextTerminal("workspace:current")
+
+	ReapOrphanSurfaces(term)
+
+	assert.Empty(t, term.state.closeCalls)
+	assert.Equal(t, []string{"surface:88"}, readTrackerRefs(trackerFile))
+}
+
+func TestReapOrphanSurfaces_PersistedCmuxFromTmuxContext_RestoresBackend(t *testing.T) {
+	orig := surfaceTrackerBase
+	surfaceTrackerBase = secureTrackerTestDir(t)
+	originalFactory := newTrackedCmuxTerminal
+	restored := newTrackerContextTerminal("workspace:13")
+	newTrackedCmuxTerminal = func(string) (terminal.Terminal, error) { return restored, nil }
+	defer func() {
+		surfaceTrackerBase = orig
+		newTrackedCmuxTerminal = originalFactory
+	}()
+	trackerFile := surfaceTrackerFile(2147480009)
+	writeTrackedSurfaces(trackerFile, trackedCmuxSurfaces("workspace:13", "surface:99"))
+
+	ReapOrphanSurfaces(&mockTerminal{name: "tmux"})
+
+	assert.Equal(t, []string{"surface:99"}, restored.state.closeCalls)
+	assert.Equal(t, []string{"workspace:13"}, restored.state.closeWorkspaces)
+	_, err := os.Stat(trackerFile)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}

--- a/pkg/orchestra/surface_tracker_fifo_unix_test.go
+++ b/pkg/orchestra/surface_tracker_fifo_unix_test.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package orchestra
+
+import "golang.org/x/sys/unix"
+
+func fifoSupported() bool { return true }
+
+func createTrackerFIFO(path string) error {
+	return unix.Mkfifo(path, 0o600)
+}
+
+func unblockTrackerFIFO(path string) {
+	fd, err := unix.Open(path, unix.O_WRONLY|unix.O_NONBLOCK, 0)
+	if err == nil {
+		_ = unix.Close(fd)
+	}
+}

--- a/pkg/orchestra/surface_tracker_fifo_windows_test.go
+++ b/pkg/orchestra/surface_tracker_fifo_windows_test.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package orchestra
+
+import "errors"
+
+func fifoSupported() bool { return false }
+
+func createTrackerFIFO(string) error { return errors.New("FIFO unsupported") }
+
+func unblockTrackerFIFO(string) {}

--- a/pkg/orchestra/surface_tracker_handoff.go
+++ b/pkg/orchestra/surface_tracker_handoff.go
@@ -1,0 +1,155 @@
+package orchestra
+
+import (
+	"io/fs"
+	"os"
+	"strings"
+
+	"github.com/insajin/autopus-adk/pkg/terminal"
+)
+
+const maxSessionClaimFileSize = 64 << 20
+
+type sessionSurfaceClaims struct {
+	exact          map[surfaceIdentity]struct{}
+	legacyTmuxRefs map[string]struct{}
+}
+
+func newSessionSurfaceClaims() sessionSurfaceClaims {
+	return sessionSurfaceClaims{
+		exact:          make(map[surfaceIdentity]struct{}),
+		legacyTmuxRefs: make(map[string]struct{}),
+	}
+}
+
+func (claims sessionSurfaceClaims) owns(tracked trackedSurface, current terminal.Terminal) bool {
+	identity, err := trackedSurfaceIdentity(tracked)
+	if err == nil {
+		_, ok := claims.exact[identity]
+		return ok
+	}
+	if tracked.TerminalKind != "" || current == nil || current.Name() != "tmux" ||
+		!hasOnlyGlobalTmuxPanes(map[string]string{"tracked": tracked.Ref}) {
+		return false
+	}
+	if _, ok := currentTmuxServerRef(); !ok {
+		return false
+	}
+	_, ok := claims.legacyTmuxRefs[tracked.Ref]
+	return ok
+}
+
+func loadPersistedSessionSurfaceClaims() sessionSurfaceClaims {
+	claims := newSessionSurfaceClaims()
+	loadPrivateSessionSurfaceClaims(claims)
+	loadLegacySessionSurfaceClaims(claims)
+	return claims
+}
+
+func loadPrivateSessionSurfaceClaims(claims sessionSurfaceClaims) {
+	root, err := openSessionRoot(false)
+	if err != nil {
+		return
+	}
+	defer func() { _ = root.Close() }()
+	if !surfaceDirSecure(sessionDirectoryPath()) {
+		return
+	}
+	loadSessionSurfaceClaimsFromRoot(claims, root, func(name string) (string, bool) {
+		if !strings.HasSuffix(name, ".json") {
+			return "", false
+		}
+		id := strings.TrimSuffix(name, ".json")
+		expected, err := sessionFilename(id)
+		return id, err == nil && expected == name
+	})
+}
+
+func loadLegacySessionSurfaceClaims(claims sessionSurfaceClaims) {
+	root, err := openLegacySessionRoot()
+	if err != nil {
+		return
+	}
+	defer func() { _ = root.Close() }()
+	loadSessionSurfaceClaimsFromRoot(claims, root, func(name string) (string, bool) {
+		if !strings.HasPrefix(name, legacySessionFilenamePrefix) || !strings.HasSuffix(name, ".json") {
+			return "", false
+		}
+		id := strings.TrimSuffix(strings.TrimPrefix(name, legacySessionFilenamePrefix), ".json")
+		expected, err := legacySessionFilename(id)
+		return id, err == nil && expected == name
+	})
+}
+
+func loadSessionSurfaceClaimsFromRoot(
+	claims sessionSurfaceClaims,
+	root *os.Root,
+	parseName func(string) (string, bool),
+) {
+	entries, err := fs.ReadDir(root.FS(), ".")
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		id, ok := parseName(name)
+		if entry.IsDir() || !ok {
+			continue
+		}
+		info, err := root.Lstat(name)
+		if err != nil || !sessionClaimFileInfoSecure(info) {
+			continue
+		}
+		session, openedInfo, err := readSessionEntry(root, name, id)
+		if err != nil || !sessionClaimFileInfoSecure(openedInfo) ||
+			!os.SameFile(info, openedInfo) {
+			continue
+		}
+		claims.addSession(session)
+	}
+}
+
+func sessionClaimFileInfoSecure(info fs.FileInfo) bool {
+	return info != nil && info.Mode().IsRegular() && info.Mode()&os.ModeSymlink == 0 &&
+		info.Size() >= 0 && info.Size() <= maxSessionClaimFileSize &&
+		trackerInfoOwnedByCurrentUser(info) && trackerModeSecure(info, 0o600)
+}
+
+func (claims sessionSurfaceClaims) addSession(session *OrchestraSession) {
+	if session == nil || len(session.Panes) == 0 {
+		return
+	}
+	switch session.TerminalKind {
+	case "cmux":
+		if session.TmuxServerRef != "" {
+			return
+		}
+		workspaceRef, err := canonicalCmuxWorkspaceRef(session.WorkspaceRef)
+		if err != nil || !hasOnlyCmuxPanes(session.Panes) {
+			return
+		}
+		for _, ref := range session.Panes {
+			claims.exact[surfaceIdentity{
+				Ref: ref, TerminalKind: "cmux", WorkspaceRef: workspaceRef,
+			}] = struct{}{}
+		}
+	case "tmux":
+		if session.WorkspaceRef != "" || !validTmuxServerRef.MatchString(session.TmuxServerRef) ||
+			!hasOnlyGlobalTmuxPanes(session.Panes) {
+			return
+		}
+		for _, ref := range session.Panes {
+			claims.exact[surfaceIdentity{
+				Ref: ref, TerminalKind: "tmux", TmuxServerRef: session.TmuxServerRef,
+			}] = struct{}{}
+		}
+	case "":
+		if session.WorkspaceRef != "" || session.TmuxServerRef != "" ||
+			!hasOnlyGlobalTmuxPanes(session.Panes) {
+			return
+		}
+		for _, ref := range session.Panes {
+			claims.legacyTmuxRefs[ref] = struct{}{}
+		}
+	}
+}

--- a/pkg/orchestra/surface_tracker_handoff_test.go
+++ b/pkg/orchestra/surface_tracker_handoff_test.go
@@ -1,0 +1,175 @@
+package orchestra
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReapOrphanSurfaces_PersistedCmuxSessionOwnsTrackedPane(t *testing.T) {
+	trackerDir := isolateTrackerAndSessionStorage(t)
+	session := OrchestraSession{
+		ID:           "handoff-protected-" + NewSessionID(),
+		TerminalKind: "cmux",
+		WorkspaceRef: "workspace:13",
+		Panes:        map[string]string{"claude": "surface:41"},
+		CreatedAt:    time.Now(),
+	}
+	require.NoError(t, SaveSession(session))
+	t.Cleanup(func() { _ = RemoveSession(session.ID) })
+	trackerFile := filepath.Join(trackerDir, "2147480130.surfaces")
+	writeTrackedSurfaces(trackerFile, trackedCmuxSurfaces("workspace:13", "surface:41"))
+	term := newTrackerContextTerminal("workspace:current")
+
+	ReapOrphanSurfaces(term)
+
+	assert.Empty(t, term.state.closeCalls, "a durable session owns the pane")
+	_, err := os.Lstat(trackerFile)
+	assert.ErrorIs(t, err, os.ErrNotExist, "handoff record should leave the orphan queue")
+	_, err = LoadSession(session.ID)
+	assert.NoError(t, err, "the durable cleanup handle remains authoritative")
+}
+
+func TestReapOrphanSurfaces_DifferentPersistedWorkspaceDoesNotClaimPane(t *testing.T) {
+	trackerDir := isolateTrackerAndSessionStorage(t)
+	session := OrchestraSession{
+		ID:           "handoff-other-workspace-" + NewSessionID(),
+		TerminalKind: "cmux",
+		WorkspaceRef: "workspace:21",
+		Panes:        map[string]string{"claude": "surface:41"},
+		CreatedAt:    time.Now(),
+	}
+	require.NoError(t, SaveSession(session))
+	t.Cleanup(func() { _ = RemoveSession(session.ID) })
+	trackerFile := filepath.Join(trackerDir, "2147480131.surfaces")
+	writeTrackedSurfaces(trackerFile, trackedCmuxSurfaces("workspace:13", "surface:41"))
+	term := newTrackerContextTerminal("workspace:current")
+
+	ReapOrphanSurfaces(term)
+
+	assert.Equal(t, []string{"surface:41"}, term.state.closeCalls)
+	assert.Equal(t, []string{"workspace:13"}, term.state.closeWorkspaces)
+}
+
+func TestReapOrphanSurfaces_PersistedTmuxSessionOwnsTrackedPane(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux-501/default,12345,7")
+	serverRef, ok := currentTmuxServerRef()
+	require.True(t, ok)
+	trackerDir := isolateTrackerAndSessionStorage(t)
+	session := OrchestraSession{
+		ID:            "handoff-tmux-" + NewSessionID(),
+		TerminalKind:  "tmux",
+		TmuxServerRef: serverRef,
+		Panes:         map[string]string{"claude": "%41"},
+		CreatedAt:     time.Now(),
+	}
+	require.NoError(t, SaveSession(session))
+	t.Cleanup(func() { _ = RemoveSession(session.ID) })
+	trackerFile := filepath.Join(trackerDir, "2147480133.surfaces")
+	writeTrackedSurfaces(trackerFile, []trackedSurface{{
+		Ref: "%41", TerminalKind: "tmux", TmuxServerRef: serverRef,
+	}})
+	term := &mockTerminal{name: "tmux"}
+
+	ReapOrphanSurfaces(term)
+
+	assert.Empty(t, term.closeCalls, "a durable session owns the pane")
+	_, err := os.Lstat(trackerFile)
+	assert.ErrorIs(t, err, os.ErrNotExist, "handoff record should leave the orphan queue")
+}
+
+func TestReapOrphanSurfaces_DifferentPersistedTmuxServerDoesNotClaimPane(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux-501/default,12345,7")
+	currentRef, ok := currentTmuxServerRef()
+	require.True(t, ok)
+	trackerDir := isolateTrackerAndSessionStorage(t)
+	session := OrchestraSession{
+		ID:            "handoff-other-tmux-" + NewSessionID(),
+		TerminalKind:  "tmux",
+		TmuxServerRef: "tmux-sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Panes:         map[string]string{"claude": "%41"},
+		CreatedAt:     time.Now(),
+	}
+	require.NoError(t, SaveSession(session))
+	t.Cleanup(func() { _ = RemoveSession(session.ID) })
+	trackerFile := filepath.Join(trackerDir, "2147480134.surfaces")
+	writeTrackedSurfaces(trackerFile, []trackedSurface{{
+		Ref: "%41", TerminalKind: "tmux", TmuxServerRef: currentRef,
+	}})
+	term := &mockTerminal{name: "tmux"}
+
+	ReapOrphanSurfaces(term)
+
+	assert.Equal(t, []string{"%41"}, term.closeCalls)
+}
+
+func TestReapOrphanSurfaces_LegacyTmuxSessionOwnsLegacyTracker(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux-501/default,12345,7")
+	trackerDir := isolateTrackerAndSessionStorage(t)
+	session := OrchestraSession{
+		ID:        "legacy-handoff-" + NewSessionID(),
+		Panes:     map[string]string{"claude": "%43"},
+		CreatedAt: time.Now(),
+	}
+	name, err := legacySessionFilename(session.ID)
+	require.NoError(t, err)
+	data, err := json.Marshal(session)
+	require.NoError(t, err)
+	legacyPath := filepath.Join(os.TempDir(), name)
+	require.NoError(t, os.WriteFile(legacyPath, data, 0o600))
+	t.Cleanup(func() { _ = os.Remove(legacyPath) })
+	trackerFile := filepath.Join(trackerDir, "2147480135.surfaces")
+	writeTrackerRefs(trackerFile, []string{"%43"})
+	term := &mockTerminal{name: "tmux"}
+
+	ReapOrphanSurfaces(term)
+
+	assert.Empty(t, term.closeCalls)
+	_, err = os.Lstat(trackerFile)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestReapOrphanSurfaces_InsecureSessionFileDoesNotClaimPane(t *testing.T) {
+	trackerDir := isolateTrackerAndSessionStorage(t)
+	session := OrchestraSession{
+		ID:           "handoff-insecure-session-" + NewSessionID(),
+		TerminalKind: "cmux",
+		WorkspaceRef: "workspace:13",
+		Panes:        map[string]string{"claude": "surface:42"},
+		CreatedAt:    time.Now(),
+	}
+	require.NoError(t, SaveSession(session))
+	path := sessionFilePath(session.ID)
+	require.NoError(t, os.Chmod(path, 0o644))
+	t.Cleanup(func() {
+		_ = os.Chmod(path, 0o600)
+		_ = RemoveSession(session.ID)
+	})
+	trackerFile := filepath.Join(trackerDir, "2147480132.surfaces")
+	writeTrackedSurfaces(trackerFile, trackedCmuxSurfaces("workspace:13", "surface:42"))
+	term := newTrackerContextTerminal("workspace:current")
+
+	ReapOrphanSurfaces(term)
+
+	assert.Equal(t, []string{"surface:42"}, term.state.closeCalls)
+}
+
+func isolateTrackerAndSessionStorage(t *testing.T) string {
+	t.Helper()
+	t.Setenv("TMPDIR", t.TempDir())
+	originalBase := surfaceTrackerBase
+	originalLegacy := surfaceTrackerLegacyBase
+	trackerDir := secureTrackerTestDir(t)
+	surfaceTrackerBase = trackerDir
+	surfaceTrackerLegacyBase = filepath.Join(secureTrackerTestDir(t), "legacy-missing")
+	t.Cleanup(func() {
+		surfaceTrackerBase = originalBase
+		surfaceTrackerLegacyBase = originalLegacy
+	})
+	return trackerDir
+}

--- a/pkg/orchestra/surface_tracker_identity.go
+++ b/pkg/orchestra/surface_tracker_identity.go
@@ -1,0 +1,138 @@
+package orchestra
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/insajin/autopus-adk/pkg/terminal"
+)
+
+const tmuxServerRefPrefix = "tmux-sha256:"
+
+var validTmuxServerRef = regexp.MustCompile(`^tmux-sha256:[0-9a-f]{64}$`)
+
+type surfaceIdentity struct {
+	Ref           string
+	TerminalKind  string
+	WorkspaceRef  string
+	TmuxServerRef string
+}
+
+// currentTmuxServerRef returns a non-routable identity derived from the tmux
+// socket and server PID. The identity is only compared and is never passed to a
+// command line.
+func currentTmuxServerRef() (string, bool) {
+	raw := strings.TrimSpace(os.Getenv("TMUX"))
+	lastComma := strings.LastIndexByte(raw, ',')
+	if lastComma <= 0 || lastComma == len(raw)-1 {
+		return "", false
+	}
+	secondComma := strings.LastIndexByte(raw[:lastComma], ',')
+	if secondComma <= 0 || secondComma == lastComma-1 {
+		return "", false
+	}
+	socket := filepath.Clean(raw[:secondComma])
+	pidText := raw[secondComma+1 : lastComma]
+	sessionText := raw[lastComma+1:]
+	pid, err := strconv.ParseUint(pidText, 10, 64)
+	if err != nil || pid == 0 || !filepath.IsAbs(socket) || !hasOnlyDecimalDigits(sessionText) {
+		return "", false
+	}
+	digest := sha256.Sum256([]byte(socket + "\x00" + strconv.FormatUint(pid, 10)))
+	return tmuxServerRefPrefix + hex.EncodeToString(digest[:]), true
+}
+
+func trackedSurfaceForTerminal(term terminal.Terminal, ref string) (trackedSurface, error) {
+	if term == nil {
+		return trackedSurface{}, errors.New("nil terminal")
+	}
+	switch term.Name() {
+	case "cmux":
+		if !hasOnlyCmuxPanes(map[string]string{"tracked": ref}) {
+			return trackedSurface{}, fmt.Errorf("invalid cmux surface ref %q", ref)
+		}
+		provider, ok := term.(terminal.WorkspaceContextProvider)
+		if !ok {
+			return trackedSurface{}, errors.New("cmux terminal has no workspace context")
+		}
+		workspaceRef, err := provider.WorkspaceRef()
+		if err != nil {
+			return trackedSurface{}, fmt.Errorf("resolve cmux workspace: %w", err)
+		}
+		workspaceRef, err = canonicalCmuxWorkspaceRef(workspaceRef)
+		if err != nil {
+			return trackedSurface{}, err
+		}
+		return trackedSurface{Ref: ref, TerminalKind: "cmux", WorkspaceRef: workspaceRef}, nil
+	case "tmux":
+		if !hasOnlyGlobalTmuxPanes(map[string]string{"tracked": ref}) {
+			return trackedSurface{}, fmt.Errorf("invalid tmux pane ref %q", ref)
+		}
+		serverRef, ok := currentTmuxServerRef()
+		if !ok {
+			return trackedSurface{}, errors.New("tmux server identity is unavailable")
+		}
+		return trackedSurface{Ref: ref, TerminalKind: "tmux", TmuxServerRef: serverRef}, nil
+	default:
+		return trackedSurface{}, fmt.Errorf("unsupported terminal kind %q", term.Name())
+	}
+}
+
+func trackedSurfaceIdentity(tracked trackedSurface) (surfaceIdentity, error) {
+	switch tracked.TerminalKind {
+	case "cmux":
+		if tracked.TmuxServerRef != "" {
+			return surfaceIdentity{}, errors.New("tracked cmux surface has conflicting tmux context")
+		}
+		if !hasOnlyCmuxPanes(map[string]string{"tracked": tracked.Ref}) {
+			return surfaceIdentity{}, errors.New("tracked cmux surface reference is invalid")
+		}
+		workspaceRef, err := canonicalCmuxWorkspaceRef(tracked.WorkspaceRef)
+		if err != nil {
+			return surfaceIdentity{}, err
+		}
+		return surfaceIdentity{Ref: tracked.Ref, TerminalKind: "cmux", WorkspaceRef: workspaceRef}, nil
+	case "tmux":
+		if tracked.WorkspaceRef != "" {
+			return surfaceIdentity{}, errors.New("tracked tmux surface has conflicting cmux context")
+		}
+		if !hasOnlyGlobalTmuxPanes(map[string]string{"tracked": tracked.Ref}) {
+			return surfaceIdentity{}, errors.New("tracked tmux pane reference is invalid")
+		}
+		if !validTmuxServerRef.MatchString(tracked.TmuxServerRef) {
+			return surfaceIdentity{}, errors.New("tracked tmux server identity is invalid")
+		}
+		return surfaceIdentity{
+			Ref: tracked.Ref, TerminalKind: "tmux", TmuxServerRef: tracked.TmuxServerRef,
+		}, nil
+	default:
+		return surfaceIdentity{}, errors.New("tracked surface has no proven backend identity")
+	}
+}
+
+func canonicalCmuxWorkspaceRef(workspaceRef string) (string, error) {
+	if _, err := terminal.NewCmuxAdapterWithWorkspace(workspaceRef); err != nil {
+		return "", fmt.Errorf("invalid cmux workspace context: %w", err)
+	}
+	if strings.HasPrefix(workspaceRef, "workspace:") {
+		index, err := strconv.ParseUint(strings.TrimPrefix(workspaceRef, "workspace:"), 10, 64)
+		if err != nil {
+			return "", fmt.Errorf("invalid cmux workspace context: %w", err)
+		}
+		return "workspace:" + strconv.FormatUint(index, 10), nil
+	}
+	return strings.ToLower(workspaceRef), nil
+}
+
+func sameTrackedSurface(left, right trackedSurface) bool {
+	leftIdentity, leftErr := trackedSurfaceIdentity(left)
+	rightIdentity, rightErr := trackedSurfaceIdentity(right)
+	return leftErr == nil && rightErr == nil && leftIdentity == rightIdentity
+}

--- a/pkg/orchestra/surface_tracker_identity_test.go
+++ b/pkg/orchestra/surface_tracker_identity_test.go
@@ -1,0 +1,194 @@
+package orchestra
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/insajin/autopus-adk/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCurrentTmuxServerRef_UsesSocketAndServerPID(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux-501/default,12345,7")
+	first, ok := currentTmuxServerRef()
+	require.True(t, ok)
+	assert.Regexp(t, `^tmux-sha256:[0-9a-f]{64}$`, first)
+
+	t.Setenv("TMUX", "/tmp/tmux-501/default,12345,99")
+	sameServer, ok := currentTmuxServerRef()
+	require.True(t, ok)
+	assert.Equal(t, first, sameServer, "session index is not part of server identity")
+
+	t.Setenv("TMUX", "/tmp/tmux-501/default,54321,7")
+	differentPID, ok := currentTmuxServerRef()
+	require.True(t, ok)
+	assert.NotEqual(t, first, differentPID)
+
+	t.Setenv("TMUX", "/tmp/tmux-501/other,12345,7")
+	differentSocket, ok := currentTmuxServerRef()
+	require.True(t, ok)
+	assert.NotEqual(t, first, differentSocket)
+}
+
+func TestCurrentTmuxServerRef_InvalidEnvironmentFailsClosed(t *testing.T) {
+	for _, value := range []string{
+		"", "missing-fields", "/tmp/socket,abc,1", "relative,123,1", "/tmp/socket,123,not-a-session",
+	} {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv("TMUX", value)
+			ref, ok := currentTmuxServerRef()
+			assert.False(t, ok)
+			assert.Empty(t, ref)
+		})
+	}
+}
+
+func TestTrackedSurfaceIdentity_RejectsConflictingBackendContext(t *testing.T) {
+	serverRef := "tmux-sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	tests := []trackedSurface{
+		{Ref: "surface:7", TerminalKind: "cmux", WorkspaceRef: "workspace:13", TmuxServerRef: serverRef},
+		{Ref: "%7", TerminalKind: "tmux", WorkspaceRef: "workspace:13", TmuxServerRef: serverRef},
+	}
+	for _, tracked := range tests {
+		_, err := trackedSurfaceIdentity(tracked)
+		assert.Error(t, err)
+	}
+}
+
+func TestUntrackSurfaceForTerminal_RemovesOnlyExactCmuxTuple(t *testing.T) {
+	original := surfaceTrackerBase
+	surfaceTrackerBase = secureTrackerTestDir(t)
+	t.Cleanup(func() { surfaceTrackerBase = original })
+	path := surfaceTrackerFile(os.Getpid())
+	writeTrackedSurfaces(path, []trackedSurface{
+		{Ref: "surface:7", TerminalKind: "cmux", WorkspaceRef: "workspace:13"},
+		{Ref: "surface:7", TerminalKind: "cmux", WorkspaceRef: "workspace:21"},
+	})
+	term := newTrackerContextTerminal("workspace:13")
+
+	require.NoError(t, untrackSurfaceForTerminal(term, "surface:7"))
+
+	assert.Equal(t, []trackedSurface{{
+		Ref: "surface:7", TerminalKind: "cmux", WorkspaceRef: "workspace:21",
+	}}, readTrackedSurfaces(path))
+}
+
+func TestUntrackSurfaceForTerminal_RemovesOnlyExactTmuxServerTuple(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux-501/default,12345,7")
+	current, ok := currentTmuxServerRef()
+	require.True(t, ok)
+	other := "tmux-sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	original := surfaceTrackerBase
+	surfaceTrackerBase = secureTrackerTestDir(t)
+	t.Cleanup(func() { surfaceTrackerBase = original })
+	path := surfaceTrackerFile(os.Getpid())
+	writeTrackedSurfaces(path, []trackedSurface{
+		{Ref: "%7", TerminalKind: "tmux", TmuxServerRef: current},
+		{Ref: "%7", TerminalKind: "tmux", TmuxServerRef: other},
+	})
+
+	require.NoError(t, untrackSurfaceForTerminal(&mockTerminal{name: "tmux"}, "%7"))
+
+	assert.Equal(t, []trackedSurface{{
+		Ref: "%7", TerminalKind: "tmux", TmuxServerRef: other,
+	}}, readTrackedSurfaces(path))
+}
+
+func TestUntrackSurface_AmbiguousStructuredRefIsPreserved(t *testing.T) {
+	original := surfaceTrackerBase
+	surfaceTrackerBase = secureTrackerTestDir(t)
+	t.Cleanup(func() { surfaceTrackerBase = original })
+	path := surfaceTrackerFile(os.Getpid())
+	want := []trackedSurface{
+		{Ref: "surface:7", TerminalKind: "cmux", WorkspaceRef: "workspace:13"},
+		{Ref: "surface:7", TerminalKind: "cmux", WorkspaceRef: "workspace:21"},
+	}
+	writeTrackedSurfaces(path, want)
+
+	untrackSurface("surface:7")
+
+	assert.Equal(t, want, readTrackedSurfaces(path))
+}
+
+func TestReapOrphanSurfaces_TmuxServerMismatchRetainsHandle(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux-501/origin,12345,1")
+	origin, ok := currentTmuxServerRef()
+	require.True(t, ok)
+	t.Setenv("TMUX", "/tmp/tmux-501/current,12345,1")
+	original := surfaceTrackerBase
+	surfaceTrackerBase = secureTrackerTestDir(t)
+	t.Cleanup(func() { surfaceTrackerBase = original })
+	path := surfaceTrackerFile(2147480120)
+	writeTrackedSurfaces(path, []trackedSurface{{
+		Ref: "%42", TerminalKind: "tmux", TmuxServerRef: origin,
+	}})
+	term := &mockTerminal{name: "tmux"}
+
+	ReapOrphanSurfaces(term)
+
+	assert.Empty(t, term.closeCalls)
+	assert.Equal(t, []string{"%42"}, readTrackerRefs(path))
+}
+
+func TestReapOrphanSurfaces_TmuxSameServerClosesHandle(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux-501/default,12345,1")
+	serverRef, ok := currentTmuxServerRef()
+	require.True(t, ok)
+	original := surfaceTrackerBase
+	surfaceTrackerBase = secureTrackerTestDir(t)
+	t.Cleanup(func() { surfaceTrackerBase = original })
+	path := surfaceTrackerFile(2147480121)
+	writeTrackedSurfaces(path, []trackedSurface{{
+		Ref: "%42", TerminalKind: "tmux", TmuxServerRef: serverRef,
+	}})
+	term := &mockTerminal{name: "tmux"}
+
+	ReapOrphanSurfaces(term)
+
+	assert.Equal(t, []string{"%42"}, term.closeCalls)
+	_, err := os.Lstat(path)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestReapOrphanSurfaces_TmuxHandleRequiresActiveTmuxContext(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux-501/default,12345,1")
+	serverRef, ok := currentTmuxServerRef()
+	require.True(t, ok)
+	original := surfaceTrackerBase
+	surfaceTrackerBase = secureTrackerTestDir(t)
+	t.Cleanup(func() { surfaceTrackerBase = original })
+	path := surfaceTrackerFile(2147480122)
+	writeTrackedSurfaces(path, []trackedSurface{{
+		Ref: "%42", TerminalKind: "tmux", TmuxServerRef: serverRef,
+	}})
+	term := newTrackerContextTerminal("workspace:current")
+
+	ReapOrphanSurfaces(term)
+
+	assert.Empty(t, term.state.closeCalls)
+	assert.Equal(t, []string{"%42"}, readTrackerRefs(path))
+}
+
+func TestTrackSurfaceForTerminal_TmuxPersistsServerIdentity(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux-501/default,12345,1")
+	original := surfaceTrackerBase
+	surfaceTrackerBase = filepath.Join(secureTrackerTestDir(t), "surfaces")
+	t.Cleanup(func() { surfaceTrackerBase = original })
+
+	trackSurfaceForTerminal(&tmuxTrackerTerminal{}, "%9")
+
+	tracked := readTrackedSurfaces(surfaceTrackerFile(os.Getpid()))
+	require.Len(t, tracked, 1)
+	assert.Equal(t, "tmux", tracked[0].TerminalKind)
+	assert.NotEmpty(t, tracked[0].TmuxServerRef)
+}
+
+type tmuxTrackerTerminal struct{ mockTerminal }
+
+func (*tmuxTrackerTerminal) Name() string                        { return "tmux" }
+func (*tmuxTrackerTerminal) Close(context.Context, string) error { return nil }
+
+var _ terminal.Terminal = (*tmuxTrackerTerminal)(nil)

--- a/pkg/orchestra/surface_tracker_owner_unix_test.go
+++ b/pkg/orchestra/surface_tracker_owner_unix_test.go
@@ -1,0 +1,38 @@
+//go:build !windows
+
+package orchestra
+
+import (
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type trackerOwnerInfo struct {
+	mode os.FileMode
+	uid  uint32
+}
+
+func (i trackerOwnerInfo) Name() string       { return "entry" }
+func (i trackerOwnerInfo) Size() int64        { return 1 }
+func (i trackerOwnerInfo) Mode() os.FileMode  { return i.mode }
+func (i trackerOwnerInfo) ModTime() time.Time { return time.Time{} }
+func (i trackerOwnerInfo) IsDir() bool        { return i.mode.IsDir() }
+func (i trackerOwnerInfo) Sys() any           { return &syscall.Stat_t{Uid: i.uid} }
+
+func TestTrackerFileInfoSecure_WrongOwnerFailsClosed(t *testing.T) {
+	wrongUID := uint32(os.Getuid()) + 1
+	info := trackerOwnerInfo{mode: 0o600, uid: wrongUID}
+
+	assert.False(t, trackerFileInfoSecure(info))
+}
+
+func TestTrackerDirectoryInfoSecure_WrongOwnerFailsClosed(t *testing.T) {
+	wrongUID := uint32(os.Getuid()) + 1
+	info := trackerOwnerInfo{mode: os.ModeDir | 0o700, uid: wrongUID}
+
+	assert.False(t, trackerDirectoryInfoSecure(info))
+}

--- a/pkg/orchestra/surface_tracker_perm_unix.go
+++ b/pkg/orchestra/surface_tracker_perm_unix.go
@@ -3,6 +3,8 @@
 package orchestra
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"syscall"
 )
@@ -17,4 +19,18 @@ func surfaceDirSecure(dir string) bool {
 		return false
 	}
 	return uint32(os.Getuid()) == stat.Uid && stat.Mode&0o077 == 0
+}
+
+func trackerInfoOwnedByCurrentUser(info fs.FileInfo) bool {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok && uint32(os.Getuid()) == stat.Uid
+}
+
+func trackerModeSecure(info fs.FileInfo, want os.FileMode) bool {
+	return info.Mode().Perm() == want
+}
+
+func trackerDirectorySyncUnavailable(err error) bool {
+	return errors.Is(err, syscall.EINVAL) || errors.Is(err, syscall.ENOTSUP) ||
+		errors.Is(err, syscall.ENOSYS)
 }

--- a/pkg/orchestra/surface_tracker_perm_windows.go
+++ b/pkg/orchestra/surface_tracker_perm_windows.go
@@ -2,7 +2,10 @@
 
 package orchestra
 
-import "os"
+import (
+	"io/fs"
+	"os"
+)
 
 // surfaceDirSecure is a compile-only fallback on Windows, where POSIX uid and
 // permission-bit checks do not apply (ACL-based model) and the orchestra pane
@@ -12,3 +15,9 @@ func surfaceDirSecure(dir string) bool {
 	info, err := os.Stat(dir)
 	return err == nil && info.IsDir()
 }
+
+func trackerInfoOwnedByCurrentUser(fs.FileInfo) bool { return true }
+
+func trackerModeSecure(fs.FileInfo, os.FileMode) bool { return true }
+
+func trackerDirectorySyncUnavailable(err error) bool { return err != nil }

--- a/pkg/orchestra/surface_tracker_records.go
+++ b/pkg/orchestra/surface_tracker_records.go
@@ -1,0 +1,74 @@
+package orchestra
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+type trackedSurface struct {
+	Ref           string `json:"surface_ref"`
+	TerminalKind  string `json:"terminal_kind,omitempty"`
+	WorkspaceRef  string `json:"workspace_ref,omitempty"`
+	TmuxServerRef string `json:"tmux_server_ref,omitempty"`
+	rawRecord     string
+}
+
+func encodeTrackedSurface(tracked trackedSurface) string {
+	if tracked.rawRecord != "" {
+		return tracked.rawRecord
+	}
+	if tracked.TerminalKind == "" && tracked.WorkspaceRef == "" && tracked.TmuxServerRef == "" {
+		return tracked.Ref
+	}
+	data, err := json.Marshal(tracked)
+	if err != nil {
+		return tracked.Ref
+	}
+	return string(data)
+}
+
+func decodeTrackedSurfaces(data []byte) []trackedSurface {
+	var tracked []trackedSurface
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		item := trackedSurface{Ref: line}
+		if strings.HasPrefix(line, "{") {
+			item = trackedSurface{}
+			if err := json.Unmarshal([]byte(line), &item); err != nil {
+				item.rawRecord = line
+			} else if item.Ref == "" {
+				item = trackedSurface{rawRecord: line}
+			}
+		}
+		tracked = append(tracked, item)
+	}
+	return tracked
+}
+
+func encodeTrackedSurfaces(tracked []trackedSurface) []byte {
+	lines := make([]string, 0, len(tracked))
+	for _, item := range tracked {
+		lines = append(lines, encodeTrackedSurface(item))
+	}
+	return []byte(strings.Join(lines, "\n") + "\n")
+}
+
+func readTrackerRefs(path string) []string {
+	tracked := readTrackedSurfaces(path)
+	refs := make([]string, 0, len(tracked))
+	for _, item := range tracked {
+		refs = append(refs, item.Ref)
+	}
+	return refs
+}
+
+func writeTrackerRefs(path string, refs []string) {
+	tracked := make([]trackedSurface, 0, len(refs))
+	for _, ref := range refs {
+		tracked = append(tracked, trackedSurface{Ref: ref})
+	}
+	writeTrackedSurfaces(path, tracked)
+}

--- a/pkg/orchestra/surface_tracker_split_error_test.go
+++ b/pkg/orchestra/surface_tracker_split_error_test.go
@@ -1,0 +1,110 @@
+package orchestra
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/insajin/autopus-adk/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitTrackedPane_CleansPartiallyCreatedPane(t *testing.T) {
+	isolateSurfaceTracker(t)
+	term := &paneCommitTerminal{
+		splitID: "surface:91", splitErr: errors.New("split acknowledgement lost"),
+	}
+
+	paneID, err := splitTrackedPane(context.Background(), term, terminal.Horizontal)
+
+	require.Error(t, err)
+	assert.Equal(t, terminal.PaneID("surface:91"), paneID)
+	assert.Equal(t, []string{"surface:91"}, term.closed)
+	assert.NotContains(t, readTrackerRefs(surfaceTrackerFile(os.Getpid())), "surface:91")
+}
+
+func TestSplitTrackedPane_PartialCleanupFailureRemainsTracked(t *testing.T) {
+	isolateSurfaceTracker(t)
+	term := &paneCommitTerminal{
+		splitID: "surface:94", splitErr: errors.New("split acknowledgement lost"),
+		closeErr: errors.New("close failed"),
+	}
+
+	paneID, err := splitTrackedPane(context.Background(), term, terminal.Horizontal)
+
+	require.Error(t, err)
+	assert.Equal(t, terminal.PaneID("surface:94"), paneID)
+	assert.Len(t, term.closed, closePaneSurfaceAttempts)
+	assert.Contains(t, readTrackerRefs(surfaceTrackerFile(os.Getpid())), "surface:94",
+		"a partial pane that cannot be closed must remain recoverable")
+}
+
+func TestInteractivePaneBackend_PartialSplitCleanupHasSingleOwner(t *testing.T) {
+	isolateSurfaceTracker(t)
+	term := &paneCommitTerminal{
+		splitID: "surface:95", splitErr: errors.New("split acknowledgement lost"),
+	}
+	backend := NewInteractivePaneBackend(OrchestraConfig{Terminal: term})
+
+	_, err := backend.Execute(context.Background(), ProviderRequest{
+		Provider: "claude",
+		Config:   ProviderConfig{Name: "claude", Binary: "claude"},
+		Prompt:   "verify partial split cleanup",
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, []string{"surface:95"}, term.closed,
+		"the split helper exclusively owns partial-pane cleanup")
+	assert.NotContains(t, readTrackerRefs(surfaceTrackerFile(os.Getpid())), "surface:95")
+}
+
+func TestSplitProviderPanes_PartialSplitCleanupHasSingleOwner(t *testing.T) {
+	isolateSurfaceTracker(t)
+	term := &paneCommitTerminal{
+		splitID: "surface:96", splitErr: errors.New("split acknowledgement lost"),
+	}
+
+	panes, failed, err := splitProviderPanes(context.Background(), OrchestraConfig{
+		Terminal:  term,
+		Providers: []ProviderConfig{{Name: "claude", Binary: "claude"}},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, panes)
+	assert.Nil(t, failed)
+	assert.Equal(t, []string{"surface:96"}, term.closed,
+		"the split helper exclusively owns partial-pane cleanup")
+	assert.NotContains(t, readTrackerRefs(surfaceTrackerFile(os.Getpid())), "surface:96")
+}
+
+func TestPartialSplitCleanup_CoversRecreateAndWarmPool(t *testing.T) {
+	t.Run("recreate preserves old pane", func(t *testing.T) {
+		term := &paneCommitTerminal{
+			splitID: "surface:92", splitErr: errors.New("split acknowledgement lost"),
+		}
+		old := paneInfo{
+			paneID: "surface:10", provider: ProviderConfig{Name: "custom", Binary: "custom"},
+		}
+
+		got, err := recreatePane(context.Background(), OrchestraConfig{Terminal: term}, old, 2)
+
+		require.Error(t, err)
+		assert.Equal(t, old, got)
+		assert.Contains(t, term.closed, "surface:92")
+		assert.NotContains(t, term.closed, "surface:10")
+	})
+
+	t.Run("warm pool does not retain partial pane", func(t *testing.T) {
+		term := &paneCommitTerminal{
+			splitID: "surface:93", splitErr: errors.New("split acknowledgement lost"),
+		}
+		pool := NewWarmPool(term, 1)
+
+		pool.Init(context.Background())
+
+		assert.Zero(t, pool.Size())
+		assert.Contains(t, term.closed, "surface:93")
+	})
+}

--- a/pkg/orchestra/surface_tracker_storage.go
+++ b/pkg/orchestra/surface_tracker_storage.go
@@ -1,0 +1,249 @@
+package orchestra
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+const maxTrackerFileSize = 1 << 20
+
+var surfaceTrackerMu sync.Mutex
+
+type trackerWritableFile interface {
+	Stat() (fs.FileInfo, error)
+	Chmod(os.FileMode) error
+	Write([]byte) (int, error)
+	Sync() error
+	Close() error
+}
+
+type trackerCommitFunc func(root *os.Root, temporary, target string) error
+
+func openSecureTrackerRoot(dir string, create bool) (*os.Root, error) {
+	if create {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return nil, fmt.Errorf("create tracker directory: %w", err)
+		}
+	}
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return nil, fmt.Errorf("inspect tracker directory: %w", err)
+	}
+	if !trackerDirectoryInfoSecure(info) {
+		return nil, errors.New("tracker directory ownership, mode, or type is insecure")
+	}
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return nil, fmt.Errorf("open tracker directory: %w", err)
+	}
+	openedInfo, err := root.Stat(".")
+	if err != nil || !os.SameFile(info, openedInfo) || !trackerDirectoryInfoSecure(openedInfo) {
+		_ = root.Close()
+		return nil, errors.New("tracker directory changed while opening")
+	}
+	return root, nil
+}
+
+func trackerDirectoryInfoSecure(info fs.FileInfo) bool {
+	return info != nil && info.IsDir() && info.Mode()&os.ModeSymlink == 0 &&
+		trackerInfoOwnedByCurrentUser(info) && trackerModeSecure(info, 0o700)
+}
+
+func trackerFileInfoSecure(info fs.FileInfo) bool {
+	return info != nil && info.Mode().IsRegular() && info.Mode()&os.ModeSymlink == 0 &&
+		trackerInfoOwnedByCurrentUser(info) && trackerModeSecure(info, 0o600)
+}
+
+func readTrackedSurfacesFromRoot(root *os.Root, name string) ([]trackedSurface, fs.FileInfo, error) {
+	initialInfo, err := root.Lstat(name)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !trackerFileInfoSecure(initialInfo) {
+		return nil, nil, errors.New("tracker entry ownership, mode, or type is insecure")
+	}
+	if initialInfo.Size() < 0 || initialInfo.Size() > maxTrackerFileSize {
+		return nil, nil, fmt.Errorf("tracker entry exceeds %d bytes", maxTrackerFileSize)
+	}
+	file, err := root.Open(name)
+	if err != nil {
+		return nil, nil, err
+	}
+	openedInfo, statErr := file.Stat()
+	currentInfo, currentErr := root.Lstat(name)
+	if statErr != nil || currentErr != nil || !trackerFileInfoSecure(openedInfo) ||
+		!trackerFileInfoSecure(currentInfo) || !os.SameFile(initialInfo, openedInfo) ||
+		!os.SameFile(openedInfo, currentInfo) {
+		_ = file.Close()
+		return nil, nil, errors.New("tracker entry changed while opening")
+	}
+	data, readErr := io.ReadAll(io.LimitReader(file, maxTrackerFileSize+1))
+	closeErr := file.Close()
+	if readErr != nil {
+		return nil, nil, readErr
+	}
+	if closeErr != nil {
+		return nil, nil, closeErr
+	}
+	if len(data) > maxTrackerFileSize {
+		return nil, nil, fmt.Errorf("tracker entry exceeds %d bytes", maxTrackerFileSize)
+	}
+	return decodeTrackedSurfaces(data), openedInfo, nil
+}
+
+func readTrackedSurfaces(path string) []trackedSurface {
+	surfaceTrackerMu.Lock()
+	defer surfaceTrackerMu.Unlock()
+	root, err := openSecureTrackerRoot(filepath.Dir(path), false)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = root.Close() }()
+	tracked, _, err := readTrackedSurfacesFromRoot(root, filepath.Base(path))
+	if err != nil {
+		return nil
+	}
+	return tracked
+}
+
+func writeTrackedSurfaces(path string, tracked []trackedSurface) {
+	_ = writeTrackedSurfacesWithCommit(path, tracked, nil)
+}
+
+func writeTrackedSurfacesWithCommit(path string, tracked []trackedSurface, commit trackerCommitFunc) error {
+	surfaceTrackerMu.Lock()
+	defer surfaceTrackerMu.Unlock()
+	root, err := openSecureTrackerRoot(filepath.Dir(path), true)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
+	return writeTrackedSurfacesToRoot(root, filepath.Base(path), tracked, commit)
+}
+
+func writeTrackedSurfacesToRoot(
+	root *os.Root,
+	name string,
+	tracked []trackedSurface,
+	commit trackerCommitFunc,
+) error {
+	originalInfo, statErr := root.Lstat(name)
+	if statErr == nil && !trackerFileInfoSecure(originalInfo) {
+		return errors.New("refusing to replace insecure tracker entry")
+	}
+	if statErr != nil && !errors.Is(statErr, fs.ErrNotExist) {
+		return statErr
+	}
+	if len(tracked) == 0 {
+		if errors.Is(statErr, fs.ErrNotExist) {
+			return nil
+		}
+		currentInfo, err := root.Lstat(name)
+		if err != nil || !trackerFileInfoSecure(currentInfo) ||
+			!os.SameFile(originalInfo, currentInfo) {
+			return errors.New("tracker entry changed before removal")
+		}
+		if err := root.Remove(name); err != nil {
+			return err
+		}
+		return syncTrackerRoot(root)
+	}
+	data := encodeTrackedSurfaces(tracked)
+	if len(data) > maxTrackerFileSize {
+		return fmt.Errorf("tracker replacement exceeds %d bytes", maxTrackerFileSize)
+	}
+	temporary := name + "." + strings.TrimPrefix(NewSessionID(), "orch-") + ".tmp"
+	file, err := root.OpenFile(temporary, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Remove(temporary) }()
+	if commit == nil {
+		commit = func(root *os.Root, temporary, target string) error {
+			currentInfo, currentErr := root.Lstat(target)
+			switch {
+			case statErr == nil && (currentErr != nil || !os.SameFile(originalInfo, currentInfo)):
+				return errors.New("tracker entry changed before replacement")
+			case errors.Is(statErr, fs.ErrNotExist) && currentErr == nil:
+				return errors.New("tracker entry appeared before replacement")
+			case currentErr != nil && !errors.Is(currentErr, fs.ErrNotExist):
+				return currentErr
+			}
+			return root.Rename(temporary, target)
+		}
+	}
+	return persistTrackerReplacement(root, temporary, name, file, data, commit)
+}
+
+func persistTrackerReplacement(
+	root *os.Root,
+	temporary string,
+	target string,
+	file trackerWritableFile,
+	data []byte,
+	commit trackerCommitFunc,
+) error {
+	rollback := func(cause error) error {
+		closeErr := file.Close()
+		_ = root.Remove(temporary)
+		return errors.Join(cause, closeErr)
+	}
+	if err := file.Chmod(0o600); err != nil {
+		return rollback(err)
+	}
+	createdInfo, err := file.Stat()
+	if err != nil {
+		return rollback(err)
+	}
+	if !trackerFileInfoSecure(createdInfo) {
+		return rollback(errors.New("created tracker replacement is insecure"))
+	}
+	written, err := file.Write(data)
+	if err == nil && written != len(data) {
+		err = io.ErrShortWrite
+	}
+	if err != nil {
+		return rollback(err)
+	}
+	if err := file.Sync(); err != nil {
+		return rollback(err)
+	}
+	if err := file.Close(); err != nil {
+		_ = root.Remove(temporary)
+		return err
+	}
+	currentInfo, err := root.Lstat(temporary)
+	if err != nil || !trackerFileInfoSecure(currentInfo) ||
+		!os.SameFile(createdInfo, currentInfo) {
+		_ = root.Remove(temporary)
+		return errors.New("tracker replacement changed before commit")
+	}
+	if commit == nil {
+		_ = root.Remove(temporary)
+		return errors.New("nil tracker commit")
+	}
+	if err := commit(root, temporary, target); err != nil {
+		_ = root.Remove(temporary)
+		return err
+	}
+	return syncTrackerRoot(root)
+}
+
+func syncTrackerRoot(root *os.Root) error {
+	directory, err := root.Open(".")
+	if err != nil {
+		return err
+	}
+	syncErr := directory.Sync()
+	if trackerDirectorySyncUnavailable(syncErr) {
+		syncErr = nil
+	}
+	closeErr := directory.Close()
+	return errors.Join(syncErr, closeErr)
+}

--- a/pkg/orchestra/surface_tracker_storage_security_test.go
+++ b/pkg/orchestra/surface_tracker_storage_security_test.go
@@ -1,0 +1,169 @@
+package orchestra
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReapOrphanSurfaces_InsecureLegacyDirectoryRejectsStructuredCapability(t *testing.T) {
+	originalBase := surfaceTrackerBase
+	originalLegacy := surfaceTrackerLegacyBase
+	t.Cleanup(func() {
+		surfaceTrackerBase = originalBase
+		surfaceTrackerLegacyBase = originalLegacy
+	})
+	surfaceTrackerBase = filepath.Join(secureTrackerTestDir(t), "primary-missing")
+	legacy := filepath.Join(secureTrackerTestDir(t), "legacy")
+	require.NoError(t, os.Mkdir(legacy, 0o700))
+	require.NoError(t, os.Chmod(legacy, 0o755))
+	surfaceTrackerLegacyBase = legacy
+	path := filepath.Join(legacy, "2147480101.surfaces")
+	require.NoError(t, os.WriteFile(path, []byte(
+		`{"surface_ref":"surface:7","terminal_kind":"cmux","workspace_ref":"workspace:13"}`+"\n",
+	), 0o600))
+	term := newTrackerContextTerminal("workspace:current")
+
+	ReapOrphanSurfaces(term)
+
+	assert.Empty(t, term.state.closeCalls)
+	_, err := os.Lstat(path)
+	assert.NoError(t, err, "untrusted input must remain untouched")
+}
+
+func TestReapOrphanSurfaces_SymlinkLegacyDirectoryFailsClosed(t *testing.T) {
+	originalBase := surfaceTrackerBase
+	originalLegacy := surfaceTrackerLegacyBase
+	t.Cleanup(func() {
+		surfaceTrackerBase = originalBase
+		surfaceTrackerLegacyBase = originalLegacy
+	})
+	surfaceTrackerBase = filepath.Join(secureTrackerTestDir(t), "primary-missing")
+	target := secureTrackerTestDir(t)
+	writeRawTrackerForTest(t, target, 2147480102,
+		`{"surface_ref":"surface:8","terminal_kind":"cmux","workspace_ref":"workspace:13"}`)
+	legacy := filepath.Join(secureTrackerTestDir(t), "legacy-link")
+	require.NoError(t, os.Symlink(target, legacy))
+	surfaceTrackerLegacyBase = legacy
+	term := newTrackerContextTerminal("workspace:current")
+
+	ReapOrphanSurfaces(term)
+
+	assert.Empty(t, term.state.closeCalls)
+}
+
+func TestReapOrphanSurfaces_RejectsSymlinkAndWrongModeFiles(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*testing.T, string, string)
+	}{
+		{
+			name: "symlink",
+			setup: func(t *testing.T, dir, path string) {
+				t.Helper()
+				target := filepath.Join(dir, "target")
+				require.NoError(t, os.WriteFile(target, []byte(
+					`{"surface_ref":"surface:9","terminal_kind":"cmux","workspace_ref":"workspace:13"}`+"\n",
+				), 0o600))
+				require.NoError(t, os.Symlink(target, path))
+			},
+		},
+		{
+			name: "wrong mode",
+			setup: func(t *testing.T, _, path string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(path, []byte(
+					`{"surface_ref":"surface:9","terminal_kind":"cmux","workspace_ref":"workspace:13"}`+"\n",
+				), 0o644))
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			original := surfaceTrackerBase
+			dir := secureTrackerTestDir(t)
+			surfaceTrackerBase = dir
+			t.Cleanup(func() { surfaceTrackerBase = original })
+			path := surfaceTrackerFile(2147480103)
+			test.setup(t, dir, path)
+			term := newTrackerContextTerminal("workspace:current")
+
+			ReapOrphanSurfaces(term)
+
+			assert.Empty(t, term.state.closeCalls)
+		})
+	}
+}
+
+func TestReapOrphanSurfaces_OversizedTrackerFailsClosed(t *testing.T) {
+	original := surfaceTrackerBase
+	surfaceTrackerBase = secureTrackerTestDir(t)
+	t.Cleanup(func() { surfaceTrackerBase = original })
+	path := surfaceTrackerFile(2147480104)
+	require.NoError(t, os.WriteFile(path, []byte(strings.Repeat("x", maxTrackerFileSize+1)), 0o600))
+	term := newTrackerContextTerminal("workspace:current")
+
+	ReapOrphanSurfaces(term)
+
+	assert.Empty(t, term.state.closeCalls)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, int64(maxTrackerFileSize+1), info.Size())
+}
+
+func TestReapOrphanSurfaces_TruncatedRecordIsRetained(t *testing.T) {
+	original := surfaceTrackerBase
+	surfaceTrackerBase = secureTrackerTestDir(t)
+	t.Cleanup(func() { surfaceTrackerBase = original })
+	path := surfaceTrackerFile(2147480105)
+	truncated := `{"surface_ref":"surface:10","terminal_kind":"cmux"`
+	valid := `{"surface_ref":"surface:11","terminal_kind":"cmux","workspace_ref":"workspace:13"}`
+	require.NoError(t, os.WriteFile(path, []byte(truncated+"\n"+valid+"\n"), 0o600))
+	term := newTrackerContextTerminal("workspace:current")
+
+	ReapOrphanSurfaces(term)
+
+	assert.Equal(t, []string{"surface:11"}, term.state.closeCalls)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, truncated+"\n", string(data))
+}
+
+func TestReapOrphanSurfaces_FIFODoesNotBlock(t *testing.T) {
+	if !fifoSupported() {
+		t.Skip("FIFO is not supported on this platform")
+	}
+	original := surfaceTrackerBase
+	surfaceTrackerBase = secureTrackerTestDir(t)
+	t.Cleanup(func() { surfaceTrackerBase = original })
+	path := surfaceTrackerFile(2147480106)
+	require.NoError(t, createTrackerFIFO(path))
+	term := newTrackerContextTerminal("workspace:current")
+	done := make(chan struct{})
+	go func() {
+		ReapOrphanSurfaces(term)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		unblockTrackerFIFO(path)
+		<-done
+		t.Fatal("reaper blocked while opening a FIFO tracker entry")
+	}
+	assert.Empty(t, term.state.closeCalls)
+}
+
+func writeRawTrackerForTest(t *testing.T, dir string, pid int, line string) string {
+	t.Helper()
+	path := filepath.Join(dir, strconv.Itoa(pid)+".surfaces")
+	require.NoError(t, os.WriteFile(path, []byte(line+"\n"), 0o600))
+	return path
+}

--- a/pkg/orchestra/surface_tracker_test.go
+++ b/pkg/orchestra/surface_tracker_test.go
@@ -26,6 +26,7 @@ func TestMain(m *testing.M) {
 	tmp, err := os.MkdirTemp("", "autopus-surface-tracker-test-")
 	if err == nil {
 		surfaceTrackerBase = filepath.Join(tmp, "surfaces")
+		surfaceTrackerLegacyBase = filepath.Join(tmp, "legacy-surfaces")
 		// Isolate the home directory so os.UserHomeDir()-based runtime roots
 		// resolve under the throwaway tree. HOME covers Unix/macOS; the rest
 		// guard alternate resolution paths.
@@ -43,6 +44,15 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
+func secureTrackerTestDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatalf("secure tracker test directory: %v", err)
+	}
+	return dir
+}
+
 func TestProcessAlive(t *testing.T) {
 	t.Parallel()
 
@@ -57,7 +67,7 @@ func TestTrackAndUntrackSurface(t *testing.T) {
 	orig := surfaceTrackerBase
 	// Use a non-existing subdirectory so MkdirAll creates it with mode 0700,
 	// satisfying the ownership/mode security check in trackSurface (REQ-007).
-	surfaceTrackerBase = filepath.Join(t.TempDir(), "surfaces")
+	surfaceTrackerBase = filepath.Join(secureTrackerTestDir(t), "surfaces")
 	defer func() { surfaceTrackerBase = orig }()
 
 	trackSurface("surface:1")
@@ -79,21 +89,25 @@ func TestTrackAndUntrackSurface(t *testing.T) {
 
 func TestReapOrphanSurfaces_ClosesOnlyDeadOwners(t *testing.T) {
 	orig := surfaceTrackerBase
-	surfaceTrackerBase = t.TempDir()
+	surfaceTrackerBase = secureTrackerTestDir(t)
 	defer func() { surfaceTrackerBase = orig }()
 
 	deadPID := 2147480001 // unused high pid → reported dead
-	writeTrackerRefs(surfaceTrackerFile(deadPID), []string{"surface:10", "surface:11"})
+	writeTrackedSurfaces(surfaceTrackerFile(deadPID),
+		trackedCmuxSurfaces("workspace:13", "surface:10", "surface:11"))
 	// A live owner that must NOT be reaped: this process.
 	selfRefs := []string{"surface:20"}
 	writeTrackerRefs(surfaceTrackerFile(os.Getpid()), selfRefs)
 
-	term := &mockTerminal{name: "cmux"}
+	term := newTrackerContextTerminal("workspace:current")
 	ReapOrphanSurfaces(term)
 
-	closed := append([]string(nil), term.closeCalls...)
+	closed := append([]string(nil), term.state.closeCalls...)
 	sort.Strings(closed)
 	assert.Equal(t, []string{"surface:10", "surface:11"}, closed, "only dead owner's surfaces are closed")
+	assert.Equal(t, []string{"workspace:13", "workspace:13"}, term.state.closeWorkspaces)
+	assert.Equal(t, "workspace:current", term.workspaceRef,
+		"orphan cleanup must not mutate the active terminal context")
 
 	_, err := os.Stat(surfaceTrackerFile(deadPID))
 	assert.True(t, os.IsNotExist(err), "dead owner's tracking file must be removed")
@@ -102,7 +116,7 @@ func TestReapOrphanSurfaces_ClosesOnlyDeadOwners(t *testing.T) {
 
 func TestReapOrphanSurfaces_NoOpForPlainOrNilTerm(t *testing.T) {
 	orig := surfaceTrackerBase
-	surfaceTrackerBase = t.TempDir()
+	surfaceTrackerBase = secureTrackerTestDir(t)
 	defer func() { surfaceTrackerBase = orig }()
 
 	deadPID := 2147480002
@@ -175,27 +189,27 @@ func TestReapOrphanSurfaces_RefValidationAndLegacyNoCreate(t *testing.T) {
 		surfaceTrackerLegacyBase = origLegacy
 	}()
 
-	base := t.TempDir()
+	base := secureTrackerTestDir(t)
 	surfaceTrackerBase = base
 
 	// Point legacy base to a path that does not exist; verify it is NOT created.
-	legacyBase := filepath.Join(t.TempDir(), "legacy-never-created")
+	legacyBase := filepath.Join(secureTrackerTestDir(t), "legacy-never-created")
 	surfaceTrackerLegacyBase = legacyBase
 
 	// Write refs including two invalid ones and one valid ref for a dead PID.
 	deadPID := 2147480004
-	writeTrackerRefs(surfaceTrackerFile(deadPID),
-		[]string{"--help", "; rm -rf /", "surface:3"})
+	writeTrackedSurfaces(surfaceTrackerFile(deadPID),
+		trackedCmuxSurfaces("workspace:13", "--help", "; rm -rf /", "surface:3"))
 	// Self entry must not be reaped.
 	writeTrackerRefs(surfaceTrackerFile(os.Getpid()), []string{"surface:99"})
 
-	term := &mockTerminal{name: "cmux"}
+	term := newTrackerContextTerminal("workspace:current")
 	logOutput := captureLog(t, func() {
 		ReapOrphanSurfaces(term)
 	})
 
 	// Only the valid ref "surface:3" must be closed.
-	assert.Equal(t, []string{"surface:3"}, term.closeCalls,
+	assert.Equal(t, []string{"surface:3"}, term.state.closeCalls,
 		"Close must receive exactly {surface:3}")
 
 	// Invalid refs must appear in log output.
@@ -211,8 +225,9 @@ func TestReapOrphanSurfaces_RefValidationAndLegacyNoCreate(t *testing.T) {
 }
 
 func TestReapOrphanSurfaces_TmuxClosesGlobalPaneRef(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux-501/default,12345,1")
 	orig := surfaceTrackerBase
-	surfaceTrackerBase = t.TempDir()
+	surfaceTrackerBase = secureTrackerTestDir(t)
 	defer func() { surfaceTrackerBase = orig }()
 
 	deadPID := 2147480005
@@ -225,36 +240,20 @@ func TestReapOrphanSurfaces_TmuxClosesGlobalPaneRef(t *testing.T) {
 		"tmux Close must receive exactly the valid global pane ref")
 }
 
-func TestReapOrphanSurfaces_CmuxPreservesTmuxGlobalPaneRef(t *testing.T) {
-	orig := surfaceTrackerBase
-	surfaceTrackerBase = t.TempDir()
-	defer func() { surfaceTrackerBase = orig }()
-
-	deadPID := 2147480006
-	trackerFile := surfaceTrackerFile(deadPID)
-	writeTrackerRefs(trackerFile, []string{"%42"})
-
-	term := &mockTerminal{name: "cmux"}
-	ReapOrphanSurfaces(term)
-
-	assert.Empty(t, term.closeCalls, "cmux must not close a tmux global pane ref")
-	assert.Equal(t, []string{"%42"}, readTrackerRefs(trackerFile),
-		"incompatible ref must remain tracked for a later tmux reaper")
-}
-
 func TestReapOrphanSurfaces_CloseErrorPreservesRefForRetry(t *testing.T) {
 	orig := surfaceTrackerBase
-	surfaceTrackerBase = t.TempDir()
+	surfaceTrackerBase = secureTrackerTestDir(t)
 	defer func() { surfaceTrackerBase = orig }()
 
 	deadPID := 2147480007
 	trackerFile := surfaceTrackerFile(deadPID)
-	writeTrackerRefs(trackerFile, []string{"surface:77"})
+	writeTrackedSurfaces(trackerFile, trackedCmuxSurfaces("workspace:13", "surface:77"))
 
-	term := &mockTerminal{name: "cmux", closeErr: errors.New("close failed")}
+	term := newTrackerContextTerminal("workspace:current")
+	term.state.closeErr = errors.New("close failed")
 	ReapOrphanSurfaces(term)
 
-	assert.Equal(t, []string{"surface:77"}, term.closeCalls,
+	assert.Equal(t, []string{"surface:77"}, term.state.closeCalls,
 		"compatible ref must be passed to Close")
 	assert.Equal(t, []string{"surface:77"}, readTrackerRefs(trackerFile),
 		"failed Close ref must remain tracked for retry")
@@ -262,7 +261,7 @@ func TestReapOrphanSurfaces_CloseErrorPreservesRefForRetry(t *testing.T) {
 
 func TestReapOrphanSurfaces_SkipsLivePeerOwner(t *testing.T) {
 	orig := surfaceTrackerBase
-	surfaceTrackerBase = t.TempDir()
+	surfaceTrackerBase = secureTrackerTestDir(t)
 	defer func() { surfaceTrackerBase = orig }()
 
 	// Simulate a concurrent, still-running orchestrator with a real live child

--- a/pkg/orchestra/types.go
+++ b/pkg/orchestra/types.go
@@ -70,6 +70,9 @@ type ProviderConfig struct {
 	// HasHook overrides whether this provider has hook-based result collection.
 	// When nil, the DefaultHookProviders() membership applies (claude/gemini/codex).
 	HasHook *bool
+	// HasStartupHook independently overrides startup-ready artifact support.
+	// When nil, only providers with generated startup wiring require the artifact.
+	HasStartupHook *bool
 }
 
 // ReliabilityFallbackMode defines deterministic degradation behavior.

--- a/pkg/orchestra/yield_session.go
+++ b/pkg/orchestra/yield_session.go
@@ -1,0 +1,57 @@
+package orchestra
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/terminal"
+)
+
+var yieldSurfaceUntracker = untrackSurfaceForTerminal
+
+func buildYieldSession(sessionID string, term terminal.Terminal, panes []paneInfo, responses []ProviderResponse, createdAt time.Time) (OrchestraSession, error) {
+	terminalKind, workspaceRef, tmuxServerRef, err := sessionTerminalContext(term)
+	if err != nil {
+		return OrchestraSession{}, err
+	}
+	session := OrchestraSession{
+		ID: sessionID, TerminalKind: terminalKind, WorkspaceRef: workspaceRef,
+		TmuxServerRef: tmuxServerRef, Panes: make(map[string]string, len(panes)),
+		Providers: make([]SessionProviderConfig, 0, len(panes)),
+		Rounds:    make([][]SessionProviderResponse, 0, 1), CreatedAt: createdAt,
+	}
+	for _, pi := range panes {
+		session.Panes[pi.provider.Name] = string(pi.paneID)
+		session.Providers = append(session.Providers, SessionProviderConfig{
+			Name: pi.provider.Name, Binary: pi.provider.Binary,
+		})
+	}
+	round := make([]SessionProviderResponse, 0, len(responses))
+	for _, response := range responses {
+		round = append(round, SessionProviderResponse{
+			Provider: response.Provider, Output: response.Output,
+			DurationMs: response.Duration.Milliseconds(), TimedOut: response.TimedOut,
+			Usage: response.Usage, UsageCapability: response.UsageCapability,
+		})
+	}
+	session.Rounds = append(session.Rounds, round)
+	return session, nil
+}
+
+func handoffYieldPanes(sessionID string, term terminal.Terminal, panes []paneInfo) error {
+	var handoffErrors []error
+	for _, pane := range panes {
+		ref := string(pane.paneID)
+		if err := yieldSurfaceUntracker(term, ref); err != nil {
+			log.Printf("[yield] session %s is durable but tracker handoff failed for %s: %v", sessionID, ref, err)
+			handoffErrors = append(handoffErrors, fmt.Errorf("untrack %s: %w", ref, err))
+		}
+	}
+	if len(handoffErrors) == 0 {
+		return nil
+	}
+	return fmt.Errorf("yield session %s is durable but tracker handoff failed; recover with auto orchestra cleanup --session-id %s: %w",
+		sessionID, sessionID, errors.Join(handoffErrors...))
+}

--- a/pkg/orchestra/yield_session_test.go
+++ b/pkg/orchestra/yield_session_test.go
@@ -4,9 +4,23 @@ import (
 	"testing"
 	"time"
 
+	"github.com/insajin/autopus-adk/pkg/terminal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type yieldSessionTerminal struct {
+	*mockTerminal
+	workspaceRef string
+}
+
+func (t *yieldSessionTerminal) WorkspaceRef() (string, error) {
+	return t.workspaceRef, nil
+}
+
+func (t *yieldSessionTerminal) WithWorkspaceRef(ref string) (terminal.Terminal, error) {
+	return &yieldSessionTerminal{mockTerminal: t.mockTerminal, workspaceRef: ref}, nil
+}
 
 func TestBuildYieldSession_PreservesProvidersInSingleRound(t *testing.T) {
 	t.Parallel()
@@ -23,9 +37,16 @@ func TestBuildYieldSession_PreservesProvidersInSingleRound(t *testing.T) {
 		{Provider: "gemini", Output: "gemini answer", Duration: 5 * time.Second},
 	}
 
-	session := buildYieldSession("orch-test", panes, responses, createdAt)
+	term := &yieldSessionTerminal{
+		mockTerminal: &mockTerminal{name: "cmux"},
+		workspaceRef: "80187A1A-6ED8-4640-9A2A-F3235FF3F6D8",
+	}
+	session, err := buildYieldSession("orch-test", term, panes, responses, createdAt)
+	require.NoError(t, err)
 
 	assert.Equal(t, "orch-test", session.ID)
+	assert.Equal(t, "cmux", session.TerminalKind)
+	assert.Equal(t, "80187A1A-6ED8-4640-9A2A-F3235FF3F6D8", session.WorkspaceRef)
 	assert.Equal(t, createdAt, session.CreatedAt)
 	assert.Equal(t, map[string]string{
 		"claude": "pane-claude",
@@ -43,4 +64,16 @@ func TestBuildYieldSession_PreservesProvidersInSingleRound(t *testing.T) {
 	assert.Equal(t, "claude", session.Rounds[0][0].Provider)
 	assert.Equal(t, "codex", session.Rounds[0][1].Provider)
 	assert.Equal(t, "gemini", session.Rounds[0][2].Provider)
+}
+
+func TestBuildYieldSession_InvalidCmuxWorkspaceFailsClosed(t *testing.T) {
+	term := &yieldSessionTerminal{
+		mockTerminal: &mockTerminal{name: "cmux"},
+		workspaceRef: "../unsafe",
+	}
+
+	_, err := buildYieldSession("orch-invalid", term, nil, nil, time.Now())
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "validate cmux workspace context")
 }

--- a/pkg/orchestra/yield_tracker_handoff_test.go
+++ b/pkg/orchestra/yield_tracker_handoff_test.go
@@ -1,0 +1,58 @@
+package orchestra
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandoffYieldPanes_DurableSession_RemovesTrackerOwnership(t *testing.T) {
+	isolateSurfaceTracker(t)
+	term := &yieldSessionTerminal{
+		mockTerminal: &mockTerminal{name: "cmux"}, workspaceRef: "workspace:13",
+	}
+	ref := "surface:1414"
+	trackSurfaceForTerminal(term, ref)
+	session := OrchestraSession{
+		ID: "yield-handoff-" + NewSessionID(), TerminalKind: "cmux",
+		WorkspaceRef: "workspace:13", Panes: map[string]string{"claude": ref},
+		CreatedAt: time.Now(),
+	}
+	require.NoError(t, SaveSession(session))
+	t.Cleanup(func() { _ = RemoveSession(session.ID) })
+	panes := []paneInfo{{paneID: terminal.PaneID(ref), provider: ProviderConfig{Name: "claude"}}}
+
+	require.NoError(t, handoffYieldPanes(session.ID, term, panes))
+
+	assert.NotContains(t, readTrackerRefs(surfaceTrackerFile(os.Getpid())), ref)
+	_, err := LoadSession(session.ID)
+	assert.NoError(t, err, "tracker handoff must leave the durable session intact")
+}
+
+func TestHandoffYieldPanes_UntrackFailure_ReportsDurableRecoveryHandle(t *testing.T) {
+	original := yieldSurfaceUntracker
+	yieldSurfaceUntracker = func(terminal.Terminal, string) error {
+		return errors.New("tracker write failed")
+	}
+	t.Cleanup(func() { yieldSurfaceUntracker = original })
+	session := OrchestraSession{
+		ID:    "yield-handoff-failure-" + NewSessionID(),
+		Panes: map[string]string{"claude": "surface:1414"}, CreatedAt: time.Now(),
+	}
+	require.NoError(t, SaveSession(session))
+	t.Cleanup(func() { _ = RemoveSession(session.ID) })
+	panes := []paneInfo{{paneID: "surface:1414", provider: ProviderConfig{Name: "claude"}}}
+
+	err := handoffYieldPanes(session.ID, &mockTerminal{name: "cmux"}, panes)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, session.ID)
+	assert.ErrorContains(t, err, "auto orchestra cleanup --session-id "+session.ID)
+	_, loadErr := LoadSession(session.ID)
+	assert.NoError(t, loadErr, "failed tracker handoff must not consume the persisted recovery handle")
+}

--- a/pkg/terminal/close_error.go
+++ b/pkg/terminal/close_error.go
@@ -1,0 +1,14 @@
+package terminal
+
+import (
+	"fmt"
+	"strings"
+)
+
+func closeCommandError(prefix string, err error, stderr string) error {
+	detail := strings.TrimSpace(stderr)
+	if detail == "" {
+		return fmt.Errorf("%s: %w", prefix, err)
+	}
+	return fmt.Errorf("%s: %w: %s", prefix, err, detail)
+}

--- a/pkg/terminal/cmux.go
+++ b/pkg/terminal/cmux.go
@@ -164,12 +164,14 @@ func (a *CmuxAdapter) SendLongText(ctx context.Context, paneID PaneID, text stri
 	pasteArgs = append(pasteArgs, "--name", cmuxInputBufferName)
 	pasteCmd := execCommandContext(ctx, "cmux", pasteArgs...)
 	if err := pasteCmd.Run(); err != nil {
-		clearCmuxInputBuffer()
+		callerErr := settleAndClearCmuxInputBuffer(ctx)
 		release()
+		if callerErr != nil {
+			return callerErr
+		}
 		return a.sendChunked(ctx, paneID, text)
 	}
-	clearCmuxInputBuffer()
-	return nil
+	return settleAndClearCmuxInputBuffer(ctx)
 }
 
 // sendChunked sends long text in chunks to avoid PTY 4KB truncation.

--- a/pkg/terminal/cmux.go
+++ b/pkg/terminal/cmux.go
@@ -10,14 +10,14 @@ import (
 
 // CmuxAdapter implements Terminal using the cmux terminal multiplexer.
 type CmuxAdapter struct {
-	workspaceRef string // e.g. "workspace:1" — stored from CreateWorkspace or env
+	workspaceRef string // e.g. "workspace:1" or a canonical UUID
 }
 
 // Name returns the adapter name.
 func (a *CmuxAdapter) Name() string { return "cmux" }
 
 // CreateWorkspace creates a new cmux workspace and renames it to the given name.
-// It stores the workspace ref internally for use by Close.
+// It stores the workspace ref internally for later workspace-scoped commands.
 func (a *CmuxAdapter) CreateWorkspace(_ context.Context, name string) error {
 	if err := validateWorkspaceName(name); err != nil {
 		return fmt.Errorf("cmux: %w", err)
@@ -27,10 +27,14 @@ func (a *CmuxAdapter) CreateWorkspace(_ context.Context, name string) error {
 	if err != nil {
 		return fmt.Errorf("cmux: create workspace: %w", err)
 	}
-	a.workspaceRef = parseCmuxRef(string(out), "workspace")
-	if a.workspaceRef == "" {
+	workspaceRef := parseCmuxRef(string(out), "workspace")
+	if workspaceRef == "" {
 		return fmt.Errorf("cmux: create workspace: failed to parse workspace ref from output %q", string(out))
 	}
+	if err := validateCmuxWorkspaceRef(workspaceRef); err != nil {
+		return fmt.Errorf("cmux: create workspace: %w", err)
+	}
+	a.workspaceRef = workspaceRef
 	renameCmd := execCommand("cmux", "rename-workspace", "--workspace", a.workspaceRef, name)
 	if err := renameCmd.Run(); err != nil {
 		return fmt.Errorf("cmux: rename workspace %q: %w", name, err)
@@ -41,7 +45,11 @@ func (a *CmuxAdapter) CreateWorkspace(_ context.Context, name string) error {
 // CreateSurface creates a new independent surface (tab) via cmux new-surface.
 // Each surface gets the full terminal width, avoiding pane width starvation.
 func (a *CmuxAdapter) CreateSurface(_ context.Context) (PaneID, error) {
-	cmd := execCommand("cmux", "new-surface")
+	args, err := a.workspaceCommandArgs("new-surface")
+	if err != nil {
+		return "", fmt.Errorf("cmux: new-surface: %w", err)
+	}
+	cmd := execCommand("cmux", args...)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("cmux: new-surface: %w", err)
@@ -59,7 +67,11 @@ func (a *CmuxAdapter) SplitPane(ctx context.Context, dir Direction) (PaneID, err
 	if dir == Vertical {
 		direction = "down"
 	}
-	cmd := execCommandContext(ctx, "cmux", "new-split", direction)
+	args, err := a.workspaceCommandArgs("new-split", direction)
+	if err != nil {
+		return "", fmt.Errorf("cmux: split pane: %w", err)
+	}
+	cmd := execCommandContext(ctx, "cmux", args...)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("cmux: split pane: %w", err)
@@ -77,7 +89,11 @@ func (a *CmuxAdapter) FocusPane(_ context.Context, paneID PaneID) error {
 	if err := validatePaneID(paneID); err != nil {
 		return fmt.Errorf("cmux: %w", err)
 	}
-	cmd := execCommand("cmux", "move-surface", "--surface", string(paneID), "--focus", "true")
+	args, err := a.surfaceCommandArgs("move-surface", paneID, "--focus", "true")
+	if err != nil {
+		return fmt.Errorf("cmux: focus pane %s: %w", paneID, err)
+	}
+	cmd := execCommand("cmux", args...)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("cmux: focus pane %s: %w", paneID, err)
 	}
@@ -90,13 +106,21 @@ func (a *CmuxAdapter) SendCommand(ctx context.Context, paneID PaneID, command st
 		return fmt.Errorf("cmux: %w", err)
 	}
 	if isEnterCommand(command) {
-		cmd := execCommandContext(ctx, "cmux", "send-key", "--surface", string(paneID), "Enter")
+		args, err := a.surfaceCommandArgs("send-key", paneID, "Enter")
+		if err != nil {
+			return fmt.Errorf("cmux: send enter to pane %s: %w", paneID, err)
+		}
+		cmd := execCommandContext(ctx, "cmux", args...)
 		if err := cmd.Run(); err != nil {
 			return fmt.Errorf("cmux: send enter to pane %s: %w", paneID, err)
 		}
 		return nil
 	}
-	cmd := execCommandContext(ctx, "cmux", "send", "--surface", string(paneID), command)
+	args, err := a.surfaceCommandArgs("send", paneID, "--", command)
+	if err != nil {
+		return fmt.Errorf("cmux: send command to pane %s: %w", paneID, err)
+	}
+	cmd := execCommandContext(ctx, "cmux", args...)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("cmux: send command to pane %s: %w", paneID, err)
 	}
@@ -114,18 +138,23 @@ func (a *CmuxAdapter) SendLongText(ctx context.Context, paneID PaneID, text stri
 	if text == "" {
 		return nil
 	}
+	pasteArgs, err := a.surfaceCommandArgs("paste-buffer", paneID)
+	if err != nil {
+		return fmt.Errorf("cmux: paste text to pane %s: %w", paneID, err)
+	}
 
 	sanitized := strings.ReplaceAll(string(paneID), ":", "-")
 	bufName := fmt.Sprintf("autopus-%s-%d", sanitized, time.Now().UnixNano())
 
 	// set-buffer
-	setCmd := execCommandContext(ctx, "cmux", "set-buffer", "--name", bufName, text)
+	setCmd := execCommandContext(ctx, "cmux", "set-buffer", "--name", bufName, "--", text)
 	if err := setCmd.Run(); err != nil {
 		// FR-10: fallback to chunked send on set-buffer failure
 		return a.sendChunked(ctx, paneID, text)
 	}
 	// paste-buffer — fall back to chunked send if paste fails (e.g., on recreated surfaces)
-	pasteCmd := execCommandContext(ctx, "cmux", "paste-buffer", "--name", bufName, "--surface", string(paneID))
+	pasteArgs = append(pasteArgs, "--name", bufName)
+	pasteCmd := execCommandContext(ctx, "cmux", pasteArgs...)
 	if err := pasteCmd.Run(); err != nil {
 		// Clean up buffer before fallback
 		delFallback := execCommandContext(ctx, "cmux", "delete-buffer", "--name", bufName)
@@ -163,52 +192,15 @@ func (a *CmuxAdapter) sendChunked(ctx context.Context, paneID PaneID, text strin
 	return nil
 }
 
-// Notify sends a notification message via cmux notify --title.
-func (a *CmuxAdapter) Notify(_ context.Context, message string) error {
-	cmd := execCommand("cmux", "notify", "--title", message)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("cmux: notify: %w", err)
-	}
-	return nil
-}
-
-// Close closes a surface or workspace by ref or stored workspace name.
-// If name is a cmux ref (surface:N or pane:N), uses close-surface.
-// If name is a workspace ref (workspace:N), uses close-workspace.
-// Otherwise, uses the stored workspaceRef from CreateWorkspace.
-func (a *CmuxAdapter) Close(_ context.Context, name string) error {
-	if isCmuxRef(name) {
-		if strings.HasPrefix(name, "surface:") || strings.HasPrefix(name, "pane:") {
-			cmd := execCommand("cmux", "close-surface", "--surface", name)
-			if err := cmd.Run(); err != nil {
-				return fmt.Errorf("cmux: close surface %s: %w", name, err)
-			}
-			return nil
-		}
-		cmd := execCommand("cmux", "close-workspace", "--workspace", name)
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("cmux: close workspace %s: %w", name, err)
-		}
-		return nil
-	}
-	// Name-based: use stored workspace ref if available.
-	ref := a.workspaceRef
-	if ref == "" {
-		return fmt.Errorf("cmux: close workspace %q: no workspace ref stored (call CreateWorkspace first)", name)
-	}
-	cmd := execCommand("cmux", "close-workspace", "--workspace", ref)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("cmux: close workspace %q: %w", name, err)
-	}
-	return nil
-}
-
 // ReadScreen reads pane content via cmux read-screen.
 func (a *CmuxAdapter) ReadScreen(ctx context.Context, paneID PaneID, opts ReadScreenOpts) (string, error) {
 	if err := validatePaneID(paneID); err != nil {
 		return "", fmt.Errorf("cmux: %w", err)
 	}
-	args := []string{"read-screen", "--surface", string(paneID)}
+	args, err := a.surfaceCommandArgs("read-screen", paneID)
+	if err != nil {
+		return "", fmt.Errorf("cmux: read-screen pane %s: %w", paneID, err)
+	}
 	if opts.Scrollback {
 		args = append(args, "--scrollback")
 	}
@@ -232,7 +224,14 @@ func (a *CmuxAdapter) PipePaneStart(_ context.Context, paneID PaneID, outputFile
 		return fmt.Errorf("cmux: %w", err)
 	}
 	// SEC-007: shell-escape outputFile to prevent command injection via malicious paths
-	cmd := execCommand("cmux", "pipe-pane", "--surface", string(paneID), "--command", "cat >> '"+strings.ReplaceAll(outputFile, "'", "'\\''")+"'")
+	args, err := a.surfaceCommandArgs(
+		"pipe-pane", paneID,
+		"--command", "cat >> '"+strings.ReplaceAll(outputFile, "'", "'\\''")+"'",
+	)
+	if err != nil {
+		return fmt.Errorf("cmux: pipe-pane start pane %s: %w", paneID, err)
+	}
+	cmd := execCommand("cmux", args...)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("cmux: pipe-pane start pane %s: %w", paneID, err)
 	}
@@ -244,25 +243,13 @@ func (a *CmuxAdapter) PipePaneStop(_ context.Context, paneID PaneID) error {
 	if err := validatePaneID(paneID); err != nil {
 		return fmt.Errorf("cmux: %w", err)
 	}
-	cmd := execCommand("cmux", "pipe-pane", "--surface", string(paneID), "--command", "")
+	args, err := a.surfaceCommandArgs("pipe-pane", paneID, "--command", "")
+	if err != nil {
+		return fmt.Errorf("cmux: pipe-pane stop pane %s: %w", paneID, err)
+	}
+	cmd := execCommand("cmux", args...)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("cmux: pipe-pane stop pane %s: %w", paneID, err)
 	}
 	return nil
-}
-
-// parseCmuxRef extracts a typed ref (e.g., "surface:7") from cmux CLI output.
-// Output format: "OK surface:7 workspace:1" or "OK workspace:5".
-func parseCmuxRef(output, refType string) string {
-	for field := range strings.FieldsSeq(strings.TrimSpace(output)) {
-		if strings.HasPrefix(field, refType+":") {
-			return field
-		}
-	}
-	return ""
-}
-
-// isCmuxRef reports whether s is a cmux reference (type:number format).
-func isCmuxRef(s string) bool {
-	return validCmuxRef.MatchString(s)
 }

--- a/pkg/terminal/cmux.go
+++ b/pkg/terminal/cmux.go
@@ -127,7 +127,7 @@ func (a *CmuxAdapter) SendCommand(ctx context.Context, paneID PaneID, command st
 	return nil
 }
 
-// SendLongText sends text to a pane via set-buffer/paste-buffer/delete-buffer.
+// SendLongText sends text to a pane via a bounded set-buffer/paste-buffer pair.
 // Buffer paste is used for short and long payloads because cmux send goes
 // through the active keyboard input path and can be affected by IME state.
 // @AX:ANCHOR: [AUTO] public API contract — Terminal interface method; fan_in=3 (interactive.go x2, interactive_debate.go)
@@ -142,28 +142,33 @@ func (a *CmuxAdapter) SendLongText(ctx context.Context, paneID PaneID, text stri
 	if err != nil {
 		return fmt.Errorf("cmux: paste text to pane %s: %w", paneID, err)
 	}
+	releaseBuffer, err := acquireCmuxInputBuffer(ctx)
+	if err != nil {
+		return fmt.Errorf("cmux: paste text to pane %s: %w", paneID, err)
+	}
+	release := func() {
+		if releaseBuffer != nil {
+			releaseBuffer()
+			releaseBuffer = nil
+		}
+	}
+	defer release()
 
-	sanitized := strings.ReplaceAll(string(paneID), ":", "-")
-	bufName := fmt.Sprintf("autopus-%s-%d", sanitized, time.Now().UnixNano())
-
-	// set-buffer
-	setCmd := execCommandContext(ctx, "cmux", "set-buffer", "--name", bufName, "--", text)
+	setCmd := execCommandContext(ctx, "cmux", "set-buffer", "--name", cmuxInputBufferName, "--", text)
 	if err := setCmd.Run(); err != nil {
 		// FR-10: fallback to chunked send on set-buffer failure
+		release()
 		return a.sendChunked(ctx, paneID, text)
 	}
 	// paste-buffer — fall back to chunked send if paste fails (e.g., on recreated surfaces)
-	pasteArgs = append(pasteArgs, "--name", bufName)
+	pasteArgs = append(pasteArgs, "--name", cmuxInputBufferName)
 	pasteCmd := execCommandContext(ctx, "cmux", pasteArgs...)
 	if err := pasteCmd.Run(); err != nil {
-		// Clean up buffer before fallback
-		delFallback := execCommandContext(ctx, "cmux", "delete-buffer", "--name", bufName)
-		_ = delFallback.Run()
+		clearCmuxInputBuffer()
+		release()
 		return a.sendChunked(ctx, paneID, text)
 	}
-	// delete-buffer (best-effort, FR-11)
-	delCmd := execCommandContext(ctx, "cmux", "delete-buffer", "--name", bufName)
-	_ = delCmd.Run()
+	clearCmuxInputBuffer()
 	return nil
 }
 

--- a/pkg/terminal/cmux_buffer_clear_test.go
+++ b/pkg/terminal/cmux_buffer_clear_test.go
@@ -1,0 +1,52 @@
+package terminal
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCmuxAdapter_SendLongText_ClearUsesIndependentContextAfterCallerCancel(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
+	for _, pasteFails := range []bool{false, true} {
+		t.Run(map[bool]string{false: "paste success", true: "paste failure"}[pasteFails], func(t *testing.T) {
+			restoreConfig := setCmuxBufferLockConfigForTest(
+				filepath.Join(t.TempDir(), "buffer.lock"), time.Second,
+			)
+			t.Cleanup(restoreConfig)
+			original := execCommand
+			originalContext := execCommandContext
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			var clearContextErr error
+			buildCommand := func(commandCtx context.Context, _ string, args ...string) *exec.Cmd {
+				if args[0] == "paste-buffer" {
+					cancel()
+					if pasteFails {
+						return exec.Command("false")
+					}
+				}
+				if args[0] == "set-buffer" && args[len(args)-1] == "" {
+					clearContextErr = commandCtx.Err()
+				}
+				return exec.Command("true")
+			}
+			execCommand = func(name string, args ...string) *exec.Cmd {
+				return buildCommand(context.Background(), name, args...)
+			}
+			execCommandContext = buildCommand
+			t.Cleanup(func() {
+				execCommand = original
+				execCommandContext = originalContext
+			})
+
+			_ = (&CmuxAdapter{}).SendLongText(ctx, "surface:7", "prompt")
+
+			assert.NoError(t, clearContextErr)
+		})
+	}
+}

--- a/pkg/terminal/cmux_buffer_clear_test.go
+++ b/pkg/terminal/cmux_buffer_clear_test.go
@@ -4,11 +4,73 @@ import (
 	"context"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+const expectedCmuxBufferSentinel = "[autopus-cleared]"
+
+func TestCmuxAdapter_SendLongText_WaitsForAsyncPasteBeforeSentinelOverwrite(t *testing.T) {
+	require.Equal(t, expectedCmuxBufferSentinel, cmuxInputBufferSentinel)
+	require.Equal(t, time.Second, cmuxBufferPostPasteMaxDelay)
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
+	restoreConfig := setCmuxBufferLockConfigForTest(
+		filepath.Join(t.TempDir(), "buffer.lock"), time.Second,
+	)
+	t.Cleanup(restoreConfig)
+	original := execCommand
+	originalContext := execCommandContext
+	var mu sync.Mutex
+	bufferContent := ""
+	consumed := make(chan string, 1)
+	buildCommand := func(_ context.Context, _ string, args ...string) *exec.Cmd {
+		switch args[0] {
+		case "set-buffer":
+			mu.Lock()
+			bufferContent = args[len(args)-1]
+			mu.Unlock()
+		case "paste-buffer":
+			go func() {
+				time.Sleep(75 * time.Millisecond)
+				mu.Lock()
+				consumed <- bufferContent
+				mu.Unlock()
+			}()
+		}
+		return exec.Command("true")
+	}
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		return buildCommand(context.Background(), name, args...)
+	}
+	execCommandContext = buildCommand
+	t.Cleanup(func() {
+		execCommand = original
+		execCommandContext = originalContext
+	})
+
+	started := time.Now()
+	err := (&CmuxAdapter{}).SendLongText(context.Background(), "surface:7", "sensitive prompt")
+	elapsed := time.Since(started)
+
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, elapsed, cmuxBufferPasteSettleDelay)
+	assert.Less(t, elapsed, cmuxBufferPostPasteMaxDelay+100*time.Millisecond)
+	select {
+	case delivered := <-consumed:
+		assert.Equal(t, "sensitive prompt", delivered)
+	case <-time.After(time.Second):
+		t.Fatal("async paste was not consumed")
+	}
+	mu.Lock()
+	retained := bufferContent
+	mu.Unlock()
+	assert.Equal(t, expectedCmuxBufferSentinel, retained)
+	assert.NotContains(t, retained, "sensitive prompt")
+}
 
 func TestCmuxAdapter_SendLongText_ClearUsesIndependentContextAfterCallerCancel(t *testing.T) {
 	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
@@ -23,6 +85,9 @@ func TestCmuxAdapter_SendLongText_ClearUsesIndependentContextAfterCallerCancel(t
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			var clearContextErr error
+			var clearHasDeadline bool
+			var clearDeadlineRemaining time.Duration
+			sendCalls := 0
 			buildCommand := func(commandCtx context.Context, _ string, args ...string) *exec.Cmd {
 				if args[0] == "paste-buffer" {
 					cancel()
@@ -30,8 +95,14 @@ func TestCmuxAdapter_SendLongText_ClearUsesIndependentContextAfterCallerCancel(t
 						return exec.Command("false")
 					}
 				}
-				if args[0] == "set-buffer" && args[len(args)-1] == "" {
+				if args[0] == "set-buffer" && args[len(args)-1] == expectedCmuxBufferSentinel {
 					clearContextErr = commandCtx.Err()
+					deadline, ok := commandCtx.Deadline()
+					clearHasDeadline = ok
+					clearDeadlineRemaining = time.Until(deadline)
+				}
+				if args[0] == "send" {
+					sendCalls++
 				}
 				return exec.Command("true")
 			}
@@ -44,9 +115,16 @@ func TestCmuxAdapter_SendLongText_ClearUsesIndependentContextAfterCallerCancel(t
 				execCommandContext = originalContext
 			})
 
-			_ = (&CmuxAdapter{}).SendLongText(ctx, "surface:7", "prompt")
+			started := time.Now()
+			err := (&CmuxAdapter{}).SendLongText(ctx, "surface:7", "prompt")
 
+			assert.ErrorIs(t, err, context.Canceled)
 			assert.NoError(t, clearContextErr)
+			assert.True(t, clearHasDeadline)
+			assert.Positive(t, clearDeadlineRemaining)
+			assert.LessOrEqual(t, clearDeadlineRemaining, time.Second)
+			assert.Less(t, time.Since(started), cmuxBufferPostPasteMaxDelay+100*time.Millisecond)
+			assert.Zero(t, sendCalls)
 		})
 	}
 }

--- a/pkg/terminal/cmux_buffer_flock_other.go
+++ b/pkg/terminal/cmux_buffer_flock_other.go
@@ -1,0 +1,18 @@
+//go:build !darwin && !linux && !windows
+
+package terminal
+
+import (
+	"errors"
+	"os"
+)
+
+func tryLockCmuxBufferFile(*os.File) (bool, error) {
+	return false, errors.New("cmux input buffer locking is unsupported")
+}
+
+func unlockCmuxBufferFile(*os.File) error {
+	return errors.New("cmux input buffer unlocking is unsupported")
+}
+
+func cmuxBufferLockOwnedByCurrentUser(os.FileInfo) bool { return false }

--- a/pkg/terminal/cmux_buffer_flock_unix.go
+++ b/pkg/terminal/cmux_buffer_flock_unix.go
@@ -1,0 +1,32 @@
+//go:build darwin || linux
+
+package terminal
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func tryLockCmuxBufferFile(file *os.File) (bool, error) {
+	err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+		return true, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("lock cmux input buffer: %w", err)
+	}
+	return false, nil
+}
+
+func unlockCmuxBufferFile(file *os.File) error {
+	return unix.Flock(int(file.Fd()), unix.LOCK_UN)
+}
+
+func cmuxBufferLockOwnedByCurrentUser(info os.FileInfo) bool {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok && stat.Uid == uint32(os.Geteuid())
+}

--- a/pkg/terminal/cmux_buffer_flock_windows.go
+++ b/pkg/terminal/cmux_buffer_flock_windows.go
@@ -1,0 +1,34 @@
+//go:build windows
+
+package terminal
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func tryLockCmuxBufferFile(file *os.File) (bool, error) {
+	err := windows.LockFileEx(
+		windows.Handle(file.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0, 1, 0, &windows.Overlapped{},
+	)
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		return true, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("lock cmux input buffer: %w", err)
+	}
+	return false, nil
+}
+
+func unlockCmuxBufferFile(file *os.File) error {
+	return windows.UnlockFileEx(
+		windows.Handle(file.Fd()), 0, 1, 0, &windows.Overlapped{},
+	)
+}
+
+func cmuxBufferLockOwnedByCurrentUser(os.FileInfo) bool { return true }

--- a/pkg/terminal/cmux_buffer_lifecycle_test.go
+++ b/pkg/terminal/cmux_buffer_lifecycle_test.go
@@ -1,0 +1,251 @@
+package terminal
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmuxAdapter_SendLongText_ReusesSingleClearedBuffer(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
+	restore, captured := newCmuxMockV2("", nil)
+	defer restore()
+
+	adapter := &CmuxAdapter{}
+	require.NoError(t, adapter.SendLongText(context.Background(), "surface:7", "first"))
+	require.NoError(t, adapter.SendLongText(context.Background(), "surface:8", "second"))
+
+	require.Len(t, captured.calls, 6)
+	for _, call := range captured.calls {
+		assert.NotEqual(t, "delete-buffer", call.args[0])
+	}
+	for _, offset := range []int{0, 3} {
+		assert.Equal(t, []string{
+			"set-buffer", "--name", "autopus-input", "--", captured.calls[offset].args[4],
+		}, captured.calls[offset].args)
+		assert.Equal(t, "paste-buffer", captured.calls[offset+1].args[0])
+		assert.Equal(t, []string{
+			"set-buffer", "--name", "autopus-input", "--", "",
+		}, captured.calls[offset+2].args)
+	}
+}
+
+func TestCmuxAdapter_SendLongText_ConcurrentCallsAreSerialized(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
+	original := execCommand
+	originalContext := execCommandContext
+	firstSetEntered := make(chan struct{})
+	releaseFirstSet := make(chan struct{})
+	secondSetEntered := make(chan struct{})
+	var payloadSets atomic.Int32
+
+	buildCommand := func(_ string, args ...string) *exec.Cmd {
+		if len(args) == 5 && args[0] == "set-buffer" && args[4] != "" {
+			switch payloadSets.Add(1) {
+			case 1:
+				close(firstSetEntered)
+				<-releaseFirstSet
+			case 2:
+				close(secondSetEntered)
+			}
+		}
+		return exec.Command("true")
+	}
+	execCommand = buildCommand
+	execCommandContext = func(_ context.Context, name string, args ...string) *exec.Cmd {
+		return buildCommand(name, args...)
+	}
+	t.Cleanup(func() {
+		execCommand = original
+		execCommandContext = originalContext
+	})
+
+	adapter := &CmuxAdapter{}
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	for pane, payload := range map[PaneID]string{
+		"surface:7": "first",
+		"surface:8": strings.Repeat("second", 10),
+	} {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- adapter.SendLongText(context.Background(), pane, payload)
+		}()
+		if pane == "surface:7" {
+			<-firstSetEntered
+		}
+	}
+
+	overlapped := false
+	select {
+	case <-secondSetEntered:
+		overlapped = true
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseFirstSet)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	assert.False(t, overlapped, "set-buffer/paste-buffer transactions must not overlap")
+}
+
+func TestCmuxAdapter_SendLongText_ClearFailureDoesNotFailDeliveredInput(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
+	var logs bytes.Buffer
+	originalLogWriter := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(originalLogWriter) })
+	original := execCommand
+	originalContext := execCommandContext
+	var calls [][]string
+	buildCommand := func(_ string, args ...string) *exec.Cmd {
+		calls = append(calls, args)
+		if len(args) == 5 && args[0] == "set-buffer" && args[4] == "" {
+			return exec.Command("false")
+		}
+		return exec.Command("true")
+	}
+	execCommand = buildCommand
+	execCommandContext = func(_ context.Context, name string, args ...string) *exec.Cmd {
+		return buildCommand(name, args...)
+	}
+	t.Cleanup(func() {
+		execCommand = original
+		execCommandContext = originalContext
+	})
+
+	adapter := &CmuxAdapter{}
+	err := adapter.SendLongText(context.Background(), "surface:7", "delivered")
+	nextErr := adapter.SendLongText(context.Background(), "surface:7", "next")
+
+	require.NoError(t, err)
+	require.NoError(t, nextErr)
+	require.Len(t, calls, 6)
+	assert.Equal(t, "", calls[2][4])
+	assert.Equal(t, "next", calls[3][4], "the next transaction must overwrite stale buffer content")
+	assert.Contains(t, logs.String(), "cmux: clear input buffer")
+	for _, call := range calls {
+		assert.NotEqual(t, "send", call[0], "clear failure must not resend delivered input")
+	}
+}
+
+func TestCmuxAdapter_SendLongText_ActiveCrossProcessLockHonorsCancellation(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
+	lockPath := filepath.Join(t.TempDir(), "cmux-buffer.lock")
+	restoreLockConfig := setCmuxBufferLockConfigForTest(lockPath, time.Second)
+	t.Cleanup(restoreLockConfig)
+	release, err := acquireCmuxInputBuffer(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(release)
+	restoreExec, captured := newCmuxMockV2("", nil)
+	defer restoreExec()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	err = (&CmuxAdapter{}).SendLongText(ctx, "surface:7", "prompt")
+
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Empty(t, captured.calls)
+}
+
+func TestCmuxAdapter_SendLongText_LiveContentionDoesNotFallbackTransport(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
+	lockPath := filepath.Join(t.TempDir(), "cmux-buffer.lock")
+	restoreLockConfig := setCmuxBufferLockConfigForTest(lockPath, 30*time.Millisecond)
+	t.Cleanup(restoreLockConfig)
+	release, err := acquireCmuxInputBuffer(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(release)
+	restoreExec, captured := newCmuxMockV2("", nil)
+	defer restoreExec()
+
+	err = (&CmuxAdapter{}).SendLongText(context.Background(), "surface:7", "fallback")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errCmuxBufferLockBusy)
+	assert.Empty(t, captured.calls)
+}
+
+func TestCmuxAdapter_SendLongText_BufferFailureReleasesLockBeforeFallback(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
+	for _, failCommand := range []string{"set-buffer", "paste-buffer"} {
+		t.Run(failCommand, func(t *testing.T) {
+			lockPath := filepath.Join(t.TempDir(), "cmux-buffer.lock")
+			restoreLockConfig := setCmuxBufferLockConfigForTest(lockPath, time.Second)
+			t.Cleanup(restoreLockConfig)
+			original := execCommand
+			originalContext := execCommandContext
+			lockAvailableAtFallback := false
+			buildCommand := func(_ string, args ...string) *exec.Cmd {
+				if args[0] == "send" {
+					probeRelease, lockErr := acquireCmuxInputBuffer(context.Background())
+					if lockErr == nil {
+						lockAvailableAtFallback = true
+						probeRelease()
+					}
+				}
+				if args[0] == failCommand && !(args[0] == "set-buffer" && args[len(args)-1] == "") {
+					return exec.Command("false")
+				}
+				return exec.Command("true")
+			}
+			execCommand = buildCommand
+			execCommandContext = func(_ context.Context, name string, args ...string) *exec.Cmd {
+				return buildCommand(name, args...)
+			}
+			t.Cleanup(func() {
+				execCommand = original
+				execCommandContext = originalContext
+			})
+
+			err := (&CmuxAdapter{}).SendLongText(context.Background(), "surface:7", "fallback")
+
+			require.NoError(t, err)
+			assert.True(t, lockAvailableAtFallback)
+		})
+	}
+}
+
+func TestAcquireCmuxInputBuffer_ReleaseDoesNotRemoveReplacementLock(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "cmux-buffer.lock")
+	restoreLockConfig := setCmuxBufferLockConfigForTest(lockPath, time.Second)
+	t.Cleanup(restoreLockConfig)
+	release, err := acquireCmuxInputBuffer(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(lockPath))
+	require.NoError(t, os.WriteFile(lockPath, []byte("replacement"), 0o600))
+
+	release()
+
+	info, err := os.Stat(lockPath)
+	require.NoError(t, err)
+	assert.True(t, info.Mode().IsRegular())
+}
+
+func setCmuxBufferLockConfigForTest(
+	path string,
+	waitLimit time.Duration,
+) func() {
+	originalPath := cmuxBufferLockPath
+	originalWaitLimit := cmuxBufferLockWaitLimit
+	cmuxBufferLockPath = path
+	cmuxBufferLockWaitLimit = waitLimit
+	return func() {
+		cmuxBufferLockPath = originalPath
+		cmuxBufferLockWaitLimit = originalWaitLimit
+	}
+}

--- a/pkg/terminal/cmux_buffer_lifecycle_test.go
+++ b/pkg/terminal/cmux_buffer_lifecycle_test.go
@@ -36,7 +36,7 @@ func TestCmuxAdapter_SendLongText_ReusesSingleClearedBuffer(t *testing.T) {
 		}, captured.calls[offset].args)
 		assert.Equal(t, "paste-buffer", captured.calls[offset+1].args[0])
 		assert.Equal(t, []string{
-			"set-buffer", "--name", "autopus-input", "--", "",
+			"set-buffer", "--name", "autopus-input", "--", cmuxInputBufferSentinel,
 		}, captured.calls[offset+2].args)
 	}
 }
@@ -51,7 +51,7 @@ func TestCmuxAdapter_SendLongText_ConcurrentCallsAreSerialized(t *testing.T) {
 	var payloadSets atomic.Int32
 
 	buildCommand := func(_ string, args ...string) *exec.Cmd {
-		if len(args) == 5 && args[0] == "set-buffer" && args[4] != "" {
+		if len(args) == 5 && args[0] == "set-buffer" && args[4] != cmuxInputBufferSentinel {
 			switch payloadSets.Add(1) {
 			case 1:
 				close(firstSetEntered)
@@ -114,7 +114,7 @@ func TestCmuxAdapter_SendLongText_ClearFailureDoesNotFailDeliveredInput(t *testi
 	var calls [][]string
 	buildCommand := func(_ string, args ...string) *exec.Cmd {
 		calls = append(calls, args)
-		if len(args) == 5 && args[0] == "set-buffer" && args[4] == "" {
+		if len(args) == 5 && args[0] == "set-buffer" && args[4] == cmuxInputBufferSentinel {
 			return exec.Command("false")
 		}
 		return exec.Command("true")
@@ -135,7 +135,7 @@ func TestCmuxAdapter_SendLongText_ClearFailureDoesNotFailDeliveredInput(t *testi
 	require.NoError(t, err)
 	require.NoError(t, nextErr)
 	require.Len(t, calls, 6)
-	assert.Equal(t, "", calls[2][4])
+	assert.Equal(t, cmuxInputBufferSentinel, calls[2][4])
 	assert.Equal(t, "next", calls[3][4], "the next transaction must overwrite stale buffer content")
 	assert.Contains(t, logs.String(), "cmux: clear input buffer")
 	for _, call := range calls {
@@ -198,7 +198,8 @@ func TestCmuxAdapter_SendLongText_BufferFailureReleasesLockBeforeFallback(t *tes
 						probeRelease()
 					}
 				}
-				if args[0] == failCommand && !(args[0] == "set-buffer" && args[len(args)-1] == "") {
+				if args[0] == failCommand &&
+					!(args[0] == "set-buffer" && args[len(args)-1] == cmuxInputBufferSentinel) {
 					return exec.Command("false")
 				}
 				return exec.Command("true")

--- a/pkg/terminal/cmux_buffer_lock.go
+++ b/pkg/terminal/cmux_buffer_lock.go
@@ -12,8 +12,11 @@ import (
 )
 
 const (
-	cmuxInputBufferName    = "autopus-input"
-	cmuxBufferClearTimeout = 750 * time.Millisecond
+	cmuxInputBufferName         = "autopus-input"
+	cmuxInputBufferSentinel     = "[autopus-cleared]"
+	cmuxBufferPasteSettleDelay  = 250 * time.Millisecond
+	cmuxBufferClearTimeout      = 750 * time.Millisecond
+	cmuxBufferPostPasteMaxDelay = cmuxBufferPasteSettleDelay + cmuxBufferClearTimeout
 )
 
 var (
@@ -104,12 +107,34 @@ func cmuxBufferWaitError(ctx context.Context) error {
 	return fmt.Errorf("%w after %s", errCmuxBufferLockBusy, cmuxBufferLockWaitLimit)
 }
 
-// clearCmuxInputBuffer does not inherit caller cancellation. A later send
+// settleAndClearCmuxInputBuffer lets cmux's async paste queue consume the
+// payload before overwrite. Cleanup survives caller cancellation, but the
+// cancellation is returned after at most cmuxBufferPostPasteMaxDelay.
+func settleAndClearCmuxInputBuffer(callerCtx context.Context) error {
+	timer := time.NewTimer(cmuxBufferPasteSettleDelay)
+	defer timer.Stop()
+	var callerErr error
+	select {
+	case <-timer.C:
+	case <-callerCtx.Done():
+		callerErr = callerCtx.Err()
+		<-timer.C
+	}
+	clearCmuxInputBuffer()
+	if callerErr == nil {
+		callerErr = callerCtx.Err()
+	}
+	return callerErr
+}
+
+// clearCmuxInputBuffer uses an independent bounded context. A later send
 // overwrites the same fixed buffer even when this diagnostic cleanup fails.
 func clearCmuxInputBuffer() {
 	ctx, cancel := context.WithTimeout(context.Background(), cmuxBufferClearTimeout)
 	defer cancel()
-	cmd := execCommandContext(ctx, "cmux", "set-buffer", "--name", cmuxInputBufferName, "--", "")
+	cmd := execCommandContext(
+		ctx, "cmux", "set-buffer", "--name", cmuxInputBufferName, "--", cmuxInputBufferSentinel,
+	)
 	if err := cmd.Run(); err != nil {
 		log.Printf("cmux: clear input buffer: %v", err)
 	}

--- a/pkg/terminal/cmux_buffer_lock.go
+++ b/pkg/terminal/cmux_buffer_lock.go
@@ -1,0 +1,116 @@
+package terminal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const (
+	cmuxInputBufferName    = "autopus-input"
+	cmuxBufferClearTimeout = 750 * time.Millisecond
+)
+
+var (
+	errCmuxBufferLockBusy   = errors.New("cmux input buffer lock busy")
+	cmuxBufferProcessGate   = make(chan struct{}, 1)
+	cmuxBufferLockPath      = filepath.Join(os.TempDir(), "autopus-cmux-input.flock")
+	cmuxBufferLockWaitLimit = 2 * time.Second
+)
+
+// acquireCmuxInputBuffer serializes the fixed cmux buffer. The advisory file
+// lock is released by the OS when an owner exits, including crashes.
+func acquireCmuxInputBuffer(ctx context.Context) (func(), error) {
+	lockCtx, cancel := context.WithTimeout(ctx, cmuxBufferLockWaitLimit)
+	defer cancel()
+	select {
+	case cmuxBufferProcessGate <- struct{}{}:
+	case <-lockCtx.Done():
+		return nil, cmuxBufferWaitError(ctx)
+	}
+	file, err := openCmuxBufferLockFile(cmuxBufferLockPath)
+	if err != nil {
+		<-cmuxBufferProcessGate
+		return nil, err
+	}
+	for {
+		busy, lockErr := tryLockCmuxBufferFile(file)
+		if lockErr != nil {
+			_ = file.Close()
+			<-cmuxBufferProcessGate
+			return nil, lockErr
+		}
+		if !busy {
+			if err := validateCmuxBufferLockFile(file, cmuxBufferLockPath); err != nil {
+				_ = unlockCmuxBufferFile(file)
+				_ = file.Close()
+				<-cmuxBufferProcessGate
+				return nil, err
+			}
+			var once sync.Once
+			return func() {
+				once.Do(func() {
+					if err := unlockCmuxBufferFile(file); err != nil {
+						log.Printf("cmux: unlock input buffer: %v", err)
+					}
+					_ = file.Close()
+					<-cmuxBufferProcessGate
+				})
+			}, nil
+		}
+		select {
+		case <-lockCtx.Done():
+			_ = file.Close()
+			<-cmuxBufferProcessGate
+			return nil, cmuxBufferWaitError(ctx)
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+func openCmuxBufferLockFile(lockPath string) (*os.File, error) {
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open cmux input buffer lock: %w", err)
+	}
+	if err := validateCmuxBufferLockFile(file, lockPath); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return file, nil
+}
+
+func validateCmuxBufferLockFile(file *os.File, lockPath string) error {
+	descriptorInfo, descriptorErr := file.Stat()
+	pathInfo, pathErr := os.Lstat(lockPath)
+	if descriptorErr != nil || pathErr != nil || !descriptorInfo.Mode().IsRegular() ||
+		!pathInfo.Mode().IsRegular() || descriptorInfo.Mode().Perm() != 0o600 ||
+		pathInfo.Mode().Perm() != 0o600 || !os.SameFile(descriptorInfo, pathInfo) ||
+		!cmuxBufferLockOwnedByCurrentUser(descriptorInfo) {
+		return errors.New("invalid cmux input buffer lock")
+	}
+	return nil
+}
+
+func cmuxBufferWaitError(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return fmt.Errorf("%w after %s", errCmuxBufferLockBusy, cmuxBufferLockWaitLimit)
+}
+
+// clearCmuxInputBuffer does not inherit caller cancellation. A later send
+// overwrites the same fixed buffer even when this diagnostic cleanup fails.
+func clearCmuxInputBuffer() {
+	ctx, cancel := context.WithTimeout(context.Background(), cmuxBufferClearTimeout)
+	defer cancel()
+	cmd := execCommandContext(ctx, "cmux", "set-buffer", "--name", cmuxInputBufferName, "--", "")
+	if err := cmd.Run(); err != nil {
+		log.Printf("cmux: clear input buffer: %v", err)
+	}
+}

--- a/pkg/terminal/cmux_buffer_process_lock_test.go
+++ b/pkg/terminal/cmux_buffer_process_lock_test.go
@@ -1,0 +1,142 @@
+package terminal
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	cmuxLockChildModeEnv  = "AUTOPUS_TEST_CMUX_LOCK_CHILD"
+	cmuxLockChildPathEnv  = "AUTOPUS_TEST_CMUX_LOCK_PATH"
+	cmuxLockChildReadyEnv = "AUTOPUS_TEST_CMUX_LOCK_READY"
+)
+
+func TestCmuxBufferLock_LiveProcessContentionDoesNotFallbackTransport(t *testing.T) {
+	if runCmuxBufferLockChild() {
+		return
+	}
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
+	tempDir := t.TempDir()
+	lockPath := filepath.Join(tempDir, "buffer.lock")
+	readyPath := filepath.Join(tempDir, "ready")
+	cmd := exec.Command(os.Args[0], "-test.run=^TestCmuxBufferLock_LiveProcessContentionDoesNotFallbackTransport$")
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
+	cmd.Env = append(os.Environ(),
+		cmuxLockChildModeEnv+"=hold",
+		cmuxLockChildPathEnv+"="+lockPath,
+		cmuxLockChildReadyEnv+"="+readyPath,
+	)
+	require.NoError(t, cmd.Start())
+	stopped := false
+	t.Cleanup(func() {
+		if !stopped {
+			_ = stdin.Close()
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	})
+	require.Eventually(t, func() bool {
+		_, statErr := os.Stat(readyPath)
+		return statErr == nil
+	}, time.Second, 10*time.Millisecond)
+
+	restoreConfig := setCmuxBufferLockConfigForTest(lockPath, 40*time.Millisecond)
+	t.Cleanup(restoreConfig)
+	restoreExec, captured := newCmuxMockV2("", nil)
+	defer restoreExec()
+	err = (&CmuxAdapter{}).SendLongText(context.Background(), "surface:7", "must-not-bypass")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errCmuxBufferLockBusy)
+	assert.Empty(t, captured.calls)
+	require.NoError(t, stdin.Close())
+	require.NoError(t, cmd.Wait())
+	stopped = true
+}
+
+func TestCmuxBufferLock_CrashedOwnerIsRecoveredImmediately(t *testing.T) {
+	if runCmuxBufferLockChild() {
+		return
+	}
+	lockPath := filepath.Join(t.TempDir(), "buffer.lock")
+	cmd := exec.Command(os.Args[0], "-test.run=^TestCmuxBufferLock_CrashedOwnerIsRecoveredImmediately$")
+	cmd.Env = append(os.Environ(),
+		cmuxLockChildModeEnv+"=crash",
+		cmuxLockChildPathEnv+"="+lockPath,
+	)
+	require.NoError(t, cmd.Run())
+	restoreConfig := setCmuxBufferLockConfigForTest(lockPath, 200*time.Millisecond)
+	t.Cleanup(restoreConfig)
+
+	started := time.Now()
+	release, err := acquireCmuxInputBuffer(context.Background())
+	require.NoError(t, err)
+	release()
+	assert.Less(t, time.Since(started), 100*time.Millisecond)
+}
+
+func TestCmuxBufferLock_UnsafePathFailsClosed(t *testing.T) {
+	for _, setup := range []struct {
+		name string
+		run  func(*testing.T, string)
+	}{
+		{
+			name: "symlink",
+			run: func(t *testing.T, path string) {
+				target := filepath.Join(t.TempDir(), "target")
+				require.NoError(t, os.WriteFile(target, nil, 0o600))
+				require.NoError(t, os.Symlink(target, path))
+			},
+		},
+		{
+			name: "permissive mode",
+			run: func(t *testing.T, path string) {
+				require.NoError(t, os.WriteFile(path, nil, 0o600))
+				require.NoError(t, os.Chmod(path, 0o644))
+			},
+		},
+	} {
+		t.Run(setup.name, func(t *testing.T) {
+			lockPath := filepath.Join(t.TempDir(), "buffer.lock")
+			setup.run(t, lockPath)
+			restoreConfig := setCmuxBufferLockConfigForTest(lockPath, 50*time.Millisecond)
+			t.Cleanup(restoreConfig)
+
+			release, err := acquireCmuxInputBuffer(context.Background())
+
+			require.Error(t, err)
+			assert.Nil(t, release)
+		})
+	}
+}
+
+func runCmuxBufferLockChild() bool {
+	mode := os.Getenv(cmuxLockChildModeEnv)
+	if mode == "" {
+		return false
+	}
+	cmuxBufferLockPath = os.Getenv(cmuxLockChildPathEnv)
+	cmuxBufferLockWaitLimit = time.Second
+	release, err := acquireCmuxInputBuffer(context.Background())
+	if err != nil {
+		os.Exit(3)
+	}
+	if mode == "crash" {
+		os.Exit(0)
+	}
+	if err := os.WriteFile(os.Getenv(cmuxLockChildReadyEnv), []byte("ready"), 0o600); err != nil {
+		os.Exit(4)
+	}
+	_, _ = io.Copy(io.Discard, os.Stdin)
+	release()
+	return true
+}

--- a/pkg/terminal/cmux_close.go
+++ b/pkg/terminal/cmux_close.go
@@ -1,0 +1,62 @@
+package terminal
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+)
+
+// Close closes a surface or workspace by ref or stored workspace name.
+// If name is a cmux ref (surface:N or pane:N), it uses close-surface.
+// If name is a workspace ref (workspace:N), it uses close-workspace.
+// Otherwise, it uses the stored workspaceRef from CreateWorkspace.
+func (a *CmuxAdapter) Close(_ context.Context, name string) error {
+	if isCmuxRef(name) {
+		if strings.HasPrefix(name, "surface:") || strings.HasPrefix(name, "pane:") {
+			return a.closeSurface(name)
+		}
+		cmd := execCommand("cmux", "close-workspace", "--workspace", name)
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("cmux: close workspace %s: %w", name, err)
+		}
+		return nil
+	}
+
+	ref := a.workspaceRef
+	if ref == "" {
+		return fmt.Errorf("cmux: close workspace %q: no workspace ref stored (call CreateWorkspace first)", name)
+	}
+	if err := validateCmuxWorkspaceRef(ref); err != nil {
+		return fmt.Errorf("cmux: close workspace %q: %w", name, err)
+	}
+	cmd := execCommand("cmux", "close-workspace", "--workspace", ref)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("cmux: close workspace %q: %w", name, err)
+	}
+	return nil
+}
+
+func (a *CmuxAdapter) closeSurface(name string) error {
+	args, err := a.surfaceCommandArgs("close-surface", PaneID(name))
+	if err != nil {
+		return fmt.Errorf("cmux: close surface %s: %w", name, err)
+	}
+
+	var stderr bytes.Buffer
+	cmd := execCommand("cmux", args...)
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if cmuxSurfaceAlreadyAbsent(stderr.String(), name) {
+			return nil
+		}
+		return closeCommandError(fmt.Sprintf("cmux: close surface %s", name), err, stderr.String())
+	}
+	return nil
+}
+
+func cmuxSurfaceAlreadyAbsent(stderr, surfaceRef string) bool {
+	message := strings.TrimSpace(stderr)
+	return message == "Error: not_found: Surface not found" ||
+		message == "Error: Surface ref not found: "+surfaceRef
+}

--- a/pkg/terminal/cmux_error_test.go
+++ b/pkg/terminal/cmux_error_test.go
@@ -50,6 +50,7 @@ func TestCmuxAdapter_CreateWorkspace_Error(t *testing.T) {
 // TestCmuxAdapter_SplitPane_Error verifies that SplitPane propagates command execution errors.
 // Note: cannot use t.Parallel() — this test mutates the package-level execCommand variable.
 func TestCmuxAdapter_SplitPane_Error(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	restore, _ := newCmuxMock(fmt.Errorf("cmux: split failed"))
 	defer restore()
 
@@ -62,6 +63,7 @@ func TestCmuxAdapter_SplitPane_Error(t *testing.T) {
 // TestCmuxAdapter_SendCommand_Error verifies that SendCommand propagates command execution errors.
 // Note: cannot use t.Parallel() — this test mutates the package-level execCommand variable.
 func TestCmuxAdapter_SendCommand_Error(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	restore, _ := newCmuxMock(fmt.Errorf("cmux: send failed"))
 	defer restore()
 
@@ -74,6 +76,7 @@ func TestCmuxAdapter_SendCommand_Error(t *testing.T) {
 // TestCmuxAdapter_Notify_Error verifies that Notify propagates command execution errors.
 // Note: cannot use t.Parallel() — this test mutates the package-level execCommand variable.
 func TestCmuxAdapter_Notify_Error(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	restore, _ := newCmuxMock(fmt.Errorf("cmux: notify failed"))
 	defer restore()
 
@@ -86,6 +89,7 @@ func TestCmuxAdapter_Notify_Error(t *testing.T) {
 // TestCmuxAdapter_Close_Error verifies that Close propagates errors for surface refs.
 // Note: cannot use t.Parallel() — this test mutates the package-level execCommand variable.
 func TestCmuxAdapter_Close_Error(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	restore, _ := newCmuxMock(fmt.Errorf("cmux: remove failed"))
 	defer restore()
 
@@ -137,6 +141,7 @@ func TestCmuxAdapter_CreateWorkspace_ParseFail(t *testing.T) {
 // TestCmuxAdapter_SplitPane_ParseFail verifies SplitPane errors when output has no surface ref.
 // Note: cannot use t.Parallel() — this test mutates the package-level execCommand variable.
 func TestCmuxAdapter_SplitPane_ParseFail(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	restore, _ := newCmuxMockV2("OK", nil) // output missing surface ref
 	defer restore()
 

--- a/pkg/terminal/cmux_focus_test.go
+++ b/pkg/terminal/cmux_focus_test.go
@@ -12,6 +12,7 @@ var _ PaneFocuser = (*CmuxAdapter)(nil)
 
 func TestCmuxAdapter_FocusPane_WithSurfaceRef_MovesSurfaceWithFocus(t *testing.T) {
 	// Given
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	restore, captured := newCmuxMockV2("", nil)
 	defer restore()
 
@@ -23,5 +24,7 @@ func TestCmuxAdapter_FocusPane_WithSurfaceRef_MovesSurfaceWithFocus(t *testing.T
 	// Then
 	require.NoError(t, err)
 	assert.Equal(t, "cmux", captured.lastName())
-	assert.Equal(t, []string{"move-surface", "--surface", "surface:7", "--focus", "true"}, captured.lastArgs())
+	assert.Equal(t, []string{
+		"move-surface", "--workspace", "workspace:1", "--surface", "surface:7", "--focus", "true",
+	}, captured.lastArgs())
 }

--- a/pkg/terminal/cmux_long_text_test.go
+++ b/pkg/terminal/cmux_long_text_test.go
@@ -13,6 +13,7 @@ import (
 // TestCmuxAdapter_SendLongText_LongText_BufferPath verifies long text (>=500B) uses
 // set-buffer/paste-buffer/delete-buffer instead of send.
 func TestCmuxAdapter_SendLongText_LongText_BufferPath(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	restore, captured := newCmuxMockV2("", nil)
 	defer restore()
 
@@ -31,6 +32,7 @@ func TestCmuxAdapter_SendLongText_LongText_BufferPath(t *testing.T) {
 // TestCmuxAdapter_SendLongText_ShortText_BufferPath verifies short text also uses
 // buffer paste so cmux input does not pass through the active IME state.
 func TestCmuxAdapter_SendLongText_ShortText_BufferPath(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	restore, captured := newCmuxMockV2("", nil)
 	defer restore()
 
@@ -48,6 +50,7 @@ func TestCmuxAdapter_SendLongText_ShortText_BufferPath(t *testing.T) {
 // TestCmuxAdapter_SendLongText_SetBufferFails_ChunkedFallback verifies fallback
 // to chunked send when set-buffer fails.
 func TestCmuxAdapter_SendLongText_SetBufferFails_ChunkedFallback(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	orig := execCommand
 	origCtx := execCommandContext
 	var calls []string
@@ -79,6 +82,7 @@ func TestCmuxAdapter_SendLongText_SetBufferFails_ChunkedFallback(t *testing.T) {
 // TestCmuxAdapter_SendLongText_PasteBufferFails_ChunkedFallback verifies fallback
 // to chunked send when paste-buffer fails (e.g., Codex ink TUI).
 func TestCmuxAdapter_SendLongText_PasteBufferFails_ChunkedFallback(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	orig := execCommand
 	origCtx := execCommandContext
 	var calls []string
@@ -114,12 +118,13 @@ func TestCmuxAdapter_SendLongText_PasteBufferFails_ChunkedFallback(t *testing.T)
 // TestCmuxAdapter_sendChunked_SplitsCorrectly verifies chunked send splits
 // text at 3500-byte boundaries.
 func TestCmuxAdapter_sendChunked_SplitsCorrectly(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	orig := execCommand
 	origCtx := execCommandContext
 	var sendPayloads []string
 	buildCmd := func(name string, args ...string) *exec.Cmd {
-		if len(args) >= 4 && args[0] == "send" {
-			sendPayloads = append(sendPayloads, args[3])
+		if len(args) >= 2 && args[0] == "send" {
+			sendPayloads = append(sendPayloads, args[len(args)-1])
 		}
 		return exec.Command("true")
 	}
@@ -144,6 +149,7 @@ func TestCmuxAdapter_sendChunked_SplitsCorrectly(t *testing.T) {
 // TestCmuxAdapter_SendLongText_UniqueBufferNames verifies different pane IDs produce
 // different buffer names.
 func TestCmuxAdapter_SendLongText_UniqueBufferNames(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	var allArgs [][]string
 	orig := execCommand
 	origCtx := execCommandContext

--- a/pkg/terminal/cmux_long_text_test.go
+++ b/pkg/terminal/cmux_long_text_test.go
@@ -26,7 +26,9 @@ func TestCmuxAdapter_SendLongText_LongText_BufferPath(t *testing.T) {
 	assert.Contains(t, strings.Join(captured.calls[0].args, " "), "autopus-")
 	assert.Contains(t, strings.Join(captured.calls[1].args, " "), "paste-buffer")
 	assert.Contains(t, strings.Join(captured.calls[1].args, " "), "surface:7")
-	assert.Equal(t, []string{"set-buffer", "--name", cmuxInputBufferName, "--", ""}, captured.calls[2].args)
+	assert.Equal(t, []string{
+		"set-buffer", "--name", cmuxInputBufferName, "--", cmuxInputBufferSentinel,
+	}, captured.calls[2].args)
 }
 
 // TestCmuxAdapter_SendLongText_ShortText_BufferPath verifies short text also uses
@@ -44,7 +46,9 @@ func TestCmuxAdapter_SendLongText_ShortText_BufferPath(t *testing.T) {
 	assert.Contains(t, strings.Join(captured.calls[0].args, " "), "set-buffer")
 	assert.Contains(t, strings.Join(captured.calls[1].args, " "), "paste-buffer")
 	assert.Contains(t, strings.Join(captured.calls[1].args, " "), "surface:7")
-	assert.Equal(t, []string{"set-buffer", "--name", cmuxInputBufferName, "--", ""}, captured.calls[2].args)
+	assert.Equal(t, []string{
+		"set-buffer", "--name", cmuxInputBufferName, "--", cmuxInputBufferSentinel,
+	}, captured.calls[2].args)
 }
 
 // TestCmuxAdapter_SendLongText_SetBufferFails_ChunkedFallback verifies fallback
@@ -172,7 +176,7 @@ func TestCmuxAdapter_SendLongText_ReusesBufferAcrossPanes(t *testing.T) {
 	var bufNames []string
 	for _, args := range allArgs {
 		combined := strings.Join(args, " ")
-		if strings.Contains(combined, "set-buffer") && args[len(args)-1] != "" {
+		if strings.Contains(combined, "set-buffer") && args[len(args)-1] != cmuxInputBufferSentinel {
 			for _, arg := range args {
 				if strings.HasPrefix(arg, "autopus-") {
 					bufNames = append(bufNames, arg)

--- a/pkg/terminal/cmux_long_text_test.go
+++ b/pkg/terminal/cmux_long_text_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestCmuxAdapter_SendLongText_LongText_BufferPath verifies long text (>=500B) uses
-// set-buffer/paste-buffer/delete-buffer instead of send.
+// TestCmuxAdapter_SendLongText_LongText_BufferPath verifies long text (>=500B)
+// uses set-buffer/paste-buffer and clears the reusable buffer instead of send.
 func TestCmuxAdapter_SendLongText_LongText_BufferPath(t *testing.T) {
 	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	restore, captured := newCmuxMockV2("", nil)
@@ -26,7 +26,7 @@ func TestCmuxAdapter_SendLongText_LongText_BufferPath(t *testing.T) {
 	assert.Contains(t, strings.Join(captured.calls[0].args, " "), "autopus-")
 	assert.Contains(t, strings.Join(captured.calls[1].args, " "), "paste-buffer")
 	assert.Contains(t, strings.Join(captured.calls[1].args, " "), "surface:7")
-	assert.Contains(t, strings.Join(captured.calls[2].args, " "), "delete-buffer")
+	assert.Equal(t, []string{"set-buffer", "--name", cmuxInputBufferName, "--", ""}, captured.calls[2].args)
 }
 
 // TestCmuxAdapter_SendLongText_ShortText_BufferPath verifies short text also uses
@@ -44,7 +44,7 @@ func TestCmuxAdapter_SendLongText_ShortText_BufferPath(t *testing.T) {
 	assert.Contains(t, strings.Join(captured.calls[0].args, " "), "set-buffer")
 	assert.Contains(t, strings.Join(captured.calls[1].args, " "), "paste-buffer")
 	assert.Contains(t, strings.Join(captured.calls[1].args, " "), "surface:7")
-	assert.Contains(t, strings.Join(captured.calls[2].args, " "), "delete-buffer")
+	assert.Equal(t, []string{"set-buffer", "--name", cmuxInputBufferName, "--", ""}, captured.calls[2].args)
 }
 
 // TestCmuxAdapter_SendLongText_SetBufferFails_ChunkedFallback verifies fallback
@@ -146,9 +146,9 @@ func TestCmuxAdapter_sendChunked_SplitsCorrectly(t *testing.T) {
 	assert.Equal(t, text, sendPayloads[0]+sendPayloads[1]+sendPayloads[2])
 }
 
-// TestCmuxAdapter_SendLongText_UniqueBufferNames verifies different pane IDs produce
-// different buffer names.
-func TestCmuxAdapter_SendLongText_UniqueBufferNames(t *testing.T) {
+// TestCmuxAdapter_SendLongText_ReusesBufferAcrossPanes verifies pane churn does
+// not create more cmux buffers.
+func TestCmuxAdapter_SendLongText_ReusesBufferAcrossPanes(t *testing.T) {
 	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	var allArgs [][]string
 	orig := execCommand
@@ -172,7 +172,7 @@ func TestCmuxAdapter_SendLongText_UniqueBufferNames(t *testing.T) {
 	var bufNames []string
 	for _, args := range allArgs {
 		combined := strings.Join(args, " ")
-		if strings.Contains(combined, "set-buffer") {
+		if strings.Contains(combined, "set-buffer") && args[len(args)-1] != "" {
 			for _, arg := range args {
 				if strings.HasPrefix(arg, "autopus-") {
 					bufNames = append(bufNames, arg)
@@ -181,5 +181,6 @@ func TestCmuxAdapter_SendLongText_UniqueBufferNames(t *testing.T) {
 		}
 	}
 	require.Len(t, bufNames, 2, "should have 2 set-buffer calls with buffer names")
-	assert.NotEqual(t, bufNames[0], bufNames[1], "buffer names must be unique per pane")
+	assert.Equal(t, bufNames[0], bufNames[1], "all panes must reuse the bounded buffer")
+	assert.Equal(t, cmuxInputBufferName, bufNames[0])
 }

--- a/pkg/terminal/cmux_option_payload_test.go
+++ b/pkg/terminal/cmux_option_payload_test.go
@@ -1,0 +1,48 @@
+package terminal
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmuxAdapter_SendCommand_OptionLikePayloadUsesArgumentSeparator(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:13")
+
+	for _, payload := range []string{"--help", "--workspace=workspace:999", "-h"} {
+		t.Run(payload, func(t *testing.T) {
+			restore, captured := newCmuxMockV2("", nil)
+			defer restore()
+
+			err := (&CmuxAdapter{}).SendCommand(context.Background(), "surface:1414", payload)
+
+			require.NoError(t, err)
+			assert.Equal(t, []string{
+				"send", "--workspace", "workspace:13", "--surface", "surface:1414", "--", payload,
+			}, captured.lastArgs())
+		})
+	}
+}
+
+func TestCmuxAdapter_SendLongText_OptionLikePayloadUsesArgumentSeparator(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:13")
+
+	for _, payload := range []string{"--help", "--workspace=workspace:999", "-h"} {
+		t.Run(payload, func(t *testing.T) {
+			restore, captured := newCmuxMockV2("", nil)
+			defer restore()
+
+			err := (&CmuxAdapter{}).SendLongText(context.Background(), "surface:1414", payload)
+
+			require.NoError(t, err)
+			require.Len(t, captured.calls, 3)
+			require.Len(t, captured.calls[0].args, 5)
+			bufferName := captured.calls[0].args[2]
+			assert.Equal(t, []string{
+				"set-buffer", "--name", bufferName, "--", payload,
+			}, captured.calls[0].args)
+		})
+	}
+}

--- a/pkg/terminal/cmux_signal.go
+++ b/pkg/terminal/cmux_signal.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -32,13 +31,9 @@ func (a *CmuxAdapter) SurfaceHealth(ctx context.Context, paneID PaneID) (Surface
 	if err := validatePaneID(paneID); err != nil {
 		return SurfaceStatus{}, fmt.Errorf("cmux: %w", err)
 	}
-	args := []string{"surface-health"}
-	workspace := a.workspaceRef
-	if workspace == "" {
-		workspace = os.Getenv("CMUX_WORKSPACE_ID")
-	}
-	if workspace != "" {
-		args = append(args, "--workspace", workspace)
+	args, err := a.workspaceCommandArgs("surface-health")
+	if err != nil {
+		return SurfaceStatus{}, fmt.Errorf("cmux: surface-health pane %s: %w", paneID, err)
 	}
 	cmd := execCommandContext(ctx, "cmux", args...)
 	out, err := cmd.Output()

--- a/pkg/terminal/cmux_signal_test.go
+++ b/pkg/terminal/cmux_signal_test.go
@@ -51,6 +51,7 @@ func TestCmuxAdapter_SurfaceHealth_Success(t *testing.T) {
 
 // TestCmuxAdapter_SurfaceHealth_NotInWindow verifies in_window=false parsing.
 func TestCmuxAdapter_SurfaceHealth_NotInWindow(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:2")
 	restore, _ := newCmuxMockV2("surface:3 type=terminal in_window=false", nil)
 	defer restore()
 
@@ -65,6 +66,7 @@ func TestCmuxAdapter_SurfaceHealth_NotInWindow(t *testing.T) {
 // TestCmuxAdapter_SurfaceHealth_MultipleSurfacesSelectsRequested verifies that
 // workspace-wide health output cannot overwrite the requested pane with the last line.
 func TestCmuxAdapter_SurfaceHealth_MultipleSurfacesSelectsRequested(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:2")
 	output := strings.Join([]string{
 		"surface:3 type=terminal in_window=false",
 		"surface:7 type=terminal in_window=true",
@@ -84,6 +86,7 @@ func TestCmuxAdapter_SurfaceHealth_MultipleSurfacesSelectsRequested(t *testing.T
 // TestCmuxAdapter_SurfaceHealth_MissingRequestedSurfaceReturnsError verifies that
 // a different healthy surface cannot make a missing provider pane look healthy.
 func TestCmuxAdapter_SurfaceHealth_MissingRequestedSurfaceReturnsError(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:2")
 	output := strings.Join([]string{
 		"surface:3 type=terminal in_window=true",
 		"surface:70 type=terminal in_window=true",
@@ -110,6 +113,7 @@ func TestCmuxAdapter_SurfaceHealth_InvalidPaneID(t *testing.T) {
 
 // TestCmuxAdapter_SurfaceHealth_CommandError verifies error propagation.
 func TestCmuxAdapter_SurfaceHealth_CommandError(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:2")
 	restore, _ := newCmuxMockV2("", fmt.Errorf("command failed"))
 	defer restore()
 

--- a/pkg/terminal/cmux_test.go
+++ b/pkg/terminal/cmux_test.go
@@ -100,6 +100,7 @@ func TestCmuxAdapter_CreateWorkspace(t *testing.T) {
 // TestCmuxAdapter_SplitPane_Horizontal verifies new-split right is called and surface ref is returned.
 // Note: cannot use t.Parallel() — this test mutates the package-level execCommand variable.
 func TestCmuxAdapter_SplitPane_Horizontal(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	restore, captured := newCmuxMockV2("OK surface:7 workspace:1", nil)
 	defer restore()
 
@@ -116,6 +117,7 @@ func TestCmuxAdapter_SplitPane_Horizontal(t *testing.T) {
 // TestCmuxAdapter_SplitPane_Vertical verifies new-split down is called and surface ref is returned.
 // Note: cannot use t.Parallel() — this test mutates the package-level execCommand variable.
 func TestCmuxAdapter_SplitPane_Vertical(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	restore, captured := newCmuxMockV2("OK surface:8 workspace:1", nil)
 	defer restore()
 
@@ -128,9 +130,10 @@ func TestCmuxAdapter_SplitPane_Vertical(t *testing.T) {
 	assert.Contains(t, combined, "down")
 }
 
-// TestCmuxAdapter_SendCommand verifies send --surface <ref> <cmd> is issued.
+// TestCmuxAdapter_SendCommand verifies send --surface <ref> -- <cmd> is issued.
 // Note: cannot use t.Parallel() — this test mutates the package-level execCommand variable.
 func TestCmuxAdapter_SendCommand(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	restore, captured := newCmuxMockV2("", nil)
 	defer restore()
 
@@ -145,6 +148,7 @@ func TestCmuxAdapter_SendCommand(t *testing.T) {
 }
 
 func TestCmuxAdapter_SendCommand_NewlineUsesEnterKey(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	restore, captured := newCmuxMockV2("", nil)
 	defer restore()
 
@@ -153,12 +157,15 @@ func TestCmuxAdapter_SendCommand_NewlineUsesEnterKey(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "cmux", captured.lastName())
-	assert.Equal(t, []string{"send-key", "--surface", "surface:7", "Enter"}, captured.lastArgs())
+	assert.Equal(t, []string{
+		"send-key", "--workspace", "workspace:1", "--surface", "surface:7", "Enter",
+	}, captured.lastArgs())
 }
 
 // TestCmuxAdapter_Notify verifies notify --title <msg> is issued.
 // Note: cannot use t.Parallel() — this test mutates the package-level execCommand variable.
 func TestCmuxAdapter_Notify(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	restore, captured := newCmuxMockV2("", nil)
 	defer restore()
 
@@ -174,6 +181,7 @@ func TestCmuxAdapter_Notify(t *testing.T) {
 // TestCmuxAdapter_Close_SurfaceRef verifies close-surface --surface <ref> for surface refs.
 // Note: cannot use t.Parallel() — this test mutates the package-level execCommand variable.
 func TestCmuxAdapter_Close_SurfaceRef(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	restore, captured := newCmuxMockV2("", nil)
 	defer restore()
 

--- a/pkg/terminal/cmux_workspace_context.go
+++ b/pkg/terminal/cmux_workspace_context.go
@@ -1,0 +1,116 @@
+package terminal
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+var canonicalCmuxWorkspaceUUID = regexp.MustCompile(
+	`^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$`,
+)
+
+// WorkspaceContextProvider exposes optional workspace affinity without changing
+// the Terminal interface implemented by tmux and plain adapters.
+type WorkspaceContextProvider interface {
+	WorkspaceRef() (string, error)
+	WithWorkspaceRef(string) (Terminal, error)
+}
+
+var _ WorkspaceContextProvider = (*CmuxAdapter)(nil)
+
+// NewCmuxAdapterWithWorkspace restores a cmux adapter for one persisted workspace.
+func NewCmuxAdapterWithWorkspace(workspaceRef string) (*CmuxAdapter, error) {
+	if err := validateCmuxWorkspaceRef(workspaceRef); err != nil {
+		return nil, fmt.Errorf("cmux: restore workspace context: %w", err)
+	}
+	return &CmuxAdapter{workspaceRef: workspaceRef}, nil
+}
+
+// WorkspaceRef returns the validated stored workspace, or the inherited cmux
+// workspace when no stored override exists.
+func (a *CmuxAdapter) WorkspaceRef() (string, error) {
+	if a.workspaceRef != "" {
+		if err := validateCmuxWorkspaceRef(a.workspaceRef); err != nil {
+			return "", fmt.Errorf("invalid stored workspace context: %w", err)
+		}
+		return a.workspaceRef, nil
+	}
+	workspaceRef := os.Getenv("CMUX_WORKSPACE_ID")
+	if workspaceRef == "" {
+		return "", fmt.Errorf("workspace context is unavailable: CMUX_WORKSPACE_ID is empty")
+	}
+	if err := validateCmuxWorkspaceRef(workspaceRef); err != nil {
+		return "", fmt.Errorf("invalid CMUX_WORKSPACE_ID: %w", err)
+	}
+	return workspaceRef, nil
+}
+
+// WithWorkspaceRef returns a validated clone, leaving the original adapter's
+// workspace affinity unchanged.
+func (*CmuxAdapter) WithWorkspaceRef(workspaceRef string) (Terminal, error) {
+	return NewCmuxAdapterWithWorkspace(workspaceRef)
+}
+
+func validateCmuxWorkspaceRef(workspaceRef string) error {
+	if strings.HasPrefix(workspaceRef, "workspace:") && validCmuxRef.MatchString(workspaceRef) {
+		return nil
+	}
+	if canonicalCmuxWorkspaceUUID.MatchString(workspaceRef) {
+		return nil
+	}
+	return fmt.Errorf("invalid workspace ref %q: want workspace:N or canonical UUID", workspaceRef)
+}
+
+func (a *CmuxAdapter) workspaceCommandArgs(command string, trailing ...string) ([]string, error) {
+	workspaceRef, err := a.WorkspaceRef()
+	if err != nil {
+		return nil, err
+	}
+	args := []string{command, "--workspace", workspaceRef}
+	return append(args, trailing...), nil
+}
+
+func (a *CmuxAdapter) surfaceCommandArgs(
+	command string,
+	paneID PaneID,
+	trailing ...string,
+) ([]string, error) {
+	workspaceRef, err := a.WorkspaceRef()
+	if err != nil {
+		return nil, err
+	}
+	args := []string{command, "--workspace", workspaceRef, "--surface", string(paneID)}
+	return append(args, trailing...), nil
+}
+
+// Notify sends a notification message in the effective cmux workspace.
+func (a *CmuxAdapter) Notify(_ context.Context, message string) error {
+	args, err := a.workspaceCommandArgs("notify", "--title", message)
+	if err != nil {
+		return fmt.Errorf("cmux: notify: %w", err)
+	}
+	cmd := execCommand("cmux", args...)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("cmux: notify: %w", err)
+	}
+	return nil
+}
+
+// parseCmuxRef extracts a typed ref (e.g., "surface:7") from cmux CLI output.
+// Output format: "OK surface:7 workspace:1" or "OK workspace:5".
+func parseCmuxRef(output, refType string) string {
+	for field := range strings.FieldsSeq(strings.TrimSpace(output)) {
+		if strings.HasPrefix(field, refType+":") {
+			return field
+		}
+	}
+	return ""
+}
+
+// isCmuxRef reports whether s is a cmux reference (type:number format).
+func isCmuxRef(s string) bool {
+	return validCmuxRef.MatchString(s)
+}

--- a/pkg/terminal/cmux_workspace_context_test.go
+++ b/pkg/terminal/cmux_workspace_context_test.go
@@ -167,7 +167,7 @@ func TestCmuxAdapter_SendLongText_WithWorkspace_AddsContextOnlyToSurfaceCommand(
 		"paste-buffer", "--workspace", "workspace:13", "--surface", "surface:1414",
 		"--name", bufferName,
 	}, captured.calls[1].args)
-	assert.Equal(t, []string{"delete-buffer", "--name", bufferName}, captured.calls[2].args)
+	assert.Equal(t, []string{"set-buffer", "--name", bufferName, "--", ""}, captured.calls[2].args)
 }
 
 func TestCmuxAdapter_SendLongTextFallback_WithWorkspace_AddsContextToSend(t *testing.T) {
@@ -196,7 +196,7 @@ func TestCmuxAdapter_SendLongTextFallback_WithWorkspace_AddsContextToSend(t *tes
 				args: []string{"send", "--workspace", "workspace:13", "--surface", "surface:1414", "--", "fallback"},
 			})
 			for _, call := range captured.calls {
-				if call.args[0] == "set-buffer" || call.args[0] == "delete-buffer" {
+				if call.args[0] == "set-buffer" {
 					assert.NotContains(t, call.args, "--workspace")
 				}
 			}

--- a/pkg/terminal/cmux_workspace_context_test.go
+++ b/pkg/terminal/cmux_workspace_context_test.go
@@ -167,7 +167,9 @@ func TestCmuxAdapter_SendLongText_WithWorkspace_AddsContextOnlyToSurfaceCommand(
 		"paste-buffer", "--workspace", "workspace:13", "--surface", "surface:1414",
 		"--name", bufferName,
 	}, captured.calls[1].args)
-	assert.Equal(t, []string{"set-buffer", "--name", bufferName, "--", ""}, captured.calls[2].args)
+	assert.Equal(t, []string{
+		"set-buffer", "--name", bufferName, "--", cmuxInputBufferSentinel,
+	}, captured.calls[2].args)
 }
 
 func TestCmuxAdapter_SendLongTextFallback_WithWorkspace_AddsContextToSend(t *testing.T) {

--- a/pkg/terminal/cmux_workspace_context_test.go
+++ b/pkg/terminal/cmux_workspace_context_test.go
@@ -1,0 +1,231 @@
+package terminal
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmuxAdapter_SurfaceTargetedCommands_WithEnvironmentWorkspace_AddWorkspaceArgument(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:13")
+
+	tests := []struct {
+		name string
+		run  func(*CmuxAdapter) error
+		want []string
+	}{
+		{
+			name: "send command",
+			run: func(adapter *CmuxAdapter) error {
+				return adapter.SendCommand(context.Background(), "surface:1414", "echo ready")
+			},
+			want: []string{"send", "--workspace", "workspace:13", "--surface", "surface:1414", "--", "echo ready"},
+		},
+		{
+			name: "send enter",
+			run: func(adapter *CmuxAdapter) error {
+				return adapter.SendCommand(context.Background(), "surface:1414", "\n")
+			},
+			want: []string{"send-key", "--workspace", "workspace:13", "--surface", "surface:1414", "Enter"},
+		},
+		{
+			name: "read screen",
+			run: func(adapter *CmuxAdapter) error {
+				_, err := adapter.ReadScreen(context.Background(), "surface:1414", ReadScreenOpts{})
+				return err
+			},
+			want: []string{"read-screen", "--workspace", "workspace:13", "--surface", "surface:1414"},
+		},
+		{
+			name: "pipe pane start",
+			run: func(adapter *CmuxAdapter) error {
+				return adapter.PipePaneStart(context.Background(), "surface:1414", "/tmp/output.txt")
+			},
+			want: []string{"pipe-pane", "--workspace", "workspace:13", "--surface", "surface:1414", "--command", "cat >> '/tmp/output.txt'"},
+		},
+		{
+			name: "pipe pane stop",
+			run: func(adapter *CmuxAdapter) error {
+				return adapter.PipePaneStop(context.Background(), "surface:1414")
+			},
+			want: []string{"pipe-pane", "--workspace", "workspace:13", "--surface", "surface:1414", "--command", ""},
+		},
+		{
+			name: "focus pane",
+			run: func(adapter *CmuxAdapter) error {
+				return adapter.FocusPane(context.Background(), "surface:1414")
+			},
+			want: []string{"move-surface", "--workspace", "workspace:13", "--surface", "surface:1414", "--focus", "true"},
+		},
+		{
+			name: "close surface",
+			run: func(adapter *CmuxAdapter) error {
+				return adapter.Close(context.Background(), "surface:1414")
+			},
+			want: []string{"close-surface", "--workspace", "workspace:13", "--surface", "surface:1414"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			restore, captured := newCmuxMockV2("screen output", nil)
+			defer restore()
+
+			require.NoError(t, test.run(&CmuxAdapter{}))
+			assert.Equal(t, test.want, captured.lastArgs())
+		})
+	}
+}
+
+func TestCmuxAdapter_SurfaceTargetedCommand_WithStoredWorkspace_OverridesEnvironment(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:13")
+	restore, captured := newCmuxMockV2("", nil)
+	defer restore()
+
+	adapter := &CmuxAdapter{workspaceRef: "workspace:21"}
+	err := adapter.SendCommand(context.Background(), "surface:1414", "echo ready")
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"send", "--workspace", "workspace:21", "--surface", "surface:1414", "--", "echo ready",
+	}, captured.lastArgs())
+}
+
+func TestCmuxAdapter_WorkspaceScopedCommands_WithCanonicalUUID_AddWorkspaceArgument(t *testing.T) {
+	const workspaceUUID = "CEC228BD-3FD5-4D00-8790-808F281E7CC1"
+	t.Setenv("CMUX_WORKSPACE_ID", workspaceUUID)
+
+	tests := []struct {
+		name   string
+		output string
+		run    func(*CmuxAdapter) error
+		want   []string
+	}{
+		{
+			name:   "new surface",
+			output: "OK surface:1414 workspace:13",
+			run: func(adapter *CmuxAdapter) error {
+				_, err := adapter.CreateSurface(context.Background())
+				return err
+			},
+			want: []string{"new-surface", "--workspace", workspaceUUID},
+		},
+		{
+			name:   "new split",
+			output: "OK surface:1414 workspace:13",
+			run: func(adapter *CmuxAdapter) error {
+				_, err := adapter.SplitPane(context.Background(), Horizontal)
+				return err
+			},
+			want: []string{"new-split", "--workspace", workspaceUUID, "right"},
+		},
+		{
+			name: "notify",
+			run: func(adapter *CmuxAdapter) error {
+				return adapter.Notify(context.Background(), "ready")
+			},
+			want: []string{"notify", "--workspace", workspaceUUID, "--title", "ready"},
+		},
+		{
+			name:   "surface health",
+			output: "surface:1414 type=terminal in_window=true",
+			run: func(adapter *CmuxAdapter) error {
+				_, err := adapter.SurfaceHealth(context.Background(), "surface:1414")
+				return err
+			},
+			want: []string{"surface-health", "--workspace", workspaceUUID},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			restore, captured := newCmuxMockV2(test.output, nil)
+			defer restore()
+
+			require.NoError(t, test.run(&CmuxAdapter{}))
+			assert.Equal(t, test.want, captured.lastArgs())
+		})
+	}
+}
+
+func TestCmuxAdapter_SendLongText_WithWorkspace_AddsContextOnlyToSurfaceCommand(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:13")
+	restore, captured := newCmuxMockV2("", nil)
+	defer restore()
+
+	text := "prompt"
+	err := (&CmuxAdapter{}).SendLongText(context.Background(), "surface:1414", text)
+
+	require.NoError(t, err)
+	require.Len(t, captured.calls, 3)
+	bufferName := captured.calls[0].args[2]
+	assert.Equal(t, []string{"set-buffer", "--name", bufferName, "--", text}, captured.calls[0].args)
+	assert.Equal(t, []string{
+		"paste-buffer", "--workspace", "workspace:13", "--surface", "surface:1414",
+		"--name", bufferName,
+	}, captured.calls[1].args)
+	assert.Equal(t, []string{"delete-buffer", "--name", bufferName}, captured.calls[2].args)
+}
+
+func TestCmuxAdapter_SendLongTextFallback_WithWorkspace_AddsContextToSend(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:13")
+
+	tests := []struct {
+		name        string
+		failCommand string
+	}{
+		{name: "set buffer failure", failCommand: "set-buffer"},
+		{name: "paste buffer failure", failCommand: "paste-buffer"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			captured := newCmuxSelectiveFailureMock(t, test.failCommand)
+
+			err := (&CmuxAdapter{}).SendLongText(context.Background(), "surface:1414", "fallback")
+
+			require.NoError(t, err)
+			assert.Contains(t, captured.calls, struct {
+				name string
+				args []string
+			}{
+				name: "cmux",
+				args: []string{"send", "--workspace", "workspace:13", "--surface", "surface:1414", "--", "fallback"},
+			})
+			for _, call := range captured.calls {
+				if call.args[0] == "set-buffer" || call.args[0] == "delete-buffer" {
+					assert.NotContains(t, call.args, "--workspace")
+				}
+			}
+		})
+	}
+}
+
+func newCmuxSelectiveFailureMock(t *testing.T, failCommand string) *capturedCmds {
+	t.Helper()
+	original := execCommand
+	originalContext := execCommandContext
+	captured := &capturedCmds{}
+	buildCommand := func(name string, args ...string) *exec.Cmd {
+		captured.calls = append(captured.calls, struct {
+			name string
+			args []string
+		}{name: name, args: args})
+		if len(args) > 0 && args[0] == failCommand {
+			return exec.Command("false")
+		}
+		return exec.Command("true")
+	}
+	execCommand = buildCommand
+	execCommandContext = func(_ context.Context, name string, args ...string) *exec.Cmd {
+		return buildCommand(name, args...)
+	}
+	t.Cleanup(func() {
+		execCommand = original
+		execCommandContext = originalContext
+	})
+	return captured
+}

--- a/pkg/terminal/cmux_workspace_restore_test.go
+++ b/pkg/terminal/cmux_workspace_restore_test.go
@@ -1,0 +1,129 @@
+package terminal
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCmuxAdapterWithWorkspace_WithCanonicalReference_RestoresContext(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:99")
+
+	tests := []struct {
+		name         string
+		workspaceRef string
+	}{
+		{name: "workspace reference", workspaceRef: "workspace:13"},
+		{name: "canonical UUID", workspaceRef: "CEC228BD-3FD5-4D00-8790-808F281E7CC1"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			adapter, err := NewCmuxAdapterWithWorkspace(test.workspaceRef)
+			require.NoError(t, err)
+
+			workspaceRef, err := adapter.WorkspaceRef()
+			require.NoError(t, err)
+			assert.Equal(t, test.workspaceRef, workspaceRef)
+		})
+	}
+}
+
+func TestNewCmuxAdapterWithWorkspace_WithInvalidReference_ReturnsError(t *testing.T) {
+	for _, workspaceRef := range []string{"", "surface:13", "workspace:abc", "not-a-uuid"} {
+		t.Run(workspaceRef, func(t *testing.T) {
+			adapter, err := NewCmuxAdapterWithWorkspace(workspaceRef)
+
+			assert.Nil(t, adapter)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid workspace ref")
+		})
+	}
+}
+
+func TestCmuxAdapter_WithWorkspaceRef_ClonesWithoutMutatingOriginal(t *testing.T) {
+	original, err := NewCmuxAdapterWithWorkspace("workspace:13")
+	require.NoError(t, err)
+
+	cloneTerminal, err := original.WithWorkspaceRef("workspace:21")
+	require.NoError(t, err)
+	clone, ok := cloneTerminal.(*CmuxAdapter)
+	require.True(t, ok)
+
+	originalRef, err := original.WorkspaceRef()
+	require.NoError(t, err)
+	cloneRef, err := clone.WorkspaceRef()
+	require.NoError(t, err)
+	assert.Equal(t, "workspace:13", originalRef)
+	assert.Equal(t, "workspace:21", cloneRef)
+}
+
+func TestCmuxAdapter_WorkspaceRef_WithoutStoredReference_UsesEnvironment(t *testing.T) {
+	const workspaceUUID = "CEC228BD-3FD5-4D00-8790-808F281E7CC1"
+	t.Setenv("CMUX_WORKSPACE_ID", workspaceUUID)
+
+	workspaceRef, err := (&CmuxAdapter{}).WorkspaceRef()
+
+	require.NoError(t, err)
+	assert.Equal(t, workspaceUUID, workspaceRef)
+}
+
+func TestCmuxAdapter_SurfaceCommand_WithInvalidWorkspace_FailsBeforeExecution(t *testing.T) {
+	tests := []struct {
+		name          string
+		stored        string
+		environment   string
+		wantErrorPart string
+	}{
+		{
+			name:          "missing environment",
+			wantErrorPart: "workspace context is unavailable",
+		},
+		{
+			name:          "invalid environment",
+			environment:   "surface:13",
+			wantErrorPart: "invalid CMUX_WORKSPACE_ID",
+		},
+		{
+			name:          "invalid stored reference does not use valid environment",
+			stored:        "workspace:invalid",
+			environment:   "workspace:13",
+			wantErrorPart: "invalid stored workspace context",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("CMUX_WORKSPACE_ID", test.environment)
+			restore, captured := newCmuxMockV2("", nil)
+			defer restore()
+
+			err := (&CmuxAdapter{workspaceRef: test.stored}).SendCommand(
+				context.Background(), "surface:1414", "echo ready",
+			)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.wantErrorPart)
+			assert.Empty(t, captured.calls, "invalid workspace must fail before cmux execution")
+		})
+	}
+}
+
+func TestCmuxAdapter_BufferAndSignalCommands_WithWorkspace_DoNotAddUnsupportedFlag(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:13")
+	restore, captured := newCmuxMockV2("", nil)
+	defer restore()
+
+	adapter := &CmuxAdapter{}
+	require.NoError(t, adapter.WaitForSignal(context.Background(), "ready", time.Second))
+	require.NoError(t, adapter.SendSignal(context.Background(), "ready"))
+
+	require.Len(t, captured.calls, 2)
+	assert.Equal(t, []string{"wait-for", "ready", "--timeout", "30"}, captured.calls[0].args)
+	assert.Equal(t, []string{"wait-for", "-S", "ready"}, captured.calls[1].args)
+	assert.NotContains(t, captured.calls[0].args, "--workspace")
+	assert.NotContains(t, captured.calls[1].args, "--workspace")
+}

--- a/pkg/terminal/read_screen_context_test.go
+++ b/pkg/terminal/read_screen_context_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestInteractive_CmuxAdapter_ReadScreen_UsesContextCommand(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	orig := execCommand
 	origCtx := execCommandContext
 	defer func() {
@@ -64,6 +65,7 @@ func TestInteractive_TmuxAdapter_ReadScreen_UsesContextCommand(t *testing.T) {
 }
 
 func TestCmuxAdapter_SendCommandUsesContextCommand(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	orig := execCommand
 	origCtx := execCommandContext
 	defer func() {
@@ -89,6 +91,7 @@ func TestCmuxAdapter_SendCommandUsesContextCommand(t *testing.T) {
 }
 
 func TestCmuxAdapter_SendLongTextUsesContextCommands(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	orig := execCommand
 	origCtx := execCommandContext
 	defer func() {

--- a/pkg/terminal/split_context_test.go
+++ b/pkg/terminal/split_context_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestCmuxAdapter_SplitPaneUsesContextCommand(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	original := execCommand
 	originalContext := execCommandContext
 	defer func() {

--- a/pkg/terminal/terminal_close_idempotency_test.go
+++ b/pkg/terminal/terminal_close_idempotency_test.go
@@ -1,0 +1,98 @@
+package terminal
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmuxAdapter_CloseSurface_AlreadyAbsentIsIdempotent(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:13")
+
+	for _, stderr := range []string{
+		"Error: not_found: Surface not found\n",
+		"Error: Surface ref not found: surface:1414\n",
+	} {
+		t.Run(strings.TrimSpace(stderr), func(t *testing.T) {
+			captured := mockTerminalCloseFailure(t, stderr)
+
+			err := (&CmuxAdapter{}).Close(context.Background(), "surface:1414")
+
+			require.NoError(t, err)
+			assert.Equal(t, []string{
+				"close-surface", "--workspace", "workspace:13", "--surface", "surface:1414",
+			}, captured.args)
+		})
+	}
+}
+
+func TestCmuxAdapter_CloseSurface_OtherFailuresRemainErrors(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:13")
+
+	for _, stderr := range []string{
+		"Error: permission_denied: Permission denied\n",
+		"Error: Socket not found at /tmp/cmux.sock\n",
+		"Error: invalid_params: Invalid surface handle\n",
+		"Error: Surface ref not found: surface:9999\n",
+	} {
+		t.Run(strings.TrimSpace(stderr), func(t *testing.T) {
+			mockTerminalCloseFailure(t, stderr)
+
+			err := (&CmuxAdapter{}).Close(context.Background(), "surface:1414")
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), strings.TrimSpace(stderr))
+		})
+	}
+}
+
+func TestTmuxAdapter_ClosePane_AlreadyAbsentIsIdempotent(t *testing.T) {
+	for _, stderr := range []string{
+		"can't find pane: %42\n",
+	} {
+		t.Run(strings.TrimSpace(stderr), func(t *testing.T) {
+			captured := mockTerminalCloseFailure(t, stderr)
+
+			err := (&TmuxAdapter{}).Close(context.Background(), "%42")
+
+			require.NoError(t, err)
+			assert.Equal(t, []string{"kill-pane", "-t", "%42"}, captured.args)
+		})
+	}
+}
+
+func TestTmuxAdapter_ClosePane_OtherFailuresRemainErrors(t *testing.T) {
+	for _, stderr := range []string{
+		"no server running on /private/tmp/tmux-501/default\n",
+		"permission denied\n",
+		"failed to connect to server: Connection refused\n",
+		"invalid pane ID: %42\n",
+		"can't find pane: %99\n",
+	} {
+		t.Run(strings.TrimSpace(stderr), func(t *testing.T) {
+			mockTerminalCloseFailure(t, stderr)
+
+			err := (&TmuxAdapter{}).Close(context.Background(), "%42")
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), strings.TrimSpace(stderr))
+		})
+	}
+}
+
+func mockTerminalCloseFailure(t *testing.T, stderr string) *capturedCmd {
+	t.Helper()
+	original := execCommand
+	captured := &capturedCmd{}
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		captured.name = name
+		captured.args = args
+		return exec.Command("sh", "-c", "printf '%s' \"$1\" >&2; exit 1", "terminal-close-test", stderr)
+	}
+	t.Cleanup(func() { execCommand = original })
+	return captured
+}

--- a/pkg/terminal/terminal_interactive_test.go
+++ b/pkg/terminal/terminal_interactive_test.go
@@ -38,6 +38,7 @@ func TestInteractive_PipePaneStop_CompileCheck(t *testing.T) {
 
 // TestInteractive_CmuxAdapter_ReadScreen_CallsReadScreenCmd verifies cmux read-screen --surface <ref>.
 func TestInteractive_CmuxAdapter_ReadScreen_CallsReadScreenCmd(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	restore, captured := newCmuxMockV2("screen content here", nil)
 	defer restore()
 
@@ -53,6 +54,7 @@ func TestInteractive_CmuxAdapter_ReadScreen_CallsReadScreenCmd(t *testing.T) {
 
 // TestInteractive_CmuxAdapter_ReadScreen_WithScrollback tests scrollback option.
 func TestInteractive_CmuxAdapter_ReadScreen_WithScrollback(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	restore, captured := newCmuxMockV2("scrollback content", nil)
 	defer restore()
 
@@ -65,6 +67,7 @@ func TestInteractive_CmuxAdapter_ReadScreen_WithScrollback(t *testing.T) {
 
 // TestInteractive_CmuxAdapter_ReadScreen_WithLines tests --lines N option.
 func TestInteractive_CmuxAdapter_ReadScreen_WithLines(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	restore, captured := newCmuxMockV2("last 50 lines", nil)
 	defer restore()
 
@@ -78,6 +81,7 @@ func TestInteractive_CmuxAdapter_ReadScreen_WithLines(t *testing.T) {
 
 // TestInteractive_CmuxAdapter_PipePaneStart_CallsPipePaneCmd tests pipe-pane start.
 func TestInteractive_CmuxAdapter_PipePaneStart_CallsPipePaneCmd(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	restore, captured := newCmuxMockV2("", nil)
 	defer restore()
 
@@ -93,6 +97,7 @@ func TestInteractive_CmuxAdapter_PipePaneStart_CallsPipePaneCmd(t *testing.T) {
 
 // TestInteractive_CmuxAdapter_PipePaneStop_CallsEmptyCommand tests pipe-pane stop.
 func TestInteractive_CmuxAdapter_PipePaneStop_CallsEmptyCommand(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	restore, captured := newCmuxMockV2("", nil)
 	defer restore()
 
@@ -151,6 +156,7 @@ func TestInteractive_TmuxAdapter_PipePaneStop_CallsPipePaneNoArgs(t *testing.T) 
 
 // TestInteractive_CmuxAdapter_ReadScreen_Error verifies error propagation.
 func TestInteractive_CmuxAdapter_ReadScreen_Error(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	restore, _ := newCmuxMockV2("", fmt.Errorf("read-screen failed"))
 	defer restore()
 
@@ -162,6 +168,7 @@ func TestInteractive_CmuxAdapter_ReadScreen_Error(t *testing.T) {
 
 // TestInteractive_CmuxAdapter_PipePaneStart_Error verifies error propagation.
 func TestInteractive_CmuxAdapter_PipePaneStart_Error(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	restore, _ := newCmuxMockV2("", fmt.Errorf("pipe-pane failed"))
 	defer restore()
 
@@ -173,6 +180,7 @@ func TestInteractive_CmuxAdapter_PipePaneStart_Error(t *testing.T) {
 
 // TestInteractive_CmuxAdapter_PipePaneStop_Error verifies error propagation.
 func TestInteractive_CmuxAdapter_PipePaneStop_Error(t *testing.T) {
+	t.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
 	restore, _ := newCmuxMockV2("", fmt.Errorf("pipe-pane stop failed"))
 	defer restore()
 

--- a/pkg/terminal/tmux.go
+++ b/pkg/terminal/tmux.go
@@ -218,22 +218,3 @@ func (a *TmuxAdapter) SendLongText(_ context.Context, paneID PaneID, text string
 
 	return nil
 }
-
-// Close kills a global tmux pane ID or the named tmux session.
-func (a *TmuxAdapter) Close(_ context.Context, name string) error {
-	if strings.HasPrefix(name, "%") {
-		if _, err := tmuxPaneTarget("", PaneID(name)); err != nil {
-			return fmt.Errorf("tmux: %w", err)
-		}
-		cmd := execCommand("tmux", "kill-pane", "-t", name)
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("tmux: kill pane %q: %w", name, err)
-		}
-		return nil
-	}
-	cmd := execCommand("tmux", "kill-session", "-t", name)
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("tmux: kill session %q: %w", name, err)
-	}
-	return nil
-}

--- a/pkg/terminal/tmux_close.go
+++ b/pkg/terminal/tmux_close.go
@@ -1,0 +1,40 @@
+package terminal
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+)
+
+// Close kills a global tmux pane ID or the named tmux session.
+func (a *TmuxAdapter) Close(_ context.Context, name string) error {
+	if strings.HasPrefix(name, "%") {
+		if _, err := tmuxPaneTarget("", PaneID(name)); err != nil {
+			return fmt.Errorf("tmux: %w", err)
+		}
+		return closeTmuxPane(name)
+	}
+	cmd := execCommand("tmux", "kill-session", "-t", name)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("tmux: kill session %q: %w", name, err)
+	}
+	return nil
+}
+
+func closeTmuxPane(target string) error {
+	var stderr bytes.Buffer
+	cmd := execCommand("tmux", "kill-pane", "-t", target)
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if tmuxPaneAlreadyAbsent(stderr.String(), target) {
+			return nil
+		}
+		return closeCommandError(fmt.Sprintf("tmux: kill pane %q", target), err, stderr.String())
+	}
+	return nil
+}
+
+func tmuxPaneAlreadyAbsent(stderr, paneTarget string) bool {
+	return strings.TrimSpace(stderr) == "can't find pane: "+paneTarget
+}


### PR DESCRIPTION
## 변경 사항

- cmux surface 명령에 생성 당시 workspace를 명시하고, yield session과 surface tracker가 terminal identity를 끝까지 보존하도록 했습니다.
- cmux 입력은 고정 buffer와 advisory lock을 사용하고, 비동기 paste 소비 뒤 17바이트 sentinel로 덮어써 buffer 누적과 민감한 입력 잔존을 막습니다.
- provider별 TUI가 실제 입력 가능한 상태인지 두 프레임 연속 확인한 뒤 프롬프트를 전달합니다.
- Claude, Codex, Gemini/Antigravity, OpenCode의 completion hook을 session directory와 provider/round cursor 안에서만 처리합니다.
- Codex 응답 파일은 payload 준비 신호로만 사용합니다. 중간 라운드는 실제 `next-ready` 또는 안정된 provider idle까지 기다리며, timeout과 terminal I/O 오류는 fail-closed로 처리합니다.
- Claude hook scope/`disableAllHooks`, Codex hook 신뢰 상태, Antigravity config root를 실제 런타임 규칙에 맞게 탐색합니다.
- Antigravity용 공식 Stop hook을 추가하고 Gemini 생성·업데이트를 두 hook asset 기준의 원자적 작업으로 바꿨습니다.
- `--yield-rounds --format json`이 `session_id`, `panes`, `round_history`를 직접 반환하도록 복구했습니다. 일반 JSON의 typed receipt 형식은 유지합니다.

## 근본 원인

pane이 열리지 않거나 다음 라운드가 멈추던 현상은 단일 원인이 아니었습니다.

1. cmux 명령이 원 workspace를 잃어 비포커스 surface를 잘못 조회하거나 닫았습니다.
2. provider CLI가 입력 가능한 상태가 되기 전에 prompt가 전달됐습니다.
3. 응답 파일 생성을 turn 완료로 오판해 Codex Stop hook이 실행되기 전에 다음 라운드로 진입했습니다.
4. provider별 hook scope, alias, startup/recovery 상태가 하나의 일반화된 계약으로 처리됐습니다.
5. yield JSON이 저장된 session context를 stdout에서 누락해 후속 `inject`, `collect`, `cleanup`이 자동으로 이어지지 못했습니다.

## 사용자 영향

- Claude Code와 Codex pane이 다른 cmux workspace에서도 안정적으로 생성되고 유지됩니다.
- 2라운드 토론은 응답 파일 작성과 실제 turn 종료를 구분합니다.
- Gemini/Antigravity judge도 공식 Stop hook 경로로 완료됩니다.
- yield 세션은 stdout에서 받은 session ID만으로 inject, collect, cleanup을 이어갈 수 있습니다.
- tmux와 hook artifact는 terminal/session identity가 증명되지 않으면 안전하게 중단됩니다.

## 검증

- `go test -p 1 ./... -count=1` 통과
- `internal/cli` 전체 일반/race 통과: 133.339s / 207.235s
- `pkg/orchestra` 전체 일반 통과: 189.913s
- `pkg/orchestra` 전체 race는 초기 1회 비재현 실패 뒤 보존 로그 기준 2회 연속 통과: 195.424s / 195.028s (`DATA RACE`, `FAIL` 없음)
- `go vet ./...`, native build, Windows amd64/Darwin arm64/Linux arm64 cross-build 통과
- shell syntax, ShellCheck, Bun TypeScript bundle, architecture, gofmt, diff gate 통과
- 변경 소스 파일은 모두 300줄 이하
- 독립 discovery/convergence review의 P0/P1 finding 0건

## 실제 cmux 카나리

- 격리된 `workspace:13`에서 Claude+Codex fastest pane 생성 및 결과 수집 통과
- Claude+Codex 2라운드 통과: Codex round 1은 실제 turn 종료까지 52.1초 대기했고 round 2는 file IPC로 10.4초에 완료
- Gemini/Antigravity judge pane 완료: 16.2초, gate/quorum/judge 모두 `passed`
- yield JSON 필수 필드 검증 후 반환된 session ID로 `collect`와 `cleanup` 통과
- 별도 yield 세션에서 Claude/Codex `inject → collect → cleanup` 통과
- 사용자 `workspace:1`은 변경하지 않았고, 테스트 workspace는 1 pane/1 surface 기준 상태로 복구
- cmux buffer 수는 전후 동일: total 2082, `autopus-*` 2058, `autopus-input` 17바이트

Related to #100
