### PR TITLE
fix(omp): 상속 샌드박스 실행 경계를 강화

### DIFF
--- a/internal/cli/pipeline_omp_context_active_process.go
+++ b/internal/cli/pipeline_omp_context_active_process.go
@@ -21,7 +21,7 @@ const (
 	pipelineOMPActiveEndpointKey    = "AUTOPUS_OMP_CONTEXT_PROVIDER_ENDPOINT"
 	pipelineOMPActiveCredentialKey  = "AUTOPUS_OMP_CONTEXT_PROVIDER_TOKEN"
 	pipelineOMPActiveRPCIdentity    = "autopus.omp-pipeline-managed-rpc.v2"
-	pipelineOMPActivePolicyIdentity = "manual-compact;auto-compaction=off;retry-off;ambient-off;sandbox=candidate-managed|producer-inherited-darwin-v1;tools=read,bash,edit,write,grep,glob,todo"
+	pipelineOMPActivePolicyIdentity = "manual-compact;auto-compaction=off;retry-off;ambient-off;sandbox=candidate-managed|producer-inherited-external-live-image-darwin-v2;tools=read,bash,edit,write,grep,glob,todo"
 )
 
 type pipelineOMPActiveProcessConfig struct {
@@ -142,7 +142,10 @@ func startPipelineOMPActiveProcess(
 		cleanup()
 		return nil, err
 	}
-	verifiedCommand.directDarwinImage = active.sandboxMode == pipelineOMPActiveSandboxInheritedParent
+	if err := configurePipelineOMPVerifiedExecSandboxMode(verifiedCommand, active.sandboxMode, true); err != nil {
+		cleanup()
+		return nil, err
+	}
 	if err := configureWorkflowContextManagedRPCProcessGroup(cmd); err != nil {
 		cleanup()
 		return nil, err

--- a/internal/cli/pipeline_omp_context_active_process.go
+++ b/internal/cli/pipeline_omp_context_active_process.go
@@ -64,7 +64,7 @@ func preparePipelineOMPActiveProcessConfig(
 	}, nil
 }
 
-// @AX:WARN [AUTO]: managed active process startup contains 17 if branches.
+// @AX:WARN [AUTO]: managed active process startup contains 18 if branches.
 // @AX:REASON [AUTO]: runtime ownership, executable identity, overlay, sandbox, process group, pipes, and readiness gates converge before admission.
 func startPipelineOMPActiveProcess(
 	ctx context.Context,

--- a/internal/cli/pipeline_omp_context_active_verified_exec_command_darwin.go
+++ b/internal/cli/pipeline_omp_context_active_verified_exec_command_darwin.go
@@ -1,0 +1,20 @@
+//go:build darwin
+
+package cli
+
+import (
+	"context"
+	"os"
+	"os/exec"
+)
+
+type pipelineOMPVerifiedExecCommand struct {
+	cmd                       *exec.Cmd
+	parentFD                  *os.File
+	expected                  pipelineOMPExecutableIdentity
+	gateContext               context.Context
+	afterFirstDarwinStop      func()
+	afterInheritedDarwinStart func()
+	inheritedDarwinPath       bool
+	inheritedDarwinPrivate    bool
+}

--- a/internal/cli/pipeline_omp_context_active_verified_exec_command_darwin.go
+++ b/internal/cli/pipeline_omp_context_active_verified_exec_command_darwin.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 )
 
+// @AX:ANCHOR [AUTO] @AX:SPEC: SPEC-OMP-004: Darwin build-selected verified-command state shared by constructors, sandbox validation, and startup.
+// @AX:REASON [AUTO]: ptrace and inherited-path execution depend on this common type preserving identity, gate, and lifecycle callback fields.
 type pipelineOMPVerifiedExecCommand struct {
 	cmd                       *exec.Cmd
 	parentFD                  *os.File

--- a/internal/cli/pipeline_omp_context_active_verified_exec_darwin.go
+++ b/internal/cli/pipeline_omp_context_active_verified_exec_darwin.go
@@ -35,19 +35,16 @@ type pipelineOMPVerifiedDarwinRegion struct {
 }
 
 type pipelineOMPVerifiedDarwinVnode struct {
-	Dev                  uint32
-	Mode, Nlink          uint16
-	Ino                  uint64
-	UID, GID             uint32
-	Atime, AtimeNsec     int64
-	Mtime, MtimeNsec     int64
-	Ctime, CtimeNsec     int64
-	Birthtime, BirthNsec int64
-	Size, Blocks         int64
-	BlockSize            int32
-	Flags, Generation    uint32
-	Rdev                 uint32
-	Spare                [2]int64
+	Dev                                                                        uint32
+	Mode, Nlink                                                                uint16
+	Ino                                                                        uint64
+	UID, GID                                                                   uint32
+	Atime, AtimeNsec, Mtime, MtimeNsec, Ctime, CtimeNsec, Birthtime, BirthNsec int64
+	Size, Blocks                                                               int64
+	BlockSize                                                                  int32
+	Flags, Generation                                                          uint32
+	Rdev                                                                       uint32
+	Spare                                                                      [2]int64
 }
 
 type pipelineOMPVerifiedDarwinRegionPath struct {
@@ -101,18 +98,17 @@ func newPipelineOMPVerifiedDarwinCommand(
 }
 
 // @AX:WARN [AUTO]: Darwin verified execution startup contains 17 if branches.
-// @AX:REASON [AUTO]: sandbox and direct-image paths share ptrace stops, executable identity checks, cleanup, timeout, and detach failure handling.
+// @AX:REASON [AUTO]: managed ptrace and inherited private-path gates share startup cleanup and executable identity enforcement.
 func (command *pipelineOMPVerifiedExecCommand) Start() error {
 	if command == nil || command.cmd == nil || command.parentFD == nil || command.expected.info == nil {
 		return errors.New("verified managed active OMP command is unavailable")
 	}
-	firstPath, firstIdentity := command.cmd.Path, command.expected
-	if !command.directDarwinImage {
-		sandboxPath, sandboxIdentity, err := canonicalPipelineOMPExecutable(command.cmd.Path)
-		if err != nil || sandboxPath != "/usr/bin/sandbox-exec" {
-			return errors.Join(errors.New("managed active Darwin sandbox executable is unavailable"), command.Close())
-		}
-		firstPath, firstIdentity = sandboxPath, sandboxIdentity
+	if command.inheritedDarwinPath {
+		return command.startDarwinInheritedPath()
+	}
+	sandboxPath, sandboxIdentity, err := canonicalPipelineOMPExecutable(command.cmd.Path)
+	if err != nil || sandboxPath != "/usr/bin/sandbox-exec" {
+		return errors.Join(errors.New("managed active Darwin sandbox executable is unavailable"), command.Close())
 	}
 	if command.cmd.SysProcAttr == nil {
 		command.cmd.SysProcAttr = &syscall.SysProcAttr{}
@@ -135,7 +131,7 @@ func (command *pipelineOMPVerifiedExecCommand) Start() error {
 	if err := command.waitDarwinExecStop(gateCtx); err != nil {
 		return command.failDarwinGate(errors.New("observe Darwin executable exec stop"), err)
 	}
-	if err := verifyPipelineOMPDarwinLiveExecutable(command.cmd.Process.Pid, firstPath, firstIdentity); err != nil {
+	if err := verifyPipelineOMPDarwinLiveExecutable(command.cmd.Process.Pid, sandboxPath, sandboxIdentity); err != nil {
 		return command.failDarwinGate(errors.New("verify Darwin executable live image"), err)
 	}
 	if command.afterFirstDarwinStop != nil {
@@ -143,12 +139,6 @@ func (command *pipelineOMPVerifiedExecCommand) Start() error {
 	}
 	if gateCtx.Err() != nil {
 		return command.failDarwinGate(errors.New("Darwin executable identity gate canceled"), gateCtx.Err())
-	}
-	if command.directDarwinImage {
-		if err := syscall.PtraceDetach(command.cmd.Process.Pid); err != nil {
-			return command.failDarwinGate(errors.New("detach verified managed active OMP trace"), err)
-		}
-		return nil
 	}
 	if err := continuePipelineOMPDarwinTrace(command.cmd.Process.Pid); err != nil {
 		return command.failDarwinGate(errors.New("continue Darwin sandbox trace"), err)
@@ -165,6 +155,30 @@ func (command *pipelineOMPVerifiedExecCommand) Start() error {
 		return command.failDarwinGate(errors.New("detach verified managed active OMP trace"), err)
 	}
 	return nil
+}
+
+func (command *pipelineOMPVerifiedExecCommand) startDarwinInheritedPath() error {
+	if len(command.cmd.ExtraFiles) != 0 || command.cmd.Path != command.parentFD.Name() ||
+		(command.cmd.SysProcAttr != nil && command.cmd.SysProcAttr.Ptrace) {
+		return errors.Join(errors.New("inherited parent sandbox verified OMP launch changed"), command.Close())
+	}
+	if err := verifyPipelineOMPExecutable(command.cmd.Path, command.expected); err != nil {
+		return errors.Join(err, command.Close())
+	}
+	startErr := command.cmd.Start()
+	if startErr != nil {
+		return errors.Join(startErr, command.Close())
+	}
+	if command.afterInheritedDarwinStart != nil {
+		command.afterInheritedDarwinStart()
+	}
+	postErr := verifyPipelineOMPExecutable(command.cmd.Path, command.expected)
+	closeErr := command.Close()
+	if postErr == nil && closeErr == nil {
+		return nil
+	}
+	return errors.Join(errors.New("inherited parent sandbox verified OMP launch failed"), postErr, closeErr,
+		terminateWorkflowContextManagedRPCProcessGroup(command.cmd), command.cmd.Wait())
 }
 
 func (command *pipelineOMPVerifiedExecCommand) parentTargetPath() string {

--- a/internal/cli/pipeline_omp_context_active_verified_exec_darwin.go
+++ b/internal/cli/pipeline_omp_context_active_verified_exec_darwin.go
@@ -97,8 +97,8 @@ func newPipelineOMPVerifiedDarwinCommand(
 	}, nil
 }
 
-// @AX:WARN [AUTO]: Darwin verified execution startup contains 17 if branches.
-// @AX:REASON [AUTO]: managed ptrace and inherited private-path gates share startup cleanup and executable identity enforcement.
+// @AX:WARN [AUTO]: Darwin verified execution startup contains 15 if branches.
+// @AX:REASON [AUTO]: sandbox ptrace startup coordinates executable identity, two exec stops, timeout, cleanup, continuation, and detach failures.
 func (command *pipelineOMPVerifiedExecCommand) Start() error {
 	if command == nil || command.cmd == nil || command.parentFD == nil || command.expected.info == nil {
 		return errors.New("verified managed active OMP command is unavailable")

--- a/internal/cli/pipeline_omp_context_active_verified_exec_darwin_test.go
+++ b/internal/cli/pipeline_omp_context_active_verified_exec_darwin_test.go
@@ -1,0 +1,157 @@
+//go:build darwin
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const pipelineOMPPrivatePathOuterSandboxFixture = "AUTOPUS_TEST_OMP_PRIVATE_PATH_OUTER_SANDBOX"
+
+func TestPipelineOMPVerifiedExecCommand_InheritedSandboxUsesVerifiedPrivateCopyWithoutPtrace(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.Chmod(root, 0o700))
+	executable := filepath.Join(root, "omp")
+	copyPipelineOMPVerifiedExecFixture(t, os.Args[0], executable)
+	path, identity, err := canonicalPipelineOMPExecutable(executable)
+	require.NoError(t, err)
+	command, err := newPipelineOMPVerifiedExecCommandContext(context.Background(), path, identity, "--version")
+	require.NoError(t, err)
+	require.NoError(t, configurePipelineOMPVerifiedExecSandboxMode(
+		command, pipelineOMPActiveSandboxInheritedParent, true,
+	))
+	require.NoError(t, configureWorkflowContextManagedRPCProcessGroup(command.cmd))
+	assert.Equal(t, path, command.cmd.Path)
+	assert.Empty(t, command.cmd.ExtraFiles)
+	require.NotNil(t, command.cmd.SysProcAttr)
+	assert.False(t, command.cmd.SysProcAttr.Ptrace)
+	var output bytes.Buffer
+	command.cmd.Stdout = &output
+	require.NoError(t, command.Start())
+	require.NoError(t, command.cmd.Wait())
+	assert.Equal(t, "omp/17.2.7\n", output.String())
+}
+
+func TestPipelineOMPVerifiedExecCommand_InheritedSandboxRejectsPrivateCopyIdentityDrift(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.Chmod(root, 0o700))
+	executable := filepath.Join(root, "omp")
+	copyPipelineOMPVerifiedExecFixture(t, os.Args[0], executable)
+	path, identity, err := canonicalPipelineOMPExecutable(executable)
+	require.NoError(t, err)
+	command, err := newPipelineOMPVerifiedExecCommandContext(context.Background(), path, identity, "--version")
+	require.NoError(t, err)
+	require.NoError(t, configurePipelineOMPVerifiedExecSandboxMode(
+		command, pipelineOMPActiveSandboxInheritedParent, true,
+	))
+	replacement := executable + ".replacement"
+	copyPipelineOMPVerifiedExecFixture(t, "/usr/bin/false", replacement)
+	require.NoError(t, os.Rename(replacement, executable))
+	require.ErrorContains(t, command.Start(), "identity changed before launch")
+	assert.Nil(t, command.cmd.Process)
+}
+
+func TestPipelineOMPVerifiedExecCommand_InheritedSandboxRejectsSharedExecutableRoot(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.Chmod(root, 0o755))
+	executable := filepath.Join(root, "omp")
+	copyPipelineOMPVerifiedExecFixture(t, os.Args[0], executable)
+	path, identity, err := canonicalPipelineOMPExecutable(executable)
+	require.NoError(t, err)
+	command, err := newPipelineOMPVerifiedExecCommandContext(context.Background(), path, identity, "--version")
+	require.NoError(t, err)
+
+	require.ErrorContains(t, configurePipelineOMPVerifiedExecSandboxMode(
+		command, pipelineOMPActiveSandboxInheritedParent, true,
+	), "private OMP root is unsafe")
+	require.NoError(t, command.Close())
+}
+
+func TestPipelineOMPVerifiedExecCommand_InheritedSandboxRejectsPostStartIdentityDrift(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.Chmod(root, 0o700))
+	executable := filepath.Join(root, "omp")
+	copyPipelineOMPVerifiedExecFixture(t, os.Args[0], executable)
+	path, identity, err := canonicalPipelineOMPExecutable(executable)
+	require.NoError(t, err)
+	command, err := newPipelineOMPVerifiedExecCommandContext(context.Background(), path, identity, "--version")
+	require.NoError(t, err)
+	require.NoError(t, configurePipelineOMPVerifiedExecSandboxMode(
+		command, pipelineOMPActiveSandboxInheritedParent, true,
+	))
+	replacement := executable + ".replacement"
+	copyPipelineOMPVerifiedExecFixture(t, "/usr/bin/false", replacement)
+	command.afterInheritedDarwinStart = func() { require.NoError(t, os.Rename(replacement, executable)) }
+
+	require.ErrorContains(t, command.Start(), "identity changed before launch")
+	require.NotNil(t, command.cmd.ProcessState)
+}
+
+func TestPipelineOMPVerifiedExecCommand_InheritedSandboxRunsInsideDenyDefaultOuterSandbox(t *testing.T) {
+	if os.Getenv(pipelineOMPPrivatePathOuterSandboxFixture) != "" {
+		assertPipelineOMPPrivatePathRunsInOuterSandbox(t)
+		return
+	}
+	root := t.TempDir()
+	require.NoError(t, os.Chmod(root, 0o700))
+	executable := filepath.Join(root, "omp")
+	copyPipelineOMPVerifiedExecFixture(t, os.Args[0], executable)
+	const profile = `(version 1)
+(deny default)
+(allow file-read*)
+(allow file-write* (literal "/dev/null"))
+(allow process*)
+(allow mach*)
+(allow sysctl-read)
+`
+	assert.NotContains(t, profile, "no-sandbox")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "/usr/bin/sandbox-exec", "-p", profile, os.Args[0],
+		"-test.run=^TestPipelineOMPVerifiedExecCommand_InheritedSandboxRunsInsideDenyDefaultOuterSandbox$")
+	cmd.Env = append(os.Environ(), pipelineOMPPrivatePathOuterSandboxFixture+"="+executable)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, strings.TrimSpace(string(output)))
+}
+
+func assertPipelineOMPPrivatePathRunsInOuterSandbox(t *testing.T) {
+	t.Helper()
+	executable := os.Getenv(pipelineOMPPrivatePathOuterSandboxFixture)
+	path, identity, err := canonicalPipelineOMPExecutable(executable)
+	require.NoError(t, err)
+	command, err := newPipelineOMPVerifiedExecCommandContext(context.Background(), path, identity, "--version")
+	require.NoError(t, err)
+	require.NoError(t, configurePipelineOMPVerifiedExecSandboxMode(
+		command, pipelineOMPActiveSandboxInheritedParent, true,
+	))
+	require.NoError(t, configureWorkflowContextManagedRPCProcessGroup(command.cmd))
+	var output bytes.Buffer
+	command.cmd.Stdout = &output
+	require.NoError(t, command.Start())
+	require.NoError(t, command.cmd.Wait())
+	assert.Equal(t, "omp/17.2.7\n", output.String())
+}
+
+func copyPipelineOMPVerifiedExecFixture(t *testing.T, source, destination string) {
+	t.Helper()
+	input, err := os.Open(source)
+	require.NoError(t, err)
+	defer input.Close()
+	output, err := os.OpenFile(destination, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o700)
+	require.NoError(t, err)
+	_, copyErr := io.Copy(output, input)
+	closeErr := output.Close()
+	require.NoError(t, copyErr)
+	require.NoError(t, closeErr)
+}

--- a/internal/cli/pipeline_omp_context_active_verified_exec_linux.go
+++ b/internal/cli/pipeline_omp_context_active_verified_exec_linux.go
@@ -9,6 +9,16 @@ import (
 	"os/exec"
 )
 
+type pipelineOMPVerifiedExecCommand struct {
+	cmd                    *exec.Cmd
+	parentFD               *os.File
+	expected               pipelineOMPExecutableIdentity
+	gateContext            context.Context
+	afterFirstDarwinStop   func()
+	inheritedDarwinPath    bool
+	inheritedDarwinPrivate bool
+}
+
 func newPipelineOMPVerifiedExecCommand(
 	path string,
 	expected pipelineOMPExecutableIdentity,

--- a/internal/cli/pipeline_omp_context_active_verified_exec_linux.go
+++ b/internal/cli/pipeline_omp_context_active_verified_exec_linux.go
@@ -9,6 +9,8 @@ import (
 	"os/exec"
 )
 
+// @AX:ANCHOR [AUTO] @AX:SPEC: SPEC-OMP-004: Linux build-selected verified-command state shared by constructors, sandbox validation, and startup.
+// @AX:REASON [AUTO]: common execution code depends on this type and its FD-backed identity fields remaining compatible across platform implementations.
 type pipelineOMPVerifiedExecCommand struct {
 	cmd                    *exec.Cmd
 	parentFD               *os.File
@@ -50,6 +52,7 @@ func newPipelineOMPVerifiedExecCommandContext(
 	if err != nil {
 		return nil, err
 	}
+	// @AX:NOTE [AUTO] @AX:SPEC: SPEC-OMP-004: fd 3 is the first descriptor assigned from exec.Cmd.ExtraFiles to the verified executable.
 	const childPath = "/proc/self/fd/3"
 	var cmd *exec.Cmd
 	if ctx == nil {

--- a/internal/cli/pipeline_omp_context_active_verified_exec_other.go
+++ b/internal/cli/pipeline_omp_context_active_verified_exec_other.go
@@ -10,10 +10,21 @@ import (
 )
 
 type pipelineOMPVerifiedExecCommand struct {
-	cmd               *exec.Cmd
-	parentFD          *os.File
-	directDarwinImage bool
+	cmd                    *exec.Cmd
+	parentFD               *os.File
+	inheritedDarwinPath    bool
+	inheritedDarwinPrivate bool
 }
+
+func configurePipelineOMPVerifiedExecSandboxMode(
+	*pipelineOMPVerifiedExecCommand,
+	pipelineOMPActiveSandboxMode,
+	bool,
+) error {
+	return errors.New("verified managed active OMP execution is unsupported")
+}
+
+func pipelineOMPVerifiedExecUsesDarwinPtrace(*pipelineOMPVerifiedExecCommand) bool { return false }
 
 func newPipelineOMPVerifiedExecCommand(
 	string,

--- a/internal/cli/pipeline_omp_context_active_verified_exec_other.go
+++ b/internal/cli/pipeline_omp_context_active_verified_exec_other.go
@@ -16,6 +16,8 @@ type pipelineOMPVerifiedExecCommand struct {
 	inheritedDarwinPrivate bool
 }
 
+// @AX:ANCHOR [AUTO] @AX:SPEC: SPEC-OMP-004: build-selected sandbox-mode contract shared by process startup, version probes, and platform tests.
+// @AX:REASON [AUTO]: unsupported platforms must preserve the common signature while rejecting inherited execution fail closed.
 func configurePipelineOMPVerifiedExecSandboxMode(
 	*pipelineOMPVerifiedExecCommand,
 	pipelineOMPActiveSandboxMode,

--- a/internal/cli/pipeline_omp_context_active_verified_exec_unix.go
+++ b/internal/cli/pipeline_omp_context_active_verified_exec_unix.go
@@ -9,17 +9,59 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 
 	"golang.org/x/sys/unix"
 )
 
 type pipelineOMPVerifiedExecCommand struct {
-	cmd                  *exec.Cmd
-	parentFD             *os.File
-	expected             pipelineOMPExecutableIdentity
-	gateContext          context.Context
-	afterFirstDarwinStop func()
-	directDarwinImage    bool
+	cmd                       *exec.Cmd
+	parentFD                  *os.File
+	expected                  pipelineOMPExecutableIdentity
+	gateContext               context.Context
+	afterFirstDarwinStop      func()
+	afterInheritedDarwinStart func()
+	inheritedDarwinPath       bool
+	inheritedDarwinPrivate    bool
+}
+
+func configurePipelineOMPVerifiedExecSandboxMode(
+	command *pipelineOMPVerifiedExecCommand,
+	mode pipelineOMPActiveSandboxMode,
+	requirePrivate bool,
+) error {
+	if mode == pipelineOMPActiveSandboxManaged {
+		return nil
+	}
+	if mode != pipelineOMPActiveSandboxInheritedParent || runtime.GOOS != "darwin" ||
+		command == nil || command.cmd == nil || command.parentFD == nil || command.expected.info == nil ||
+		command.cmd.Path != command.parentFD.Name() || len(command.cmd.Args) == 0 ||
+		command.cmd.Args[0] != command.cmd.Path || len(command.cmd.ExtraFiles) != 0 {
+		return errors.New("inherited parent sandbox verified OMP command is unsafe")
+	}
+	if requirePrivate && !pipelineOMPVerifiedPrivateExecutableRoot(command.cmd.Path) {
+		return errors.New("inherited parent sandbox private OMP root is unsafe")
+	}
+	command.inheritedDarwinPath = true
+	command.inheritedDarwinPrivate = requirePrivate
+	return nil
+}
+
+func pipelineOMPVerifiedPrivateExecutableRoot(path string) bool {
+	root := filepath.Dir(path)
+	resolved, resolveErr := filepath.EvalSymlinks(root)
+	info, statErr := os.Lstat(root)
+	if resolveErr != nil || statErr != nil || filepath.Clean(resolved) != filepath.Clean(root) ||
+		!info.IsDir() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm() != 0o700 {
+		return false
+	}
+	owner, ownerErr := pipelineOMPExecutableOwner(info)
+	return ownerErr == nil && owner.uid == uint32(os.Geteuid())
+}
+
+func pipelineOMPVerifiedExecUsesDarwinPtrace(command *pipelineOMPVerifiedExecCommand) bool {
+	return command != nil && command.cmd != nil && command.cmd.SysProcAttr != nil && command.cmd.SysProcAttr.Ptrace
 }
 
 func openPipelineOMPVerifiedExecutable(

--- a/internal/cli/pipeline_omp_context_active_verified_exec_unix.go
+++ b/internal/cli/pipeline_omp_context_active_verified_exec_unix.go
@@ -26,6 +26,8 @@ type pipelineOMPVerifiedExecCommand struct {
 	inheritedDarwinPrivate    bool
 }
 
+// @AX:ANCHOR [AUTO] @AX:SPEC: SPEC-OMP-004: build-selected sandbox-mode contract shared by process startup, version probes, and platform tests.
+// @AX:REASON [AUTO]: callers depend on exact command, parent FD, private-root, and Darwin-only invariants before inherited execution.
 func configurePipelineOMPVerifiedExecSandboxMode(
 	command *pipelineOMPVerifiedExecCommand,
 	mode pipelineOMPActiveSandboxMode,
@@ -64,6 +66,8 @@ func pipelineOMPVerifiedExecUsesDarwinPtrace(command *pipelineOMPVerifiedExecCom
 	return command != nil && command.cmd != nil && command.cmd.SysProcAttr != nil && command.cmd.SysProcAttr.Ptrace
 }
 
+// @AX:WARN [AUTO]: executable FD verification contains 8 if branches.
+// @AX:REASON [AUTO]: no-follow open, pre/post identity, ownership, digest, mutation detection, and rewind checks must fail closed together.
 func openPipelineOMPVerifiedExecutable(
 	path string,
 	expected pipelineOMPExecutableIdentity,

--- a/internal/cli/pipeline_omp_context_active_verified_exec_unix.go
+++ b/internal/cli/pipeline_omp_context_active_verified_exec_unix.go
@@ -3,28 +3,15 @@
 package cli
 
 import (
-	"context"
 	"crypto/sha256"
 	"errors"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 
 	"golang.org/x/sys/unix"
 )
-
-type pipelineOMPVerifiedExecCommand struct {
-	cmd                       *exec.Cmd
-	parentFD                  *os.File
-	expected                  pipelineOMPExecutableIdentity
-	gateContext               context.Context
-	afterFirstDarwinStop      func()
-	afterInheritedDarwinStart func()
-	inheritedDarwinPath       bool
-	inheritedDarwinPrivate    bool
-}
 
 // @AX:ANCHOR [AUTO] @AX:SPEC: SPEC-OMP-004: build-selected sandbox-mode contract shared by process startup, version probes, and platform tests.
 // @AX:REASON [AUTO]: callers depend on exact command, parent FD, private-root, and Darwin-only invariants before inherited execution.

--- a/internal/cli/workflow_context_runtime_implementation_identity_test.go
+++ b/internal/cli/workflow_context_runtime_implementation_identity_test.go
@@ -18,7 +18,7 @@ func TestWorkflowContextImplementationIdentityCommand(t *testing.T) {
 	var identity workflowContextImplementationIdentityV1
 	require.NoError(t, json.Unmarshal(output.Bytes(), &identity))
 	require.Equal(t, workflowContextImplementationIdentitySchemaV1, identity.SchemaVersion)
-	require.Equal(t, "sha256:280d2623208d375520db86e4e4ac45d8a22f2395376f996a92fe059cc1767d2f",
+	require.Equal(t, "sha256:b338d5c6ee2a681e7c67555f1dee4743837c30ed347af5867412966de50e0b9e",
 		identity.PipelineImplementationDigest)
 	require.Equal(t, "autopus.omp-pipeline-managed-rpc.v2", identity.RPCIdentity)
 	require.Equal(t, pipelineOMPActivePolicyIdentity, identity.PolicyIdentity)

--- a/internal/cli/workflow_context_runtime_observe_session_setup_test.go
+++ b/internal/cli/workflow_context_runtime_observe_session_setup_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"context"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -12,6 +14,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const workflowContextInheritedVersionOuterSandboxFixture = "AUTOPUS_TEST_OMP_VERSION_OUTER_SANDBOX"
 
 func TestWorkflowContextObserveSessionPhaseModels_BindsAllCanonicalPhases(t *testing.T) {
 	t.Parallel()
@@ -69,6 +73,50 @@ func TestWorkflowContextObserveVersion_InheritedModeUsesVerifiedPathWithoutInner
 	assert.Equal(t, executable, command.cmd.Args[0])
 	assert.Empty(t, command.cmd.ExtraFiles)
 	assert.False(t, pipelineOMPVerifiedExecUsesDarwinPtrace(command))
+	require.NoError(t, command.Close())
+
+	got, err := probeWorkflowContextObserveVersion(ctx, options, pipelineOMPActiveSandboxInheritedParent)
+	require.NoError(t, err)
+	assert.Equal(t, "omp/17.2.7", got)
+}
+
+func TestWorkflowContextObserveVersion_InheritedModeStripsSecretsInsideDenyDefaultSandbox(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("inherited parent sandbox is Darwin-only")
+	}
+	if os.Getenv(workflowContextInheritedVersionOuterSandboxFixture) == "" {
+		const profile = `(version 1)
+(deny default)
+(allow file-read*)
+(allow file-write* (literal "/dev/null"))
+(allow process*)
+(allow mach*)
+(allow sysctl-read)
+`
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "/usr/bin/sandbox-exec", "-p", profile, os.Args[0],
+			"-test.run=^TestWorkflowContextObserveVersion_InheritedModeStripsSecretsInsideDenyDefaultSandbox$")
+		cmd.Env = append(os.Environ(), workflowContextInheritedVersionOuterSandboxFixture+"=1")
+		require.NoError(t, cmd.Run())
+		return
+	}
+
+	options := WorkflowContextManagedRPCOptions{
+		Executable: os.Args[0], Workspace: filepath.Dir(os.Args[0]),
+		Environment: []string{
+			"PATH=/sentinel/bin", pipelineOMPActiveCredentialKey + "=pipeline-sentinel",
+			"OPENAI_API_KEY=provider-sentinel", "UNRELATED_SECRET=unrelated-sentinel",
+		},
+		AllowedEndpoint: "http://127.0.0.1:43123",
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	command, _, err := newWorkflowContextObserveInheritedVersionCommand(ctx, options)
+	require.NoError(t, err)
+	if command.cmd.Env == nil || len(command.cmd.Env) != 0 {
+		t.Fatalf("inherited version environment is not empty: entries=%d", len(command.cmd.Env))
+	}
 	require.NoError(t, command.Close())
 
 	got, err := probeWorkflowContextObserveVersion(ctx, options, pipelineOMPActiveSandboxInheritedParent)

--- a/internal/cli/workflow_context_runtime_observe_session_setup_test.go
+++ b/internal/cli/workflow_context_runtime_observe_session_setup_test.go
@@ -49,7 +49,7 @@ func TestWorkflowContextObserveSessionCommand_InheritedParentSandboxIsExplicitOp
 	require.NoError(t, validateWorkflowContextObserveSessionOptions(options))
 }
 
-func TestWorkflowContextObserveVersion_InheritedModeUsesDirectVerifiedImage(t *testing.T) {
+func TestWorkflowContextObserveVersion_InheritedModeUsesVerifiedPathWithoutInnerWrapper(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("inherited parent sandbox is Darwin-only")
 	}
@@ -61,8 +61,14 @@ func TestWorkflowContextObserveVersion_InheritedModeUsesDirectVerifiedImage(t *t
 	defer cancel()
 	command, _, err := newWorkflowContextObserveInheritedVersionCommand(ctx, options)
 	require.NoError(t, err)
-	assert.True(t, command.directDarwinImage)
-	assert.NotEqual(t, "/usr/bin/sandbox-exec", command.cmd.Path)
+	executable, _, err := canonicalPipelineOMPExecutable(os.Args[0])
+	require.NoError(t, err)
+	assert.True(t, command.inheritedDarwinPath)
+	assert.False(t, command.inheritedDarwinPrivate)
+	assert.Equal(t, executable, command.cmd.Path)
+	assert.Equal(t, executable, command.cmd.Args[0])
+	assert.Empty(t, command.cmd.ExtraFiles)
+	assert.False(t, pipelineOMPVerifiedExecUsesDarwinPtrace(command))
 	require.NoError(t, command.Close())
 
 	got, err := probeWorkflowContextObserveVersion(ctx, options, pipelineOMPActiveSandboxInheritedParent)

--- a/internal/cli/workflow_context_runtime_observe_version.go
+++ b/internal/cli/workflow_context_runtime_observe_version.go
@@ -46,7 +46,11 @@ func newWorkflowContextObserveInheritedVersionCommand(
 	); err != nil {
 		return nil, identity, errors.Join(err, command.Close())
 	}
-	command.directDarwinImage = true
+	if err := configurePipelineOMPVerifiedExecSandboxMode(
+		command, pipelineOMPActiveSandboxInheritedParent, false,
+	); err != nil {
+		return nil, identity, errors.Join(err, command.Close())
+	}
 	if err := configureWorkflowContextManagedRPCProcessGroup(command.cmd); err != nil {
 		return nil, identity, errors.Join(err, command.Close())
 	}

--- a/internal/cli/workflow_context_runtime_observe_version.go
+++ b/internal/cli/workflow_context_runtime_observe_version.go
@@ -40,7 +40,8 @@ func newWorkflowContextObserveInheritedVersionCommand(
 	if err != nil {
 		return nil, identity, err
 	}
-	command.cmd.Dir, command.cmd.Env = options.Workspace, options.Environment
+	// The absolute verified --version command requires no ambient authority.
+	command.cmd.Dir, command.cmd.Env = options.Workspace, []string{}
 	if err := configurePipelineOMPActiveSandbox(
 		command.cmd, options.AllowedEndpoint, pipelineOMPActiveSandboxInheritedParent,
 	); err != nil {


### PR DESCRIPTION
## 변경
- inherited Darwin 경로에서 내부 ptrace를 제거하고 outer sandbox를 상속합니다.
- private 0700 OMP copy와 실행 전후 identity를 검증합니다.
- managed 2-stage ptrace 경로와 cross-platform fail-close를 유지합니다.
- policy identity 및 implementation digest를 갱신합니다.

## 검증
- focused/race/deny-default outer sandbox PASS
- go test -race ./internal/cli PASS
- go vet ./... PASS
- Linux/Windows compile PASS
- AX annotation gate PASS
- 독립 review APPROVE (Critical 0, High 0)

## 릴리즈 게이트
- producer의 evaluator request/result provenance High 이슈가 별도 수렴되기 전에는 live promotion 및 release를 진행하지 않습니다.

🐙 Autopus