### PR TITLE
fix(omp): 라이브 관찰 세션 부팅 계약을 교정한다

### DIFF
--- a/internal/cli/pipeline_omp_context_active_evaluator.go
+++ b/internal/cli/pipeline_omp_context_active_evaluator.go
@@ -6,6 +6,13 @@ import (
 	"strings"
 )
 
+type pipelineOMPActiveSandboxMode uint8
+
+const (
+	pipelineOMPActiveSandboxManaged pipelineOMPActiveSandboxMode = iota
+	pipelineOMPActiveSandboxInheritedParent
+)
+
 // pipelineOMPActiveEvaluatorSession uses the production process and protocol
 // implementation without consuming promotion authority. Only the explicit-live
 // observe-session command may construct it.
@@ -19,17 +26,21 @@ type pipelineOMPActiveEvaluatorSession struct {
 	sequence  int
 }
 
+// @AX:ANCHOR [AUTO] @AX:SPEC: SPEC-OMP-004: evaluator startup is the shared full and optimized live-session boundary.
+// @AX:REASON [AUTO]: observe-session and RPC integration callers depend on identical process, protocol, binding, and sandbox-mode construction.
 func startPipelineOMPActiveEvaluatorSession(
 	ctx context.Context,
 	backend pipelineOMPBackendConfig,
 	candidate pipelineOMPManagedActiveCandidate,
 	prepared pipelineOMPManagedActivePrepared,
 	optimized bool,
+	sandboxMode pipelineOMPActiveSandboxMode,
 ) (*pipelineOMPActiveEvaluatorSession, error) {
 	active, err := preparePipelineOMPActiveProcessConfig(backend, candidate, prepared)
 	if err != nil {
 		return nil, err
 	}
+	active.sandboxMode = sandboxMode
 	process, err := startPipelineOMPActiveProcess(ctx, active)
 	if err != nil {
 		return nil, err

--- a/internal/cli/pipeline_omp_context_active_lifecycle.go
+++ b/internal/cli/pipeline_omp_context_active_lifecycle.go
@@ -96,39 +96,50 @@ func (protocol *pipelineOMPRPCProtocol) manualCompact(
 	return nil
 }
 
+// @AX:WARN [AUTO]: managed prompt lifecycle validation contains 11 if branches.
+// @AX:REASON [AUTO]: response correlation, safe widget filtering, provider start/turn/end order, and prompt-result proof must fail closed together.
 func (protocol *pipelineOMPRPCProtocol) callManagedPrompt(ctx context.Context, prompt string) error {
 	protocol.nextID++
 	id := fmt.Sprintf("pipeline-active-prompt-%d", protocol.nextID)
 	if err := protocol.process.send(pipelineOMPRPCCommand{ID: id, Type: "prompt", Message: prompt}); err != nil {
 		return err
 	}
-	responded, started, turned, ended := false, false, false, false
+	responded, resultSeen := false, false
+	started, turnStarted, turned, ended := false, false, false, false
 	for !(responded && started && turned && ended) {
 		frame, err := protocol.process.next(ctx)
 		if err != nil {
 			return err
 		}
-		if frame.Type == "extension_error" || frame.Type == "extension_ui_request" ||
+		if frame.Type == "extension_ui_request" {
+			if frame.Method == "setWidget" && frame.ID != "" && responded && started && !ended {
+				continue
+			}
+			return errors.New("managed active OMP maintenance crossed the primary provider boundary")
+		}
+		if frame.Type == "extension_error" ||
 			frame.Type == "auto_compaction_start" || frame.Type == "auto_compaction_end" {
 			return errors.New("managed active OMP maintenance crossed the primary provider boundary")
 		}
 		switch frame.Type {
 		case "response":
-			var result struct {
-				AgentInvoked *bool `json:"agentInvoked"`
-			}
 			if frame.ID != id || responded || started || !frame.Success || frame.Command != "prompt" ||
-				json.Unmarshal(frame.Data, &result) != nil || result.AgentInvoked == nil || !*result.AgentInvoked {
+				!validPipelineOMPActivePromptResponseData(frame.Data) {
 				return errors.New("managed active OMP prompt was rejected")
 			}
 			responded = true
 		case "agent_start":
-			if !responded || started || turned || ended {
+			if !responded || started || turnStarted || turned || ended {
 				return errors.New("managed active OMP primary start is out of order")
 			}
 			started = true
+		case "turn_start":
+			if !started || turnStarted || turned || ended {
+				return errors.New("managed active OMP primary turn start is out of order")
+			}
+			turnStarted = true
 		case "turn_end":
-			if !started || turned || ended {
+			if !turnStarted || turned || ended {
 				return errors.New("managed active OMP primary turn is out of order")
 			}
 			turned = true
@@ -138,12 +149,30 @@ func (protocol *pipelineOMPRPCProtocol) callManagedPrompt(ctx context.Context, p
 			}
 			ended = true
 		case "prompt_result":
-			if frame.ID != id || frame.AgentInvoked == nil || !*frame.AgentInvoked {
+			if !responded || resultSeen || frame.ID != id || frame.AgentInvoked == nil || !*frame.AgentInvoked {
 				return errors.New("managed active OMP prompt did not invoke the agent")
 			}
+			resultSeen = true
 		}
 	}
 	return nil
+}
+
+func validPipelineOMPActivePromptResponseData(data json.RawMessage) bool {
+	body := bytes.TrimSpace(data)
+	if len(body) == 0 || bytes.Equal(body, []byte("null")) {
+		return true
+	}
+	if rejectDuplicatePipelineOMPJSON(body) != nil {
+		return false
+	}
+	var exact map[string]json.RawMessage
+	if json.Unmarshal(body, &exact) != nil || len(exact) != 1 {
+		return false
+	}
+	var invoked bool
+	value, ok := exact["agentInvoked"]
+	return ok && json.Unmarshal(value, &invoked) == nil && invoked
 }
 
 func (protocol *pipelineOMPRPCProtocol) confirmPipelineOMPActiveBridge(id string) error {

--- a/internal/cli/pipeline_omp_context_active_process.go
+++ b/internal/cli/pipeline_omp_context_active_process.go
@@ -20,17 +20,17 @@ import (
 const (
 	pipelineOMPActiveEndpointKey    = "AUTOPUS_OMP_CONTEXT_PROVIDER_ENDPOINT"
 	pipelineOMPActiveCredentialKey  = "AUTOPUS_OMP_CONTEXT_PROVIDER_TOKEN"
-	pipelineOMPActiveRPCIdentity    = "autopus.omp-pipeline-managed-rpc.v1"
-	pipelineOMPActivePolicyIdentity = "manual-compact;retry-off;ambient-off;tools=read,bash,edit,write,grep,glob,todo"
+	pipelineOMPActiveRPCIdentity    = "autopus.omp-pipeline-managed-rpc.v2"
+	pipelineOMPActivePolicyIdentity = "manual-compact;auto-compaction=off;retry-off;ambient-off;sandbox=candidate-managed|producer-inherited-darwin-v1;tools=read,bash,edit,write,grep,glob,todo"
 )
 
 type pipelineOMPActiveProcessConfig struct {
-	backend    pipelineOMPBackendConfig
-	candidate  pipelineOMPManagedActiveCandidate
-	prepared   pipelineOMPManagedActivePrepared
-	binding    WorkflowContextBridgeBinding
-	endpoint   string
-	credential string
+	backend              pipelineOMPBackendConfig
+	candidate            pipelineOMPManagedActiveCandidate
+	prepared             pipelineOMPManagedActivePrepared
+	binding              WorkflowContextBridgeBinding
+	endpoint, credential string
+	sandboxMode          pipelineOMPActiveSandboxMode
 }
 
 func preparePipelineOMPActiveProcessConfig(
@@ -64,6 +64,8 @@ func preparePipelineOMPActiveProcessConfig(
 	}, nil
 }
 
+// @AX:WARN [AUTO]: managed active process startup contains 17 if branches.
+// @AX:REASON [AUTO]: runtime ownership, executable identity, overlay, sandbox, process group, pipes, and readiness gates converge before admission.
 func startPipelineOMPActiveProcess(
 	ctx context.Context,
 	active pipelineOMPActiveProcessConfig,
@@ -99,7 +101,7 @@ func startPipelineOMPActiveProcess(
 		cleanup()
 		return nil, err
 	}
-	_, configPath, err := newWorkflowContextProductOverlay(runtimeRoot, config.OMPContextMemoryOff)
+	configPath, err := newWorkflowContextManagedManualCompactionOverlay(runtimeRoot, config.OMPContextMemoryOff)
 	if err != nil {
 		cleanup()
 		return nil, err
@@ -119,7 +121,7 @@ func startPipelineOMPActiveProcess(
 		"--cwd", active.backend.ProjectDir, "--model", active.candidate.Provider + "/" + active.candidate.Model,
 		"--config", configPath, "--tools", "read,bash,edit,write,grep,glob,todo",
 		"--no-skills", "--no-rules", "--no-lsp", "--no-pty", "--no-title",
-		"--max-time", active.backend.MaxTime.String(),
+		"--max-time", pipelineOMPMaxTimeSeconds(active.backend.MaxTime),
 	}
 	privateExecutable, privateIdentity, err := canonicalPipelineOMPExecutable(privateExecutable)
 	if err != nil || privateIdentity.digest != active.backend.executableID.digest {
@@ -136,10 +138,11 @@ func startPipelineOMPActiveProcess(
 	cmd.Dir, cmd.Env, cmd.Stderr = active.backend.ProjectDir,
 		workflowContextManagedRPCEnvironment(environment, active.binding), io.Discard
 	cmd.WaitDelay = 500 * time.Millisecond
-	if _, err := configureWorkflowContextManagedRPCSandbox(cmd, active.endpoint); err != nil {
+	if err := configurePipelineOMPActiveSandbox(cmd, active.endpoint, active.sandboxMode); err != nil {
 		cleanup()
 		return nil, err
 	}
+	verifiedCommand.directDarwinImage = active.sandboxMode == pipelineOMPActiveSandboxInheritedParent
 	if err := configureWorkflowContextManagedRPCProcessGroup(cmd); err != nil {
 		cleanup()
 		return nil, err

--- a/internal/cli/pipeline_omp_context_active_rpc_integration_test.go
+++ b/internal/cli/pipeline_omp_context_active_rpc_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -56,9 +57,33 @@ func TestPipelineOMPActiveRPC_UnsafeFirstOutputClosesBeforeSecondProviderCall(t 
 	assert.Zero(t, countPipelineOMPRPCCommand(commands, "compact"))
 }
 
+func TestPipelineOMPActiveRPC_InheritedParentSandboxUsesDirectVerifiedImage(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("inherited parent sandbox is Darwin-only")
+	}
+	session, _, _ := pipelineOMPActiveRPCSessionFixtureWithSandbox(
+		t, false, pipelineOMPActiveSandboxInheritedParent,
+	)
+	t.Cleanup(func() { require.NoError(t, session.Close()) })
+
+	output, receipt, err := session.Execute(context.Background(), "safe inherited prompt")
+
+	require.NoError(t, err)
+	assert.Equal(t, "safe assistant output 1", output)
+	assert.True(t, receipt.SameProcess)
+}
+
 func pipelineOMPActiveRPCSessionFixture(
 	t *testing.T,
 	unsafe bool,
+) (*pipelineOMPActiveEvaluatorSession, pipelineOMPBackendConfig, string) {
+	return pipelineOMPActiveRPCSessionFixtureWithSandbox(t, unsafe, pipelineOMPActiveSandboxManaged)
+}
+
+func pipelineOMPActiveRPCSessionFixtureWithSandbox(
+	t *testing.T,
+	unsafe bool,
+	sandboxMode pipelineOMPActiveSandboxMode,
 ) (*pipelineOMPActiveEvaluatorSession, pipelineOMPBackendConfig, string) {
 	t.Helper()
 	requireDarwinManagedOMPSandboxForTest(t)
@@ -91,7 +116,7 @@ func pipelineOMPActiveRPCSessionFixture(
 		ModelScopeDigest: candidate.ModelScopeDigest,
 	}}
 	session, err := startPipelineOMPActiveEvaluatorSession(
-		context.Background(), config, candidate, prepared, true,
+		context.Background(), config, candidate, prepared, true, sandboxMode,
 	)
 	require.NoError(t, err)
 	return session, config, logPath
@@ -166,8 +191,9 @@ func runPipelineOMPActiveRPCFixture() int {
 				json.RawMessage(fmt.Sprintf(`{"role":"user","content":%q}`, command.Message)),
 				json.RawMessage(fmt.Sprintf(`{"role":"assistant","content":%q}`, assistant)),
 			)
-			writePipelineOMPActiveResponse(output, command, map[string]any{"agentInvoked": true})
+			writePipelineOMPActiveResponse(output, command, nil)
 			_ = output.Encode(map[string]any{"type": "agent_start"})
+			_ = output.Encode(map[string]any{"type": "turn_start"})
 			_ = output.Encode(map[string]any{"type": "turn_end"})
 			_ = output.Encode(map[string]any{"type": "agent_end", "isTerminal": true})
 		case "get_last_assistant_text":

--- a/internal/cli/pipeline_omp_context_active_sandbox.go
+++ b/internal/cli/pipeline_omp_context_active_sandbox.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"errors"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"time"
+)
+
+// @AX:ANCHOR [AUTO] @AX:SPEC: SPEC-OMP-004: shared sandbox boundary for managed child startup and version probes.
+// @AX:REASON [AUTO]: active execution, observe-call, and inherited-version callers depend on the mode switch remaining fail closed and Darwin-only.
+func configurePipelineOMPActiveSandbox(
+	cmd *exec.Cmd,
+	endpoint string,
+	mode pipelineOMPActiveSandboxMode,
+) error {
+	if cmd == nil || cmd.Path == "" {
+		return errors.New("managed active OMP sandbox command is unavailable")
+	}
+	switch mode {
+	case pipelineOMPActiveSandboxManaged:
+		_, err := configureWorkflowContextManagedRPCSandbox(cmd, endpoint)
+		return err
+	case pipelineOMPActiveSandboxInheritedParent:
+		if runtime.GOOS != "darwin" {
+			return errors.New("inherited parent sandbox is supported only on Darwin")
+		}
+		if _, err := validatePipelineOMPActiveEndpoint(endpoint); err != nil {
+			return errors.New("inherited parent sandbox endpoint is invalid")
+		}
+		return nil
+	default:
+		return errors.New("managed active OMP sandbox mode is invalid")
+	}
+}
+
+func pipelineOMPMaxTimeSeconds(maxTime time.Duration) string {
+	seconds := maxTime / time.Second
+	if maxTime%time.Second > 0 {
+		seconds++
+	}
+	return strconv.FormatInt(int64(seconds), 10)
+}

--- a/internal/cli/pipeline_omp_context_active_test.go
+++ b/internal/cli/pipeline_omp_context_active_test.go
@@ -2,8 +2,11 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
+	"os/exec"
+	"runtime"
 	"testing"
 	"time"
 
@@ -131,6 +134,97 @@ func TestPipelineOMPBackend_ActiveRunNeverFallsBackAfterPreflightDrift(t *testin
 	assert.Equal(t, 1, runner.closeCalls)
 	_, statErr := os.Stat(logPath)
 	assert.ErrorIs(t, statErr, os.ErrNotExist, "active drift must not start canonical RPC")
+}
+
+func TestPipelineOMPMaxTimeSeconds_UsesPositiveWholeSeconds(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		maxTime time.Duration
+		want    string
+	}{
+		{name: "ten minutes", maxTime: 10 * time.Minute, want: "600"},
+		{name: "subsecond", maxTime: time.Nanosecond, want: "1"},
+		{name: "fractional second", maxTime: 1500 * time.Millisecond, want: "2"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.want, pipelineOMPMaxTimeSeconds(test.maxTime))
+		})
+	}
+}
+
+func TestConfigurePipelineOMPActiveSandbox_InheritedParentSkipsInnerWrapperOnDarwin(t *testing.T) {
+	t.Parallel()
+	cmd := exec.Command("/usr/bin/true")
+	originalPath := cmd.Path
+	err := configurePipelineOMPActiveSandbox(
+		cmd, "http://127.0.0.1:43123", pipelineOMPActiveSandboxInheritedParent,
+	)
+	if runtime.GOOS != "darwin" {
+		require.ErrorContains(t, err, "Darwin")
+		return
+	}
+	require.NoError(t, err)
+	assert.Equal(t, originalPath, cmd.Path)
+	assert.Equal(t, []string{"/usr/bin/true"}, cmd.Args)
+}
+
+func TestPipelineOMPActiveManagedPrompt_AcceptsNullResponseLifecycleAndSafeWidget(t *testing.T) {
+	t.Parallel()
+	terminal := true
+	frames := []pipelineOMPRPCFrame{
+		{ID: "pipeline-active-prompt-1", Type: "response", Command: "prompt", Success: true, Data: json.RawMessage(`null`)},
+		{ID: "pipeline-active-prompt-1", Type: "prompt_result", AgentInvoked: boolPointer(true)},
+		{Type: "agent_start"},
+		{Type: "turn_start"},
+		{Type: "turn_end"},
+		{ID: "widget-1", Type: "extension_ui_request", Method: "setWidget"},
+		{Type: "agent_end", IsTerminal: &terminal},
+	}
+	protocol, sent := pipelineOMPProtocolFixture(frames)
+
+	err := protocol.callManagedPrompt(context.Background(), "safe prompt")
+
+	require.NoError(t, err)
+	assert.NotContains(t, sent.String(), "extension_ui_response")
+}
+
+func TestPipelineOMPActiveManagedPrompt_RejectsInteractiveOrUncorrelatedActivity(t *testing.T) {
+	t.Parallel()
+	success := pipelineOMPRPCFrame{
+		ID: "pipeline-active-prompt-1", Type: "response", Command: "prompt", Success: true, Data: json.RawMessage(`null`),
+	}
+	tests := []struct {
+		name, want string
+		frames     []pipelineOMPRPCFrame
+	}{
+		{name: "interactive confirm", want: "maintenance crossed", frames: []pipelineOMPRPCFrame{
+			success, {Type: "agent_start"}, {Type: "turn_start"}, {Type: "turn_end"},
+			{ID: "confirm-1", Type: "extension_ui_request", Method: "confirm"},
+		}},
+		{name: "fire and forget notify remains closed", want: "maintenance crossed", frames: []pipelineOMPRPCFrame{
+			success, {Type: "agent_start"}, {Type: "turn_start"}, {Type: "turn_end"},
+			{ID: "notify-1", Type: "extension_ui_request", Method: "notify"},
+		}},
+		{name: "uncorrelated result", want: "did not invoke", frames: []pipelineOMPRPCFrame{
+			success, {ID: "other", Type: "prompt_result", AgentInvoked: boolPointer(true)},
+		}},
+		{name: "local only result", want: "did not invoke", frames: []pipelineOMPRPCFrame{
+			success, {ID: "pipeline-active-prompt-1", Type: "prompt_result", AgentInvoked: boolPointer(false)},
+		}},
+		{name: "lifecycle before response", want: "out of order", frames: []pipelineOMPRPCFrame{
+			{Type: "agent_start"}, success,
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			protocol, _ := pipelineOMPProtocolFixture(test.frames)
+			err := protocol.callManagedPrompt(context.Background(), "safe prompt")
+			require.ErrorContains(t, err, test.want)
+		})
+	}
 }
 
 type pipelineOMPManagedActiveRunnerSpy struct {

--- a/internal/cli/pipeline_omp_context_active_verified_exec_darwin.go
+++ b/internal/cli/pipeline_omp_context_active_verified_exec_darwin.go
@@ -100,13 +100,19 @@ func newPipelineOMPVerifiedDarwinCommand(
 	}, nil
 }
 
+// @AX:WARN [AUTO]: Darwin verified execution startup contains 17 if branches.
+// @AX:REASON [AUTO]: sandbox and direct-image paths share ptrace stops, executable identity checks, cleanup, timeout, and detach failure handling.
 func (command *pipelineOMPVerifiedExecCommand) Start() error {
 	if command == nil || command.cmd == nil || command.parentFD == nil || command.expected.info == nil {
 		return errors.New("verified managed active OMP command is unavailable")
 	}
-	sandboxPath, sandboxIdentity, err := canonicalPipelineOMPExecutable(command.cmd.Path)
-	if err != nil || sandboxPath != "/usr/bin/sandbox-exec" {
-		return errors.Join(errors.New("managed active Darwin sandbox executable is unavailable"), command.Close())
+	firstPath, firstIdentity := command.cmd.Path, command.expected
+	if !command.directDarwinImage {
+		sandboxPath, sandboxIdentity, err := canonicalPipelineOMPExecutable(command.cmd.Path)
+		if err != nil || sandboxPath != "/usr/bin/sandbox-exec" {
+			return errors.Join(errors.New("managed active Darwin sandbox executable is unavailable"), command.Close())
+		}
+		firstPath, firstIdentity = sandboxPath, sandboxIdentity
 	}
 	if command.cmd.SysProcAttr == nil {
 		command.cmd.SysProcAttr = &syscall.SysProcAttr{}
@@ -127,16 +133,22 @@ func (command *pipelineOMPVerifiedExecCommand) Start() error {
 	gateCtx, cancel := context.WithTimeout(gateCtx, pipelineOMPVerifiedDarwinGateTimeout)
 	defer cancel()
 	if err := command.waitDarwinExecStop(gateCtx); err != nil {
-		return command.failDarwinGate(errors.New("observe Darwin sandbox exec stop"), err)
+		return command.failDarwinGate(errors.New("observe Darwin executable exec stop"), err)
 	}
-	if err := verifyPipelineOMPDarwinLiveExecutable(command.cmd.Process.Pid, sandboxPath, sandboxIdentity); err != nil {
-		return command.failDarwinGate(errors.New("verify Darwin sandbox live image"), err)
+	if err := verifyPipelineOMPDarwinLiveExecutable(command.cmd.Process.Pid, firstPath, firstIdentity); err != nil {
+		return command.failDarwinGate(errors.New("verify Darwin executable live image"), err)
 	}
 	if command.afterFirstDarwinStop != nil {
 		command.afterFirstDarwinStop()
 	}
 	if gateCtx.Err() != nil {
 		return command.failDarwinGate(errors.New("Darwin executable identity gate canceled"), gateCtx.Err())
+	}
+	if command.directDarwinImage {
+		if err := syscall.PtraceDetach(command.cmd.Process.Pid); err != nil {
+			return command.failDarwinGate(errors.New("detach verified managed active OMP trace"), err)
+		}
+		return nil
 	}
 	if err := continuePipelineOMPDarwinTrace(command.cmd.Process.Pid); err != nil {
 		return command.failDarwinGate(errors.New("continue Darwin sandbox trace"), err)

--- a/internal/cli/pipeline_omp_context_active_verified_exec_other.go
+++ b/internal/cli/pipeline_omp_context_active_verified_exec_other.go
@@ -10,8 +10,9 @@ import (
 )
 
 type pipelineOMPVerifiedExecCommand struct {
-	cmd      *exec.Cmd
-	parentFD *os.File
+	cmd               *exec.Cmd
+	parentFD          *os.File
+	directDarwinImage bool
 }
 
 func newPipelineOMPVerifiedExecCommand(

--- a/internal/cli/pipeline_omp_context_active_verified_exec_unix.go
+++ b/internal/cli/pipeline_omp_context_active_verified_exec_unix.go
@@ -19,6 +19,7 @@ type pipelineOMPVerifiedExecCommand struct {
 	expected             pipelineOMPExecutableIdentity
 	gateContext          context.Context
 	afterFirstDarwinStop func()
+	directDarwinImage    bool
 }
 
 func openPipelineOMPVerifiedExecutable(

--- a/internal/cli/workflow_context_runtime_implementation_identity_test.go
+++ b/internal/cli/workflow_context_runtime_implementation_identity_test.go
@@ -18,9 +18,10 @@ func TestWorkflowContextImplementationIdentityCommand(t *testing.T) {
 	var identity workflowContextImplementationIdentityV1
 	require.NoError(t, json.Unmarshal(output.Bytes(), &identity))
 	require.Equal(t, workflowContextImplementationIdentitySchemaV1, identity.SchemaVersion)
-	require.Equal(t, pipelineOMPActiveImplementationDigest(), identity.PipelineImplementationDigest)
-	require.NotEmpty(t, identity.RPCIdentity)
-	require.NotEmpty(t, identity.PolicyIdentity)
+	require.Equal(t, "sha256:280d2623208d375520db86e4e4ac45d8a22f2395376f996a92fe059cc1767d2f",
+		identity.PipelineImplementationDigest)
+	require.Equal(t, "autopus.omp-pipeline-managed-rpc.v2", identity.RPCIdentity)
+	require.Equal(t, pipelineOMPActivePolicyIdentity, identity.PolicyIdentity)
 	require.NotEmpty(t, identity.BridgeTarget)
 	require.NotEmpty(t, identity.BridgeSHA256)
 	require.NotEmpty(t, identity.RouteTarget)

--- a/internal/cli/workflow_context_runtime_observe_call_setup.go
+++ b/internal/cli/workflow_context_runtime_observe_call_setup.go
@@ -27,6 +27,8 @@ type workflowContextObserveCallSetup struct {
 	version    string
 }
 
+// @AX:WARN [AUTO]: observe-call setup contains 20 if branches.
+// @AX:REASON [AUTO]: canonical delivery, credential, isolated roots, generated surfaces, overlay, model authority, identity probe, and cleanup converge here.
 func prepareWorkflowContextObserveCall(
 	ctx context.Context,
 	request workflowContextObserveCallRequest,
@@ -125,7 +127,7 @@ func prepareWorkflowContextObserveCall(
 		Model: options.Provider + "/" + options.Model, AllowedEndpoint: endpoint,
 		Environment: environment, MaxTime: 2 * time.Minute, CaptureOutput: true, CaptureStats: true,
 	}
-	version, err := probeWorkflowContextObserveVersion(ctx, managed)
+	version, err := probeWorkflowContextObserveVersion(ctx, managed, pipelineOMPActiveSandboxManaged)
 	if err != nil {
 		return setup, err
 	}
@@ -223,12 +225,30 @@ func writeWorkflowContextObserveModels(
 	return os.Chmod(path, 0o600)
 }
 
-func probeWorkflowContextObserveVersion(ctx context.Context, options WorkflowContextManagedRPCOptions) (string, error) {
+// @AX:ANCHOR [AUTO] @AX:SPEC: SPEC-OMP-004: shared installed-version evidence boundary for observe-call and observe-session.
+// @AX:REASON [AUTO]: managed and inherited-sandbox callers depend on bounded output and verified executable identity before provider execution.
+func probeWorkflowContextObserveVersion(
+	ctx context.Context,
+	options WorkflowContextManagedRPCOptions,
+	sandboxMode pipelineOMPActiveSandboxMode,
+) (string, error) {
 	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
+	if sandboxMode == pipelineOMPActiveSandboxInheritedParent {
+		command, identity, err := newWorkflowContextObserveInheritedVersionCommand(probeCtx, options)
+		if err != nil {
+			return "", err
+		}
+		output, err := outputWorkflowContextObserveInheritedVersion(command, identity)
+		version := strings.TrimSpace(string(output))
+		if err != nil || !installedOMPVersionPattern.MatchString(version) {
+			return "", errors.New("observe-call OMP identity probe failed")
+		}
+		return version, nil
+	}
 	cmd := exec.CommandContext(probeCtx, options.Executable, "--version")
 	cmd.Dir, cmd.Env = options.Workspace, options.Environment
-	if _, err := configureWorkflowContextManagedRPCSandbox(cmd, options.AllowedEndpoint); err != nil {
+	if err := configurePipelineOMPActiveSandbox(cmd, options.AllowedEndpoint, sandboxMode); err != nil {
 		return "", err
 	}
 	output, err := processprobe.OutputLimited(cmd, 4<<10)

--- a/internal/cli/workflow_context_runtime_observe_session_command.go
+++ b/internal/cli/workflow_context_runtime_observe_session_command.go
@@ -9,7 +9,7 @@ import (
 
 func newWorkflowContextObserveSessionCmd() *cobra.Command {
 	var input, output, format string
-	var explicitLive bool
+	var explicitLive, inheritParentSandbox bool
 	options := workflowContextObserveSessionOptions{}
 	cmd := &cobra.Command{
 		Use:           "observe-session",
@@ -24,6 +24,7 @@ func newWorkflowContextObserveSessionCmd() *cobra.Command {
 			if input != "-" || output != "-" || strings.ToLower(strings.TrimSpace(format)) != "jsonl" {
 				return errors.New("workflow context-runtime observe-session requires --input-jsonl - --output - --format jsonl")
 			}
+			options.SandboxMode = workflowContextObserveSessionSandboxMode(inheritParentSandbox)
 			if err := validateWorkflowContextObserveSessionOptions(options); err != nil {
 				return err
 			}
@@ -31,6 +32,7 @@ func newWorkflowContextObserveSessionCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&explicitLive, "explicit-live", false, "Acknowledge external provider execution")
+	cmd.Flags().BoolVar(&inheritParentSandbox, "inherit-parent-sandbox", false, "Reuse the producer-owned Darwin sandbox")
 	cmd.Flags().StringVar(&input, "input-jsonl", "", "Read strict handshake/call/shutdown JSONL from stdin (-)")
 	cmd.Flags().StringVar(&output, "output", "", "Write strict response JSONL (-)")
 	cmd.Flags().StringVar(&format, "format", "jsonl", "Output format (jsonl)")
@@ -43,4 +45,11 @@ func newWorkflowContextObserveSessionCmd() *cobra.Command {
 	cmd.Flags().StringVar(&options.Executable, "omp", "omp", "OMP executable")
 	cmd.Flags().StringVar(&options.TargetGitCommit, "target-git-commit", "", "Exact target project commit")
 	return cmd
+}
+
+func workflowContextObserveSessionSandboxMode(inheritParent bool) pipelineOMPActiveSandboxMode {
+	if inheritParent {
+		return pipelineOMPActiveSandboxInheritedParent
+	}
+	return pipelineOMPActiveSandboxManaged
 }

--- a/internal/cli/workflow_context_runtime_observe_session_setup.go
+++ b/internal/cli/workflow_context_runtime_observe_session_setup.go
@@ -23,6 +23,7 @@ type workflowContextObserveSessionSetup struct {
 	optimized           *pipelineOMPActiveEvaluatorSession
 	ompVersion          string
 	ompExecutableSHA256 string
+	sandboxMode         pipelineOMPActiveSandboxMode
 }
 
 func validateWorkflowContextObserveSessionOptions(options workflowContextObserveSessionOptions) error {
@@ -31,12 +32,16 @@ func validateWorkflowContextObserveSessionOptions(options workflowContextObserve
 		!workflowContextMetadataPattern.MatchString(options.SpecID) ||
 		!pipelineOMPContextCohortLocatorPattern.MatchString(options.CredentialLocator) ||
 		!validPipelineOMPActiveGitHash(options.TargetGitCommit) ||
+		(options.SandboxMode != pipelineOMPActiveSandboxManaged &&
+			options.SandboxMode != pipelineOMPActiveSandboxInheritedParent) ||
 		strings.TrimSpace(options.Endpoint) == "" || strings.TrimSpace(options.Executable) == "" {
 		return errors.New("workflow context-runtime observe-session coordinates are invalid")
 	}
 	return nil
 }
 
+// @AX:WARN [AUTO]: observe-session setup contains 13 if branches.
+// @AX:REASON [AUTO]: provider authority, executable provenance, isolated runtime, phase scope, version proof, lease binding, and cleanup converge here.
 func prepareWorkflowContextObserveSession(
 	ctx context.Context,
 	options workflowContextObserveSessionOptions,
@@ -83,7 +88,7 @@ func prepareWorkflowContextObserveSession(
 	if err := os.Mkdir(runtimeBase, 0o700); err != nil {
 		return setup, err
 	}
-	phaseModels := map[pipeline.PhaseID]string{pipeline.PhasePlan: options.Provider + "/" + options.Model}
+	phaseModels := workflowContextObserveSessionPhaseModels(options.Provider + "/" + options.Model)
 	backend, err := normalizePipelineOMPBackendConfig(pipelineOMPBackendConfig{
 		Executable: executable, executableID: executableID, ProjectDir: projectDir,
 		SpecID: options.SpecID, SpecDir: filepath.Join(projectDir, ".autopus", "specs", options.SpecID),
@@ -99,7 +104,7 @@ func prepareWorkflowContextObserveSession(
 	}
 	ompVersion, err := probeWorkflowContextObserveVersion(ctx, WorkflowContextManagedRPCOptions{
 		Executable: executable, Workspace: projectDir, Environment: backend.Environment, AllowedEndpoint: endpoint,
-	})
+	}, options.SandboxMode)
 	if err != nil || verifyPipelineOMPExecutable(executable, executableID) != nil {
 		return setup, errors.New("observe-session OMP identity probe failed")
 	}
@@ -121,16 +126,21 @@ func prepareWorkflowContextObserveSession(
 	setup.backend, setup.candidate, setup.prepared = backend, candidate, prepared
 	setup.ompVersion = ompVersion
 	setup.ompExecutableSHA256 = fmt.Sprintf("sha256:%x", executableID.digest[:])
+	setup.sandboxMode = options.SandboxMode
 	failed = false
 	return setup, nil
 }
 
 func (setup *workflowContextObserveSessionSetup) start(ctx context.Context) error {
-	full, err := startPipelineOMPActiveEvaluatorSession(ctx, setup.backend, setup.candidate, setup.prepared, false)
+	full, err := startPipelineOMPActiveEvaluatorSession(
+		ctx, setup.backend, setup.candidate, setup.prepared, false, setup.sandboxMode,
+	)
 	if err != nil {
 		return err
 	}
-	optimized, err := startPipelineOMPActiveEvaluatorSession(ctx, setup.backend, setup.candidate, setup.prepared, true)
+	optimized, err := startPipelineOMPActiveEvaluatorSession(
+		ctx, setup.backend, setup.candidate, setup.prepared, true, setup.sandboxMode,
+	)
 	if err != nil {
 		_ = full.Close()
 		return err
@@ -147,4 +157,14 @@ func (setup *workflowContextObserveSessionSetup) close() error {
 	err = errors.Join(err, os.RemoveAll(setup.taskRoot))
 	setup.taskRoot = ""
 	return err
+}
+
+func workflowContextObserveSessionPhaseModels(selector string) map[pipeline.PhaseID]string {
+	return map[pipeline.PhaseID]string{
+		pipeline.PhasePlan:         selector,
+		pipeline.PhaseTestScaffold: selector,
+		pipeline.PhaseImplement:    selector,
+		pipeline.PhaseValidate:     selector,
+		pipeline.PhaseReview:       selector,
+	}
 }

--- a/internal/cli/workflow_context_runtime_observe_session_setup_test.go
+++ b/internal/cli/workflow_context_runtime_observe_session_setup_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/pipeline"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkflowContextObserveSessionPhaseModels_BindsAllCanonicalPhases(t *testing.T) {
+	t.Parallel()
+	const selector = "openai/gpt-5.6-sol"
+	want := map[pipeline.PhaseID]string{
+		pipeline.PhasePlan:         selector,
+		pipeline.PhaseTestScaffold: selector,
+		pipeline.PhaseImplement:    selector,
+		pipeline.PhaseValidate:     selector,
+		pipeline.PhaseReview:       selector,
+	}
+
+	phaseModels := workflowContextObserveSessionPhaseModels(selector)
+	assert.Equal(t, want, phaseModels)
+	provider, digest, err := pipelineOMPActiveModelScope(phaseModels)
+	require.NoError(t, err)
+	assert.Equal(t, "openai", provider)
+	assert.Equal(t, "sha256:386816349ebf9b5c2a113889fb3160662121a4fd4fa4085d2bdef97660142adf", digest)
+}
+
+func TestWorkflowContextObserveSessionCommand_InheritedParentSandboxIsExplicitOptIn(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, pipelineOMPActiveSandboxManaged, workflowContextObserveSessionSandboxMode(false))
+	assert.Equal(t, pipelineOMPActiveSandboxInheritedParent, workflowContextObserveSessionSandboxMode(true))
+	flag := newWorkflowContextObserveSessionCmd().Flags().Lookup("inherit-parent-sandbox")
+	require.NotNil(t, flag)
+	assert.Equal(t, "false", flag.DefValue)
+	assert.Nil(t, newWorkflowContextObserveCallCmd().Flags().Lookup("inherit-parent-sandbox"))
+
+	options := workflowContextObserveSessionOptions{
+		Provider: "openai", Model: "gpt-5.6-sol", SpecID: "SPEC-OMP-004",
+		CredentialLocator: "AUTOPUS_OMP_CONTEXT_PROVIDER_OPENAI", TargetGitCommit: strings.Repeat("a", 40),
+		Endpoint: "http://127.0.0.1:43123", Executable: "omp",
+	}
+	require.NoError(t, validateWorkflowContextObserveSessionOptions(options))
+}
+
+func TestWorkflowContextObserveVersion_InheritedModeUsesDirectVerifiedImage(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("inherited parent sandbox is Darwin-only")
+	}
+	options := WorkflowContextManagedRPCOptions{
+		Executable: os.Args[0], Workspace: t.TempDir(), Environment: os.Environ(),
+		AllowedEndpoint: "http://127.0.0.1:43123",
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	command, _, err := newWorkflowContextObserveInheritedVersionCommand(ctx, options)
+	require.NoError(t, err)
+	assert.True(t, command.directDarwinImage)
+	assert.NotEqual(t, "/usr/bin/sandbox-exec", command.cmd.Path)
+	require.NoError(t, command.Close())
+
+	got, err := probeWorkflowContextObserveVersion(ctx, options, pipelineOMPActiveSandboxInheritedParent)
+	require.NoError(t, err)
+	assert.Equal(t, "omp/17.2.7", got)
+}

--- a/internal/cli/workflow_context_runtime_observe_session_types.go
+++ b/internal/cli/workflow_context_runtime_observe_session_types.go
@@ -60,4 +60,5 @@ type workflowContextObserveSessionOptions struct {
 	CredentialLocator string
 	Executable        string
 	TargetGitCommit   string
+	SandboxMode       pipelineOMPActiveSandboxMode
 }

--- a/internal/cli/workflow_context_runtime_observe_version.go
+++ b/internal/cli/workflow_context_runtime_observe_version.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"io"
+)
+
+// @AX:NOTE [AUTO] @AX:SPEC: SPEC-OMP-004: the 4 KiB cap bounds untrusted executable version output before identity parsing.
+const workflowContextObserveVersionOutputLimit = 4 << 10
+
+type workflowContextObserveVersionOutput struct {
+	body     []byte
+	exceeded bool
+}
+
+func (output *workflowContextObserveVersionOutput) Write(data []byte) (int, error) {
+	written := len(data)
+	remaining := workflowContextObserveVersionOutputLimit - len(output.body)
+	if remaining >= len(data) {
+		output.body = append(output.body, data...)
+		return written, nil
+	}
+	if remaining > 0 {
+		output.body = append(output.body, data[:remaining]...)
+	}
+	output.exceeded = true
+	return written, errors.New("observe-call OMP version output limit exceeded")
+}
+
+func newWorkflowContextObserveInheritedVersionCommand(
+	ctx context.Context,
+	options WorkflowContextManagedRPCOptions,
+) (*pipelineOMPVerifiedExecCommand, pipelineOMPExecutableIdentity, error) {
+	executable, identity, err := canonicalPipelineOMPExecutable(options.Executable)
+	if err != nil {
+		return nil, identity, err
+	}
+	command, err := newPipelineOMPVerifiedExecCommandContext(ctx, executable, identity, "--version")
+	if err != nil {
+		return nil, identity, err
+	}
+	command.cmd.Dir, command.cmd.Env = options.Workspace, options.Environment
+	if err := configurePipelineOMPActiveSandbox(
+		command.cmd, options.AllowedEndpoint, pipelineOMPActiveSandboxInheritedParent,
+	); err != nil {
+		return nil, identity, errors.Join(err, command.Close())
+	}
+	command.directDarwinImage = true
+	if err := configureWorkflowContextManagedRPCProcessGroup(command.cmd); err != nil {
+		return nil, identity, errors.Join(err, command.Close())
+	}
+	return command, identity, nil
+}
+
+func outputWorkflowContextObserveInheritedVersion(
+	command *pipelineOMPVerifiedExecCommand,
+	identity pipelineOMPExecutableIdentity,
+) ([]byte, error) {
+	output := &workflowContextObserveVersionOutput{}
+	command.cmd.Stdout, command.cmd.Stderr = output, io.Discard
+	if err := command.Start(); err != nil {
+		return nil, err
+	}
+	waitErr := command.cmd.Wait()
+	verifyErr := verifyPipelineOMPExecutable(command.cmd.Path, identity)
+	if waitErr != nil || output.exceeded || verifyErr != nil {
+		return nil, errors.Join(errors.New("observe-call verified OMP version probe failed"), waitErr, verifyErr)
+	}
+	return append([]byte(nil), output.body...), nil
+}

--- a/internal/cli/workflow_context_runtime_product_overlay.go
+++ b/internal/cli/workflow_context_runtime_product_overlay.go
@@ -28,35 +28,51 @@ func newWorkflowContextProductOverlay(
 	runtimeRoot string,
 	memoryMode string,
 ) (WorkflowContextOverlayController, string, error) {
-	if memoryMode != config.OMPContextMemoryOff && memoryMode != config.OMPContextMemoryShadow {
-		return nil, "", errors.New("product OMP overlay memory mode is invalid")
-	}
-	root, err := filepath.Abs(runtimeRoot)
+	path, body, activeInfo, err := prepareWorkflowContextProductOverlay(runtimeRoot, memoryMode, true)
 	if err != nil {
-		return nil, "", fmt.Errorf("resolve product OMP overlay root: %w", err)
-	}
-	root = filepath.Clean(root)
-	info, err := os.Lstat(root)
-	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
-		return nil, "", errors.New("product OMP overlay root is unsafe")
-	}
-	if err := os.Chmod(root, 0o700); err != nil {
-		return nil, "", fmt.Errorf("secure product OMP overlay root: %w", err)
-	}
-	path := filepath.Join(root, "context-product.yml")
-	body := workflowContextProductOverlayBody(true)
-	if err := writeWorkflowContextProductOverlay(path, body); err != nil {
 		return nil, "", err
-	}
-	activeInfo, err := os.Lstat(path)
-	if err != nil {
-		return nil, "", fmt.Errorf("inspect product OMP overlay: %w", err)
 	}
 	return &workflowContextProductOverlay{
 		path: path, memoryMode: memoryMode, activeBody: body,
 		activeHash: workflowContextProductOverlayHash(body), activeInfo: activeInfo,
 		effectiveMode: config.OMPContextHistoryActive,
 	}, path, nil
+}
+
+func newWorkflowContextManagedManualCompactionOverlay(runtimeRoot, memoryMode string) (string, error) {
+	path, _, _, err := prepareWorkflowContextProductOverlay(runtimeRoot, memoryMode, false)
+	return path, err
+}
+
+func prepareWorkflowContextProductOverlay(
+	runtimeRoot, memoryMode string,
+	automaticCompaction bool,
+) (string, []byte, fs.FileInfo, error) {
+	if memoryMode != config.OMPContextMemoryOff && memoryMode != config.OMPContextMemoryShadow {
+		return "", nil, nil, errors.New("product OMP overlay memory mode is invalid")
+	}
+	root, err := filepath.Abs(runtimeRoot)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("resolve product OMP overlay root: %w", err)
+	}
+	root = filepath.Clean(root)
+	info, err := os.Lstat(root)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return "", nil, nil, errors.New("product OMP overlay root is unsafe")
+	}
+	if err := os.Chmod(root, 0o700); err != nil {
+		return "", nil, nil, fmt.Errorf("secure product OMP overlay root: %w", err)
+	}
+	path := filepath.Join(root, "context-product.yml")
+	body := workflowContextProductOverlayBody(automaticCompaction)
+	if err := writeWorkflowContextProductOverlay(path, body); err != nil {
+		return "", nil, nil, err
+	}
+	activeInfo, err := os.Lstat(path)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("inspect product OMP overlay: %w", err)
+	}
+	return path, body, activeInfo, nil
 }
 
 func (overlay *workflowContextProductOverlay) Apply(

--- a/internal/cli/workflow_context_runtime_product_overlay_test.go
+++ b/internal/cli/workflow_context_runtime_product_overlay_test.go
@@ -81,6 +81,25 @@ func TestWorkflowContextProductOverlay_ActiveReuseAndShadowRollbackStayTaskOwned
 	assert.Equal(t, projectBefore, snapshotWorkflowContextProductOverlayTree(t, filepath.Join(input.ProjectDir, ".omp")))
 }
 
+func TestWorkflowContextManagedManualCompactionOverlay_DisablesAutomaticCompactionOnly(t *testing.T) {
+	t.Parallel()
+	productRoot, managedRoot := t.TempDir(), t.TempDir()
+	_, productPath, err := newWorkflowContextProductOverlay(productRoot, config.OMPContextMemoryOff)
+	require.NoError(t, err)
+	managedPath, err := newWorkflowContextManagedManualCompactionOverlay(managedRoot, config.OMPContextMemoryOff)
+	require.NoError(t, err)
+
+	productBody, err := os.ReadFile(productPath)
+	require.NoError(t, err)
+	managedBody, err := os.ReadFile(managedPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(productBody), "compaction:\n  enabled: true\n")
+	assert.Contains(t, string(managedBody), "compaction:\n  enabled: false\n")
+	assert.NotEqual(t, productBody, managedBody)
+	assertWorkflowContextProductOverlayPath(t, managedRoot, managedPath)
+	assertWorkflowContextProductOverlayOnlyFile(t, managedRoot, managedPath)
+}
+
 func TestWorkflowContextProductOverlay_FailsClosedOnUnsafeInputsAndStateDrift(t *testing.T) {
 	t.Run("invalid memory mode", func(t *testing.T) {
 		_, _, err := newWorkflowContextProductOverlay(t.TempDir(), "active")


### PR DESCRIPTION
## 변경 사항
- OMP 17.2.7의 `--max-time` 정수 초 계약과 null prompt response/lifecycle을 지원합니다.
- 관찰용 managed session에서 자동 compaction을 시작 전부터 비활성화하고 5개 canonical phase 모델 scope를 고정합니다.
- producer outer sandbox를 상속하는 observe-session 전용 opt-in을 추가하되, 기본 inner sandbox와 exact live executable gate를 유지합니다.
- `setWidget`만 fire-and-forget UI 이벤트로 허용하고 interactive UI 요청은 fail-close합니다.

## 검증
- focused `go test ./internal/cli ... -count=1`
- focused race PASS
- direct verified-exec managed/inherited/version-probe integration PASS
- `go vet ./internal/cli`
- `git diff --check`
- changed source 300줄 이하

🐙