### PR TITLE
fix(doctor): 플랫폼 네이티브 팀 템플릿 오탐 제거

### DIFF
--- a/pkg/content/generate_ownership.go
+++ b/pkg/content/generate_ownership.go
@@ -6,9 +6,9 @@ import (
 )
 
 // IsGeneratedTemplatePath reports whether GenerateAllTemplates owns relPath.
-// Static command, prompt, rule, shared, and auto-* route templates are excluded
-// so reverse drift checks can flag obsolete generated residue without treating
-// hand-authored templates as deleted-source artifacts.
+// Static command, prompt, rule, shared, auto-* route, and platform-native team
+// templates are excluded so reverse drift checks can flag obsolete generated
+// residue without treating hand-authored templates as deleted-source artifacts.
 func IsGeneratedTemplatePath(relPath string) bool {
 	clean := path.Clean(strings.ReplaceAll(relPath, "\\", "/"))
 	if clean == "." || path.IsAbs(clean) || strings.HasPrefix(clean, "../") {
@@ -22,10 +22,12 @@ func IsGeneratedTemplatePath(relPath string) bool {
 		return hasNamedSuffix(parts[2], ".md.tmpl")
 	}
 	if len(parts) == 3 && parts[0] == "codex" && parts[1] == "skills" {
-		return !strings.HasPrefix(parts[2], "auto-") && hasNamedSuffix(parts[2], ".md.tmpl")
+		return parts[2] != "agent-teams.md.tmpl" &&
+			!strings.HasPrefix(parts[2], "auto-") && hasNamedSuffix(parts[2], ".md.tmpl")
 	}
 	if len(parts) == 4 && parts[0] == "gemini" && parts[1] == "skills" {
-		return parts[2] != "" && !strings.HasPrefix(parts[2], "auto-") && parts[3] == "SKILL.md.tmpl"
+		return parts[2] != "" && parts[2] != "agent-teams" &&
+			!strings.HasPrefix(parts[2], "auto-") && parts[3] == "SKILL.md.tmpl"
 	}
 	if len(parts) == 3 && parts[0] == "claude" && parts[1] == "workflows" {
 		return hasNamedSuffix(parts[2], ".workflow.js.tmpl")

--- a/pkg/content/generate_ownership_test.go
+++ b/pkg/content/generate_ownership_test.go
@@ -21,7 +21,9 @@ func TestIsGeneratedTemplatePath(t *testing.T) {
 	static := []string{
 		"codex/prompts/auto-fix.md.tmpl",
 		"codex/skills/auto-fix.md.tmpl",
+		"codex/skills/agent-teams.md.tmpl",
 		"gemini/skills/auto-fix/SKILL.md.tmpl",
+		"gemini/skills/agent-teams/SKILL.md.tmpl",
 		"gemini/rules/autopus/doc-storage.md.tmpl",
 		"shared/autopus.yaml.tmpl",
 		"../templates/codex/agents/executor.toml.tmpl",


### PR DESCRIPTION
## 변경 사항
- Codex/Gemini `agent-teams` 템플릿을 생성기 소유권 역방향 검사에서 제외
- 두 플랫폼 경로에 대한 회귀 테스트 추가

## 근거
`GenerateAllTemplates`는 `agent-teams`를 플랫폼 네이티브 어댑터 소유로 의도적으로 건너뛰지만, doctor는 이를 생성 잔여물로 분류해 경고했습니다.

## 검증
- `go test ./pkg/content ./internal/cli`
- `go test -race ./pkg/content -run ^TestIsGeneratedTemplatePath$ -count=100`
- 수정 소스의 `auto doctor --required-only`에서 template regeneration 경고 0건
- 격리 update worktree의 tracked/runtime hygiene 통과