### PR TITLE
feat(omp): productize native orchestration and context authority

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -169,6 +169,48 @@ jobs:
             bash -n "$script"
           done < <(git ls-files -z '*.sh')
 
+  omp-native-smoke:
+    name: omp-native-smoke
+    permissions:
+      contents: read
+    runs-on: macos-15
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run pinned OMP native task hub smoke
+        shell: bash
+        run: |
+          set -euo pipefail
+          umask 077
+          [[ "$(uname -s)" == 'Darwin' ]]
+          [[ "$(uname -m)" == 'arm64' ]]
+          omp_binary="${RUNNER_TEMP}/omp-v17.2.7-darwin-arm64"
+          [[ ! -e "$omp_binary" && ! -L "$omp_binary" ]]
+          cleanup_omp() {
+            rm -f -- "$omp_binary"
+          }
+          trap cleanup_omp EXIT
+          /usr/bin/curl --proto '=https' --proto-redir '=https' --tlsv1.2 \
+            --fail --location --silent --show-error \
+            --output "$omp_binary" \
+            'https://github.com/can1357/oh-my-pi/releases/download/v17.2.7/omp-darwin-arm64'
+          expected='cd2f47545cb3f8eb5e15c91bc9054d73967774652e020b432e294803d1b71ea0'
+          actual=$(/usr/bin/shasum -a 256 "$omp_binary" | /usr/bin/awk '{print $1}')
+          [[ "$actual" == "$expected" ]]
+          /bin/chmod 0555 "$omp_binary"
+          [[ "$("$omp_binary" --version)" == 'omp/17.2.7' ]]
+          AUTOPUS_OMP_NATIVE_LIVE=1 \
+          AUTOPUS_OMP_LIVE_EXECUTABLE="$omp_binary" \
+            go test -count=1 -timeout=90s \
+            -run '^TestOMPNativeTaskHubLiveSmoke$' ./pkg/adapter/omp
+
   macos-runtime:
     name: macos-runtime
     runs-on: macos-15

--- a/.github/workflows/omp-context-promote.yml
+++ b/.github/workflows/omp-context-promote.yml
@@ -127,10 +127,13 @@ jobs:
           [[ "${#fetched_files[@]}" -eq 1 && "${fetched_files[0]}" == "$report_path" ]] || fail 'isolated evidence directory contains unexpected files'
           shopt -u nullglob dotglob
 
-          readonly issued_epoch=$(date -u +%s)
-          readonly issued_at=$(date -u --date="@${issued_epoch}" '+%Y-%m-%dT%H:%M:%SZ')
+          issued_epoch=$(date -u +%s)
+          readonly issued_epoch
+          issued_at=$(date -u --date="@${issued_epoch}" '+%Y-%m-%dT%H:%M:%SZ')
+          readonly issued_at
           readonly not_before="$issued_at"
-          readonly expires_at=$(date -u --date="@$((issued_epoch + 86400))" '+%Y-%m-%dT%H:%M:%SZ')
+          expires_at=$(date -u --date="@$((issued_epoch + 86400))" '+%Y-%m-%dT%H:%M:%SZ')
+          readonly expires_at
           printf '%s' "$OMP_CONTEXT_EVIDENCE_SIGNING_KEY" |
             env -i PATH="$PATH" HOME="$HOME" TMPDIR="$RUNNER_TEMP" \
               "$tools_dir/auto" companion-manifest omp-context-promotion-attestation \
@@ -150,8 +153,10 @@ jobs:
           [[ "$report_sha256" =~ ^[0-9a-f]{64}$ ]] || fail 'report digest is malformed'
           [[ "$attestation_sha256" =~ ^[0-9a-f]{64}$ ]] || fail 'attestation digest is malformed'
 
-          readonly published_report_blob=$(git hash-object -w -- "$report_path")
-          readonly published_attestation_blob=$(git hash-object -w -- "$attestation_path")
+          published_report_blob=$(git hash-object -w -- "$report_path")
+          readonly published_report_blob
+          published_attestation_blob=$(git hash-object -w -- "$attestation_path")
+          readonly published_attestation_blob
           [[ "$published_report_blob" == "$report_blob" ]] || fail 'promotion report bytes changed after fetch'
           readonly evidence_index="$work_root/evidence.index"
           GIT_INDEX_FILE="$evidence_index" git read-tree --empty
@@ -159,7 +164,8 @@ jobs:
             --cacheinfo "100644,$published_report_blob,$report_name"
           GIT_INDEX_FILE="$evidence_index" git update-index --add \
             --cacheinfo "100644,$published_attestation_blob,$attestation_name"
-          readonly evidence_tree=$(GIT_INDEX_FILE="$evidence_index" git write-tree)
+          evidence_tree=$(GIT_INDEX_FILE="$evidence_index" git write-tree)
+          readonly evidence_tree
           mapfile -d '' -t published_entries < <(git ls-tree -z "$evidence_tree")
           [[ "${#published_entries[@]}" -eq 2 ]] || fail 'published evidence tree does not contain exactly two entries'
           for name in "$report_name" "$attestation_name"; do
@@ -167,13 +173,14 @@ jobs:
             [[ "$entry" =~ ^100644\ blob\ [0-9a-f]{40}$'\t'"$name"$ ]] || fail "published evidence entry ${name} is unsafe"
           done
 
-          readonly evidence_commit=$(printf '%s\n' 'OMP context promotion evidence v0.50.93' |
+          published_evidence_commit=$(printf '%s\n' 'OMP context promotion evidence v0.50.93' |
             git -c user.name='github-actions[bot]' \
               -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
               commit-tree "$evidence_tree")
-          [[ "$(git rev-list --parents -n 1 "$evidence_commit")" == "$evidence_commit" ]] || fail 'published evidence commit is not zero-parent'
-          git cat-file blob "$evidence_commit:$report_name" >"$verify_dir/$report_name"
-          git cat-file blob "$evidence_commit:$attestation_name" >"$verify_dir/$attestation_name"
+          readonly published_evidence_commit
+          [[ "$(git rev-list --parents -n 1 "$published_evidence_commit")" == "$published_evidence_commit" ]] || fail 'published evidence commit is not zero-parent'
+          git cat-file blob "$published_evidence_commit:$report_name" >"$verify_dir/$report_name"
+          git cat-file blob "$published_evidence_commit:$attestation_name" >"$verify_dir/$attestation_name"
           chmod 0600 "$verify_dir/$report_name" "$verify_dir/$attestation_name"
           cmp "$report_path" "$verify_dir/$report_name" || fail 'published report bytes differ from fetched evidence'
           cmp "$attestation_path" "$verify_dir/$attestation_name" || fail 'published attestation bytes differ from signer output'
@@ -193,9 +200,10 @@ jobs:
           git -c user.name='github-actions[bot]' \
             -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
             -c tag.gpgSign=false \
-            tag -a "$evidence_tag" "$evidence_commit" -m 'OMP context promotion evidence v0.50.93'
+            tag -a "$evidence_tag" "$published_evidence_commit" -m 'OMP context promotion evidence v0.50.93'
           [[ "$(git cat-file -t "$tag_ref")" == 'tag' ]] || fail 'promotion tag is not annotated'
-          readonly tag_object=$(git rev-parse --verify "$tag_ref")
+          tag_object=$(git rev-parse --verify "$tag_ref")
+          readonly tag_object
           git push origin "$tag_ref:$tag_ref"
           remote_tag_line=$(git ls-remote --refs origin "$tag_ref")
           remote_tag_object=${remote_tag_line%%$'\t'*}

--- a/.github/workflows/omp-context-promote.yml
+++ b/.github/workflows/omp-context-promote.yml
@@ -1,0 +1,208 @@
+name: Promote OMP context evidence
+
+on:
+  workflow_dispatch:
+    inputs:
+      evidence_commit:
+        description: Exact commit containing only promotion-report-v1.json
+        required: true
+        type: string
+      source_commit:
+        description: Exact Autopus ADK source commit
+        required: true
+        type: string
+      source_tree:
+        description: Exact Autopus ADK source tree
+        required: true
+        type: string
+      candidate_sha256:
+        description: Exact promoted candidate SHA-256
+        required: true
+        type: string
+      static_policy_b64:
+        description: Canonical raw-base64url OMP context static policy
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  actions: write
+
+concurrency:
+  group: omp-context-evidence-v0.50.93
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Check out exact source commit
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ inputs.source_commit }}
+          fetch-depth: 1
+          persist-credentials: true
+
+      - name: Set up pinned Go toolchain
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Verify, sign, and publish exact evidence
+        shell: bash
+        env:
+          EVIDENCE_COMMIT: ${{ inputs.evidence_commit }}
+          SOURCE_COMMIT: ${{ inputs.source_commit }}
+          SOURCE_TREE: ${{ inputs.source_tree }}
+          CANDIDATE_SHA256: ${{ inputs.candidate_sha256 }}
+          STATIC_POLICY_B64: ${{ inputs.static_policy_b64 }}
+          OMP_CONTEXT_EVIDENCE_SIGNING_KEY: ${{ secrets.OMP_CONTEXT_EVIDENCE_SIGNING_KEY }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          umask 077
+
+          fail() {
+            printf 'OMP context promotion: %s\n' "$1" >&2
+            exit 1
+          }
+
+          readonly evidence_tag='omp-context-evidence-v0.50.93'
+          readonly tag_ref="refs/tags/${evidence_tag}"
+          readonly report_name='promotion-report-v1.json'
+          readonly attestation_name='omp-context-promotion-attestation.v2.json'
+          readonly candidate_repository='Insajin/autopus-adk'
+
+          [[ "$EVIDENCE_COMMIT" =~ ^[0-9a-f]{40}$ ]] || fail 'evidence_commit must be exact lowercase 40-hex'
+          [[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]] || fail 'source_commit must be exact lowercase 40-hex'
+          [[ "$SOURCE_TREE" =~ ^[0-9a-f]{40}$ ]] || fail 'source_tree must be exact lowercase 40-hex'
+          [[ "$CANDIDATE_SHA256" =~ ^[0-9a-f]{64}$ ]] || fail 'candidate_sha256 must be exact lowercase 64-hex'
+          [[ "$STATIC_POLICY_B64" =~ ^[A-Za-z0-9_-]+$ ]] || fail 'static_policy_b64 is malformed'
+          [[ "$GITHUB_REPOSITORY" == "$candidate_repository" ]] || fail 'workflow repository is not the production candidate repository'
+          [[ -n "${OMP_CONTEXT_EVIDENCE_SIGNING_KEY:-}" ]] || fail 'promotion signing key is unavailable'
+          [[ "$(git rev-parse --verify 'HEAD^{commit}')" == "$SOURCE_COMMIT" ]] || fail 'checkout differs from source_commit'
+          [[ "$(git rev-parse --verify 'HEAD^{tree}')" == "$SOURCE_TREE" ]] || fail 'checkout differs from source_tree'
+
+          if git show-ref --verify --quiet "$tag_ref"; then
+            fail 'fixed promotion tag already exists locally'
+          fi
+          remote_tag_status=0
+          git ls-remote --exit-code --refs origin "$tag_ref" >/dev/null 2>&1 || remote_tag_status=$?
+          case "$remote_tag_status" in
+            0) fail 'fixed promotion tag already exists remotely' ;;
+            2) ;;
+            *) fail 'cannot inspect fixed promotion tag' ;;
+          esac
+
+          readonly work_root="${RUNNER_TEMP}/omp-context-promote-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          [[ ! -e "$work_root" && ! -L "$work_root" ]] || fail 'isolated promotion root already exists'
+          install -d -m 0700 "$work_root"
+          trap 'rm -rf -- "$work_root"' EXIT
+          readonly report_dir="$work_root/fetched-evidence"
+          readonly output_dir="$work_root/signed-evidence"
+          readonly verify_dir="$work_root/verified-tree"
+          readonly tools_dir="$work_root/tools"
+          install -d -m 0700 "$report_dir" "$output_dir" "$verify_dir" "$tools_dir"
+          readonly report_path="$report_dir/$report_name"
+          readonly attestation_path="$output_dir/$attestation_name"
+
+          go build -trimpath -o "$tools_dir/auto" ./cmd/auto
+          go build -trimpath -o "$tools_dir/ompcontextverify" ./scripts/companion-release/ompcontextverify
+
+          git fetch --no-tags --depth=1 origin "$EVIDENCE_COMMIT"
+          [[ "$(git rev-parse --verify "${EVIDENCE_COMMIT}^{commit}")" == "$EVIDENCE_COMMIT" ]] || fail 'fetched evidence commit identity differs'
+          mapfile -d '' -t evidence_entries < <(git ls-tree -z "$EVIDENCE_COMMIT")
+          [[ "${#evidence_entries[@]}" -eq 1 ]] || fail 'evidence commit tree must contain exactly one entry'
+          evidence_metadata=${evidence_entries[0]%%$'\t'*}
+          evidence_path=${evidence_entries[0]#*$'\t'}
+          [[ "$evidence_path" == "$report_name" ]] || fail 'evidence commit contains an unsafe path'
+          [[ "$evidence_metadata" =~ ^100644\ blob\ ([0-9a-f]{40})$ ]] || fail 'promotion report is not one regular 100644 blob'
+          readonly report_blob=${BASH_REMATCH[1]}
+          git cat-file blob "$report_blob" >"$report_path"
+          chmod 0600 "$report_path"
+          shopt -s nullglob dotglob
+          fetched_files=("$report_dir"/*)
+          [[ "${#fetched_files[@]}" -eq 1 && "${fetched_files[0]}" == "$report_path" ]] || fail 'isolated evidence directory contains unexpected files'
+          shopt -u nullglob dotglob
+
+          readonly issued_epoch=$(date -u +%s)
+          readonly issued_at=$(date -u --date="@${issued_epoch}" '+%Y-%m-%dT%H:%M:%SZ')
+          readonly not_before="$issued_at"
+          readonly expires_at=$(date -u --date="@$((issued_epoch + 86400))" '+%Y-%m-%dT%H:%M:%SZ')
+          printf '%s' "$OMP_CONTEXT_EVIDENCE_SIGNING_KEY" |
+            env -i PATH="$PATH" HOME="$HOME" TMPDIR="$RUNNER_TEMP" \
+              "$tools_dir/auto" companion-manifest omp-context-promotion-attestation \
+                --report "$report_path" \
+                --issued-at "$issued_at" \
+                --not-before "$not_before" \
+                --expires-at "$expires_at" \
+                --output "$attestation_path"
+          unset OMP_CONTEXT_EVIDENCE_SIGNING_KEY
+          [[ -f "$attestation_path" && ! -L "$attestation_path" ]] || fail 'signer did not produce a safe attestation'
+          [[ "$(stat -c '%a' "$attestation_path")" == '600' ]] || fail 'attestation permissions are not private'
+
+          report_sha256=$(sha256sum "$report_path")
+          readonly report_sha256=${report_sha256%% *}
+          attestation_sha256=$(sha256sum "$attestation_path")
+          readonly attestation_sha256=${attestation_sha256%% *}
+          [[ "$report_sha256" =~ ^[0-9a-f]{64}$ ]] || fail 'report digest is malformed'
+          [[ "$attestation_sha256" =~ ^[0-9a-f]{64}$ ]] || fail 'attestation digest is malformed'
+
+          readonly published_report_blob=$(git hash-object -w -- "$report_path")
+          readonly published_attestation_blob=$(git hash-object -w -- "$attestation_path")
+          [[ "$published_report_blob" == "$report_blob" ]] || fail 'promotion report bytes changed after fetch'
+          readonly evidence_index="$work_root/evidence.index"
+          GIT_INDEX_FILE="$evidence_index" git read-tree --empty
+          GIT_INDEX_FILE="$evidence_index" git update-index --add \
+            --cacheinfo "100644,$published_report_blob,$report_name"
+          GIT_INDEX_FILE="$evidence_index" git update-index --add \
+            --cacheinfo "100644,$published_attestation_blob,$attestation_name"
+          readonly evidence_tree=$(GIT_INDEX_FILE="$evidence_index" git write-tree)
+          mapfile -d '' -t published_entries < <(git ls-tree -z "$evidence_tree")
+          [[ "${#published_entries[@]}" -eq 2 ]] || fail 'published evidence tree does not contain exactly two entries'
+          for name in "$report_name" "$attestation_name"; do
+            entry=$(git ls-tree "$evidence_tree" -- "$name")
+            [[ "$entry" =~ ^100644\ blob\ [0-9a-f]{40}$'\t'"$name"$ ]] || fail "published evidence entry ${name} is unsafe"
+          done
+
+          readonly evidence_commit=$(printf '%s\n' 'OMP context promotion evidence v0.50.93' |
+            git -c user.name='github-actions[bot]' \
+              -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+              commit-tree "$evidence_tree")
+          [[ "$(git rev-list --parents -n 1 "$evidence_commit")" == "$evidence_commit" ]] || fail 'published evidence commit is not zero-parent'
+          git cat-file blob "$evidence_commit:$report_name" >"$verify_dir/$report_name"
+          git cat-file blob "$evidence_commit:$attestation_name" >"$verify_dir/$attestation_name"
+          chmod 0600 "$verify_dir/$report_name" "$verify_dir/$attestation_name"
+          cmp "$report_path" "$verify_dir/$report_name" || fail 'published report bytes differ from fetched evidence'
+          cmp "$attestation_path" "$verify_dir/$attestation_name" || fail 'published attestation bytes differ from signer output'
+
+          "$tools_dir/ompcontextverify" \
+            --mode historical \
+            --report "$verify_dir/$report_name" \
+            --attestation "$verify_dir/$attestation_name" \
+            --report-sha256 "$report_sha256" \
+            --attestation-sha256 "$attestation_sha256" \
+            --candidate-repository "$candidate_repository" \
+            --candidate-revision "$SOURCE_COMMIT" \
+            --candidate-tree "$SOURCE_TREE" \
+            --candidate-artifact-sha256 "$CANDIDATE_SHA256" \
+            --static-policy-b64 "$STATIC_POLICY_B64"
+
+          git -c user.name='github-actions[bot]' \
+            -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+            -c tag.gpgSign=false \
+            tag -a "$evidence_tag" "$evidence_commit" -m 'OMP context promotion evidence v0.50.93'
+          [[ "$(git cat-file -t "$tag_ref")" == 'tag' ]] || fail 'promotion tag is not annotated'
+          readonly tag_object=$(git rev-parse --verify "$tag_ref")
+          git push origin "$tag_ref:$tag_ref"
+          remote_tag_line=$(git ls-remote --refs origin "$tag_ref")
+          remote_tag_object=${remote_tag_line%%$'\t'*}
+          remote_tag_ref=${remote_tag_line#*$'\t'}
+          [[ "$remote_tag_object" == "$tag_object" && "$remote_tag_ref" == "$tag_ref" ]] || fail 'remote promotion tag differs after push'
+
+          gh variable set OMP_CONTEXT_EVIDENCE_TAG --repo "$GITHUB_REPOSITORY" --body "$evidence_tag"
+          gh variable set OMP_CONTEXT_EVIDENCE_REPORT_SHA256 --repo "$GITHUB_REPOSITORY" --body "$report_sha256"
+          gh variable set OMP_CONTEXT_EVIDENCE_ATTESTATION_SHA256 --repo "$GITHUB_REPOSITORY" --body "$attestation_sha256"
+          gh variable set OMP_CONTEXT_STATIC_POLICY_B64 --repo "$GITHUB_REPOSITORY" --body "$STATIC_POLICY_B64"

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 ### A harness *of* the agents, *by* the agents, *for* the agents.
 
-Make your AI coding tools (Claude Code, Codex, Antigravity CLI, OpenCode) work like a real engineering team — with planning, testing, code review, and security audits built in.
+Make your AI coding tools (Claude Code, Codex, Antigravity CLI, OpenCode, Oh My Pi) work like a real engineering team — with planning, testing, code review, and security audits built in.
 
 **16 agents. 40 skills. One config. Every platform.**
 
 [![GitHub Stars](https://img.shields.io/github/stars/Insajin/autopus-adk?style=social)](https://github.com/Insajin/autopus-adk/stargazers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Go Version](https://img.shields.io/badge/Go-1.26-00ADD8?logo=go&logoColor=white)](https://golang.org)
-[![Platforms](https://img.shields.io/badge/Platforms-4-orange)](#-one-config-four-platforms)
+[![Platforms](https://img.shields.io/badge/Platforms-5-orange)](#-one-config-five-platforms)
 [![Agents](https://img.shields.io/badge/Agents-16-blueviolet)](#-16-specialized-agents)
 [![Skills](https://img.shields.io/badge/Skills-40-ff69b4)](#-all-commands)
 
@@ -500,7 +500,7 @@ Fallback: providers without hooks use ReadScreen + idle detection (SPEC-ORCH-006
 | **Signature Map** | `auto setup` | Extract exported API signatures (Go + TypeScript) via AST analysis |
 | **Test Runner Detection** | `auto init` | Auto-detect jest, vitest, pytest, cargo test frameworks |
 
-### 🌐 One Config, Four Platforms
+### 🌐 One Config, Five Platforms
 
 ```bash
 auto init   # auto-detects supported installed AI coding CLIs
@@ -514,6 +514,7 @@ One `autopus.yaml` generates **native configuration** for every detected support
 | **Codex** | `.codex/`, `.agents/skills/`, `.agents/plugins/marketplace.json`, `.autopus/plugins/auto/`, `AGENTS.md` |
 | **Antigravity CLI** | `.gemini/`, `GEMINI.md` |
 | **OpenCode** | `.opencode/rules/`, `.opencode/agents/`, `.opencode/commands/`, `.opencode/plugins/`, `.agents/skills/`, `AGENTS.md`, `opencode.json` |
+| **Oh My Pi (OMP)** | `.omp/agents/`, `.omp/skills/`, `.omp/commands/`, `.omp/extensions/autopus-context.ts`, `.omp/config.yml`, `.agents/skills/` |
 Same 16 agents. Same rules. Shared skills stay full by default. If you want a smaller mixed Codex + OpenCode surface without breaking backward-compatible defaults, keep `skills.shared_surface` as-is and opt into `skills.compiler.mode: split`.
 
 Codex note:
@@ -532,7 +533,20 @@ OpenCode note:
 
 ### OMP role routing and context optimization (opt-in)
 
-OMP policies are provider-neutral and inactive until a named profile is selected. Start with the non-destructive `overlay` mode, then replace the illustrative selectors below with exact, authenticated `provider/model` selectors reported by the installed OMP catalog.
+Operator commands:
+
+```bash
+auto platform omp models                 # installed model catalog
+auto platform omp profile init --name omp-balanced --plan
+auto platform omp profile apply omp-balanced
+auto platform omp explain
+auto status --platform omp
+```
+
+With the current upstream OMP 17.2.7 catalog, `models` returns the exact native selector, context window, reasoning flag, thinking levels, and input modes as a successful `degraded`/display-only result. OMP does not yet expose the family, Autopus capability, or authorization metadata required for safe automatic routing, so `strict_routing_ready` remains `false` and profile init/apply stays blocked with `catalog_metadata_insufficient`. Autopus does not guess those fields or inspect credentials.
+
+
+OMP policies are provider-neutral and inactive until a named profile is selected. Start with the non-destructive `overlay` mode only after the strict catalog is ready, then replace the illustrative selectors below with exact, authenticated `provider/model` selectors.
 
 ```yaml
 role_model_policy:
@@ -713,18 +727,19 @@ cd your-project
 auto init
 ```
 
-`auto init` scans your machine for supported installed AI coding CLIs (Claude Code, Codex, Antigravity CLI, OpenCode) and generates **native configuration** for each one — rules, skills, agents, and platform-specific settings — all from a single `autopus.yaml`.
+`auto init` scans your machine for supported installed AI coding CLIs (Claude Code, Codex, Antigravity CLI, OpenCode, Oh My Pi) and generates **native configuration** for each one — rules, skills, agents, commands, and platform-specific settings — all from a single `autopus.yaml`.
 
 Claude Code statusline note:
 - If `.claude/settings.json` already has a `statusLine.command`, `auto init` / `auto update` now lets you choose `keep`, `merge`, or `replace` in interactive mode.
 - You can force the same behavior non-interactively with `--statusline-mode keep|merge|replace`.
 
 ```
-✓ Detected: claude-code, codex, antigravity-cli, opencode
+✓ Detected: claude-code, codex, antigravity-cli, opencode, omp
 ✓ Generated: .claude/rules/, .claude/skills/, .claude/agents/, CLAUDE.md
 ✓ Generated: .codex/, AGENTS.md
 ✓ Generated: .gemini/, GEMINI.md
 ✓ Generated: .opencode/, .agents/skills/, AGENTS.md, opencode.json
+✓ Generated: .omp/agents/, .omp/skills/, .omp/commands/, .omp/extensions/, .omp/config.yml
 ✓ Created: autopus.yaml
 ```
 
@@ -733,7 +748,7 @@ Claude Code statusline note:
 This is the most important step. **AI agents lose all memory between sessions** — every conversation is their first day on the job. `/auto setup` creates the "onboarding documents" that let agents understand your project instantly.
 
 ```bash
-/auto setup     # Claude Code, Antigravity CLI, OpenCode
+/auto setup     # Claude Code, Antigravity CLI, OpenCode, Oh My Pi
 @auto setup     # Codex after local plugin install
 $auto setup     # Codex fallback before plugin install
 ```

--- a/autopus.yaml
+++ b/autopus.yaml
@@ -5,7 +5,19 @@ platforms:
     - codex
     - antigravity-cli
     - opencode
+    - omp
 isolate_rules: true
+omp_context_policy:
+    profile: omp-active-probed
+    profiles:
+        omp-active-probed:
+            history_mode: active
+            memory_mode: off
+            history_target_tokens: 1000
+            fallback: canonical_full
+            capability_policy: probe_required
+            runtime_root_policy: isolated_task_owned
+            mutation_scope: session_overlay
 language:
     comments: en
     commits: ko

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -4,14 +4,14 @@
 
 ### 에이전트*로 이루어진*, 에이전트*에 의해 운영되는*, 에이전트*를 위한* 하네스.
 
-AI 코딩 도구(Claude Code, Codex, Antigravity CLI, OpenCode)가 진짜 개발팀처럼 일하게 만듭니다 — 기획, 테스트, 코드 리뷰, 보안 감사까지 자동으로.
+AI 코딩 도구(Claude Code, Codex, Antigravity CLI, OpenCode, Oh My Pi)가 진짜 개발팀처럼 일하게 만듭니다 — 기획, 테스트, 코드 리뷰, 보안 감사까지 자동으로.
 
 **16개 에이전트. 40개 스킬. 하나의 설정. 모든 플랫폼.**
 
 [![GitHub Stars](https://img.shields.io/github/stars/Insajin/autopus-adk?style=social)](https://github.com/Insajin/autopus-adk/stargazers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Go Version](https://img.shields.io/badge/Go-1.26-00ADD8?logo=go&logoColor=white)](https://golang.org)
-[![Platforms](https://img.shields.io/badge/Platforms-4-orange)](#-하나의-설정-네-개-플랫폼)
+[![Platforms](https://img.shields.io/badge/Platforms-5-orange)](#-하나의-설정-다섯-개-플랫폼)
 [![Agents](https://img.shields.io/badge/Agents-16-blueviolet)](#-16개-전문-에이전트)
 [![Skills](https://img.shields.io/badge/Skills-40-ff69b4)](#-전체-명령어)
 
@@ -411,7 +411,7 @@ Autopus가 코드베이스(Cobra 커맨드, API 라우트, 프론트엔드 페�
 | **시그니처 맵** | `auto setup` | AST 분석으로 exported API 시그니처 추출 (Go + TypeScript) |
 | **테스트 러너 감지** | `auto init` | jest, vitest, pytest, cargo 테스트 프레임워크 자동 감지 |
 
-### 🌐 하나의 설정, 네 개 플랫폼
+### 🌐 하나의 설정, 다섯 개 플랫폼
 
 ```bash
 auto init   # 지원되는 설치된 AI 코딩 CLI 자동 감지
@@ -425,6 +425,7 @@ auto init   # 지원되는 설치된 AI 코딩 CLI 자동 감지
 | **Codex** | `.codex/`, `.agents/skills/`, `.agents/plugins/marketplace.json`, `.autopus/plugins/auto/`, `AGENTS.md` |
 | **Antigravity CLI** | `.gemini/`, `GEMINI.md` |
 | **OpenCode** | `.opencode/rules/`, `.opencode/agents/`, `.opencode/commands/`, `.opencode/plugins/`, `.agents/skills/`, `AGENTS.md`, `opencode.json` |
+| **Oh My Pi (OMP)** | `.omp/agents/`, `.omp/skills/`, `.omp/commands/`, `.omp/extensions/autopus-context.ts`, `.omp/config.yml`, `.agents/skills/` |
 동일한 16개 에이전트. 동일한 규칙. 공유 스킬은 기본적으로 전체가 생성됩니다. 기존 호환성을 유지하면서 mixed Codex + OpenCode 표면을 더 작게 만들고 싶다면 `skills.shared_surface`를 건드리는 대신 `skills.compiler.mode: split`을 opt-in 하세요.
 
 Codex 참고:
@@ -443,7 +444,20 @@ OpenCode 참고:
 
 ### OMP 역할 라우팅과 컨텍스트 최적화(선택 적용)
 
-OMP 정책은 프로바이더에 종속되지 않으며 이름 있는 프로필을 선택하기 전에는 활성화되지 않습니다. 먼저 기존 설정을 직접 소유하지 않는 `overlay` 모드로 시작하고, 아래 예시 selector는 설치된 OMP 카탈로그가 보고한 정확한 인증 가능 `provider/model` 값으로 바꾸세요.
+운영자 명령:
+
+```bash
+auto platform omp models                 # 설치된 모델 카탈로그
+auto platform omp profile init --name omp-balanced --plan
+auto platform omp profile apply omp-balanced
+auto platform omp explain
+auto status --platform omp
+```
+
+현재 upstream OMP 17.2.7 카탈로그에서는 `models`가 정확한 native selector, context window, reasoning 여부, thinking 단계, input mode를 성공적인 `degraded`/조회 전용 결과로 표시합니다. OMP가 안전한 자동 라우팅에 필요한 family, Autopus capability, 인증 가능 여부 메타데이터를 아직 제공하지 않으므로 `strict_routing_ready`는 `false`이고 profile init/apply는 `catalog_metadata_insufficient`로 차단됩니다. Autopus는 이 값을 추측하거나 credential을 읽지 않습니다.
+
+
+OMP 정책은 프로바이더에 종속되지 않으며 이름 있는 프로필을 선택하기 전에는 활성화되지 않습니다. strict catalog가 준비된 뒤에만 기존 설정을 직접 소유하지 않는 `overlay` 모드로 시작하고, 아래 예시 selector는 정확한 인증 가능 `provider/model` 값으로 바꾸세요.
 
 ```yaml
 role_model_policy:
@@ -606,7 +620,7 @@ auto init
 
 Windows에서 `powershell -c ...`를 Git Bash 안에서 실행한 경우에는, 부모 Bash 프로세스의 `PATH`가 즉시 갱신되지 않으므로 설치 후 Git Bash를 다시 열어야 합니다. 이 경우 설치 스크립트가 실제 설치 경로와 `export PATH=...` 안내를 함께 출력합니다.
 
-`auto init`은 설치된 AI 코딩 CLI(Claude Code, Codex, Antigravity CLI, OpenCode)를 자동 감지하고, 각 플랫폼에 맞는 **네이티브 설정** — 규칙, 스킬, 에이전트 — 을 하나의 `autopus.yaml`에서 생성합니다.
+`auto init`은 설치된 AI 코딩 CLI(Claude Code, Codex, Antigravity CLI, OpenCode, Oh My Pi)를 자동 감지하고, 각 플랫폼에 맞는 **네이티브 설정** — 규칙, 스킬, 에이전트, 명령 — 을 하나의 `autopus.yaml`에서 생성합니다.
 
 Claude Code statusline 참고:
 - `.claude/settings.json`에 기존 `statusLine.command`가 있으면, `auto init` / `auto update` 인터랙티브 실행 시 `keep`, `merge`, `replace` 중 하나를 고를 수 있습니다.
@@ -615,14 +629,15 @@ Claude Code statusline 참고:
 플랫폼별 명령 문법:
 - Codex: 생성된 로컬 플러그인을 설치한 뒤 `@auto ...`를 사용하고, 그 전에는 `$auto ...`를 사용합니다
 - OpenCode: `/auto ...` 또는 `/auto-<subcommand> ...`를 사용합니다
-- Claude Code / Antigravity CLI: `/auto ...`를 사용합니다
+- Claude Code / Antigravity CLI / Oh My Pi: `/auto ...`를 사용합니다
 
 ```
-✓ 감지됨: claude-code, codex, antigravity-cli, opencode
+✓ 감지됨: claude-code, codex, antigravity-cli, opencode, omp
 ✓ 생성됨: .claude/rules/, .claude/skills/, .claude/agents/, CLAUDE.md
 ✓ 생성됨: .codex/, AGENTS.md
 ✓ 생성됨: .gemini/, GEMINI.md
 ✓ 생성됨: .opencode/, .agents/skills/, AGENTS.md, opencode.json
+✓ 생성됨: .omp/agents/, .omp/skills/, .omp/commands/, .omp/extensions/, .omp/config.yml
 ✓ 생성됨: autopus.yaml
 ```
 

--- a/install_scripts_test.go
+++ b/install_scripts_test.go
@@ -165,6 +165,48 @@ func TestMacOSRuntimeCIExecutesUnsignedBoundedVersionSmoke(t *testing.T) {
 	}
 }
 
+func TestOMPNativeSmokeCIPinsExactBinaryAndTest(t *testing.T) {
+	workflow := readInstallerFile(t, ".github/workflows/ci.yaml")
+	nativeJob := strings.Index(workflow, "  omp-native-smoke:")
+	macOSJob := strings.Index(workflow, "  macos-runtime:")
+	if nativeJob < 0 || macOSJob <= nativeJob {
+		t.Fatal("cannot isolate omp-native-smoke job")
+	}
+	section := workflow[nativeJob:macOSJob]
+	required := []string{
+		`name: omp-native-smoke`,
+		`runs-on: macos-15`,
+		`timeout-minutes: 5`,
+		`persist-credentials: false`,
+		`set -euo pipefail`,
+		`[[ "$(uname -m)" == 'arm64' ]]`,
+		`trap cleanup_omp EXIT`,
+		`https://github.com/can1357/oh-my-pi/releases/download/v17.2.7/omp-darwin-arm64`,
+		`expected='cd2f47545cb3f8eb5e15c91bc9054d73967774652e020b432e294803d1b71ea0'`,
+		`/usr/bin/shasum -a 256 "$omp_binary"`,
+		`/bin/chmod 0555 "$omp_binary"`,
+		`[[ "$("$omp_binary" --version)" == 'omp/17.2.7' ]]`,
+		`AUTOPUS_OMP_NATIVE_LIVE=1`,
+		`AUTOPUS_OMP_LIVE_EXECUTABLE="$omp_binary"`,
+		`go test -count=1 -timeout=90s`,
+		`-run '^TestOMPNativeTaskHubLiveSmoke$' ./pkg/adapter/omp`,
+	}
+	for _, fragment := range required {
+		if !strings.Contains(section, fragment) {
+			t.Fatalf("omp-native-smoke must contain %q", fragment)
+		}
+	}
+	if strings.Count(section, "go test ") != 1 ||
+		strings.Count(section, "-run '^TestOMPNativeTaskHubLiveSmoke$'") != 1 {
+		t.Fatal("omp-native-smoke must run one exactly anchored Go smoke")
+	}
+	for _, forbidden := range []string{"./...", "${{ secrets.", "AUTOPUS_OMP_LIVE=1"} {
+		if strings.Contains(section, forbidden) {
+			t.Fatalf("omp-native-smoke widened or gained credentials through %q", forbidden)
+		}
+	}
+}
+
 func TestWindowsRuntimeRunsSelfUpdateAdmissionContracts(t *testing.T) {
 	workflow := readInstallerFile(t, ".github/workflows/ci.yaml")
 	windowsJob := strings.Index(workflow, "  windows-runtime:")

--- a/internal/cli/companion_manifest.go
+++ b/internal/cli/companion_manifest.go
@@ -52,6 +52,7 @@ func newCompanionManifestCmd() *cobra.Command {
 	command.AddCommand(newCompanionManifestSignCmd())
 	command.AddCommand(newCompanionPublicKeyReceiptCmd())
 	command.AddCommand(newCompanionOMPContextReleaseLineageCmd())
+	command.AddCommand(newCompanionOMPContextPromotionAttestationCmd())
 	return command
 }
 

--- a/internal/cli/companion_omp_context_promotion_attestation.go
+++ b/internal/cli/companion_omp_context_promotion_attestation.go
@@ -1,0 +1,231 @@
+package cli
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/insajin/autopus-adk/pkg/promptlayer"
+)
+
+const maxOMPContextPromotionReportInputBytes = 512 * 1024
+
+type companionOMPContextPromotionAttestationOptions struct {
+	reportPath string
+	issuedAt   string
+	notBefore  string
+	expiresAt  string
+	outputPath string
+}
+
+func newCompanionOMPContextPromotionAttestationCmd() *cobra.Command {
+	var options companionOMPContextPromotionAttestationOptions
+	command := &cobra.Command{
+		Use:          "omp-context-promotion-attestation",
+		Short:        "Sign a canonical OMP context promotion report using a stdin key",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(command *cobra.Command, _ []string) error {
+			return runCompanionOMPContextPromotionAttestation(command, options)
+		},
+	}
+	flags := command.Flags()
+	flags.StringVar(&options.reportPath, "report", "", "Canonical promotion-report-v1 JSON file")
+	flags.StringVar(&options.issuedAt, "issued-at", "", "Canonical UTC issuance time")
+	flags.StringVar(&options.notBefore, "not-before", "", "Canonical UTC validity start")
+	flags.StringVar(&options.expiresAt, "expires-at", "", "Canonical UTC expiry time")
+	flags.StringVar(&options.outputPath, "output", "", "New canonical promotion attestation output file")
+	for _, name := range []string{"report", "issued-at", "not-before", "expires-at", "output"} {
+		_ = command.MarkFlagRequired(name)
+	}
+	return command
+}
+
+func runCompanionOMPContextPromotionAttestation(
+	command *cobra.Command,
+	options companionOMPContextPromotionAttestationOptions,
+) error {
+	reportPath, outputPath, err := resolveOMPContextPromotionAttestationPaths(
+		options.reportPath,
+		options.outputPath,
+	)
+	if err != nil {
+		return err
+	}
+	reportBytes, err := readStableOMPContextPromotionReport(reportPath)
+	if err != nil {
+		return err
+	}
+	privateKey, err := readPrivateKey(command.InOrStdin())
+	if err != nil {
+		return err
+	}
+	defer clear(privateKey)
+	attestationBytes, err := promptlayer.SignOMPContextPromotionAttestationV2(
+		promptlayer.OMPContextPromotionAttestationSignInputV2{
+			ReportBytes: reportBytes,
+			IssuedAt:    options.issuedAt,
+			NotBefore:   options.notBefore,
+			ExpiresAt:   options.expiresAt,
+		},
+		privateKey,
+	)
+	if err != nil {
+		return err
+	}
+	return writeNewPrivateOMPContextPromotionAttestation(outputPath, attestationBytes)
+}
+
+func resolveOMPContextPromotionAttestationPaths(reportPath, outputPath string) (string, string, error) {
+	report, err := filepath.Abs(filepath.Clean(reportPath))
+	if err != nil {
+		return "", "", errors.New("resolve OMP context promotion report path")
+	}
+	output, err := filepath.Abs(filepath.Clean(outputPath))
+	if err != nil {
+		return "", "", errors.New("resolve OMP context promotion attestation output path")
+	}
+	if report == output {
+		return "", "", errors.New("OMP context promotion report and attestation output must be distinct")
+	}
+	if err := validateOMPContextPromotionParent(filepath.Dir(report)); err != nil {
+		return "", "", errors.New("OMP context promotion report directory is unsafe")
+	}
+	if err := validateOMPContextPromotionParent(filepath.Dir(output)); err != nil {
+		return "", "", errors.New("OMP context promotion attestation output directory is unsafe")
+	}
+	if info, err := os.Lstat(output); err == nil || !errors.Is(err, os.ErrNotExist) {
+		if err == nil && info != nil {
+			return "", "", errors.New("OMP context promotion attestation output already exists")
+		}
+		return "", "", errors.New("inspect OMP context promotion attestation output")
+	}
+	return report, output, nil
+}
+
+func validateOMPContextPromotionParent(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return errors.New("unsafe parent directory")
+	}
+	return nil
+}
+
+func readStableOMPContextPromotionReport(path string) (body []byte, resultErr error) {
+	parentPath, name := filepath.Dir(path), filepath.Base(path)
+	root, err := os.OpenRoot(parentPath)
+	if err != nil {
+		return nil, errors.New("open OMP context promotion report directory")
+	}
+	defer func() { resultErr = errors.Join(resultErr, root.Close()) }()
+	initial, err := root.Lstat(name)
+	if err != nil || !initial.Mode().IsRegular() || initial.Mode()&os.ModeSymlink != 0 ||
+		initial.Size() <= 0 || initial.Size() > maxOMPContextPromotionReportInputBytes {
+		return nil, errors.New("OMP context promotion report must be a bounded regular file")
+	}
+	file, err := root.Open(name)
+	if err != nil {
+		return nil, errors.New("open OMP context promotion report")
+	}
+	defer file.Close()
+	opened, err := file.Stat()
+	if err != nil || !opened.Mode().IsRegular() || !os.SameFile(initial, opened) {
+		return nil, errors.New("OMP context promotion report identity changed while opening")
+	}
+	first, err := io.ReadAll(io.LimitReader(file, maxOMPContextPromotionReportInputBytes+1))
+	if err != nil || len(first) == 0 || len(first) > maxOMPContextPromotionReportInputBytes {
+		return nil, errors.New("read OMP context promotion report")
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return nil, errors.New("rewind OMP context promotion report")
+	}
+	second, err := io.ReadAll(io.LimitReader(file, maxOMPContextPromotionReportInputBytes+1))
+	current, statErr := root.Lstat(name)
+	openedAfter, openedErr := file.Stat()
+	if err != nil || !bytes.Equal(first, second) || statErr != nil || openedErr != nil ||
+		!current.Mode().IsRegular() || !openedAfter.Mode().IsRegular() ||
+		!os.SameFile(initial, current) || !os.SameFile(initial, openedAfter) {
+		return nil, errors.New("OMP context promotion report changed while reading")
+	}
+	return first, nil
+}
+
+func writeNewPrivateOMPContextPromotionAttestation(path string, body []byte) (resultErr error) {
+	parentPath, name := filepath.Dir(path), filepath.Base(path)
+	parentBefore, err := os.Lstat(parentPath)
+	if err != nil || !parentBefore.IsDir() || parentBefore.Mode()&os.ModeSymlink != 0 {
+		return errors.New("OMP context promotion attestation output directory is unsafe")
+	}
+	root, err := os.OpenRoot(parentPath)
+	if err != nil {
+		return errors.New("open OMP context promotion attestation output directory")
+	}
+	defer func() { resultErr = errors.Join(resultErr, root.Close()) }()
+	openedParent, err := root.Stat(".")
+	if err != nil || !os.SameFile(parentBefore, openedParent) {
+		return errors.New("OMP context promotion attestation output directory changed")
+	}
+	if _, err := root.Lstat(name); err == nil || !errors.Is(err, os.ErrNotExist) {
+		return errors.New("OMP context promotion attestation output already exists")
+	}
+	var nonce [16]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		return errors.New("prepare OMP context promotion attestation output")
+	}
+	stageName := "." + name + ".stage-" + hex.EncodeToString(nonce[:])
+	stage, err := root.OpenFile(stageName, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return errors.New("create OMP context promotion attestation stage")
+	}
+	stageOpen := true
+	defer func() {
+		if stageOpen {
+			_ = stage.Close()
+		}
+		_ = root.Remove(stageName)
+	}()
+	if err := stage.Chmod(0o600); err != nil {
+		return errors.New("secure OMP context promotion attestation stage")
+	}
+	if _, err := io.Copy(stage, bytes.NewReader(body)); err != nil {
+		return errors.New("write OMP context promotion attestation stage")
+	}
+	if err := stage.Sync(); err != nil {
+		return errors.New("sync OMP context promotion attestation stage")
+	}
+	if err := stage.Close(); err != nil {
+		return errors.New("close OMP context promotion attestation stage")
+	}
+	stageOpen = false
+	if _, err := root.Lstat(name); err == nil || !errors.Is(err, os.ErrNotExist) {
+		return errors.New("OMP context promotion attestation output became occupied")
+	}
+	if err := root.Link(stageName, name); err != nil {
+		return errors.New("publish OMP context promotion attestation")
+	}
+	stageInfo, stageErr := root.Lstat(stageName)
+	outputInfo, outputErr := root.Lstat(name)
+	if stageErr != nil || outputErr != nil || !outputInfo.Mode().IsRegular() ||
+		outputInfo.Mode().Perm() != 0o600 || !os.SameFile(stageInfo, outputInfo) {
+		_ = root.Remove(name)
+		return errors.New("verify OMP context promotion attestation output")
+	}
+	if err := root.Remove(stageName); err != nil {
+		return errors.New("remove OMP context promotion attestation stage")
+	}
+	directory, err := root.Open(".")
+	if err != nil {
+		return errors.New("open OMP context promotion attestation directory for sync")
+	}
+	defer directory.Close()
+	if err := directory.Sync(); err != nil {
+		return errors.New("sync OMP context promotion attestation directory")
+	}
+	return nil
+}

--- a/internal/cli/companion_omp_context_promotion_attestation_test.go
+++ b/internal/cli/companion_omp_context_promotion_attestation_test.go
@@ -1,0 +1,204 @@
+package cli
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCompanionOMPContextPromotionAttestationCommand_IsRegisteredWithoutSecretFlags(t *testing.T) {
+	root := NewRootCmd()
+	command, _, err := root.Find([]string{"companion-manifest", "omp-context-promotion-attestation"})
+	if err != nil || command.Name() != "omp-context-promotion-attestation" {
+		t.Fatalf("registered command=%v error=%v", command, err)
+	}
+	for _, required := range []string{"report", "issued-at", "not-before", "expires-at", "output"} {
+		flag := command.Flags().Lookup(required)
+		if flag == nil {
+			t.Fatalf("required flag %q is not registered", required)
+		}
+	}
+	for _, forbidden := range []string{"key", "key-file", "private-key", "private-key-file", "signing-key"} {
+		if command.Flags().Lookup(forbidden) != nil {
+			t.Fatalf("secret-bearing flag %q is registered", forbidden)
+		}
+	}
+}
+
+func TestCompanionOMPContextPromotionAttestation_RejectsExistingOrSymlinkOutput(t *testing.T) {
+	for _, symlink := range []bool{false, true} {
+		name := "existing"
+		if symlink {
+			name = "symlink"
+		}
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			report := filepath.Join(dir, "promotion-report-v1.json")
+			output := filepath.Join(dir, "omp-context-promotion-attestation.v2.json")
+			protected := filepath.Join(dir, "protected")
+			if err := os.WriteFile(report, []byte(`{}`), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(protected, []byte("protected-bytes"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if symlink {
+				if err := os.Symlink(protected, output); err != nil {
+					t.Fatal(err)
+				}
+			} else if err := os.WriteFile(output, []byte("existing-bytes"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			result := executeOMPContextPromotionAttestationCommand(report, output, validTestPrivateKeyBase64())
+			if result.err == nil {
+				t.Fatal("existing output was accepted")
+			}
+			got, err := os.ReadFile(protected)
+			if err != nil || string(got) != "protected-bytes" {
+				t.Fatalf("protected file changed to %q error=%v", got, err)
+			}
+			if !symlink {
+				got, err = os.ReadFile(output)
+				if err != nil || string(got) != "existing-bytes" {
+					t.Fatalf("existing output changed to %q error=%v", got, err)
+				}
+			}
+		})
+	}
+}
+
+func TestCompanionOMPContextPromotionAttestation_RejectsSymlinkReportAndDuplicateJSON(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "report-target")
+	if err := os.WriteFile(target, []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	symlinkReport := filepath.Join(dir, "report-link")
+	if err := os.Symlink(target, symlinkReport); err != nil {
+		t.Fatal(err)
+	}
+	output := filepath.Join(dir, "symlink-output")
+	if result := executeOMPContextPromotionAttestationCommand(
+		symlinkReport,
+		output,
+		validTestPrivateKeyBase64(),
+	); result.err == nil {
+		t.Fatal("symlink report was accepted")
+	}
+	if _, err := os.Lstat(output); !os.IsNotExist(err) {
+		t.Fatalf("symlink-report failure created output: %v", err)
+	}
+
+	duplicateReport := filepath.Join(dir, "duplicate-report.json")
+	if err := os.WriteFile(
+		duplicateReport,
+		[]byte(`{"schema_version":"first","schema_version":"second"}`),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	duplicateOutput := filepath.Join(dir, "duplicate-output")
+	if result := executeOMPContextPromotionAttestationCommand(
+		duplicateReport,
+		duplicateOutput,
+		validTestPrivateKeyBase64(),
+	); result.err == nil {
+		t.Fatal("duplicate report JSON was accepted")
+	}
+	if _, err := os.Lstat(duplicateOutput); !os.IsNotExist(err) {
+		t.Fatalf("duplicate-report failure created output: %v", err)
+	}
+}
+
+func TestCompanionOMPContextPromotionAttestation_FailureDoesNotLeakSigningKey(t *testing.T) {
+	dir := t.TempDir()
+	report := filepath.Join(dir, "invalid-report.json")
+	output := filepath.Join(dir, "attestation.json")
+	if err := os.WriteFile(report, []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	seed := sha256.Sum256([]byte("sensitive-cli-promotion-key"))
+	privateKey := ed25519.NewKeyFromSeed(seed[:])
+	encoded := base64.StdEncoding.EncodeToString(privateKey)
+	result := executeOMPContextPromotionAttestationCommand(report, output, encoded)
+	if result.err == nil {
+		t.Fatal("invalid report unexpectedly signed")
+	}
+	surface := append(append([]byte(result.stdout), result.stderr...), []byte(result.err.Error())...)
+	for _, secret := range [][]byte{seed[:], privateKey, []byte(encoded)} {
+		if bytes.Contains(surface, secret) {
+			t.Fatal("command failure leaked signing key material")
+		}
+	}
+	if _, err := os.Lstat(output); !os.IsNotExist(err) {
+		t.Fatalf("failed signer created output: %v", err)
+	}
+}
+
+func TestWriteNewPrivateOMPContextPromotionAttestation_IsAtomicPrivateAndNoOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "omp-context-promotion-attestation.v2.json")
+	body := []byte(`{"canonical":"attestation"}`)
+	if err := writeNewPrivateOMPContextPromotionAttestation(path, body); err != nil {
+		t.Fatalf("write private attestation: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil || !bytes.Equal(got, body) {
+		t.Fatalf("attestation bytes=%q error=%v", got, err)
+	}
+	info, err := os.Stat(path)
+	if err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatalf("attestation mode=%v error=%v", info.Mode(), err)
+	}
+	if err := writeNewPrivateOMPContextPromotionAttestation(path, []byte("replacement")); err == nil {
+		t.Fatal("writer overwrote an existing attestation")
+	}
+	got, err = os.ReadFile(path)
+	if err != nil || !bytes.Equal(got, body) {
+		t.Fatalf("attestation changed to %q error=%v", got, err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil || len(entries) != 1 || strings.Contains(entries[0].Name(), ".stage-") {
+		t.Fatalf("unexpected output directory entries=%v error=%v", entries, err)
+	}
+}
+
+type ompContextPromotionAttestationCommandResult struct {
+	stdout string
+	stderr string
+	err    error
+}
+
+func executeOMPContextPromotionAttestationCommand(
+	report,
+	output,
+	encodedKey string,
+) ompContextPromotionAttestationCommandResult {
+	command := newCompanionOMPContextPromotionAttestationCmd()
+	var stdout, stderr bytes.Buffer
+	command.SetIn(strings.NewReader(encodedKey + "\n"))
+	command.SetOut(&stdout)
+	command.SetErr(&stderr)
+	command.SetArgs([]string{
+		"--report", report,
+		"--issued-at", "2026-08-04T02:59:00Z",
+		"--not-before", "2026-08-04T02:59:00Z",
+		"--expires-at", "2026-08-04T03:59:00Z",
+		"--output", output,
+	})
+	return ompContextPromotionAttestationCommandResult{
+		stdout: stdout.String(),
+		stderr: stderr.String(),
+		err:    command.Execute(),
+	}
+}
+
+func validTestPrivateKeyBase64() string {
+	seed := sha256.Sum256([]byte("cli-promotion-key"))
+	return base64.StdEncoding.EncodeToString(ed25519.NewKeyFromSeed(seed[:]))
+}

--- a/internal/cli/companion_omp_context_promotion_attestation_workflow_test.go
+++ b/internal/cli/companion_omp_context_promotion_attestation_workflow_test.go
@@ -120,7 +120,7 @@ func TestOMPContextPromoteWorkflow_SecretStdinHistoricalVerifyAndOrphanTreePrece
 		`--cacheinfo "100644,$published_attestation_blob,$attestation_name"`,
 		`[[ "${#published_entries[@]}" -eq 2 ]]`,
 		`commit-tree "$evidence_tree"`,
-		`git rev-list --parents -n 1 "$evidence_commit"`,
+		`git rev-list --parents -n 1 "$published_evidence_commit"`,
 		`tag -a "$evidence_tag"`,
 		`cmp "$report_path" "$verify_dir/$report_name"`,
 	} {

--- a/internal/cli/companion_omp_context_promotion_attestation_workflow_test.go
+++ b/internal/cli/companion_omp_context_promotion_attestation_workflow_test.go
@@ -1,0 +1,192 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type ompContextPromoteWorkflow struct {
+	On map[string]struct {
+		Inputs map[string]struct {
+			Required bool   `yaml:"required"`
+			Type     string `yaml:"type"`
+		} `yaml:"inputs"`
+	} `yaml:"on"`
+	Permissions map[string]string `yaml:"permissions"`
+	Jobs        map[string]any    `yaml:"jobs"`
+}
+
+func TestOMPContextPromoteWorkflow_DispatchOnlyExactInputsAndLeastPermissions(t *testing.T) {
+	source := readOMPContextPromoteWorkflow(t)
+	var workflow ompContextPromoteWorkflow
+	if err := yaml.Unmarshal([]byte(source), &workflow); err != nil {
+		t.Fatalf("parse promotion workflow: %v", err)
+	}
+	if len(workflow.On) != 1 {
+		t.Fatalf("workflow triggers=%v, want workflow_dispatch only", workflow.On)
+	}
+	dispatch, ok := workflow.On["workflow_dispatch"]
+	if !ok {
+		t.Fatalf("workflow triggers=%v, want workflow_dispatch", workflow.On)
+	}
+	wantInputs := []string{
+		"candidate_sha256",
+		"evidence_commit",
+		"source_commit",
+		"source_tree",
+		"static_policy_b64",
+	}
+	gotInputs := make([]string, 0, len(dispatch.Inputs))
+	for name, input := range dispatch.Inputs {
+		gotInputs = append(gotInputs, name)
+		if !input.Required || input.Type != "string" {
+			t.Fatalf("dispatch input %s=%#v, want required string", name, input)
+		}
+	}
+	sort.Strings(gotInputs)
+	if strings.Join(gotInputs, ",") != strings.Join(wantInputs, ",") {
+		t.Fatalf("dispatch inputs=%v, want %v", gotInputs, wantInputs)
+	}
+	wantPermissions := map[string]string{"actions": "write", "contents": "write"}
+	if len(workflow.Permissions) != len(wantPermissions) {
+		t.Fatalf("workflow permissions=%v", workflow.Permissions)
+	}
+	for permission, want := range wantPermissions {
+		if workflow.Permissions[permission] != want {
+			t.Fatalf("workflow permission %s=%q, want %q", permission, workflow.Permissions[permission], want)
+		}
+	}
+	if len(workflow.Jobs) != 1 || workflow.Jobs["promote"] == nil {
+		t.Fatalf("workflow jobs=%v, want one promote job", workflow.Jobs)
+	}
+}
+
+func TestOMPContextPromoteWorkflow_PinsActionsAndExactPromotionCoordinates(t *testing.T) {
+	source := readOMPContextPromoteWorkflow(t)
+	wantActions := []string{
+		"actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10",
+		"actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16",
+	}
+	usesPattern := regexp.MustCompile(`(?m)^\s*uses:\s+([^\s#]+)`)
+	matches := usesPattern.FindAllStringSubmatch(source, -1)
+	if len(matches) != len(wantActions) {
+		t.Fatalf("workflow uses=%v, want exactly %v", matches, wantActions)
+	}
+	for index, want := range wantActions {
+		if matches[index][1] != want {
+			t.Fatalf("workflow action %d=%q, want %q", index, matches[index][1], want)
+		}
+	}
+	for _, required := range []string{
+		"omp-context-evidence-v0.50.93",
+		"promotion-report-v1.json",
+		"omp-context-promotion-attestation.v2.json",
+		"Insajin/autopus-adk",
+		`[[ "$EVIDENCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]`,
+		`[[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]`,
+		`[[ "$SOURCE_TREE" =~ ^[0-9a-f]{40}$ ]]`,
+		`[[ "$CANDIDATE_SHA256" =~ ^[0-9a-f]{64}$ ]]`,
+		`[[ "$(git rev-parse --verify 'HEAD^{tree}')" == "$SOURCE_TREE" ]]`,
+		`--candidate-revision "$SOURCE_COMMIT"`,
+		`--candidate-tree "$SOURCE_TREE"`,
+		`--candidate-artifact-sha256 "$CANDIDATE_SHA256"`,
+		`--static-policy-b64 "$STATIC_POLICY_B64"`,
+	} {
+		if !strings.Contains(source, required) {
+			t.Fatalf("workflow is missing exact coordinate contract %q", required)
+		}
+	}
+}
+
+func TestOMPContextPromoteWorkflow_SecretStdinHistoricalVerifyAndOrphanTreePrecedePush(t *testing.T) {
+	source := readOMPContextPromoteWorkflow(t)
+	for _, required := range []string{
+		`git fetch --no-tags --depth=1 origin "$EVIDENCE_COMMIT"`,
+		`mapfile -d '' -t evidence_entries < <(git ls-tree -z "$EVIDENCE_COMMIT")`,
+		`[[ "${#evidence_entries[@]}" -eq 1 ]]`,
+		`git cat-file blob "$report_blob" >"$report_path"`,
+		`[[ "$published_report_blob" == "$report_blob" ]]`,
+		`printf '%s' "$OMP_CONTEXT_EVIDENCE_SIGNING_KEY" |`,
+		`env -i PATH="$PATH" HOME="$HOME" TMPDIR="$RUNNER_TEMP"`,
+		`companion-manifest omp-context-promotion-attestation`,
+		`--mode historical`,
+		`--cacheinfo "100644,$published_report_blob,$report_name"`,
+		`--cacheinfo "100644,$published_attestation_blob,$attestation_name"`,
+		`[[ "${#published_entries[@]}" -eq 2 ]]`,
+		`commit-tree "$evidence_tree"`,
+		`git rev-list --parents -n 1 "$evidence_commit"`,
+		`tag -a "$evidence_tag"`,
+		`cmp "$report_path" "$verify_dir/$report_name"`,
+	} {
+		if !strings.Contains(source, required) {
+			t.Fatalf("workflow is missing publication safety contract %q", required)
+		}
+	}
+	if strings.Contains(source, `commit-tree "$evidence_tree" -p`) ||
+		strings.Contains(source, `commit-tree -p`) {
+		t.Fatal("workflow gives the evidence commit a parent")
+	}
+	verifyIndex := strings.Index(source, `--mode historical`)
+	pushIndex := strings.Index(source, `git push origin "$tag_ref:$tag_ref"`)
+	variableIndex := strings.Index(source, `gh variable set OMP_CONTEXT_EVIDENCE_TAG`)
+	if verifyIndex < 0 || pushIndex <= verifyIndex || variableIndex <= pushIndex {
+		t.Fatalf("workflow order verify=%d push=%d variables=%d", verifyIndex, pushIndex, variableIndex)
+	}
+	variablePattern := regexp.MustCompile(`gh variable set ([A-Z0-9_]+) `)
+	matches := variablePattern.FindAllStringSubmatch(source[variableIndex:], -1)
+	gotVariables := make([]string, 0, len(matches))
+	for _, match := range matches {
+		gotVariables = append(gotVariables, match[1])
+	}
+	wantVariables := []string{
+		"OMP_CONTEXT_EVIDENCE_TAG",
+		"OMP_CONTEXT_EVIDENCE_REPORT_SHA256",
+		"OMP_CONTEXT_EVIDENCE_ATTESTATION_SHA256",
+		"OMP_CONTEXT_STATIC_POLICY_B64",
+	}
+	if strings.Join(gotVariables, ",") != strings.Join(wantVariables, ",") {
+		t.Fatalf("repository variables=%v, want %v", gotVariables, wantVariables)
+	}
+}
+
+func TestOMPContextPromoteWorkflow_ExposesNoProviderCredentialsOrRawSigningSecret(t *testing.T) {
+	source := readOMPContextPromoteWorkflow(t)
+	secretPattern := regexp.MustCompile(`\$\{\{\s*secrets\.([A-Z0-9_]+)\s*\}\}`)
+	secretMatches := secretPattern.FindAllStringSubmatch(source, -1)
+	if len(secretMatches) != 1 || secretMatches[0][1] != "OMP_CONTEXT_EVIDENCE_SIGNING_KEY" {
+		t.Fatalf("workflow secret references=%v", secretMatches)
+	}
+	for _, forbidden := range []string{
+		"OPENAI_API_KEY",
+		"ANTHROPIC_API_KEY",
+		"GOOGLE_API_KEY",
+		"AZURE_OPENAI",
+		"AWS_ACCESS_KEY",
+		"--private-key",
+		"--signing-key",
+		"set -x",
+		`echo "$OMP_CONTEXT_EVIDENCE_SIGNING_KEY"`,
+		`printf "$OMP_CONTEXT_EVIDENCE_SIGNING_KEY"`,
+		"$GITHUB_ENV",
+	} {
+		if strings.Contains(source, forbidden) {
+			t.Fatalf("workflow contains forbidden credential surface %q", forbidden)
+		}
+	}
+}
+
+func readOMPContextPromoteWorkflow(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join("..", "..", ".github", "workflows", "omp-context-promote.yml")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read promotion workflow: %v", err)
+	}
+	return string(body)
+}

--- a/internal/cli/pipeline_backend_omp.go
+++ b/internal/cli/pipeline_backend_omp.go
@@ -14,21 +14,22 @@ import (
 )
 
 type pipelineOMPBackendConfig struct {
-	Executable     string
-	ProjectDir     string
-	SpecID         string
-	SpecDir        string
-	SnapshotHash   string
-	GitCommitHash  string
-	RuntimeBase    string
-	Environment    []string
-	canonicalEnv   []string
-	PhaseModels    map[pipeline.PhaseID]string
-	MaxTime        time.Duration
-	ManagedActive  pipelineOMPManagedActiveRunner
-	managedInner   bool
-	ownRuntimeBase bool
-	executableID   pipelineOMPExecutableIdentity
+	Executable         string
+	ProjectDir         string
+	SpecID             string
+	SpecDir            string
+	SnapshotHash       string
+	GitCommitHash      string
+	RuntimeBase        string
+	Environment        []string
+	canonicalEnv       []string
+	PhaseModels        map[pipeline.PhaseID]string
+	ModelContextWindow int
+	MaxTime            time.Duration
+	ManagedActive      pipelineOMPManagedActiveRunner
+	managedInner       bool
+	ownRuntimeBase     bool
+	executableID       pipelineOMPExecutableIdentity
 }
 
 type pipelineOMPRunMode uint8
@@ -122,6 +123,12 @@ func normalizePipelineOMPBackendConfig(config pipelineOMPBackendConfig) (pipelin
 			_ = os.Remove(config.RuntimeBase)
 		}
 		return config, errors.New("OMP pipeline runtime base is unsafe")
+	}
+	if config.ModelContextWindow == 0 {
+		config.ModelContextWindow = pipelineOMPActiveDefaultContextWindow
+	}
+	if config.ModelContextWindow < 8192 || config.ModelContextWindow > 1<<30 {
+		return config, errors.New("OMP pipeline model context window is invalid")
 	}
 	if config.MaxTime <= 0 {
 		config.MaxTime = 15 * time.Minute

--- a/internal/cli/pipeline_omp_context_active_authority.go
+++ b/internal/cli/pipeline_omp_context_active_authority.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"errors"
+	"strings"
+)
+
+const pipelineOMPActiveCredentialMaxBytes = 64 << 10
+
+func pipelineOMPActiveProviderAuthorityDigest(
+	policyDigest string,
+	implementationDigest string,
+	modelScopeDigest string,
+	endpointRaw string,
+	credential string,
+) (string, error) {
+	endpoint, err := validatePipelineOMPActiveEndpoint(endpointRaw)
+	if err != nil || !validPipelineOMPActiveHash(policyDigest) ||
+		!validPipelineOMPActiveHash(implementationDigest) || !validPipelineOMPActiveHash(modelScopeDigest) ||
+		credential == "" || len(credential) > pipelineOMPActiveCredentialMaxBytes || strings.ContainsRune(credential, 0) {
+		return "", errors.New("pipeline: managed active provider authority is invalid")
+	}
+	credentialDigest := pipelineOMPActiveHash([]byte(credential))
+	return pipelineOMPActiveHash([]byte(strings.Join([]string{
+		policyDigest, implementationDigest, modelScopeDigest, endpoint, credentialDigest,
+	}, "\x00"))), nil
+}

--- a/internal/cli/pipeline_omp_context_active_authority.go
+++ b/internal/cli/pipeline_omp_context_active_authority.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 )
 
@@ -11,17 +12,19 @@ func pipelineOMPActiveProviderAuthorityDigest(
 	policyDigest string,
 	implementationDigest string,
 	modelScopeDigest string,
+	contextWindow int,
 	endpointRaw string,
 	credential string,
 ) (string, error) {
 	endpoint, err := validatePipelineOMPActiveEndpoint(endpointRaw)
 	if err != nil || !validPipelineOMPActiveHash(policyDigest) ||
 		!validPipelineOMPActiveHash(implementationDigest) || !validPipelineOMPActiveHash(modelScopeDigest) ||
-		credential == "" || len(credential) > pipelineOMPActiveCredentialMaxBytes || strings.ContainsRune(credential, 0) {
+		contextWindow < 8192 || contextWindow > 1<<30 || credential == "" ||
+		len(credential) > pipelineOMPActiveCredentialMaxBytes || strings.ContainsRune(credential, 0) {
 		return "", errors.New("pipeline: managed active provider authority is invalid")
 	}
 	credentialDigest := pipelineOMPActiveHash([]byte(credential))
 	return pipelineOMPActiveHash([]byte(strings.Join([]string{
-		policyDigest, implementationDigest, modelScopeDigest, endpoint, credentialDigest,
+		policyDigest, implementationDigest, modelScopeDigest, strconv.Itoa(contextWindow), endpoint, credentialDigest,
 	}, "\x00"))), nil
 }

--- a/internal/cli/pipeline_omp_context_active_authority_test.go
+++ b/internal/cli/pipeline_omp_context_active_authority_test.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPipelineOMPActiveProviderAuthorityDigest_IsolatesEndpointCredentialModelAndPolicy(t *testing.T) {
+	policy := workflowContextRuntimeHash("active-policy")
+	implementation := pipelineOMPActiveImplementationDigest()
+	modelScope := workflowContextRuntimeHash("model-scope")
+	endpoint := "http://127.0.0.1:43123"
+	credential := "provider-credential-value-123456"
+	baseline, err := pipelineOMPActiveProviderAuthorityDigest(policy, implementation, modelScope, endpoint, credential)
+	require.NoError(t, err)
+	repeated, err := pipelineOMPActiveProviderAuthorityDigest(policy, implementation, modelScope, endpoint, credential)
+	require.NoError(t, err)
+	assert.Equal(t, baseline, repeated)
+
+	cases := []struct {
+		policy, implementation, modelScope, endpoint, credential string
+	}{
+		{workflowContextRuntimeHash("other-policy"), implementation, modelScope, endpoint, credential},
+		{policy, workflowContextRuntimeHash("other-implementation"), modelScope, endpoint, credential},
+		{policy, implementation, workflowContextRuntimeHash("other-model"), endpoint, credential},
+		{policy, implementation, modelScope, "http://127.0.0.1:43124", credential},
+		{policy, implementation, modelScope, endpoint, "other-provider-credential-123456"},
+	}
+	for _, testCase := range cases {
+		digest, err := pipelineOMPActiveProviderAuthorityDigest(
+			testCase.policy, testCase.implementation, testCase.modelScope,
+			testCase.endpoint, testCase.credential,
+		)
+		require.NoError(t, err)
+		assert.NotEqual(t, baseline, digest)
+	}
+}
+
+func TestPipelineOMPActiveProviderAuthorityDigest_RejectsMissingOrNonLoopbackAuthority(t *testing.T) {
+	hash := workflowContextRuntimeHash("authority")
+	for _, input := range []struct{ endpoint, credential string }{
+		{"https://api.example.com", "credential-value-123456"},
+		{"http://127.0.0.1:43123", ""},
+		{"http://127.0.0.1:43123", "bad\x00credential"},
+	} {
+		_, err := pipelineOMPActiveProviderAuthorityDigest(hash, hash, hash, input.endpoint, input.credential)
+		require.Error(t, err)
+	}
+}

--- a/internal/cli/pipeline_omp_context_active_authority_test.go
+++ b/internal/cli/pipeline_omp_context_active_authority_test.go
@@ -13,25 +13,35 @@ func TestPipelineOMPActiveProviderAuthorityDigest_IsolatesEndpointCredentialMode
 	modelScope := workflowContextRuntimeHash("model-scope")
 	endpoint := "http://127.0.0.1:43123"
 	credential := "provider-credential-value-123456"
-	baseline, err := pipelineOMPActiveProviderAuthorityDigest(policy, implementation, modelScope, endpoint, credential)
+	baseline, err := pipelineOMPActiveProviderAuthorityDigest(
+		policy, implementation, modelScope, pipelineOMPActiveDefaultContextWindow, endpoint, credential)
 	require.NoError(t, err)
-	repeated, err := pipelineOMPActiveProviderAuthorityDigest(policy, implementation, modelScope, endpoint, credential)
+	repeated, err := pipelineOMPActiveProviderAuthorityDigest(
+		policy, implementation, modelScope, pipelineOMPActiveDefaultContextWindow, endpoint, credential)
 	require.NoError(t, err)
 	assert.Equal(t, baseline, repeated)
 
 	cases := []struct {
 		policy, implementation, modelScope, endpoint, credential string
+		contextWindow                                            int
 	}{
-		{workflowContextRuntimeHash("other-policy"), implementation, modelScope, endpoint, credential},
-		{policy, workflowContextRuntimeHash("other-implementation"), modelScope, endpoint, credential},
-		{policy, implementation, workflowContextRuntimeHash("other-model"), endpoint, credential},
-		{policy, implementation, modelScope, "http://127.0.0.1:43124", credential},
-		{policy, implementation, modelScope, endpoint, "other-provider-credential-123456"},
+		{policy: workflowContextRuntimeHash("other-policy"), implementation: implementation,
+			modelScope: modelScope, contextWindow: pipelineOMPActiveDefaultContextWindow, endpoint: endpoint, credential: credential},
+		{policy: policy, implementation: workflowContextRuntimeHash("other-implementation"),
+			modelScope: modelScope, contextWindow: pipelineOMPActiveDefaultContextWindow, endpoint: endpoint, credential: credential},
+		{policy: policy, implementation: implementation, modelScope: workflowContextRuntimeHash("other-model"),
+			contextWindow: pipelineOMPActiveDefaultContextWindow, endpoint: endpoint, credential: credential},
+		{policy: policy, implementation: implementation, modelScope: modelScope,
+			contextWindow: 1_000_000, endpoint: endpoint, credential: credential},
+		{policy: policy, implementation: implementation, modelScope: modelScope,
+			contextWindow: pipelineOMPActiveDefaultContextWindow, endpoint: "http://127.0.0.1:43124", credential: credential},
+		{policy: policy, implementation: implementation, modelScope: modelScope,
+			contextWindow: pipelineOMPActiveDefaultContextWindow, endpoint: endpoint, credential: "other-provider-credential-123456"},
 	}
 	for _, testCase := range cases {
 		digest, err := pipelineOMPActiveProviderAuthorityDigest(
 			testCase.policy, testCase.implementation, testCase.modelScope,
-			testCase.endpoint, testCase.credential,
+			testCase.contextWindow, testCase.endpoint, testCase.credential,
 		)
 		require.NoError(t, err)
 		assert.NotEqual(t, baseline, digest)
@@ -40,12 +50,17 @@ func TestPipelineOMPActiveProviderAuthorityDigest_IsolatesEndpointCredentialMode
 
 func TestPipelineOMPActiveProviderAuthorityDigest_RejectsMissingOrNonLoopbackAuthority(t *testing.T) {
 	hash := workflowContextRuntimeHash("authority")
-	for _, input := range []struct{ endpoint, credential string }{
-		{"https://api.example.com", "credential-value-123456"},
-		{"http://127.0.0.1:43123", ""},
-		{"http://127.0.0.1:43123", "bad\x00credential"},
+	for _, input := range []struct {
+		endpoint, credential string
+		contextWindow        int
+	}{
+		{"https://api.example.com", "credential-value-123456", pipelineOMPActiveDefaultContextWindow},
+		{"http://127.0.0.1:43123", "", pipelineOMPActiveDefaultContextWindow},
+		{"http://127.0.0.1:43123", "bad\x00credential", pipelineOMPActiveDefaultContextWindow},
+		{"http://127.0.0.1:43123", "credential-value-123456", 0},
 	} {
-		_, err := pipelineOMPActiveProviderAuthorityDigest(hash, hash, hash, input.endpoint, input.credential)
+		_, err := pipelineOMPActiveProviderAuthorityDigest(
+			hash, hash, hash, input.contextWindow, input.endpoint, input.credential)
 		require.Error(t, err)
 	}
 }

--- a/internal/cli/pipeline_omp_context_active_coordinator.go
+++ b/internal/cli/pipeline_omp_context_active_coordinator.go
@@ -31,14 +31,23 @@ type pipelineOMPActivePolicyProvider func(
 type pipelineOMPActiveCurrentRuntimeProvider func(
 	context.Context,
 	pipelineOMPManagedActiveCandidate,
+	promptlayer.OMPContextPromotionStaticPolicyV3,
 ) (promptlayer.OMPContextPromotionCurrentRuntimeV3, error)
-
 type pipelineOMPActiveGrantLoader func(
 	string,
 	time.Time,
 	promptlayer.OMPContextPromotionStaticPolicyV3,
 	promptlayer.OMPContextPromotionCurrentRuntimeV3,
 ) (pipelineOMPVerifiedGrant, error)
+
+type pipelineOMPActiveEvidenceVerifier func(
+	pipelineOMPManagedActiveCandidate,
+	pipelineOMPVerifiedGrant,
+	promptlayer.OMPContextPromotionPolicyV1,
+	promptlayer.OMPContextBindingReceipt,
+	string, string, string,
+	time.Time,
+) (time.Time, error)
 
 // pipelineOMPActiveSessionSpawn consumes a prepared lease and must enter the
 // managed child spawn without another caller-controlled authority lookup.
@@ -60,14 +69,15 @@ type pipelineOMPActiveSessionStart func(
 ) (pipelineOMPActivePersistentSession, error)
 
 type pipelineOMPManagedActiveCoordinator struct {
-	mu        sync.Mutex
-	now       func() time.Time
-	policy    pipelineOMPActivePolicyProvider
-	current   pipelineOMPActiveCurrentRuntimeProvider
-	loadGrant pipelineOMPActiveGrantLoader
-	spawn     pipelineOMPActiveSessionSpawn
-	start     pipelineOMPActiveSessionStart
-	session   pipelineOMPActivePersistentSession
+	mu             sync.Mutex
+	now            func() time.Time
+	policy         pipelineOMPActivePolicyProvider
+	current        pipelineOMPActiveCurrentRuntimeProvider
+	loadGrant      pipelineOMPActiveGrantLoader
+	verifyEvidence pipelineOMPActiveEvidenceVerifier
+	spawn          pipelineOMPActiveSessionSpawn
+	start          pipelineOMPActiveSessionStart
+	session        pipelineOMPActivePersistentSession
 }
 
 func newPipelineOMPManagedActiveCoordinator() *pipelineOMPManagedActiveCoordinator {
@@ -80,6 +90,7 @@ func newPipelineOMPManagedActiveCoordinator() *pipelineOMPManagedActiveCoordinat
 			_ = now
 			return promptlayer.LoadVerifiedOMPContextPromotionRuntimeV3(root, expected, current)
 		},
+		verifyEvidence: verifyPipelineOMPActiveRunEvidence,
 	}
 }
 
@@ -88,7 +99,7 @@ func (runner *pipelineOMPManagedActiveCoordinator) Prepare(
 	candidate pipelineOMPManagedActiveCandidate,
 ) (pipelineOMPManagedActivePrepared, error) {
 	if runner == nil || runner.policy == nil || runner.current == nil || runner.loadGrant == nil ||
-		(runner.spawn == nil && runner.start == nil) {
+		runner.verifyEvidence == nil || (runner.spawn == nil && runner.start == nil) {
 		return pipelineOMPManagedActivePrepared{}, errors.New("pipeline: managed active trust pins are unavailable")
 	}
 	if ctx == nil || ctx.Err() != nil {
@@ -102,7 +113,7 @@ func (runner *pipelineOMPManagedActiveCoordinator) Prepare(
 	if err != nil {
 		return pipelineOMPManagedActivePrepared{}, err
 	}
-	current, err := runner.current(ctx, candidate)
+	current, err := runner.current(ctx, candidate, expected)
 	if err != nil {
 		return pipelineOMPManagedActivePrepared{}, err
 	}
@@ -111,11 +122,14 @@ func (runner *pipelineOMPManagedActiveCoordinator) Prepare(
 	if err != nil || grant == nil || !grant.Valid() {
 		return pipelineOMPManagedActivePrepared{}, errors.New("pipeline: signed managed active grant is unavailable")
 	}
-	binding, err := buildPipelineOMPActiveLeaseBinding(candidate, grant, expected)
+	binding, evidenceExpiresAt, err := buildPipelineOMPActiveLeaseBinding(candidate, grant, expected, now, runner.verifyEvidence)
 	if err != nil {
 		return pipelineOMPManagedActivePrepared{}, err
 	}
 	validFor := grant.ExpiresAt().Sub(now)
+	if evidenceValidFor := evidenceExpiresAt.Sub(now); evidenceValidFor < validFor {
+		validFor = evidenceValidFor
+	}
 	if validFor > pipelineOMPActiveLeaseMaxValidity {
 		validFor = pipelineOMPActiveLeaseMaxValidity
 	}
@@ -192,7 +206,9 @@ func buildPipelineOMPActiveLeaseBinding(
 	candidate pipelineOMPManagedActiveCandidate,
 	grant pipelineOMPVerifiedGrant,
 	expected promptlayer.OMPContextPromotionStaticPolicyV3,
-) (pipelineOMPActiveLeaseBinding, error) {
+	now time.Time,
+	verifyEvidence pipelineOMPActiveEvidenceVerifier,
+) (pipelineOMPActiveLeaseBinding, time.Time, error) {
 	provider, modelScope := grant.ProviderScope()
 	runtime := grant.RuntimeCoordinates()
 	coordinates := grant.CandidateCoordinates()
@@ -205,23 +221,23 @@ func buildPipelineOMPActiveLeaseBinding(
 		runtime.AutoVersion != expected.AutoVersion ||
 		runtime.PipelineImplementationDigest != expected.PipelineImplementationDigest ||
 		runtime.PipelineImplementationDigest != pipelineOMPActiveImplementationDigest() {
-		return pipelineOMPActiveLeaseBinding{}, errors.New("pipeline: signed managed active coordinates mismatch")
+		return pipelineOMPActiveLeaseBinding{}, time.Time{}, errors.New("pipeline: signed managed active coordinates mismatch")
 	}
 	cfg, err := loadHarnessConfigForDir(candidate.Snapshot.ProjectDir, globalFlags{})
 	if err != nil {
-		return pipelineOMPActiveLeaseBinding{}, err
+		return pipelineOMPActiveLeaseBinding{}, time.Time{}, err
 	}
 	policy, selected, err := workflowContextPolicyFromConfig(cfg)
 	if err != nil || !selected || policy.HistoryMode != config.OMPContextHistoryActive ||
 		policy.MemoryMode != config.OMPContextMemoryOff {
-		return pipelineOMPActiveLeaseBinding{}, errors.New("pipeline: managed active policy is unavailable")
+		return pipelineOMPActiveLeaseBinding{}, time.Time{}, errors.New("pipeline: managed active policy is unavailable")
 	}
 	options := promptlayer.ContextDeliveryOptions{
 		Root: candidate.Snapshot.ProjectDir, Command: candidate.DeliveryCommand, SpecDir: candidate.Snapshot.SpecDir,
 	}
 	delivery, err := promptlayer.BuildContextDelivery(options)
 	if err != nil || promptlayer.VerifyContextDeliveryForOptions(options, delivery) != nil {
-		return pipelineOMPActiveLeaseBinding{}, errors.New("pipeline: managed active canonical delivery is unavailable")
+		return pipelineOMPActiveLeaseBinding{}, time.Time{}, errors.New("pipeline: managed active canonical delivery is unavailable")
 	}
 	identity := pipelineOMPContextIdentity(candidate.Snapshot)
 	history := pipelineOMPContextHistory(candidate.Snapshot.CompletedHistory)
@@ -233,7 +249,19 @@ func buildPipelineOMPActiveLeaseBinding(
 		}, History: history,
 	})
 	if err != nil {
-		return pipelineOMPActiveLeaseBinding{}, err
+		return pipelineOMPActiveLeaseBinding{}, time.Time{}, err
+	}
+	evidencePolicy := promptlayer.OMPContextPromotionPolicyV1{
+		Profile: policy.Profile, HistoryMode: policy.HistoryMode, MemoryMode: policy.MemoryMode,
+		HistoryTargetTokens: policy.HistoryTargetTokens, Fallback: policy.Fallback,
+		CapabilityPolicy: policy.CapabilityPolicy, RuntimeRootPolicy: policy.RuntimeRootPolicy,
+		MutationScope: policy.MutationScope,
+	}
+	evidenceExpiresAt, err := verifyEvidence(
+		candidate, grant, evidencePolicy, receipt, cfg.ProjectName, identity[0], identity[1], now,
+	)
+	if err != nil {
+		return pipelineOMPActiveLeaseBinding{}, time.Time{}, err
 	}
 	return pipelineOMPActiveLeaseBinding{
 		GrantDigest: grant.ReportDigest(), PolicyDigest: grant.PolicyDigest(), WorkspaceID: cfg.ProjectName,
@@ -247,7 +275,7 @@ func buildPipelineOMPActiveLeaseBinding(
 		AutoSourceCommit: candidate.AutoSourceCommit, AutoSourceTree: candidate.AutoSourceTree,
 		CohortDigest: expected.CohortManifestDigest, OracleDigest: expected.OraclePolicyDigest,
 		EligibleHistoryHash: hashPipelineOMPActiveHistory(receipt.EligibleHistoryRefs),
-	}, nil
+	}, evidenceExpiresAt, nil
 }
 
 func hashPipelineOMPActiveHistory(rows []promptlayer.OMPContextHistoryReference) string {

--- a/internal/cli/pipeline_omp_context_active_coordinator_test.go
+++ b/internal/cli/pipeline_omp_context_active_coordinator_test.go
@@ -20,13 +20,14 @@ func TestPipelineOMPManagedActiveCoordinator_NarrowsOpaqueGrantToOneUseLease(t *
 	spawnCalls := 0
 	runner := newPipelineOMPManagedActiveCoordinator()
 	runner.now = func() time.Time { return now }
+	runner.verifyEvidence = pipelineOMPActiveEvidenceVerifierFixture(grant.expires)
 	runner.policy = func(got pipelineOMPManagedActiveCandidate) (promptlayer.OMPContextPromotionStaticPolicyV3, error) {
 		assert.Equal(t, candidate.Snapshot.Prompt, got.Snapshot.Prompt)
 		return expected, nil
 	}
-	runner.current = func(_ context.Context, got pipelineOMPManagedActiveCandidate) (
-		promptlayer.OMPContextPromotionCurrentRuntimeV3, error,
-	) {
+	runner.current = func(_ context.Context, got pipelineOMPManagedActiveCandidate,
+		_ promptlayer.OMPContextPromotionStaticPolicyV3,
+	) (promptlayer.OMPContextPromotionCurrentRuntimeV3, error) {
 		assert.Equal(t, candidate.AutoSourceCommit, got.AutoSourceCommit)
 		return pipelineOMPActiveCurrentRuntimeFixture(expected), nil
 	}
@@ -66,12 +67,13 @@ func TestPipelineOMPManagedActiveCoordinator_RejectsGrantThatExpiresBeforeExecut
 	grant.expires = now.Add(time.Second)
 	runner := newPipelineOMPManagedActiveCoordinator()
 	runner.now = func() time.Time { return now }
+	runner.verifyEvidence = pipelineOMPActiveEvidenceVerifierFixture(grant.expires)
 	runner.policy = func(pipelineOMPManagedActiveCandidate) (promptlayer.OMPContextPromotionStaticPolicyV3, error) {
 		return expected, nil
 	}
-	runner.current = func(context.Context, pipelineOMPManagedActiveCandidate) (
-		promptlayer.OMPContextPromotionCurrentRuntimeV3, error,
-	) {
+	runner.current = func(context.Context, pipelineOMPManagedActiveCandidate,
+		promptlayer.OMPContextPromotionStaticPolicyV3,
+	) (promptlayer.OMPContextPromotionCurrentRuntimeV3, error) {
 		return pipelineOMPActiveCurrentRuntimeFixture(expected), nil
 	}
 	runner.loadGrant = func(string, time.Time, promptlayer.OMPContextPromotionStaticPolicyV3,
@@ -102,9 +104,9 @@ func TestPipelineOMPManagedActiveCoordinator_RejectsCrossCandidateBeforeLease(t 
 	runner.policy = func(pipelineOMPManagedActiveCandidate) (promptlayer.OMPContextPromotionStaticPolicyV3, error) {
 		return expected, nil
 	}
-	runner.current = func(context.Context, pipelineOMPManagedActiveCandidate) (
-		promptlayer.OMPContextPromotionCurrentRuntimeV3, error,
-	) {
+	runner.current = func(context.Context, pipelineOMPManagedActiveCandidate,
+		promptlayer.OMPContextPromotionStaticPolicyV3,
+	) (promptlayer.OMPContextPromotionCurrentRuntimeV3, error) {
 		return pipelineOMPActiveCurrentRuntimeFixture(expected), nil
 	}
 	runner.loadGrant = func(string, time.Time, promptlayer.OMPContextPromotionStaticPolicyV3,
@@ -123,10 +125,12 @@ func TestPipelineOMPManagedActiveCoordinator_RejectsCrossCandidateBeforeLease(t 
 
 type pipelineOMPVerifiedGrantStub struct {
 	digest, evidence, policy, provider, modelScope string
+	providerAuthority, sessionAuthority            string
 	expires                                        time.Time
 	producer                                       promptlayer.OMPContextPromotionProducerV1
 	candidate                                      promptlayer.OMPContextPromotionCandidateV1
 	runtime                                        promptlayer.OMPContextPromotionRuntimeV1
+	rows                                           []promptlayer.OMPContextCanaryRowV1
 }
 
 func (grant pipelineOMPVerifiedGrantStub) Valid() bool {
@@ -147,6 +151,15 @@ func (grant pipelineOMPVerifiedGrantStub) RuntimeCoordinates() promptlayer.OMPCo
 }
 func (grant pipelineOMPVerifiedGrantStub) ProviderScope() (string, string) {
 	return grant.provider, grant.modelScope
+}
+func (grant pipelineOMPVerifiedGrantStub) ProviderAuthorityDigest() string {
+	return grant.providerAuthority
+}
+func (grant pipelineOMPVerifiedGrantStub) SessionAuthorityDigest() string {
+	return grant.sessionAuthority
+}
+func (grant pipelineOMPVerifiedGrantStub) CanaryRows() []promptlayer.OMPContextCanaryRowV1 {
+	return append([]promptlayer.OMPContextCanaryRowV1(nil), grant.rows...)
 }
 
 func pipelineOMPActiveCoordinatorFixture(t *testing.T, now time.Time) (
@@ -231,5 +244,18 @@ func pipelineOMPActiveCurrentRuntimeFixture(
 		AutoVersion: policy.AutoVersion, OMPVersion: policy.OMPVersion,
 		OMPExecutableSHA256:          policy.OMPExecutableSHA256,
 		PipelineImplementationDigest: policy.PipelineImplementationDigest,
+	}
+}
+
+func pipelineOMPActiveEvidenceVerifierFixture(expires time.Time) pipelineOMPActiveEvidenceVerifier {
+	return func(
+		pipelineOMPManagedActiveCandidate,
+		pipelineOMPVerifiedGrant,
+		promptlayer.OMPContextPromotionPolicyV1,
+		promptlayer.OMPContextBindingReceipt,
+		string, string, string,
+		time.Time,
+	) (time.Time, error) {
+		return expires, nil
 	}
 }

--- a/internal/cli/pipeline_omp_context_active_evaluator.go
+++ b/internal/cli/pipeline_omp_context_active_evaluator.go
@@ -17,13 +17,14 @@ const (
 // implementation without consuming promotion authority. Only the explicit-live
 // observe-session command may construct it.
 type pipelineOMPActiveEvaluatorSession struct {
-	process   *pipelineOMPProcess
-	protocol  *pipelineOMPRPCProtocol
-	binding   WorkflowContextBridgeBinding
-	selector  string
-	sessionID string
-	optimized bool
-	sequence  int
+	process     *pipelineOMPProcess
+	protocol    *pipelineOMPRPCProtocol
+	binding     WorkflowContextBridgeBinding
+	selector    string
+	sessionID   string
+	optimized   bool
+	sequence    int
+	compactions int
 }
 
 // @AX:ANCHOR [AUTO] @AX:SPEC: SPEC-OMP-004: evaluator startup is the shared full and optimized live-session boundary.
@@ -84,6 +85,7 @@ func (session *pipelineOMPActiveEvaluatorSession) Execute(
 		return "", pipelineOMPActiveCallReceipt{}, errors.New("pipeline: active evaluator compaction evidence is incomplete")
 	}
 	session.sequence++
+	session.compactions += receipt.CompactionCycles
 	receipt.Sequence = session.sequence
 	receipt.ImplementationHash = pipelineOMPActiveImplementationDigest()
 	return output, receipt, nil

--- a/internal/cli/pipeline_omp_context_active_evaluator.go
+++ b/internal/cli/pipeline_omp_context_active_evaluator.go
@@ -67,9 +67,10 @@ func (session *pipelineOMPActiveEvaluatorSession) Execute(
 		strings.TrimSpace(prompt) == "" || strings.HasPrefix(strings.TrimSpace(prompt), "/auto") {
 		return "", pipelineOMPActiveCallReceipt{}, errors.New("pipeline: active evaluator input is invalid")
 	}
+	compactBefore := session.optimized && session.sequence > 0
 	output, receipt, err := session.protocol.executeManaged(
 		ctx, session.selector, session.binding, session.sessionID,
-		session.optimized,
+		compactBefore,
 		func() (string, error) { return prompt, nil },
 	)
 	if err != nil {
@@ -77,10 +78,13 @@ func (session *pipelineOMPActiveEvaluatorSession) Execute(
 		return "", pipelineOMPActiveCallReceipt{}, err
 	}
 	receipt.ContextBindingHash = session.binding.BindingHash
-	if session.optimized && (receipt.CompactionCycles != 1 || receipt.PreCompactionACKs != 1 ||
-		receipt.PostCompactionACKs != 1 || receipt.CanonicalReadmissions != 1 ||
-		receipt.EphemeralReadmissions != 1) ||
-		!session.optimized && receipt.CompactionCycles != 0 {
+	expectedCompactions := receipt.CompactionCycles
+	if expectedCompactions < 0 || expectedCompactions > 1 ||
+		!compactBefore && expectedCompactions != 0 ||
+		receipt.PreCompactionACKs != expectedCompactions ||
+		receipt.PostCompactionACKs != expectedCompactions ||
+		receipt.CanonicalReadmissions != expectedCompactions ||
+		receipt.EphemeralReadmissions != expectedCompactions {
 		_ = session.Close()
 		return "", pipelineOMPActiveCallReceipt{}, errors.New("pipeline: active evaluator compaction evidence is incomplete")
 	}

--- a/internal/cli/pipeline_omp_context_active_evidence.go
+++ b/internal/cli/pipeline_omp_context_active_evidence.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"errors"
+	"reflect"
+	"sort"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/promptlayer"
+)
+
+type pipelineOMPVerifiedRunEvidence interface {
+	ProviderAuthorityDigest() string
+	SessionAuthorityDigest() string
+	CanaryRows() []promptlayer.OMPContextCanaryRowV1
+}
+
+func verifyPipelineOMPActiveRunEvidence(
+	candidate pipelineOMPManagedActiveCandidate,
+	grant pipelineOMPVerifiedGrant,
+	policy promptlayer.OMPContextPromotionPolicyV1,
+	receipt promptlayer.OMPContextBindingReceipt,
+	workspaceID string,
+	taskID string,
+	sessionID string,
+	now time.Time,
+) (time.Time, error) {
+	evidence, ok := grant.(pipelineOMPVerifiedRunEvidence)
+	policyDigest, err := promptlayer.OMPContextPromotionPolicyDigestV1(policy)
+	if !ok || err != nil || policyDigest != grant.PolicyDigest() ||
+		!validPipelineOMPActiveHash(evidence.ProviderAuthorityDigest()) ||
+		!validPipelineOMPActiveHash(evidence.SessionAuthorityDigest()) || len(evidence.CanaryRows()) != 40 {
+		return time.Time{}, errors.New("pipeline: signed observed run evidence is incomplete")
+	}
+	verified, err := promptlayer.LoadOMPContextEvidenceForExpectationV1(
+		candidate.Snapshot.ProjectDir,
+		promptlayer.OMPContextEvidenceExpectationV1{
+			WorkspaceID: workspaceID, SpecID: candidate.Snapshot.SpecID,
+			SnapshotHash: candidate.Snapshot.SnapshotHash, GitCommitHash: candidate.Snapshot.GitCommitHash,
+			RuntimeVersion: grant.RuntimeCoordinates().OMPVersion,
+		},
+		promptlayer.OMPContextPromotionSubjectV1{
+			WorkspaceID: workspaceID, SpecID: candidate.Snapshot.SpecID, TaskID: taskID,
+			Phase: string(candidate.Snapshot.PhaseID), SessionID: sessionID, BindingHash: receipt.BindingHash,
+		},
+		policy,
+		now,
+	)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if len(verified.HistoryRefs) != 0 ||
+		!reflect.DeepEqual(canonicalPipelineOMPActiveCanaryRows(verified.Promotion.Rows),
+			canonicalPipelineOMPActiveCanaryRows(evidence.CanaryRows())) {
+		return time.Time{}, errors.New("pipeline: observed run evidence does not match the signed cohort")
+	}
+	expiresAt := verified.Promotion.Attestation.ExpiresAt()
+	if expiresAt.IsZero() || !now.Before(expiresAt) {
+		return time.Time{}, errors.New("pipeline: observed run evidence is stale")
+	}
+	return expiresAt, nil
+}
+
+func canonicalPipelineOMPActiveCanaryRows(
+	rows []promptlayer.OMPContextCanaryRowV1,
+) []promptlayer.OMPContextCanaryRowV1 {
+	ordered := append([]promptlayer.OMPContextCanaryRowV1(nil), rows...)
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].TaskID != ordered[j].TaskID {
+			return ordered[i].TaskID < ordered[j].TaskID
+		}
+		if ordered[i].Variant != ordered[j].Variant {
+			return ordered[i].Variant < ordered[j].Variant
+		}
+		return ordered[i].Order < ordered[j].Order
+	})
+	return ordered
+}

--- a/internal/cli/pipeline_omp_context_active_evidence_test.go
+++ b/internal/cli/pipeline_omp_context_active_evidence_test.go
@@ -1,0 +1,170 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/config"
+	"github.com/insajin/autopus-adk/pkg/promptlayer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPipelineOMPActiveEvidence_CurrentRunActivatesWithFreshObservedAuthority(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	candidate, expected, grant, policy := pipelineOMPActiveObservedEvidenceFixture(t, now)
+	writePipelineOMPActiveObservedStore(t, candidate, grant, policy, now, time.Hour)
+	spawned := 0
+	runner := pipelineOMPActiveObservedRunner(now, expected, grant, func() { spawned++ })
+
+	prepared, err := runner.Prepare(context.Background(), candidate)
+	require.NoError(t, err)
+	assert.Equal(t, candidate.Snapshot.SnapshotHash, prepared.Binding.SnapshotHash)
+	assert.Equal(t, candidate.Snapshot.GitCommitHash, prepared.Binding.GitCommitHash)
+	assert.NotEmpty(t, prepared.Binding.BindingHash)
+	output, err := runner.Execute(context.Background(), candidate, prepared)
+	require.NoError(t, err)
+	assert.Equal(t, "observed active output", output)
+	assert.Equal(t, 1, spawned)
+}
+
+func TestPipelineOMPActiveEvidence_StalePartialTamperedMissingAndCrossRunFailClosed(t *testing.T) {
+	for name, mutate := range map[string]func(
+		t *testing.T,
+		candidate *pipelineOMPManagedActiveCandidate,
+		grant *pipelineOMPVerifiedGrantStub,
+		policy promptlayer.OMPContextPromotionPolicyV1,
+		now time.Time,
+	){
+		"missing": func(*testing.T, *pipelineOMPManagedActiveCandidate, *pipelineOMPVerifiedGrantStub, promptlayer.OMPContextPromotionPolicyV1, time.Time) {
+		},
+		"stale": func(t *testing.T, candidate *pipelineOMPManagedActiveCandidate, grant *pipelineOMPVerifiedGrantStub, policy promptlayer.OMPContextPromotionPolicyV1, now time.Time) {
+			writePipelineOMPActiveObservedStore(t, *candidate, *grant, policy, now.Add(-2*time.Hour), time.Hour)
+		},
+		"partial grant": func(t *testing.T, candidate *pipelineOMPManagedActiveCandidate, grant *pipelineOMPVerifiedGrantStub, policy promptlayer.OMPContextPromotionPolicyV1, now time.Time) {
+			writePipelineOMPActiveObservedStore(t, *candidate, *grant, policy, now, time.Hour)
+			grant.rows = grant.rows[:39]
+		},
+		"missing authority": func(t *testing.T, candidate *pipelineOMPManagedActiveCandidate, grant *pipelineOMPVerifiedGrantStub, policy promptlayer.OMPContextPromotionPolicyV1, now time.Time) {
+			writePipelineOMPActiveObservedStore(t, *candidate, *grant, policy, now, time.Hour)
+			grant.sessionAuthority = ""
+		},
+		"tampered cohort": func(t *testing.T, candidate *pipelineOMPManagedActiveCandidate, grant *pipelineOMPVerifiedGrantStub, policy promptlayer.OMPContextPromotionPolicyV1, now time.Time) {
+			tampered := *grant
+			tampered.rows = append([]promptlayer.OMPContextCanaryRowV1(nil), grant.rows...)
+			tampered.rows[0].Tokens++
+			writePipelineOMPActiveObservedStore(t, *candidate, tampered, policy, now, time.Hour)
+		},
+		"cross run snapshot": func(t *testing.T, candidate *pipelineOMPManagedActiveCandidate, grant *pipelineOMPVerifiedGrantStub, policy promptlayer.OMPContextPromotionPolicyV1, now time.Time) {
+			writePipelineOMPActiveObservedStore(t, *candidate, *grant, policy, now, time.Hour)
+			candidate.Snapshot.SnapshotHash = workflowContextRuntimeHash("different-run-snapshot")
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			now := time.Now().UTC().Truncate(time.Second)
+			candidate, expected, grant, policy := pipelineOMPActiveObservedEvidenceFixture(t, now)
+			mutate(t, &candidate, &grant, policy, now)
+			spawned := 0
+			runner := pipelineOMPActiveObservedRunner(now, expected, grant, func() { spawned++ })
+			_, err := runner.Prepare(context.Background(), candidate)
+			require.Error(t, err)
+			assert.Zero(t, spawned)
+		})
+	}
+}
+
+func pipelineOMPActiveObservedEvidenceFixture(t *testing.T, now time.Time) (
+	pipelineOMPManagedActiveCandidate,
+	promptlayer.OMPContextPromotionStaticPolicyV3,
+	pipelineOMPVerifiedGrantStub,
+	promptlayer.OMPContextPromotionPolicyV1,
+) {
+	t.Helper()
+	candidate, expected, grant := pipelineOMPActiveCoordinatorFixture(t, now)
+	policy := promptlayer.OMPContextPromotionPolicyV1{
+		Profile: "active", HistoryMode: config.OMPContextHistoryActive, MemoryMode: config.OMPContextMemoryOff,
+		HistoryTargetTokens: 1000, Fallback: config.OMPContextFallbackCanonicalFull,
+		CapabilityPolicy:  config.OMPContextCapabilityProbeRequired,
+		RuntimeRootPolicy: config.OMPContextRuntimeIsolatedTaskOwned,
+		MutationScope:     config.OMPContextMutationSessionOverlay,
+	}
+	policyDigest, err := promptlayer.OMPContextPromotionPolicyDigestV1(policy)
+	require.NoError(t, err)
+	expected.PolicyDigest, grant.policy = policyDigest, policyDigest
+	grant.providerAuthority = workflowContextRuntimeHash("endpoint-credential-authority")
+	grant.sessionAuthority = workflowContextRuntimeHash("stable-two-session-authority")
+	grant.rows = pipelineOMPActiveObservedRows()
+	return candidate, expected, grant, policy
+}
+
+func pipelineOMPActiveObservedRows() []promptlayer.OMPContextCanaryRowV1 {
+	rows := make([]promptlayer.OMPContextCanaryRowV1, 0, 40)
+	for index := range 20 {
+		fullOrder, optimizedOrder := 1, 2
+		if index%2 == 1 {
+			fullOrder, optimizedOrder = 2, 1
+		}
+		taskID := workflowContextRuntimeHash("active-observed-task-" + strings.Repeat("x", index+1))
+		rows = append(rows,
+			promptlayer.OMPContextCanaryRowV1{
+				TaskID: taskID, Variant: promptlayer.OMPContextCanaryVariantFullV1, Order: fullOrder,
+				Tokens: 10000, IntegrityPassed: true, SecurityPassed: true, QualityScore: 100,
+			},
+			promptlayer.OMPContextCanaryRowV1{
+				TaskID: taskID, Variant: promptlayer.OMPContextCanaryVariantOptimizedV1, Order: optimizedOrder,
+				Tokens: 7500, IntegrityPassed: true, SecurityPassed: true, QualityScore: 100,
+				FallbackVerified: true, RollbackVerified: true,
+			},
+		)
+	}
+	return rows
+}
+
+func writePipelineOMPActiveObservedStore(
+	t *testing.T,
+	candidate pipelineOMPManagedActiveCandidate,
+	grant pipelineOMPVerifiedGrantStub,
+	policy promptlayer.OMPContextPromotionPolicyV1,
+	checkedAt time.Time,
+	validFor time.Duration,
+) {
+	t.Helper()
+	require.NoError(t, promptlayer.WriteOMPContextEvidenceStoreV1(
+		candidate.Snapshot.ProjectDir,
+		promptlayer.OMPContextEvidenceStoreV1{
+			Binding: promptlayer.OMPContextEvidenceStoreBindingV1{
+				WorkspaceID: "autopus-adk", SpecID: candidate.Snapshot.SpecID,
+				SnapshotHash:   candidate.Snapshot.SnapshotHash,
+				GitCommitHash:  candidate.Snapshot.GitCommitHash,
+				RuntimeVersion: grant.runtime.OMPVersion, CheckedAt: checkedAt, ValidFor: validFor,
+			},
+			Policy: policy, CanaryRows: grant.rows,
+		},
+	))
+}
+
+func pipelineOMPActiveObservedRunner(
+	now time.Time,
+	expected promptlayer.OMPContextPromotionStaticPolicyV3,
+	grant pipelineOMPVerifiedGrantStub,
+	onSpawn func(),
+) *pipelineOMPManagedActiveCoordinator {
+	runner := newPipelineOMPManagedActiveCoordinator()
+	runner.now = func() time.Time { return now }
+	runner.policy = func(pipelineOMPManagedActiveCandidate) (promptlayer.OMPContextPromotionStaticPolicyV3, error) {
+		return expected, nil
+	}
+	runner.current = func(context.Context, pipelineOMPManagedActiveCandidate, promptlayer.OMPContextPromotionStaticPolicyV3) (promptlayer.OMPContextPromotionCurrentRuntimeV3, error) {
+		return pipelineOMPActiveCurrentRuntimeFixture(expected), nil
+	}
+	runner.loadGrant = func(string, time.Time, promptlayer.OMPContextPromotionStaticPolicyV3, promptlayer.OMPContextPromotionCurrentRuntimeV3) (pipelineOMPVerifiedGrant, error) {
+		return grant, nil
+	}
+	runner.spawn = func(context.Context, pipelineOMPManagedActiveCandidate, pipelineOMPManagedActivePrepared) (string, error) {
+		onSpawn()
+		return "observed active output", nil
+	}
+	return runner
+}

--- a/internal/cli/pipeline_omp_context_active_lifecycle.go
+++ b/internal/cli/pipeline_omp_context_active_lifecycle.go
@@ -6,84 +6,104 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 )
+
+const pipelineOMPActiveCompactionNoopMessage = "Nothing to compact (session too small)"
 
 func (protocol *pipelineOMPRPCProtocol) manualCompact(
 	ctx context.Context,
 	binding WorkflowContextBridgeBinding,
 	expectedSession string,
 	preparePrompt func() (string, error),
-) error {
+) (bool, error) {
 	preProof, _, err := protocol.validatePipelineOMPActiveTranscript(ctx, false)
 	if err != nil {
-		return err
+		return false, err
 	}
 	protocol.nextID++
 	id := fmt.Sprintf("pipeline-active-compact-%d", protocol.nextID)
 	if err := protocol.process.send(pipelineOMPRPCCommand{ID: id, Type: "compact"}); err != nil {
-		return err
+		return false, err
 	}
 	started, preACKed, postACKed, responded, ended := false, false, false, false, false
 	var nativeResult []byte
 	for !ended {
 		frame, err := protocol.process.next(ctx)
 		if err != nil {
-			return err
+			return false, err
 		}
 		if frame.Type == "extension_error" {
-			return errors.New("managed active OMP extension failed during manual compaction")
+			return false, errors.New("managed active OMP extension failed during manual compaction")
 		}
 		switch frame.Type {
 		case "auto_compaction_start":
 			if started || postACKed || frame.Action != "snapcompact" || frame.Reason != "manual" {
-				return errors.New("managed active OMP manual compaction start is invalid")
+				return false, errors.New("managed active OMP manual compaction start is invalid")
 			}
 			started = true
 		case "extension_ui_request":
 			event, bridgeErr := validatePipelineOMPActiveBridgeFrame(frame, binding)
 			if bridgeErr != nil {
-				return bridgeErr
+				return false, bridgeErr
 			}
 			if event == WorkflowContextEventPreCompaction {
 				if preACKed || postACKed || responded {
-					return errors.New("managed active OMP pre-compaction checkpoint is out of order")
+					return false, errors.New("managed active OMP pre-compaction checkpoint is out of order")
 				}
 				preACKed = true
 			} else {
-				if !started || !preACKed || postACKed || responded {
-					return errors.New("managed active OMP post-compaction rehydration is out of order")
+				if !preACKed || postACKed || responded {
+					return false, errors.New("managed active OMP post-compaction rehydration is out of order")
 				}
 				if _, err := preparePrompt(); err != nil {
-					return err
+					return false, err
 				}
 				postACKed = true
 			}
 			if err := protocol.confirmPipelineOMPActiveBridge(frame.ID); err != nil {
-				return err
+				return false, err
 			}
 		case "response":
+			if frame.ID == id && frame.Command == "compact" && !frame.Success && !started &&
+				!preACKed && !postACKed && !responded &&
+				frame.Error == pipelineOMPActiveCompactionNoopMessage {
+				postProof, _, proofErr := protocol.validatePipelineOMPActiveTranscript(ctx, false)
+				state, stateErr := protocol.readIdleState(ctx, "managed-compaction-noop")
+				if proofErr != nil || postProof != preProof || stateErr != nil ||
+					state.SessionID != expectedSession || state.AutoCompactionEnabled == nil ||
+					*state.AutoCompactionEnabled {
+					return false, errors.New("managed active OMP no-op compaction proof is invalid")
+				}
+				return false, nil
+			}
 			if frame.ID != id || frame.Command != "compact" || !frame.Success || responded ||
-				!started || !preACKed || !postACKed {
-				return errors.New("managed active OMP manual compaction response is invalid")
+				!preACKed || !postACKed || !validPipelineOMPActiveManualResult(frame.Data) {
+				return false, errors.New("managed active OMP manual compaction response is invalid")
 			}
 			responded = true
-		case "auto_compaction_end":
-			if !responded || ended || !validPipelineOMPActiveNativeEnd(frame) {
-				return errors.New("managed active OMP manual compaction completion is invalid")
+			nativeResult = frame.Data
+			if !started {
+				ended = true
 			}
-			nativeResult = append([]byte(nil), frame.Result...)
+		case "auto_compaction_end":
+			if !started || !responded || ended || !validPipelineOMPActiveNativeEnd(frame) {
+				return false, errors.New("managed active OMP manual compaction completion is invalid")
+			}
+			nativeResult = append(nativeResult, 0)
+			nativeResult = append(nativeResult, frame.Result...)
 			ended = true
 		case "agent_start", "turn_end", "agent_end", "prompt_result":
-			return errors.New("managed active OMP provider activity crossed the compaction barrier")
+			return false, errors.New("managed active OMP provider activity crossed the compaction barrier")
 		}
 	}
 	postProof, images, err := protocol.validatePipelineOMPActiveTranscript(ctx, true)
 	if err != nil {
-		return err
+		return false, err
 	}
 	provenance := pipelineOMPActiveHash([]byte(preProof + "\x00" + pipelineOMPActiveHash(nativeResult) + "\x00" + postProof))
 	if !validPipelineOMPActiveHash(provenance) {
-		return errors.New("managed active OMP compaction provenance is invalid")
+		return false, errors.New("managed active OMP compaction provenance is invalid")
 	}
 	for _, digest := range images {
 		protocol.safeCompactionImages[digest] = struct{}{}
@@ -91,9 +111,9 @@ func (protocol *pipelineOMPRPCProtocol) manualCompact(
 	state, err := protocol.readIdleState(ctx, "managed-post-compaction")
 	if err != nil || state.SessionID != expectedSession || state.AutoCompactionEnabled == nil ||
 		*state.AutoCompactionEnabled {
-		return errors.New("managed active OMP post-compaction state is invalid")
+		return false, errors.New("managed active OMP post-compaction state is invalid")
 	}
-	return nil
+	return true, nil
 }
 
 // @AX:WARN [AUTO]: managed prompt lifecycle validation contains 11 if branches.
@@ -180,6 +200,13 @@ func (protocol *pipelineOMPRPCProtocol) confirmPipelineOMPActiveBridge(id string
 	return protocol.process.send(pipelineOMPRPCCommand{
 		ID: id, Type: "extension_ui_response", Confirmed: &confirmed,
 	})
+}
+
+func validPipelineOMPActiveManualResult(data json.RawMessage) bool {
+	var result struct {
+		Summary string `json:"summary"`
+	}
+	return json.Unmarshal(data, &result) == nil && strings.TrimSpace(result.Summary) != ""
 }
 
 func validPipelineOMPActiveNativeEnd(frame pipelineOMPRPCFrame) bool {

--- a/internal/cli/pipeline_omp_context_active_policy.go
+++ b/internal/cli/pipeline_omp_context_active_policy.go
@@ -83,7 +83,7 @@ func newPipelineOMPActiveCurrentRuntimeProviderWithHooks(
 		}
 		providerAuthority, err := pipelineOMPActiveProviderAuthorityDigest(
 			expected.PolicyDigest, expected.PipelineImplementationDigest,
-			candidate.ModelScopeDigest, endpoint, credential,
+			candidate.ModelScopeDigest, config.ModelContextWindow, endpoint, credential,
 		)
 		if err != nil {
 			return promptlayer.OMPContextPromotionCurrentRuntimeV3{}, err

--- a/internal/cli/pipeline_omp_context_active_policy.go
+++ b/internal/cli/pipeline_omp_context_active_policy.go
@@ -69,12 +69,24 @@ func newPipelineOMPActiveCurrentRuntimeProviderWithHooks(
 	config pipelineOMPBackendConfig,
 	hooks pipelineOMPActiveCurrentRuntimeHooks,
 ) pipelineOMPActiveCurrentRuntimeProvider {
-	return func(ctx context.Context, candidate pipelineOMPManagedActiveCandidate) (
-		promptlayer.OMPContextPromotionCurrentRuntimeV3, error,
-	) {
-		_, found := pipelineOMPEnvironmentValue(config.Environment, pipelineOMPActiveEndpointKey)
-		if !found {
-			return promptlayer.OMPContextPromotionCurrentRuntimeV3{}, errors.New("pipeline: active OMP endpoint is unavailable")
+	return func(ctx context.Context, candidate pipelineOMPManagedActiveCandidate,
+		expected promptlayer.OMPContextPromotionStaticPolicyV3,
+	) (promptlayer.OMPContextPromotionCurrentRuntimeV3, error) {
+		autoExecutableSHA256, err := pipelineOMPActiveCurrentAutoExecutableSHA256()
+		if err != nil {
+			return promptlayer.OMPContextPromotionCurrentRuntimeV3{}, err
+		}
+		endpoint, endpointFound := pipelineOMPEnvironmentValue(config.Environment, pipelineOMPActiveEndpointKey)
+		credential, credentialFound := pipelineOMPEnvironmentValue(config.Environment, pipelineOMPActiveCredentialKey)
+		if !endpointFound || !credentialFound {
+			return promptlayer.OMPContextPromotionCurrentRuntimeV3{}, errors.New("pipeline: active OMP provider authority is unavailable")
+		}
+		providerAuthority, err := pipelineOMPActiveProviderAuthorityDigest(
+			expected.PolicyDigest, expected.PipelineImplementationDigest,
+			candidate.ModelScopeDigest, endpoint, credential,
+		)
+		if err != nil {
+			return promptlayer.OMPContextPromotionCurrentRuntimeV3{}, err
 		}
 		if err := verifyPipelineOMPExecutable(config.Executable, config.executableID); err != nil {
 			return promptlayer.OMPContextPromotionCurrentRuntimeV3{}, err
@@ -88,11 +100,12 @@ func newPipelineOMPActiveCurrentRuntimeProviderWithHooks(
 			return promptlayer.OMPContextPromotionCurrentRuntimeV3{}, errors.New("pipeline: active OMP identity probe failed")
 		}
 		return promptlayer.OMPContextPromotionCurrentRuntimeV3{
-			SourceCommit: candidate.AutoSourceCommit, SourceTree: candidate.AutoSourceTree,
+			ExecutableSHA256: autoExecutableSHA256,
+			SourceCommit:     candidate.AutoSourceCommit, SourceTree: candidate.AutoSourceTree,
 			Target: runtime.GOOS + "-" + runtime.GOARCH, AutoVersion: version.Version(),
-			OMPVersion:                   ompVersion,
-			OMPExecutableSHA256:          fmt.Sprintf("sha256:%x", config.executableID.digest[:]),
-			PipelineImplementationDigest: pipelineOMPActiveImplementationDigest(),
+			OMPVersion: ompVersion, OMPExecutableSHA256: fmt.Sprintf("sha256:%x", config.executableID.digest[:]),
+			PipelineImplementationDigest: expected.PipelineImplementationDigest,
+			ProviderAuthorityDigest:      providerAuthority,
 		}, nil
 	}
 }
@@ -234,4 +247,16 @@ func materializePipelineOMPActiveRuntimeConfig(
 	config.Executable, config.executableID = privateExecutable, privateIdentity
 	failed = false
 	return config, runtimeRoot, nil
+}
+
+func pipelineOMPActiveCurrentAutoExecutableSHA256() (string, error) {
+	executable, err := os.Executable()
+	if err != nil {
+		return "", errors.New("pipeline: active auto executable is unavailable")
+	}
+	_, identity, err := canonicalPipelineOMPExecutable(executable)
+	if err != nil {
+		return "", errors.New("pipeline: active auto executable identity is unavailable")
+	}
+	return fmt.Sprintf("sha256:%x", identity.digest[:]), nil
 }

--- a/internal/cli/pipeline_omp_context_active_policy_test.go
+++ b/internal/cli/pipeline_omp_context_active_policy_test.go
@@ -111,7 +111,7 @@ func TestPipelineOMPActivePinnedRuntime_ReplacementHookKeepsProbeAndSessionOnVer
 	assert.True(t, validPipelineOMPActiveHash(current.ExecutableSHA256))
 	expectedAuthority, err := pipelineOMPActiveProviderAuthorityDigest(
 		staticPolicy.PolicyDigest, staticPolicy.PipelineImplementationDigest, candidate.ModelScopeDigest,
-		"http://127.0.0.1:43123", "fixture-token-value",
+		pinned.ModelContextWindow, "http://127.0.0.1:43123", "fixture-token-value",
 	)
 	require.NoError(t, err)
 	assert.Equal(t, expectedAuthority, current.ProviderAuthorityDigest)

--- a/internal/cli/pipeline_omp_context_active_policy_test.go
+++ b/internal/cli/pipeline_omp_context_active_policy_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/insajin/autopus-adk/pkg/pipeline"
+	"github.com/insajin/autopus-adk/pkg/promptlayer"
 )
 
 func TestCompiledPipelineOMPActiveStaticPolicy_ExactCanonicalBase64URLPasses(t *testing.T) {
@@ -101,11 +102,19 @@ func TestPipelineOMPActivePinnedRuntime_ReplacementHookKeepsProbeAndSessionOnVer
 		},
 	})
 	candidate := pipelineOMPActivePinnedRuntimeCandidate(t, pinned)
-	current, err := provider(context.Background(), candidate)
+	staticPolicy := pipelineOMPActivePinnedRuntimePolicy()
+	current, err := provider(context.Background(), candidate, staticPolicy)
 	require.NoError(t, err)
 	assert.Equal(t, 1, hookCalls)
 	assert.Equal(t, "omp/17.2.7", current.OMPVersion)
 	assert.Equal(t, fmt.Sprintf("sha256:%x", pinned.executableID.digest[:]), current.OMPExecutableSHA256)
+	assert.True(t, validPipelineOMPActiveHash(current.ExecutableSHA256))
+	expectedAuthority, err := pipelineOMPActiveProviderAuthorityDigest(
+		staticPolicy.PolicyDigest, staticPolicy.PipelineImplementationDigest, candidate.ModelScopeDigest,
+		"http://127.0.0.1:43123", "fixture-token-value",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, expectedAuthority, current.ProviderAuthorityDigest)
 
 	session, err := newPipelineOMPActiveSessionStart(pinned)(
 		context.Background(), candidate, pipelineOMPActivePinnedRuntimePrepared(candidate),
@@ -145,7 +154,7 @@ func TestPipelineOMPActivePinnedRuntime_PinnedPathSwapFailsClosedWithoutProbeAut
 			require.NoError(t, os.Rename(next, pinned.Executable))
 		},
 	})
-	_, err = provider(context.Background(), pipelineOMPActivePinnedRuntimeCandidate(t, pinned))
+	_, err = provider(context.Background(), pipelineOMPActivePinnedRuntimeCandidate(t, pinned), pipelineOMPActivePinnedRuntimePolicy())
 	require.ErrorContains(t, err, "identity probe failed")
 	assert.Equal(t, 1, hookCalls)
 	_, statErr := os.Lstat(marker)
@@ -253,8 +262,10 @@ func pipelineOMPActivePinnedRuntimePrepared(
 	candidate pipelineOMPManagedActiveCandidate,
 ) pipelineOMPManagedActivePrepared {
 	return pipelineOMPManagedActivePrepared{Binding: pipelineOMPActiveLeaseBinding{
-		GrantDigest: pipelineOMPContextCohortHash("grant"), WorkspaceID: "autopus-adk",
-		SpecID: candidate.Snapshot.SpecID, GitCommitHash: candidate.Snapshot.GitCommitHash,
+		GrantDigest:  pipelineOMPContextCohortHash("grant"),
+		PolicyDigest: pipelineOMPActivePinnedRuntimePolicy().PolicyDigest,
+		WorkspaceID:  "autopus-adk", SpecID: candidate.Snapshot.SpecID,
+		GitCommitHash:    candidate.Snapshot.GitCommitHash,
 		ModelScopeDigest: candidate.ModelScopeDigest,
 	}}
 }
@@ -271,4 +282,11 @@ func copyPipelineOMPActiveNativeFixture(t *testing.T, destination string) {
 	closeErr := output.Close()
 	require.NoError(t, errors.Join(copyErr, syncErr, closeErr))
 	require.NoError(t, os.Chmod(destination, 0o700))
+}
+
+func pipelineOMPActivePinnedRuntimePolicy() promptlayer.OMPContextPromotionStaticPolicyV3 {
+	return promptlayer.OMPContextPromotionStaticPolicyV3{
+		PolicyDigest:                 workflowContextRuntimeHash("pinned-runtime-policy"),
+		PipelineImplementationDigest: pipelineOMPActiveImplementationDigest(),
+	}
 }

--- a/internal/cli/pipeline_omp_context_active_process.go
+++ b/internal/cli/pipeline_omp_context_active_process.go
@@ -21,8 +21,10 @@ const (
 	pipelineOMPActiveEndpointKey    = "AUTOPUS_OMP_CONTEXT_PROVIDER_ENDPOINT"
 	pipelineOMPActiveCredentialKey  = "AUTOPUS_OMP_CONTEXT_PROVIDER_TOKEN"
 	pipelineOMPActiveRPCIdentity    = "autopus.omp-pipeline-managed-rpc.v3"
-	pipelineOMPActivePolicyIdentity = "manual-compact-every-call;canonical-ephemeral-readmission;correlated-ack;provider-bound-endpoint;auto-compaction=off;retry-off;ambient-off;sandbox=candidate-managed|producer-inherited-external-live-image-darwin-v3;tools=read,bash,edit,write,grep,glob,todo"
+	pipelineOMPActivePolicyIdentity = "manual-compact-completed-history-before-reused-call;canonical-ephemeral-readmission;correlated-ack;provider-bound-endpoint;auto-compaction=off;retry-off;ambient-off;sandbox=candidate-managed|producer-inherited-external-live-image-darwin-v3;tools=read,bash,edit,write,grep,glob,todo"
 )
+
+const pipelineOMPActiveDefaultContextWindow = 262144
 
 type pipelineOMPActiveProcessConfig struct {
 	backend              pipelineOMPBackendConfig
@@ -50,7 +52,8 @@ func preparePipelineOMPActiveProcessConfig(
 	}
 	implementation := pipelineOMPActiveImplementationDigest()
 	providerAuthority, err := pipelineOMPActiveProviderAuthorityDigest(
-		prepared.Binding.PolicyDigest, implementation, candidate.ModelScopeDigest, endpoint, credential,
+		prepared.Binding.PolicyDigest, implementation, candidate.ModelScopeDigest,
+		backend.ModelContextWindow, endpoint, credential,
 	)
 	if err != nil {
 		return pipelineOMPActiveProcessConfig{}, err
@@ -262,7 +265,8 @@ func writePipelineOMPActiveModels(runtimeRoot string, active pipelineOMPActivePr
 		}
 		sort.Strings(ids)
 		for _, id := range ids {
-			fmt.Fprintf(&body, "      - id: %s\n        name: Managed Active\n        reasoning: true\n        input: [text]\n        contextWindow: 262144\n        maxTokens: 32768\n", id)
+			fmt.Fprintf(&body, "      - id: %s\n        name: Managed Active\n        reasoning: true\n        input: [text]\n        contextWindow: %d\n        maxTokens: 32768\n",
+				id, active.backend.ModelContextWindow)
 		}
 	}
 	path := filepath.Join(runtimeRoot, "models.yml")

--- a/internal/cli/pipeline_omp_context_active_process.go
+++ b/internal/cli/pipeline_omp_context_active_process.go
@@ -41,7 +41,7 @@ func preparePipelineOMPActiveProcessConfig(
 	endpointRaw, endpointFound := pipelineOMPEnvironmentValue(backend.Environment, pipelineOMPActiveEndpointKey)
 	credential, credentialFound := pipelineOMPEnvironmentValue(backend.Environment, pipelineOMPActiveCredentialKey)
 	endpoint, err := validatePipelineOMPActiveEndpoint(endpointRaw)
-	if !endpointFound || !credentialFound || err != nil || credential == "" || strings.ContainsRune(credential, 0) {
+	if !endpointFound || !credentialFound || err != nil {
 		return pipelineOMPActiveProcessConfig{}, errors.New("pipeline: managed active broker authority is unavailable")
 	}
 	nonce, err := newWorkflowContextRunNonceHash()
@@ -49,6 +49,12 @@ func preparePipelineOMPActiveProcessConfig(
 		return pipelineOMPActiveProcessConfig{}, err
 	}
 	implementation := pipelineOMPActiveImplementationDigest()
+	providerAuthority, err := pipelineOMPActiveProviderAuthorityDigest(
+		prepared.Binding.PolicyDigest, implementation, candidate.ModelScopeDigest, endpoint, credential,
+	)
+	if err != nil {
+		return pipelineOMPActiveProcessConfig{}, err
+	}
 	return pipelineOMPActiveProcessConfig{
 		backend: backend, candidate: candidate, prepared: prepared, endpoint: endpoint, credential: credential,
 		binding: WorkflowContextBridgeBinding{
@@ -56,11 +62,9 @@ func preparePipelineOMPActiveProcessConfig(
 			BindingHash: workflowContextRuntimeHash(strings.Join([]string{
 				prepared.Binding.GrantDigest, prepared.Binding.WorkspaceID, prepared.Binding.SpecID,
 				prepared.Binding.GitCommitHash, prepared.Binding.AutoSourceCommit, prepared.Binding.AutoSourceTree,
-				candidate.ScopeProvider, candidate.ModelScopeDigest, endpoint,
+				candidate.ScopeProvider, candidate.ModelScopeDigest, providerAuthority,
 			}, "\x00")),
-			OptionsHash: workflowContextRuntimeHash(strings.Join([]string{
-				prepared.Binding.PolicyDigest, implementation, candidate.ModelScopeDigest, endpoint,
-			}, "\x00")),
+			OptionsHash: providerAuthority,
 			SessionHash: workflowContextRuntimeHash(prepared.Binding.WorkspaceID + "\x00" + prepared.Binding.SpecID + "\x00" + prepared.Binding.GitCommitHash),
 			NonceHash:   nonce,
 		},

--- a/internal/cli/pipeline_omp_context_active_rpc.go
+++ b/internal/cli/pipeline_omp_context_active_rpc.go
@@ -116,17 +116,22 @@ func (session *pipelineOMPActiveRPCSession) Execute(
 		}
 		return prompt, nil
 	}
+	compactBefore := session.sequence > 0
 	output, receipt, err := session.protocol.executeManaged(
-		ctx, selector, session.binding, session.sessionID, true, preparePrompt,
+		ctx, selector, session.binding, session.sessionID, compactBefore, preparePrompt,
 	)
 	if err != nil {
 		_ = session.closeLocked()
 		return "", err
 	}
 	receipt.ContextBindingHash = prepared.Binding.BindingHash
-	if receipt.CompactionCycles != 1 || receipt.PreCompactionACKs != 1 ||
-		receipt.PostCompactionACKs != 1 || receipt.CanonicalReadmissions != 1 ||
-		receipt.EphemeralReadmissions != 1 ||
+	expectedCompactions := receipt.CompactionCycles
+	if expectedCompactions < 0 || expectedCompactions > 1 ||
+		!compactBefore && expectedCompactions != 0 ||
+		receipt.PreCompactionACKs != expectedCompactions ||
+		receipt.PostCompactionACKs != expectedCompactions ||
+		receipt.CanonicalReadmissions != expectedCompactions ||
+		receipt.EphemeralReadmissions != expectedCompactions ||
 		receipt.SessionBindingHash != workflowContextRuntimeHash(session.sessionID+"\x00"+session.binding.NonceHash) ||
 		receipt.ContextBindingHash == "" || !receipt.SameProcess || !receipt.SameSession || !receipt.TerminalIdle {
 		_ = session.closeLocked()
@@ -161,9 +166,9 @@ func (session *pipelineOMPActiveRPCSession) closeLocked() error {
 	if session.closed {
 		return nil
 	}
-	session.closed = true
 	var evidenceErr error
-	if session.sequence > 0 && session.compactions != 0 && session.compactions != session.sequence {
+	maxCompactions := max(session.sequence-1, 0)
+	if session.compactions < 0 || session.compactions > maxCompactions {
 		evidenceErr = errors.New("pipeline: managed active multi-compaction session gate failed")
 	}
 	if session.process == nil {

--- a/internal/cli/pipeline_omp_context_active_rpc_execute.go
+++ b/internal/cli/pipeline_omp_context_active_rpc_execute.go
@@ -41,31 +41,25 @@ func (protocol *pipelineOMPRPCProtocol) executeManaged(
 		preparedPrompt, promptReady = body, true
 		return preparedPrompt, nil
 	}
-	maintenanceInput, maintenanceOutput := int64(0), int64(0)
-	maintenanceTotal := int64(0)
+	compactionPerformed := false
 	if compactBefore {
-		beforeMaintenance, statsErr := protocol.sessionStats(ctx, expectedSession)
-		if statsErr != nil {
-			return "", pipelineOMPActiveCallReceipt{}, statsErr
-		}
-		if err := protocol.manualCompact(ctx, binding, expectedSession, rehydrate); err != nil {
+		compactionPerformed, err = protocol.manualCompact(ctx, binding, expectedSession, rehydrate)
+		if err != nil {
 			return "", pipelineOMPActiveCallReceipt{}, err
 		}
-		if !promptReady || rehydrationCalls != 1 {
+		if compactionPerformed && (!promptReady || rehydrationCalls != 1) {
 			return "", pipelineOMPActiveCallReceipt{}, errors.New("managed active OMP post-compaction re-admission is incomplete")
 		}
-		afterMaintenance, statsErr := protocol.sessionStats(ctx, expectedSession)
-		if statsErr != nil || afterMaintenance.Input < beforeMaintenance.Input ||
-			afterMaintenance.Output < beforeMaintenance.Output || afterMaintenance.Total < beforeMaintenance.Total {
-			return "", pipelineOMPActiveCallReceipt{}, errors.New("managed active OMP maintenance usage is not monotonic")
-		}
-		maintenanceInput = afterMaintenance.Input - beforeMaintenance.Input
-		maintenanceOutput = afterMaintenance.Output - beforeMaintenance.Output
-		maintenanceTotal = afterMaintenance.Total - beforeMaintenance.Total
+		// get_session_stats aggregates the rewritten active history, not cumulative
+		// provider billing. Its totals may decrease after a successful compaction.
 	}
 	prompt, err := rehydrate()
 	if err != nil {
 		return "", pipelineOMPActiveCallReceipt{}, err
+	}
+	beforePromptState, err := protocol.readIdleState(ctx, "managed-pre-provider")
+	if err != nil || beforePromptState.SessionID != expectedSession {
+		return "", pipelineOMPActiveCallReceipt{}, errors.New("managed active OMP pre-provider session changed")
 	}
 	beforeStats, err := protocol.sessionStats(ctx, expectedSession)
 	if err != nil {
@@ -76,7 +70,7 @@ func (protocol *pipelineOMPRPCProtocol) executeManaged(
 		return "", pipelineOMPActiveCallReceipt{}, err
 	}
 	afterState, err := protocol.readIdleState(ctx, "managed-post-prompt")
-	if err != nil || afterState.SessionID != expectedSession || *afterState.MessageCount <= *beforeState.MessageCount {
+	if err != nil || afterState.SessionID != expectedSession || *afterState.MessageCount <= *beforePromptState.MessageCount {
 		return "", pipelineOMPActiveCallReceipt{}, errors.New("managed active OMP primary did not settle in the same session")
 	}
 	afterStats, err := protocol.sessionStats(ctx, expectedSession)
@@ -107,13 +101,12 @@ func (protocol *pipelineOMPRPCProtocol) executeManaged(
 	}
 	return output.Text, pipelineOMPActiveCallReceipt{
 		SessionID: expectedSession, InputTokens: inputDelta, OutputTokens: outputDelta,
-		MaintenanceInputTokens: maintenanceInput, MaintenanceOutputTokens: maintenanceOutput,
-		TotalTokens:           totalDelta + maintenanceTotal,
-		CompactionCycles:      boolToPipelineOMPCount(compactBefore),
-		PreCompactionACKs:     boolToPipelineOMPCount(compactBefore),
-		PostCompactionACKs:    boolToPipelineOMPCount(compactBefore),
-		CanonicalReadmissions: boolToPipelineOMPCount(compactBefore),
-		EphemeralReadmissions: boolToPipelineOMPCount(compactBefore),
+		TotalTokens:           totalDelta,
+		CompactionCycles:      boolToPipelineOMPCount(compactionPerformed),
+		PreCompactionACKs:     boolToPipelineOMPCount(compactionPerformed),
+		PostCompactionACKs:    boolToPipelineOMPCount(compactionPerformed),
+		CanonicalReadmissions: boolToPipelineOMPCount(compactionPerformed),
+		EphemeralReadmissions: boolToPipelineOMPCount(compactionPerformed),
 		SameProcess:           true, SameSession: true, TerminalIdle: true,
 		BridgeBindingHash:  binding.BindingHash,
 		SessionBindingHash: workflowContextRuntimeHash(expectedSession + "\x00" + binding.NonceHash),

--- a/internal/cli/pipeline_omp_context_active_rpc_integration_test.go
+++ b/internal/cli/pipeline_omp_context_active_rpc_integration_test.go
@@ -156,7 +156,8 @@ func pipelineOMPActiveRPCSessionFixtureWithSandbox(
 	)
 	require.NoError(t, err)
 	prepared := pipelineOMPManagedActivePrepared{Binding: pipelineOMPActiveLeaseBinding{
-		GrantDigest: workflowContextRuntimeHash("grant"), WorkspaceID: "autopus-adk",
+		GrantDigest:  workflowContextRuntimeHash("grant"),
+		PolicyDigest: workflowContextRuntimeHash("active-rpc-policy"), WorkspaceID: "autopus-adk",
 		SpecID: config.SpecID, GitCommitHash: config.GitCommitHash,
 		ModelScopeDigest: candidate.ModelScopeDigest,
 	}}
@@ -195,7 +196,7 @@ func runPipelineOMPActiveRPCFixture() int {
 	logEncoder, output := json.NewEncoder(logFile), json.NewEncoder(os.Stdout)
 	_ = logEncoder.Encode(pipelineOMPRPCRecord{Kind: "start", PID: os.Getpid(), Args: os.Args})
 	_ = output.Encode(map[string]any{"type": "ready"})
-	messageCount, promptCount := 0, 0
+	messageCount, promptCount, compactionCount := 0, 0, 0
 	inputTokens, outputTokens := int64(0), int64(0)
 	transcript := []json.RawMessage{json.RawMessage(`{"role":"system","content":"safe system context"}`)}
 	scanner := bufio.NewScanner(os.Stdin)
@@ -205,7 +206,7 @@ func runPipelineOMPActiveRPCFixture() int {
 			return 82
 		}
 		_ = logEncoder.Encode(pipelineOMPRPCRecord{
-			Kind: "command", ID: command.ID, Type: command.Type, Enabled: command.Enabled,
+			Kind: "command", PID: os.Getpid(), ID: command.ID, Type: command.Type, Enabled: command.Enabled,
 			Provider: command.Provider, ModelID: command.ModelID, Message: command.Message,
 			Protocol: command.ProtocolVersion,
 		})
@@ -225,7 +226,11 @@ func runPipelineOMPActiveRPCFixture() int {
 			})
 		case "prompt":
 			promptCount++
-			inputTokens += int64(100 - promptCount*10)
+			inputDelta := int64(100)
+			if compactionCount > 0 {
+				inputDelta = 40
+			}
+			inputTokens += inputDelta
 			outputTokens += 10
 			messageCount += 2
 			assistant := fmt.Sprintf("safe assistant output %d", promptCount)
@@ -252,6 +257,7 @@ func runPipelineOMPActiveRPCFixture() int {
 				Messages: transcript, TotalMessages: len(transcript), NextCursor: nil,
 			})
 		case "compact":
+			compactionCount++
 			inputTokens += 20
 			outputTokens += 5
 			writePipelineOMPActiveCompaction(output, command)

--- a/internal/cli/pipeline_omp_context_active_rpc_integration_test.go
+++ b/internal/cli/pipeline_omp_context_active_rpc_integration_test.go
@@ -29,25 +29,44 @@ func TestPipelineOMPActiveRPC_ReusesOneSessionAcrossManualCompaction(t *testing.
 	assert.Equal(t, "safe assistant output 1", first)
 	assert.Equal(t, "safe assistant output 2", second)
 	assert.Equal(t, firstReceipt.SessionID, secondReceipt.SessionID)
-	assert.Equal(t, 1, firstReceipt.CompactionCycles)
+	assert.Zero(t, firstReceipt.CompactionCycles)
 	assert.Equal(t, 1, secondReceipt.CompactionCycles)
-	assert.Equal(t, 1, firstReceipt.PreCompactionACKs)
-	assert.Equal(t, 1, firstReceipt.PostCompactionACKs)
-	assert.Equal(t, 1, firstReceipt.CanonicalReadmissions)
-	assert.Equal(t, 1, firstReceipt.EphemeralReadmissions)
+	assert.Zero(t, firstReceipt.PreCompactionACKs)
+	assert.Zero(t, firstReceipt.PostCompactionACKs)
+	assert.Zero(t, firstReceipt.CanonicalReadmissions)
+	assert.Zero(t, firstReceipt.EphemeralReadmissions)
 	assert.Equal(t, firstReceipt.SessionBindingHash, secondReceipt.SessionBindingHash)
 	assert.NotEmpty(t, firstReceipt.BridgeBindingHash)
 	assert.True(t, secondReceipt.SameProcess)
 	assert.True(t, secondReceipt.SameSession)
+	assert.Equal(t, int64(40), secondReceipt.InputTokens)
+	assert.Equal(t, int64(10), secondReceipt.OutputTokens)
+	assert.Zero(t, secondReceipt.MaintenanceInputTokens)
+	assert.Zero(t, secondReceipt.MaintenanceOutputTokens)
+	assert.Equal(t, int64(50), secondReceipt.TotalTokens)
 	records := readPipelineOMPRPCRecords(t, logPath)
 	starts, commands := pipelineOMPRPCRecordsByKind(records)
 	require.Len(t, starts, 1)
 	assert.Equal(t, 2, countPipelineOMPRPCCommand(commands, "prompt"))
-	assert.Equal(t, 2, countPipelineOMPRPCCommand(commands, "compact"))
-	assert.Equal(t, 6, countPipelineOMPRPCCommand(commands, "get_messages_page"))
+	assert.Equal(t, 1, countPipelineOMPRPCCommand(commands, "compact"))
+	assert.Equal(t, 4, countPipelineOMPRPCCommand(commands, "get_messages_page"))
 	assertPipelineOMPRPCBooleanCommand(t, commands, "set_auto_compaction", false)
 	require.NoError(t, session.Close())
 	assertPipelineOMPRuntimeEmpty(t, config.RuntimeBase)
+}
+
+func TestPipelineOMPActiveRPC_AcceptsLegacyManualCompactionLifecycle(t *testing.T) {
+	t.Setenv("AUTOPUS_TEST_OMP_ACTIVE_LEGACY_COMPACTION", "1")
+	session, _, _ := pipelineOMPActiveRPCSessionFixture(t, false)
+	t.Cleanup(func() { require.NoError(t, session.Close()) })
+
+	_, firstReceipt, err := session.Execute(context.Background(), "safe plan phase")
+	require.NoError(t, err)
+	_, secondReceipt, err := session.Execute(context.Background(), "safe implementation phase")
+
+	require.NoError(t, err)
+	assert.Zero(t, firstReceipt.CompactionCycles)
+	assert.Equal(t, 1, secondReceipt.CompactionCycles)
 }
 
 func TestPipelineOMPActiveRPC_UnsafeFirstOutputClosesBeforeSecondProviderCall(t *testing.T) {
@@ -60,8 +79,40 @@ func TestPipelineOMPActiveRPC_UnsafeFirstOutputClosesBeforeSecondProviderCall(t 
 
 	_, commands := pipelineOMPRPCRecordsByKind(readPipelineOMPRPCRecords(t, logPath))
 	assert.Equal(t, 1, countPipelineOMPRPCCommand(commands, "prompt"))
-	assert.Equal(t, 1, countPipelineOMPRPCCommand(commands, "compact"))
+	assert.Zero(t, countPipelineOMPRPCCommand(commands, "compact"))
 }
+
+func TestPipelineOMPActiveRPC_AcceptsProvenEmptyNoopCompaction(t *testing.T) {
+	page, err := json.Marshal(pipelineOMPActiveMessagesPage{
+		Messages: nil, TotalMessages: 0, NextCursor: nil,
+	})
+	require.NoError(t, err)
+	idle, err := json.Marshal(map[string]any{
+		"sessionId": "active-session", "isStreaming": false, "isCompacting": false,
+		"messageCount": 0, "queuedMessageCount": 0, "autoCompactionEnabled": false,
+	})
+	require.NoError(t, err)
+	protocol, _ := pipelineOMPProtocolFixture([]pipelineOMPRPCFrame{
+		{ID: "pipeline-1", Type: "response", Command: "get_messages_page", Success: true, Data: page},
+		{ID: "pipeline-active-compact-2", Type: "response", Command: "compact", Error: pipelineOMPActiveCompactionNoopMessage},
+		{ID: "pipeline-3", Type: "response", Command: "get_messages_page", Success: true, Data: page},
+		{ID: "pipeline-4", Type: "response", Command: "get_state", Success: true, Data: idle},
+	})
+	prepareCalls := 0
+
+	compacted, err := protocol.manualCompact(
+		context.Background(), WorkflowContextBridgeBinding{}, "active-session",
+		func() (string, error) {
+			prepareCalls++
+			return "unused", nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.False(t, compacted)
+	assert.Zero(t, prepareCalls)
+}
+
 func TestPipelineOMPActiveProcessConfig_BindsProviderEndpointWithoutCredentialMaterial(t *testing.T) {
 	config, _ := pipelineOMPBackendTestConfig(t)
 	config.PhaseModels = map[pipeline.PhaseID]string{pipeline.PhasePlan: "provider-a/model-a"}
@@ -197,7 +248,7 @@ func runPipelineOMPActiveRPCFixture() int {
 	_ = logEncoder.Encode(pipelineOMPRPCRecord{Kind: "start", PID: os.Getpid(), Args: os.Args})
 	_ = output.Encode(map[string]any{"type": "ready"})
 	messageCount, promptCount, compactionCount := 0, 0, 0
-	inputTokens, outputTokens := int64(0), int64(0)
+	inputTokens, outputTokens, cacheReadTokens := int64(0), int64(0), int64(0)
 	transcript := []json.RawMessage{json.RawMessage(`{"role":"system","content":"safe system context"}`)}
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
@@ -221,16 +272,17 @@ func runPipelineOMPActiveRPCFixture() int {
 		case "get_session_stats":
 			writePipelineOMPActiveResponse(output, command, map[string]any{
 				"sessionId": "active-session", "tokens": map[string]any{
-					"input": inputTokens, "output": outputTokens, "total": inputTokens + outputTokens,
+					"input": inputTokens, "output": outputTokens, "cacheRead": cacheReadTokens,
+					"cacheWrite": 0, "total": inputTokens + outputTokens + cacheReadTokens,
 				},
 			})
 		case "prompt":
 			promptCount++
-			inputDelta := int64(100)
 			if compactionCount > 0 {
-				inputDelta = 40
+				cacheReadTokens += 40
+			} else {
+				inputTokens += 100
 			}
-			inputTokens += inputDelta
 			outputTokens += 10
 			messageCount += 2
 			assistant := fmt.Sprintf("safe assistant output %d", promptCount)
@@ -258,8 +310,10 @@ func runPipelineOMPActiveRPCFixture() int {
 			})
 		case "compact":
 			compactionCount++
-			inputTokens += 20
-			outputTokens += 5
+			inputTokens = 0
+			outputTokens = 0
+			cacheReadTokens = 0
+			messageCount = 0
 			writePipelineOMPActiveCompaction(output, command)
 		default:
 			writePipelineOMPActiveResponse(output, command, nil)
@@ -285,7 +339,10 @@ func writePipelineOMPActiveCompaction(output *json.Encoder, command pipelineOMPR
 		SessionHash:   os.Getenv("AUTOPUS_OMP_CONTEXT_SESSION_HASH"),
 		NonceHash:     os.Getenv("AUTOPUS_OMP_CONTEXT_NONCE_HASH"),
 	}
-	_ = output.Encode(map[string]any{"type": "auto_compaction_start", "reason": "manual", "action": "snapcompact"})
+	legacyLifecycle := os.Getenv("AUTOPUS_TEST_OMP_ACTIVE_LEGACY_COMPACTION") == "1"
+	if legacyLifecycle {
+		_ = output.Encode(map[string]any{"type": "auto_compaction_start", "reason": "manual", "action": "snapcompact"})
+	}
 	for index, event := range []string{WorkflowContextEventPreCompaction, WorkflowContextEventPostCompaction} {
 		envelope, _ := json.Marshal(workflowContextManagedBridgeEnvelope{
 			SchemaVersion: binding.SchemaVersion, Event: event, BindingHash: binding.BindingHash,
@@ -297,9 +354,11 @@ func writePipelineOMPActiveCompaction(output *json.Encoder, command pipelineOMPR
 			"title": "Autopus context " + event, "message": json.RawMessage(message),
 		})
 	}
-	writePipelineOMPActiveResponse(output, command, map[string]any{})
-	_ = output.Encode(map[string]any{
-		"type": "auto_compaction_end", "reason": "manual", "action": "snapcompact",
-		"result": map[string]any{"summary": "safe compacted context"},
-	})
+	writePipelineOMPActiveResponse(output, command, map[string]any{"summary": "safe compacted context"})
+	if legacyLifecycle {
+		_ = output.Encode(map[string]any{
+			"type": "auto_compaction_end", "reason": "manual", "action": "snapcompact",
+			"result": map[string]any{"summary": "safe compacted context"},
+		})
+	}
 }

--- a/internal/cli/pipeline_omp_context_active_test.go
+++ b/internal/cli/pipeline_omp_context_active_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
@@ -153,6 +154,24 @@ func TestPipelineOMPMaxTimeSeconds_UsesPositiveWholeSeconds(t *testing.T) {
 			assert.Equal(t, test.want, pipelineOMPMaxTimeSeconds(test.maxTime))
 		})
 	}
+}
+
+func TestWritePipelineOMPActiveModels_BindsConfiguredContextWindow(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	active := pipelineOMPActiveProcessConfig{
+		backend: pipelineOMPBackendConfig{
+			PhaseModels:        map[pipeline.PhaseID]string{pipeline.PhaseImplement: "openai/model-a"},
+			ModelContextWindow: 1_000_000,
+		},
+		endpoint: "http://127.0.0.1:43123",
+	}
+
+	require.NoError(t, writePipelineOMPActiveModels(root, active))
+	body, err := os.ReadFile(filepath.Join(root, "models.yml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "contextWindow: 1000000")
+	assert.NotContains(t, string(body), "contextWindow: 262144")
 }
 
 func TestConfigurePipelineOMPActiveSandbox_InheritedParentSkipsInnerWrapperOnDarwin(t *testing.T) {

--- a/internal/cli/pipeline_omp_context_active_transcript.go
+++ b/internal/cli/pipeline_omp_context_active_transcript.go
@@ -82,7 +82,7 @@ func (protocol *pipelineOMPRPCProtocol) validatePipelineOMPActiveTranscript(
 		seenCursors[*page.NextCursor] = struct{}{}
 		cursor = *page.NextCursor
 	}
-	if count == 0 || count != expectedTotal {
+	if count != expectedTotal {
 		return "", nil, errors.New("managed active OMP transcript page count is incomplete")
 	}
 	return pipelineOMPActiveHash(all), newImages, nil

--- a/internal/cli/pipeline_omp_context_active_transcript_test.go
+++ b/internal/cli/pipeline_omp_context_active_transcript_test.go
@@ -43,6 +43,16 @@ func TestPipelineOMPActiveTranscript_AcceptsExactSanitizedPage(t *testing.T) {
 	assert.Empty(t, images)
 }
 
+func TestPipelineOMPActiveTranscript_AcceptsEmptyFreshSession(t *testing.T) {
+	protocol := pipelineOMPActiveTranscriptFixture(t, nil)
+
+	proof, images, err := protocol.validatePipelineOMPActiveTranscript(context.Background(), false)
+
+	require.NoError(t, err)
+	assert.True(t, validPipelineOMPActiveHash(proof))
+	assert.Empty(t, images)
+}
+
 func pipelineOMPActiveTranscriptFixture(
 	t *testing.T,
 	messages []json.RawMessage,

--- a/internal/cli/pipeline_omp_context_active_usage.go
+++ b/internal/cli/pipeline_omp_context_active_usage.go
@@ -16,9 +16,11 @@ func boolToPipelineOMPCount(value bool) int {
 type pipelineOMPActiveSessionStats struct {
 	SessionID string `json:"sessionId"`
 	Tokens    struct {
-		Input  int64 `json:"input"`
-		Output int64 `json:"output"`
-		Total  int64 `json:"total"`
+		Input      int64 `json:"input"`
+		Output     int64 `json:"output"`
+		CacheRead  int64 `json:"cacheRead"`
+		CacheWrite int64 `json:"cacheWrite"`
+		Total      int64 `json:"total"`
 	} `json:"tokens"`
 }
 
@@ -37,9 +39,20 @@ func (protocol *pipelineOMPRPCProtocol) sessionStats(
 		return pipelineOMPActiveUsage{}, err
 	}
 	var stats pipelineOMPActiveSessionStats
-	if json.Unmarshal(data, &stats) != nil || stats.SessionID != expectedSession || stats.Tokens.Input < 0 ||
-		stats.Tokens.Output < 0 || stats.Tokens.Total < 0 || stats.Tokens.Total < stats.Tokens.Input+stats.Tokens.Output {
+	if json.Unmarshal(data, &stats) != nil || stats.SessionID != expectedSession {
 		return pipelineOMPActiveUsage{}, errors.New("managed active OMP session stats are invalid")
 	}
-	return pipelineOMPActiveUsage{Input: stats.Tokens.Input, Output: stats.Tokens.Output, Total: stats.Tokens.Total}, nil
+	tokens := stats.Tokens
+	effectiveInput := tokens.Input + tokens.CacheRead
+	if tokens.Input < 0 || tokens.Output < 0 || tokens.CacheRead < 0 || tokens.CacheWrite < 0 ||
+		tokens.Total < 0 || effectiveInput < tokens.Input {
+		return pipelineOMPActiveUsage{}, errors.New("managed active OMP session stats are invalid")
+	}
+	effectiveInputWithWrite := effectiveInput + tokens.CacheWrite
+	minimumTotal := effectiveInputWithWrite + tokens.Output
+	if effectiveInputWithWrite < effectiveInput || minimumTotal < effectiveInputWithWrite ||
+		tokens.Total < minimumTotal {
+		return pipelineOMPActiveUsage{}, errors.New("managed active OMP session stats are invalid")
+	}
+	return pipelineOMPActiveUsage{Input: effectiveInputWithWrite, Output: tokens.Output, Total: tokens.Total}, nil
 }

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -15,10 +15,12 @@ import (
 
 // pipelineRunConfig holds parsed flag values for the pipeline run command.
 type pipelineRunConfig struct {
-	Platform string
-	Strategy string
-	Continue bool
-	DryRun   bool
+	Platform               string
+	Strategy               string
+	ExecutionOwner         string
+	executionOwnerExplicit bool
+	Continue               bool
+	DryRun                 bool
 }
 
 // newPipelineRunCmd creates the `auto pipeline run <spec-id>` subcommand.
@@ -31,8 +33,9 @@ func newPipelineRunCmd() *cobra.Command {
 // given config pointer, allowing tests to inspect parsed flag values.
 func newPipelineRunCmdWithConfig(cfg *pipelineRunConfig) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "run <spec-id>",
-		Short: "Execute a full pipeline for a SPEC",
+		Use:          "run <spec-id>",
+		Short:        "Execute a full pipeline for a SPEC",
+		SilenceUsage: true,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return fmt.Errorf("spec-id argument is required: auto pipeline run <spec-id>")
@@ -49,6 +52,11 @@ func newPipelineRunCmdWithConfig(cfg *pipelineRunConfig) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&cfg.Platform, "platform", "", "AI platform to use (claude, codex, gemini, omp). Auto-detected when omitted.")
+	cmd.Flags().Var(
+		newExecutionOwnerValue(&cfg.ExecutionOwner, &cfg.executionOwnerExplicit),
+		"execution-owner",
+		"OMP DAG owner: exact value omp or orca. Defaults to omp.",
+	)
 	// @AX:NOTE [AUTO]: magic constant — default strategy "sequential" encodes execution policy; change with care
 	cmd.Flags().Var(newStrategyValue("sequential", &cfg.Strategy), "strategy", "Execution strategy: sequential.")
 	cmd.Flags().BoolVar(&cfg.Continue, "continue", false, "Resume from the last saved checkpoint.")
@@ -115,6 +123,10 @@ func runPipeline(cmd *cobra.Command, specID string, cfg *pipelineRunConfig) erro
 	if err := pipeline.ValidateSpecID(specID); err != nil {
 		return err
 	}
+	ownerDecision, err := resolvePipelineExecutionOwner(cfg)
+	if err != nil {
+		return err
+	}
 	gitHash, _ := getCurrentGitHash()
 	requestedStrategy := pipeline.Strategy(cfg.Strategy)
 	resolvedSpec, err := resolvePipelineSpec(specID)
@@ -132,6 +144,17 @@ func runPipeline(cmd *cobra.Command, specID string, cfg *pipelineRunConfig) erro
 			fmt.Errorf("pipeline: resolve project directory: %w", err))
 	}
 	projectDir = filepath.Clean(projectDir)
+	if platform == "omp" {
+		ownerReceipt, ownerReceiptPath, receiptErr := persistPipelineExecutionOwnerReceipt(
+			specID, ownerDecision,
+		)
+		if receiptErr != nil {
+			return receiptErr
+		}
+		if ownerDecision.Owner == pipelineExecutionOwnerOrca {
+			return emitPipelineExecutionOwnerHandoff(cmd, ownerReceipt, ownerReceiptPath)
+		}
+	}
 
 	cp, err := LoadCheckpointIfContinue(specID, cfg.Continue)
 	if err != nil {

--- a/internal/cli/pipeline_run_owner.go
+++ b/internal/cli/pipeline_run_owner.go
@@ -1,0 +1,170 @@
+package cli
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	pipelineExecutionOwnerOMP            = "omp"
+	pipelineExecutionOwnerOrca           = "orca"
+	pipelineExecutionOwnerSourceDefault  = "default"
+	pipelineExecutionOwnerSourceExplicit = "explicit"
+	pipelineExecutionOwnerReceiptSchema  = "pipeline_execution_owner_receipt.v1"
+	pipelineExecutionOwnerResultSchema   = "pipeline_execution_owner_result.v1"
+)
+
+var errPipelineExecutionOwnerHandoffRequired = errors.New(
+	"pipeline: execution owner orca requires a supervised Orca orchestration handoff",
+)
+
+type executionOwnerValue struct {
+	value    *string
+	explicit *bool
+}
+
+func newExecutionOwnerValue(value *string, explicit *bool) *executionOwnerValue {
+	*value = pipelineExecutionOwnerOMP
+	*explicit = false
+	return &executionOwnerValue{value: value, explicit: explicit}
+}
+
+func (v *executionOwnerValue) String() string { return *v.value }
+
+func (v *executionOwnerValue) Type() string { return "execution-owner" }
+
+func (v *executionOwnerValue) Set(owner string) error {
+	if *v.explicit {
+		return errors.New("--execution-owner must be specified exactly once")
+	}
+	if owner != pipelineExecutionOwnerOMP && owner != pipelineExecutionOwnerOrca {
+		return fmt.Errorf("invalid execution owner %q: must be exactly omp or orca", owner)
+	}
+	*v.value = owner
+	*v.explicit = true
+	return nil
+}
+
+type pipelineExecutionOwnerDecision struct {
+	Owner  string
+	Source string
+	Reason string
+}
+
+func resolvePipelineExecutionOwner(cfg *pipelineRunConfig) (pipelineExecutionOwnerDecision, error) {
+	if cfg == nil {
+		return pipelineExecutionOwnerDecision{}, errors.New("pipeline: execution owner config is required")
+	}
+	owner := cfg.ExecutionOwner
+	if owner == "" {
+		owner = pipelineExecutionOwnerOMP
+	}
+	if owner != pipelineExecutionOwnerOMP && owner != pipelineExecutionOwnerOrca {
+		return pipelineExecutionOwnerDecision{}, fmt.Errorf(
+			"invalid execution owner %q: must be exactly omp or orca", owner,
+		)
+	}
+	if owner == pipelineExecutionOwnerOrca && !cfg.executionOwnerExplicit {
+		return pipelineExecutionOwnerDecision{}, errors.New(
+			"pipeline: execution owner orca must be selected explicitly",
+		)
+	}
+	source := pipelineExecutionOwnerSourceDefault
+	if cfg.executionOwnerExplicit {
+		if cfg.Platform != "omp" {
+			return pipelineExecutionOwnerDecision{}, errors.New(
+				"pipeline: --execution-owner requires exact --platform omp",
+			)
+		}
+		source = pipelineExecutionOwnerSourceExplicit
+	}
+	reason := "native_omp_dag_selected"
+	if owner == pipelineExecutionOwnerOrca {
+		reason = "supervised_durable_cross_worktree_run_selected"
+	}
+	return pipelineExecutionOwnerDecision{Owner: owner, Source: source, Reason: reason}, nil
+}
+
+type pipelineExecutionOwnerReceipt struct {
+	Schema             string    `json:"schema"`
+	Owner              string    `json:"owner"`
+	Source             string    `json:"source"`
+	Reason             string    `json:"reason"`
+	SpecID             string    `json:"spec_id"`
+	RunID              string    `json:"run_id"`
+	CheckedAt          time.Time `json:"checked_at"`
+	VerificationStatus string    `json:"verification_status"`
+}
+
+type pipelineExecutionOwnerResult struct {
+	Schema         string `json:"schema"`
+	Status         string `json:"status"`
+	Owner          string `json:"owner"`
+	Source         string `json:"source"`
+	Reason         string `json:"reason"`
+	SpecID         string `json:"spec_id"`
+	RunID          string `json:"run_id"`
+	ReceiptPath    string `json:"receipt_path"`
+	RequiredAction string `json:"required_action"`
+}
+
+func persistPipelineExecutionOwnerReceipt(
+	specID string,
+	decision pipelineExecutionOwnerDecision,
+) (pipelineExecutionOwnerReceipt, string, error) {
+	receipt := pipelineExecutionOwnerReceipt{
+		Schema: pipelineExecutionOwnerReceiptSchema, Owner: decision.Owner,
+		Source: decision.Source, Reason: decision.Reason, SpecID: specID,
+		RunID: newPipelineExecutionOwnerRunID(), CheckedAt: time.Now().UTC(),
+		VerificationStatus: "verified",
+	}
+	data, err := json.MarshalIndent(receipt, "", "  ")
+	if err != nil {
+		return pipelineExecutionOwnerReceipt{}, "", fmt.Errorf("encode execution owner receipt: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.MkdirAll(pipelineStateDir, 0o700); err != nil {
+		return pipelineExecutionOwnerReceipt{}, "", fmt.Errorf("create execution owner receipt directory: %w", err)
+	}
+	path := filepath.Join(pipelineStateDir, specID+".execution-owner.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return pipelineExecutionOwnerReceipt{}, "", fmt.Errorf("write execution owner receipt: %w", err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		return pipelineExecutionOwnerReceipt{}, "", fmt.Errorf("secure execution owner receipt: %w", err)
+	}
+	return receipt, filepath.ToSlash(path), nil
+}
+
+func newPipelineExecutionOwnerRunID() string {
+	var value [8]byte
+	if _, err := rand.Read(value[:]); err == nil {
+		return "pipeline-owner-" + hex.EncodeToString(value[:])
+	}
+	return fmt.Sprintf("pipeline-owner-%d", time.Now().UTC().UnixNano())
+}
+
+func emitPipelineExecutionOwnerHandoff(
+	cmd *cobra.Command,
+	receipt pipelineExecutionOwnerReceipt,
+	receiptPath string,
+) error {
+	result := pipelineExecutionOwnerResult{
+		Schema: pipelineExecutionOwnerResultSchema, Status: "handoff_required",
+		Owner: receipt.Owner, Source: receipt.Source, Reason: receipt.Reason,
+		SpecID: receipt.SpecID, RunID: receipt.RunID, ReceiptPath: receiptPath,
+		RequiredAction: "orca skills get orchestration --full",
+	}
+	if err := json.NewEncoder(cmd.OutOrStdout()).Encode(result); err != nil {
+		return fmt.Errorf("encode execution owner handoff result: %w", err)
+	}
+	return &jsonFatalError{cause: errPipelineExecutionOwnerHandoffRequired}
+}

--- a/internal/cli/pipeline_run_owner_test.go
+++ b/internal/cli/pipeline_run_owner_test.go
@@ -1,0 +1,259 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPipelineRunCmd_ExecutionOwnerAcceptsOnlyExactSingleValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []string
+		want   string
+	}{
+		{name: "default", want: pipelineExecutionOwnerOMP},
+		{name: "explicit omp", values: []string{"omp"}, want: pipelineExecutionOwnerOMP},
+		{name: "explicit orca", values: []string{"orca"}, want: pipelineExecutionOwnerOrca},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := &pipelineRunConfig{}
+			cmd := newPipelineRunCmdWithConfig(cfg)
+			args := []string{"SPEC-OWNER-001", "--platform", "omp"}
+			for _, value := range test.values {
+				args = append(args, "--execution-owner", value)
+			}
+
+			require.NoError(t, cmd.ParseFlags(args))
+			assert.Equal(t, test.want, cfg.ExecutionOwner)
+			assert.Equal(t, len(test.values) == 1, cfg.executionOwnerExplicit)
+		})
+	}
+
+	for _, value := range []string{"OMP", "Orca", "omp,orca", "omp ", "local", "supervised"} {
+		t.Run("reject "+value, func(t *testing.T) {
+			cmd := newPipelineRunCmdWithConfig(&pipelineRunConfig{})
+			err := cmd.ParseFlags([]string{
+				"SPEC-OWNER-001", "--platform", "omp", "--execution-owner", value,
+			})
+			assert.ErrorContains(t, err, "must be exactly omp or orca")
+		})
+	}
+
+	cmd := newPipelineRunCmdWithConfig(&pipelineRunConfig{})
+	err := cmd.ParseFlags([]string{
+		"SPEC-OWNER-001", "--platform", "omp",
+		"--execution-owner", "omp", "--execution-owner", "orca",
+	})
+	assert.ErrorContains(t, err, "specified exactly once")
+}
+
+func TestPipelineRunCmd_InvalidOrMixedOwnerStopsBeforeFilesystemEffects(t *testing.T) {
+	for _, args := range [][]string{
+		{"SPEC-OWNER-001", "--platform", "omp", "--execution-owner", "omp,orca"},
+		{"SPEC-OWNER-001", "--platform", "omp", "--execution-owner", "omp", "--execution-owner", "orca"},
+	} {
+		t.Run(args[len(args)-1], func(t *testing.T) {
+			root := t.TempDir()
+			chdirForTest(t, root)
+			cmd := newPipelineRunCmd()
+			cmd.SetArgs(args)
+
+			require.Error(t, cmd.Execute())
+			_, err := os.Stat(pipelineStateDir)
+			assert.ErrorIs(t, err, os.ErrNotExist)
+		})
+	}
+}
+
+func TestResolvePipelineExecutionOwner_IsMutuallyExclusiveAndRequiresOMPBoundary(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     pipelineRunConfig
+		owner   string
+		source  string
+		wantErr string
+	}{
+		{
+			name: "default omp", cfg: pipelineRunConfig{Platform: "omp"},
+			owner: pipelineExecutionOwnerOMP, source: pipelineExecutionOwnerSourceDefault,
+		},
+		{
+			name:  "explicit omp",
+			cfg:   pipelineRunConfig{Platform: "omp", ExecutionOwner: "omp", executionOwnerExplicit: true},
+			owner: pipelineExecutionOwnerOMP, source: pipelineExecutionOwnerSourceExplicit,
+		},
+		{
+			name:  "explicit orca",
+			cfg:   pipelineRunConfig{Platform: "omp", ExecutionOwner: "orca", executionOwnerExplicit: true},
+			owner: pipelineExecutionOwnerOrca, source: pipelineExecutionOwnerSourceExplicit,
+		},
+		{
+			name:    "implicit orca rejected",
+			cfg:     pipelineRunConfig{Platform: "omp", ExecutionOwner: "orca"},
+			wantErr: "must be selected explicitly",
+		},
+		{
+			name:    "non OMP boundary rejected",
+			cfg:     pipelineRunConfig{Platform: "codex", ExecutionOwner: "omp", executionOwnerExplicit: true},
+			wantErr: "requires exact --platform omp",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			decision, err := resolvePipelineExecutionOwner(&test.cfg)
+			if test.wantErr != "" {
+				assert.ErrorContains(t, err, test.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.owner, decision.Owner)
+			assert.Equal(t, test.source, decision.Source)
+			assert.NotEmpty(t, decision.Reason)
+			assert.NotEqual(t, decision.Owner == pipelineExecutionOwnerOMP,
+				decision.Owner == pipelineExecutionOwnerOrca,
+				"exactly one execution owner must be selected")
+		})
+	}
+}
+
+func TestPipelineRun_OrcaOwnerEmitsHandoffBeforeOMPProcess(t *testing.T) {
+	root := t.TempDir()
+	chdirForTest(t, root)
+	specID := "SPEC-OWNER-ORCA-001"
+	writePipelineOwnerSpec(t, root, specID)
+	marker := installPipelineOwnerProcessTrap(t, root, "omp")
+
+	var stdout bytes.Buffer
+	cmd := newPipelineRunCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		specID, "--platform", "omp", "--execution-owner", "orca",
+	})
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errPipelineExecutionOwnerHandoffRequired)
+	assert.True(t, isJSONFatalError(err), "structured handoff must not add an unstructured stderr error")
+	assert.NoFileExists(t, marker, "Orca ownership must fail closed before starting OMP")
+	assert.NoFileExists(t, specCheckpointPath(specID), "handoff must not create an OMP checkpoint")
+
+	var result pipelineExecutionOwnerResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result), "stdout=%q err=%v", stdout.String(), err)
+	assert.Equal(t, pipelineExecutionOwnerResultSchema, result.Schema)
+	assert.Equal(t, "handoff_required", result.Status)
+	assert.Equal(t, pipelineExecutionOwnerOrca, result.Owner)
+	assert.Equal(t, pipelineExecutionOwnerSourceExplicit, result.Source)
+	assert.Equal(t, specID, result.SpecID)
+	assert.NotEmpty(t, result.RunID)
+	assert.Equal(t, "orca skills get orchestration --full", result.RequiredAction)
+
+	receiptBytes, readErr := os.ReadFile(filepath.FromSlash(result.ReceiptPath))
+	require.NoError(t, readErr)
+	var receipt pipelineExecutionOwnerReceipt
+	require.NoError(t, json.Unmarshal(receiptBytes, &receipt))
+	assert.Equal(t, result.RunID, receipt.RunID)
+	assert.Equal(t, "verified", receipt.VerificationStatus)
+	assertPipelineExecutionOwnerReceiptIsBodyFree(t, receiptBytes)
+	if runtime.GOOS != "windows" {
+		info, statErr := os.Stat(filepath.FromSlash(result.ReceiptPath))
+		require.NoError(t, statErr)
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	}
+}
+
+func TestPipelineRun_OMPOwnerPreservesDryRunForDefaultAndExplicitSelection(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		flag   []string
+		source string
+	}{
+		{name: "default", source: pipelineExecutionOwnerSourceDefault},
+		{name: "explicit", flag: []string{"--execution-owner", "omp"}, source: pipelineExecutionOwnerSourceExplicit},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			chdirForTest(t, root)
+			specID := "SPEC-OWNER-OMP-001"
+			writePipelineOwnerSpec(t, root, specID)
+			orcaMarker := installPipelineOwnerProcessTrap(t, root, "orca")
+			var stdout bytes.Buffer
+			cmd := newPipelineRunCmd()
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&bytes.Buffer{})
+			args := []string{specID, "--platform", "omp", "--dry-run"}
+			args = append(args, test.flag...)
+			cmd.SetArgs(args)
+
+			require.NoError(t, cmd.Execute())
+			assert.Contains(t, stdout.String(), "Pipeline complete: 5 phases executed")
+			assert.NoFileExists(t, orcaMarker, "OMP ownership must not create an Orca Run")
+			var receipt pipelineExecutionOwnerReceipt
+			body, err := os.ReadFile(filepath.Join(pipelineStateDir, specID+".execution-owner.json"))
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &receipt))
+			assert.Equal(t, pipelineExecutionOwnerOMP, receipt.Owner)
+			assert.Equal(t, test.source, receipt.Source)
+			assert.Equal(t, specID, receipt.SpecID)
+			assert.NotEmpty(t, receipt.RunID)
+			assert.False(t, receipt.CheckedAt.IsZero())
+			assertPipelineExecutionOwnerReceiptIsBodyFree(t, body)
+		})
+	}
+}
+
+func assertPipelineExecutionOwnerReceiptIsBodyFree(t *testing.T, body []byte) {
+	t.Helper()
+	var fields map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(body, &fields))
+	assert.ElementsMatch(t, []string{
+		"schema", "owner", "source", "reason", "spec_id", "run_id", "checked_at", "verification_status",
+	}, mapKeys(fields))
+	for _, forbidden := range []string{"body", "prompt", "output", "task_body", "spec_body"} {
+		assert.NotContains(t, fields, forbidden)
+	}
+}
+
+func writePipelineOwnerSpec(t *testing.T, root, specID string) {
+	t.Helper()
+	dir := filepath.Join(root, ".autopus", "specs", specID)
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	for name, body := range map[string]string{
+		"spec.md":       "# " + specID + ": execution owner contract\n",
+		"plan.md":       "# Plan\nPreserve one execution owner.\n",
+		"acceptance.md": "# Acceptance\nExactly one owner is active.\n",
+	} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600))
+	}
+}
+
+func installPipelineOwnerProcessTrap(t *testing.T, root, name string) string {
+	t.Helper()
+	marker := filepath.Join(root, name+"-started")
+	if runtime.GOOS == "windows" {
+		return marker
+	}
+	binDir := filepath.Join(root, "bin-"+name)
+	require.NoError(t, os.MkdirAll(binDir, 0o700))
+	script := "#!/bin/sh\nprintf started > \"" + marker + "\"\nexit 97\n"
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, name), []byte(script), 0o700))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return marker
+}
+
+func mapKeys[V any](values map[string]V) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	return keys
+}

--- a/internal/cli/platform.go
+++ b/internal/cli/platform.go
@@ -32,6 +32,7 @@ func newPlatformCmd() *cobra.Command {
 	cmd.AddCommand(newPlatformListCmd(&dir))
 	cmd.AddCommand(newPlatformAddCmd(&dir))
 	cmd.AddCommand(newPlatformRemoveCmd(&dir))
+	cmd.AddCommand(newPlatformOMPCmd(&dir))
 
 	return cmd
 }

--- a/internal/cli/platform_omp.go
+++ b/internal/cli/platform_omp.go
@@ -1,0 +1,187 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/insajin/autopus-adk/pkg/adapter/omp"
+	"github.com/insajin/autopus-adk/pkg/config"
+)
+
+type ompPlatformDependencies struct {
+	newRunner func() omp.OMPModelCatalogRunner
+	activate  func(context.Context, string, *config.HarnessConfig) error
+	now       func() time.Time
+}
+
+func defaultOMPPlatformDependencies() ompPlatformDependencies {
+	return ompPlatformDependencies{
+		newRunner: func() omp.OMPModelCatalogRunner { return newOMPOperatorExecRunner() },
+		activate: func(ctx context.Context, root string, cfg *config.HarnessConfig) error {
+			recognized, err := updateHarnessPlatform(ctx, root, "omp", cfg)
+			if !recognized && err == nil {
+				return fmt.Errorf("OMP update path is unavailable")
+			}
+			return err
+		},
+		now: func() time.Time { return time.Now().UTC() },
+	}
+}
+
+func normalizeOMPPlatformDependencies(deps ompPlatformDependencies) ompPlatformDependencies {
+	defaults := defaultOMPPlatformDependencies()
+	if deps.newRunner == nil {
+		deps.newRunner = defaults.newRunner
+	}
+	if deps.activate == nil {
+		deps.activate = defaults.activate
+	}
+	if deps.now == nil {
+		deps.now = defaults.now
+	}
+	return deps
+}
+
+func newPlatformOMPCmd(dir *string) *cobra.Command {
+	return newPlatformOMPCmdWithDependencies(dir, defaultOMPPlatformDependencies())
+}
+
+func newPlatformOMPCmdWithDependencies(dir *string, deps ompPlatformDependencies) *cobra.Command {
+	deps = normalizeOMPPlatformDependencies(deps)
+	cmd := &cobra.Command{
+		Use:   "omp",
+		Short: "Inspect and manage installed OMP models",
+	}
+	cmd.AddCommand(newPlatformOMPModelsCmd(dir, deps))
+	cmd.AddCommand(newPlatformOMPProfileCmd(dir, deps))
+	cmd.AddCommand(newPlatformOMPExplainCmd(dir, deps))
+	return cmd
+}
+
+func newPlatformOMPModelsCmd(dir *string, deps ompPlatformDependencies) *cobra.Command {
+	var jsonOutput bool
+	var format string
+	cmd := &cobra.Command{
+		Use:   "models",
+		Short: "List the installed exact OMP model catalog",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			jsonMode, err := resolveOMPOutputMode(cmd, jsonOutput, format)
+			if err != nil {
+				return err
+			}
+			root, err := resolveDir(*dir)
+			if err != nil {
+				return err
+			}
+			return runOMPModelsCommand(cmd, root, jsonMode, deps.newRunner())
+		},
+	}
+	addJSONFlags(cmd, &jsonOutput, &format)
+	return cmd
+}
+
+func newPlatformOMPProfileCmd(dir *string, deps ompPlatformDependencies) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "profile",
+		Short: "Plan or apply an OMP model profile",
+	}
+	cmd.AddCommand(newPlatformOMPProfileInitCmd(dir, deps))
+	cmd.AddCommand(newPlatformOMPProfileApplyCmd(dir, deps))
+	return cmd
+}
+
+func newPlatformOMPProfileInitCmd(dir *string, deps ompPlatformDependencies) *cobra.Command {
+	var name string
+	var plan bool
+	var jsonOutput bool
+	var format string
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Propose a deterministic six-capability profile without writing files",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			jsonMode, err := resolveOMPOutputMode(cmd, jsonOutput, format)
+			if err != nil {
+				return err
+			}
+			root, err := resolveDir(*dir)
+			if err != nil {
+				return err
+			}
+			return runOMPProfileInitCommand(cmd, root, name, plan, jsonMode, deps.newRunner())
+		},
+	}
+	cmd.Flags().StringVar(&name, "name", "", "Profile name")
+	cmd.Flags().BoolVar(&plan, "plan", false, "Show the zero-write apply plan")
+	addJSONFlags(cmd, &jsonOutput, &format)
+	_ = cmd.MarkFlagRequired("name")
+	return cmd
+}
+
+func newPlatformOMPProfileApplyCmd(dir *string, deps ompPlatformDependencies) *cobra.Command {
+	var jsonOutput bool
+	var format string
+	cmd := &cobra.Command{
+		Use:   "apply <name>",
+		Short: "Persist, select, and activate an OMP model profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			jsonMode, err := resolveOMPOutputMode(cmd, jsonOutput, format)
+			if err != nil {
+				return err
+			}
+			root, err := resolveDir(*dir)
+			if err != nil {
+				return err
+			}
+			return runOMPProfileApplyCommand(
+				cmd, root, args[0], jsonMode, deps.newRunner(), deps.activate,
+			)
+		},
+	}
+	addJSONFlags(cmd, &jsonOutput, &format)
+	return cmd
+}
+
+func newPlatformOMPExplainCmd(dir *string, deps ompPlatformDependencies) *cobra.Command {
+	var jsonOutput bool
+	var format string
+	cmd := &cobra.Command{
+		Use:   "explain",
+		Short: "Explain effective OMP agent model routing and fallbacks",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			jsonMode, err := resolveOMPOutputMode(cmd, jsonOutput, format)
+			if err != nil {
+				return err
+			}
+			root, err := resolveDir(*dir)
+			if err != nil {
+				return err
+			}
+			projection := buildOMPPlatformProjection(
+				cmd.Context(), root, deps.newRunner(), deps.now(),
+			)
+			return renderOMPExplain(cmd, projection, jsonMode)
+		},
+	}
+	addJSONFlags(cmd, &jsonOutput, &format)
+	return cmd
+}
+
+func resolveOMPOutputMode(cmd *cobra.Command, jsonOutput bool, format string) (bool, error) {
+	jsonMode, err := resolveJSONMode(jsonOutput, format)
+	if err == nil {
+		return jsonMode, nil
+	}
+	if jsonOutput {
+		return false, writeJSONResultAndExit(
+			cmd, jsonStatusError, err, "invalid_format", map[string]any{}, nil, nil,
+		)
+	}
+	return false, err
+}

--- a/internal/cli/platform_omp_config.go
+++ b/internal/cli/platform_omp_config.go
@@ -1,0 +1,124 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/insajin/autopus-adk/pkg/config"
+)
+
+func readOwnedAutopusConfig(root string) (string, []byte, os.FileMode, error) {
+	rootInfo, err := os.Lstat(root)
+	if err != nil || !rootInfo.IsDir() || rootInfo.Mode()&os.ModeSymlink != 0 {
+		return "", nil, 0, errors.New("workspace_root_unsafe")
+	}
+	path := filepath.Join(root, "autopus.yaml")
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return "", nil, 0, errors.New("autopus_config_missing")
+	}
+	if err != nil {
+		return "", nil, 0, errors.New("autopus_config_unreadable")
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return "", nil, 0, errors.New("autopus_config_unsafe")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", nil, 0, errors.New("autopus_config_unreadable")
+	}
+	return path, data, info.Mode().Perm(), nil
+}
+
+func verifyAutopusConfigSnapshot(path string, want []byte, mode os.FileMode) error {
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 ||
+		info.Mode().Perm() != mode {
+		return errors.New("autopus_config_changed")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || !bytes.Equal(data, want) {
+		return errors.New("autopus_config_changed")
+	}
+	return nil
+}
+
+func marshalAutopusConfig(original []byte, cfg *config.HarnessConfig) ([]byte, error) {
+	if cfg == nil || cfg.Validate() != nil {
+		return nil, errors.New("autopus_config_invalid")
+	}
+	var document yaml.Node
+	if yaml.Unmarshal(original, &document) != nil || len(document.Content) != 1 ||
+		document.Content[0].Kind != yaml.MappingNode {
+		return nil, errors.New("autopus_config_invalid")
+	}
+	policyData, err := yaml.Marshal(cfg.RoleModelPolicy)
+	if err != nil {
+		return nil, errors.New("autopus_config_marshal_failed")
+	}
+	var policyDocument yaml.Node
+	if yaml.Unmarshal(policyData, &policyDocument) != nil || len(policyDocument.Content) != 1 {
+		return nil, errors.New("autopus_config_marshal_failed")
+	}
+	mapping := document.Content[0]
+	seen := make(map[string]struct{}, len(mapping.Content)/2)
+	policyIndex := -1
+	for index := 0; index < len(mapping.Content); index += 2 {
+		key := mapping.Content[index]
+		if key.Kind != yaml.ScalarNode || key.Value == "" {
+			return nil, errors.New("autopus_config_invalid")
+		}
+		if _, duplicate := seen[key.Value]; duplicate {
+			return nil, errors.New("autopus_config_duplicate_key")
+		}
+		seen[key.Value] = struct{}{}
+		if key.Value == "role_model_policy" {
+			policyIndex = index + 1
+		}
+	}
+	if policyIndex >= 0 {
+		mapping.Content[policyIndex] = policyDocument.Content[0]
+	} else {
+		mapping.Content = append(mapping.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "role_model_policy"},
+			policyDocument.Content[0],
+		)
+	}
+	encoded, err := yaml.Marshal(&document)
+	if err != nil {
+		return nil, errors.New("autopus_config_marshal_failed")
+	}
+	return encoded, nil
+}
+
+func atomicWriteAutopusConfig(root, path string, data []byte, mode os.FileMode) error {
+	temp, err := os.CreateTemp(root, ".autopus.yaml.tmp-")
+	if err != nil {
+		return err
+	}
+	tempPath := temp.Name()
+	defer func() {
+		_ = temp.Close()
+		_ = os.Remove(tempPath)
+	}()
+	if err := temp.Chmod(mode); err != nil {
+		return err
+	}
+	if _, err := temp.Write(data); err != nil {
+		return err
+	}
+	if err := temp.Sync(); err != nil {
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/cli/platform_omp_models.go
+++ b/internal/cli/platform_omp_models.go
@@ -1,0 +1,171 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/insajin/autopus-adk/pkg/adapter/omp"
+)
+
+type ompCatalogPayload struct {
+	Platform           string                   `json:"platform"`
+	Status             string                   `json:"status"`
+	Reason             string                   `json:"reason"`
+	Version            string                   `json:"version,omitempty"`
+	Fingerprint        string                   `json:"fingerprint,omitempty"`
+	StrictRoutingReady bool                     `json:"strict_routing_ready"`
+	Models             []ompCatalogModelPayload `json:"models"`
+}
+
+type ompCatalogModelPayload struct {
+	Provider              string   `json:"provider"`
+	Model                 string   `json:"model"`
+	Selector              string   `json:"selector"`
+	Name                  string   `json:"name,omitempty"`
+	Family                string   `json:"family,omitempty"`
+	Capabilities          []string `json:"capabilities,omitempty"`
+	Thinking              []string `json:"thinking,omitempty"`
+	AuthAvailability      string   `json:"auth_availability"`
+	Disabled              bool     `json:"disabled,omitempty"`
+	SemanticMetadataReady bool     `json:"semantic_metadata_ready"`
+	ContextWindow         int64    `json:"context_window,omitempty"`
+	Reasoning             *bool    `json:"reasoning,omitempty"`
+	NativeThinking        []string `json:"native_thinking,omitempty"`
+	Input                 []string `json:"input,omitempty"`
+}
+
+type ompCatalogUnavailableError struct {
+	reason string
+}
+
+func (e ompCatalogUnavailableError) Error() string {
+	return "OMP model catalog unavailable: " + e.reason
+}
+
+func probeInstalledOMPCatalog(
+	ctx context.Context,
+	runner omp.OMPModelCatalogRunner,
+) (omp.OMPModelCatalogProbeResult, error) {
+	result := omp.ProbeOMPModelCatalog(ctx, omp.OMPModelCatalogProbeOptions{
+		Executable: "omp",
+		Runner:     runner,
+		Timeout:    ompDoctorProbeTimeout,
+		MaxOutput:  ompModelDoctorProbeOutput,
+	})
+	if result.Status != "ready" || result.Reason != "catalog_ready" {
+		reason := safeOMPOperatorReason(result.Reason)
+		if reason == "not_available" {
+			reason = "catalog_invalid"
+		}
+		return result, ompCatalogUnavailableError{reason: reason}
+	}
+	return result, nil
+}
+
+func runOMPModelsCommand(
+	cmd *cobra.Command,
+	_ string,
+	jsonMode bool,
+	runner omp.OMPModelCatalogRunner,
+) error {
+	result, err := probeInstalledOMPCatalog(cmd.Context(), runner)
+	if err != nil && result.Reason == ompRawCatalogFallbackReason {
+		return runOMPRawDisplayCatalogCommand(cmd, jsonMode, runner, result)
+	}
+	payload := catalogPayloadFromProbe(result)
+	if err != nil {
+		if jsonMode {
+			return writeJSONResultAndExit(
+				cmd,
+				jsonStatusError,
+				err,
+				"omp_catalog_unavailable",
+				payload,
+				[]jsonMessage{{Code: "omp_catalog_unavailable", Message: payload.Reason}},
+				nil,
+			)
+		}
+		return err
+	}
+	if jsonMode {
+		return writeJSONResult(cmd, jsonStatusOK, payload, nil, []jsonCheck{{
+			ID: "omp.catalog", Severity: "info", Status: "pass", Detail: "catalog_ready",
+		}})
+	}
+	return renderOMPModelsText(cmd, payload)
+}
+
+func catalogPayloadFromProbe(result omp.OMPModelCatalogProbeResult) ompCatalogPayload {
+	models := []ompCatalogModelPayload{}
+	strictRoutingReady := result.Status == "ready" && result.Reason == "catalog_ready"
+	if strictRoutingReady {
+		models = make([]ompCatalogModelPayload, 0, len(result.Catalog.Models))
+		for _, model := range result.Catalog.Models {
+			models = append(models, ompCatalogModelPayload{
+				Provider: model.Provider, Model: model.Model, Selector: model.Provider + "/" + model.Model,
+				Family: model.Family, Capabilities: append([]string(nil), model.Capabilities...),
+				Thinking: append([]string(nil), model.Thinking...), AuthAvailability: ompModelAvailability(model),
+				Disabled: model.Disabled, SemanticMetadataReady: true,
+			})
+		}
+	}
+	return ompCatalogPayload{
+		Platform: "omp", Status: result.Status, Reason: safeOMPOperatorReason(result.Reason),
+		Version: safeOMPOperatorVersion(result.Version), Fingerprint: result.Catalog.Fingerprint,
+		StrictRoutingReady: strictRoutingReady, Models: models,
+	}
+}
+
+func renderOMPModelsText(cmd *cobra.Command, payload ompCatalogPayload) error {
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintln(out, "OMP installed model catalog")
+	_, _ = fmt.Fprintf(out, "Status: %s (%s)\n", payload.Status, payload.Reason)
+	_, _ = fmt.Fprintf(out, "Version: %s\n", payload.Version)
+	_, _ = fmt.Fprintf(out, "Strict routing ready: %t\n", payload.StrictRoutingReady)
+	if payload.Fingerprint != "" {
+		_, _ = fmt.Fprintf(out, "Fingerprint: %s\n", payload.Fingerprint)
+	}
+	_, _ = fmt.Fprintf(out, "Models: %d\n", len(payload.Models))
+	for _, model := range payload.Models {
+		if model.SemanticMetadataReady {
+			_, _ = fmt.Fprintf(
+				out,
+				"- %s family=%s availability=%s capabilities=%s thinking=%s\n",
+				model.Selector,
+				model.Family,
+				model.AuthAvailability,
+				strings.Join(model.Capabilities, ","),
+				strings.Join(model.Thinking, ","),
+			)
+			continue
+		}
+		_, _ = fmt.Fprintf(
+			out,
+			"- %s name=%q context_window=%d reasoning=%s native_thinking=%s input=%s semantic_metadata=unavailable\n",
+			model.Selector,
+			model.Name,
+			model.ContextWindow,
+			formatOMPDisplayBool(model.Reasoning),
+			formatOMPDisplayThinking(model.NativeThinking),
+			strings.Join(model.Input, ","),
+		)
+	}
+	if !payload.StrictRoutingReady && len(payload.Models) != 0 {
+		_, _ = fmt.Fprintln(out, "Routing/profile apply: blocked (catalog_metadata_insufficient)")
+	}
+	return nil
+}
+
+func ompModelAvailability(model omp.OMPModelMetadata) string {
+	switch {
+	case model.Disabled:
+		return "disabled"
+	case !model.Keyless && !model.AuthEnabled:
+		return "unauthorized"
+	default:
+		return "available"
+	}
+}

--- a/internal/cli/platform_omp_models_raw.go
+++ b/internal/cli/platform_omp_models_raw.go
@@ -1,0 +1,250 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/spf13/cobra"
+
+	"github.com/insajin/autopus-adk/pkg/adapter/omp"
+)
+
+const ompRawCatalogFallbackReason = "catalog_metadata_insufficient"
+
+type rawOMPDisplayCatalog struct {
+	Models *[]rawOMPDisplayModel `json:"models"`
+}
+
+type rawOMPDisplayModel struct {
+	Provider      string      `json:"provider"`
+	ID            string      `json:"id"`
+	Selector      string      `json:"selector"`
+	Name          string      `json:"name"`
+	ContextWindow json.Number `json:"contextWindow"`
+	Reasoning     *bool       `json:"reasoning"`
+	Thinking      *[]string   `json:"thinking"`
+	Input         *[]string   `json:"input"`
+}
+
+func runOMPRawDisplayCatalogCommand(
+	cmd *cobra.Command,
+	jsonMode bool,
+	runner omp.OMPModelCatalogRunner,
+	strict omp.OMPModelCatalogProbeResult,
+) error {
+	body, runErr := runner.Run(cmd.Context(), "omp", "models", "--json", "--no-extensions")
+	models, reason := normalizeOMPRawDisplayCatalog(body, ompModelDoctorProbeOutput)
+	if runErr != nil || reason != "catalog_ready" {
+		if reason == "catalog_ready" {
+			reason = "catalog_invalid"
+		}
+		strict.Status, strict.Reason = "blocked", reason
+		err := ompCatalogUnavailableError{reason: reason}
+		payload := catalogPayloadFromProbe(strict)
+		if jsonMode {
+			return writeJSONResultAndExit(
+				cmd, jsonStatusError, err, "omp_catalog_unavailable", payload,
+				[]jsonMessage{{Code: "omp_catalog_unavailable", Message: reason}}, nil,
+			)
+		}
+		return err
+	}
+	payload := ompCatalogPayload{
+		Platform: "omp", Status: "degraded", Reason: ompRawCatalogFallbackReason,
+		Version: safeOMPOperatorVersion(strict.Version), StrictRoutingReady: false, Models: models,
+	}
+	if jsonMode {
+		return writeJSONResult(
+			cmd, jsonStatusWarn, payload,
+			[]jsonMessage{{
+				Code:    "omp_catalog_metadata_insufficient",
+				Message: "observed native models are display-only; profile init/apply and routing remain blocked",
+			}},
+			[]jsonCheck{{
+				ID: "omp.catalog.semantic_metadata", Severity: "warning", Status: "warn",
+				Detail: ompRawCatalogFallbackReason,
+			}},
+		)
+	}
+	return renderOMPModelsText(cmd, payload)
+}
+
+func normalizeOMPRawDisplayCatalog(body []byte, maxBytes int) ([]ompCatalogModelPayload, string) {
+	if len(body) == 0 || maxBytes <= 0 || len(body) > maxBytes || rejectDuplicatePipelineOMPJSON(body) != nil {
+		return nil, "catalog_invalid"
+	}
+	if secretKeyInOMPDisplayJSON(body) {
+		return nil, "catalog_invalid"
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	var raw rawOMPDisplayCatalog
+	if decoder.Decode(&raw) != nil {
+		return nil, "catalog_invalid"
+	}
+	var trailing any
+	if decoder.Decode(&trailing) != io.EOF || raw.Models == nil || len(*raw.Models) == 0 {
+		return nil, "catalog_invalid"
+	}
+	models := make([]ompCatalogModelPayload, 0, len(*raw.Models))
+	seen := make(map[string]struct{}, len(*raw.Models))
+	for _, entry := range *raw.Models {
+		model, err := normalizeOMPRawDisplayModel(entry)
+		if err != nil {
+			return nil, "catalog_invalid"
+		}
+		if _, exists := seen[model.Selector]; exists {
+			return nil, "catalog_invalid"
+		}
+		seen[model.Selector] = struct{}{}
+		models = append(models, model)
+	}
+	sort.Slice(models, func(i, j int) bool {
+		if models[i].Provider != models[j].Provider {
+			return models[i].Provider < models[j].Provider
+		}
+		return models[i].Model < models[j].Model
+	})
+	return models, "catalog_ready"
+}
+
+func normalizeOMPRawDisplayModel(raw rawOMPDisplayModel) (ompCatalogModelPayload, error) {
+	provider, model := safeOMPOperatorToken(raw.Provider), safeOMPOperatorToken(raw.ID)
+	if provider != raw.Provider || model != raw.ID || raw.Selector != raw.Provider+"/"+raw.ID ||
+		safeOMPOperatorToken(raw.Selector) != raw.Selector || !safeOMPDisplayName(raw.Name) ||
+		raw.Reasoning == nil || raw.Input == nil {
+		return ompCatalogModelPayload{}, errors.New("unsafe native model metadata")
+	}
+	contextWindow, err := raw.ContextWindow.Int64()
+	if err != nil || contextWindow <= 0 || contextWindow > 1<<30 {
+		return ompCatalogModelPayload{}, errors.New("invalid native context window")
+	}
+	input, err := normalizeOMPDisplayInput(*raw.Input)
+	if err != nil {
+		return ompCatalogModelPayload{}, err
+	}
+	thinking, err := normalizeOMPDisplayThinking(raw.Thinking)
+	if err != nil {
+		return ompCatalogModelPayload{}, err
+	}
+	return ompCatalogModelPayload{
+		Provider: provider, Model: model, Selector: raw.Selector, Name: raw.Name,
+		ContextWindow: contextWindow, Reasoning: raw.Reasoning, NativeThinking: thinking,
+		Input: input, AuthAvailability: "unknown", SemanticMetadataReady: false,
+	}, nil
+}
+
+func normalizeOMPDisplayInput(values []string) ([]string, error) {
+	if len(values) == 0 || len(values) > 2 {
+		return nil, errors.New("invalid native input modes")
+	}
+	seen := map[string]bool{}
+	for _, value := range values {
+		if value != "text" && value != "image" || seen[value] {
+			return nil, errors.New("invalid native input mode")
+		}
+		seen[value] = true
+	}
+	result := append([]string(nil), values...)
+	sort.Strings(result)
+	return result, nil
+}
+
+func normalizeOMPDisplayThinking(values *[]string) ([]string, error) {
+	if values == nil {
+		return nil, nil
+	}
+	if len(*values) == 0 || len(*values) > 6 {
+		return nil, errors.New("invalid native thinking levels")
+	}
+	order := map[string]int{"minimal": 0, "low": 1, "medium": 2, "high": 3, "xhigh": 4, "max": 5}
+	seen := map[string]bool{}
+	result := append([]string(nil), (*values)...)
+	for _, value := range result {
+		if _, allowed := order[value]; !allowed || seen[value] {
+			return nil, errors.New("invalid native thinking level")
+		}
+		seen[value] = true
+	}
+	sort.Slice(result, func(i, j int) bool { return order[result[i]] < order[result[j]] })
+	return result, nil
+}
+
+func safeOMPDisplayName(value string) bool {
+	if value == "" || len(value) > 256 || strings.TrimSpace(value) != value || !utf8.ValidString(value) {
+		return false
+	}
+	lower := strings.ToLower(value)
+	for _, marker := range ompDisplaySecretMarkers() {
+		if strings.Contains(lower, marker) {
+			return false
+		}
+	}
+	for _, char := range value {
+		if char < 0x20 || char == 0x7f {
+			return false
+		}
+	}
+	return true
+}
+
+func secretKeyInOMPDisplayJSON(body []byte) bool {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	var value any
+	if decoder.Decode(&value) != nil {
+		return true
+	}
+	var inspect func(any) bool
+	inspect = func(current any) bool {
+		switch typed := current.(type) {
+		case map[string]any:
+			for key, child := range typed {
+				lower := strings.ToLower(key)
+				for _, marker := range ompDisplaySecretMarkers() {
+					if strings.Contains(lower, marker) {
+						return true
+					}
+				}
+				if inspect(child) {
+					return true
+				}
+			}
+		case []any:
+			for _, child := range typed {
+				if inspect(child) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	return inspect(value)
+}
+
+func ompDisplaySecretMarkers() []string {
+	return []string{
+		"authorization", "api_key", "api-key", "apikey", "password", "secret",
+		"access_token", "refresh_token", "credential", "private_key",
+	}
+}
+
+func formatOMPDisplayBool(value *bool) string {
+	if value == nil {
+		return "unknown"
+	}
+	return fmt.Sprint(*value)
+}
+
+func formatOMPDisplayThinking(values []string) string {
+	if len(values) == 0 {
+		return "unknown"
+	}
+	return strings.Join(values, ",")
+}

--- a/internal/cli/platform_omp_models_raw_test.go
+++ b/internal/cli/platform_omp_models_raw_test.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/adapter/omp"
+)
+
+func TestPlatformOMPModelsNativeCatalogDegradesToSafeDisplayOnlyRows(t *testing.T) {
+	runner := &ompCLIFakeRunner{catalog: ompCLINativeCatalogJSON()}
+	root := t.TempDir()
+	deps := normalizeOMPPlatformDependencies(ompPlatformDependencies{
+		newRunner: func() omp.OMPModelCatalogRunner { return runner },
+	})
+
+	text := executeOMPSubcommand(t, newPlatformOMPModelsCmd(&root, deps))
+	assert.Contains(t, text, "Status: degraded (catalog_metadata_insufficient)")
+	assert.Contains(t, text, "openai-codex/gpt-5.4-mini")
+	assert.Contains(t, text, "semantic_metadata=unavailable")
+	assert.Contains(t, text, "Routing/profile apply: blocked")
+	assert.NotContains(t, text, "$2.50")
+
+	encoded := executeOMPSubcommand(t, newPlatformOMPModelsCmd(&root, deps), "--json")
+	var envelope ompCLIJSONEnvelope
+	require.NoError(t, json.Unmarshal([]byte(encoded), &envelope))
+	assert.Equal(t, jsonStatusWarn, envelope.Status)
+	var payload ompCatalogPayload
+	require.NoError(t, json.Unmarshal(envelope.Data, &payload))
+	assert.Equal(t, "degraded", payload.Status)
+	assert.Equal(t, ompRawCatalogFallbackReason, payload.Reason)
+	assert.False(t, payload.StrictRoutingReady)
+	require.Len(t, payload.Models, 2)
+	assert.Equal(t, "anthropic/claude-haiku-4-5", payload.Models[0].Selector)
+	assert.Equal(t, "openai-codex/gpt-5.4-mini", payload.Models[1].Selector)
+	assert.Equal(t, int64(272000), payload.Models[1].ContextWindow)
+	assert.Equal(t, []string{"image", "text"}, payload.Models[1].Input)
+	assert.Empty(t, payload.Models[1].Family)
+	assert.Empty(t, payload.Models[1].Capabilities)
+	assert.Empty(t, payload.Models[1].Thinking)
+	assert.Equal(t, "unknown", payload.Models[1].AuthAvailability)
+	assert.NotContains(t, strings.ToLower(encoded), "cache_read")
+}
+
+func TestNormalizeOMPRawDisplayCatalogRejectsUntrustedShapes(t *testing.T) {
+	valid := `{"models":[{"provider":"p","id":"m","selector":"p/m","name":"Model M","contextWindow":200000,"reasoning":true,"thinking":["low","high"],"input":["text"]}]}`
+	tests := map[string]string{
+		"duplicate key":       `{"models":[],"models":[]}`,
+		"trailing":            valid + ` {}`,
+		"credential field":    `{"models":[{"provider":"p","id":"m","selector":"p/m","name":"Model M","contextWindow":200000,"reasoning":true,"thinking":["high"],"input":["text"],"access_token":"sentinel"}]}`,
+		"duplicate selector":  `{"models":[{"provider":"p","id":"m","selector":"p/m","name":"One","contextWindow":1,"reasoning":true,"thinking":["high"],"input":["text"]},{"provider":"p","id":"m","selector":"p/m","name":"Two","contextWindow":1,"reasoning":true,"thinking":["high"],"input":["text"]}]}`,
+		"unsafe display name": `{"models":[{"provider":"p","id":"m","selector":"p/m","name":"bad\u001bname","contextWindow":1,"reasoning":true,"thinking":["high"],"input":["text"]}]}`,
+		"fractional context":  `{"models":[{"provider":"p","id":"m","selector":"p/m","name":"Model M","contextWindow":1.5,"reasoning":true,"thinking":["high"],"input":["text"]}]}`,
+		"unknown input":       `{"models":[{"provider":"p","id":"m","selector":"p/m","name":"Model M","contextWindow":1,"reasoning":true,"thinking":["high"],"input":["audio"]}]}`,
+	}
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			models, reason := normalizeOMPRawDisplayCatalog([]byte(body), 1<<20)
+			assert.Equal(t, "catalog_invalid", reason)
+			assert.Empty(t, models)
+		})
+	}
+	models, reason := normalizeOMPRawDisplayCatalog([]byte(valid), 1<<20)
+	assert.Equal(t, "catalog_ready", reason)
+	require.Len(t, models, 1)
+	assert.Equal(t, "p/m", models[0].Selector)
+}
+
+func TestPlatformOMPModelsInvalidCatalogDoesNotUseNativeFallback(t *testing.T) {
+	runner := &ompCLIFakeRunner{catalog: []byte(`{"models":[]} trailing`)}
+	root := t.TempDir()
+	deps := normalizeOMPPlatformDependencies(ompPlatformDependencies{
+		newRunner: func() omp.OMPModelCatalogRunner { return runner },
+	})
+	cmd := newPlatformOMPModelsCmd(&root, deps)
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"--json"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Equal(t, 1, countOMPModelProbeCalls(runner.calls))
+	var envelope struct {
+		Status jsonEnvelopeStatus `json:"status"`
+		Data   ompCatalogPayload  `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(output.Bytes(), &envelope))
+	assert.Equal(t, jsonStatusError, envelope.Status)
+	assert.Equal(t, "catalog_invalid", envelope.Data.Reason)
+	assert.Empty(t, envelope.Data.Models)
+}
+
+func TestPlatformOMPProfileInitKeepsNativeDisplayCatalogFailClosed(t *testing.T) {
+	runner := &ompCLIFakeRunner{catalog: ompCLINativeCatalogJSON()}
+	root := t.TempDir()
+	deps := normalizeOMPPlatformDependencies(ompPlatformDependencies{
+		newRunner: func() omp.OMPModelCatalogRunner { return runner },
+	})
+	cmd := newPlatformOMPProfileInitCmd(&root, deps)
+	cmd.SetArgs([]string{"--name", "balanced"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ompRawCatalogFallbackReason)
+	assert.Equal(t, 1, countOMPModelProbeCalls(runner.calls))
+}
+
+func countOMPModelProbeCalls(calls []string) int {
+	count := 0
+	for _, call := range calls {
+		if strings.HasSuffix(call, " models --json --no-extensions") {
+			count++
+		}
+	}
+	return count
+}
+
+func ompCLINativeCatalogJSON() []byte {
+	return []byte(`{"models":[
+		{"provider":"openai-codex","id":"gpt-5.4-mini","selector":"openai-codex/gpt-5.4-mini","name":"GPT-5.4 mini","contextWindow":272000,"reasoning":true,"thinking":["minimal","low","medium","high","xhigh"],"input":["text","image"],"cost":{"input":2.5,"output":15,"cacheRead":0.25,"cacheWrite":0},"ownedBy":"openai-codex"},
+		{"provider":"anthropic","id":"claude-haiku-4-5","selector":"anthropic/claude-haiku-4-5","name":"Claude Haiku 4.5","contextWindow":200000,"reasoning":true,"thinking":null,"input":["text","image"],"cost":{"input":1,"output":5,"cacheRead":0.1,"cacheWrite":1.25},"ownedBy":"anthropic"}
+	]}`)
+}

--- a/internal/cli/platform_omp_profile_apply.go
+++ b/internal/cli/platform_omp_profile_apply.go
@@ -1,0 +1,192 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/insajin/autopus-adk/pkg/adapter/omp"
+	"github.com/insajin/autopus-adk/pkg/config"
+)
+
+type ompProfileActivator func(context.Context, string, *config.HarnessConfig) error
+
+type ompProfileApplyPayload struct {
+	Platform           string                        `json:"platform"`
+	Name               string                        `json:"name"`
+	Status             string                        `json:"status"`
+	Generated          bool                          `json:"generated"`
+	ConfigPath         string                        `json:"config_path"`
+	Activation         string                        `json:"activation"`
+	CatalogVersion     string                        `json:"catalog_version"`
+	CatalogFingerprint string                        `json:"catalog_fingerprint"`
+	Capabilities       []ompProfileCapabilityPayload `json:"capabilities"`
+}
+
+func runOMPProfileApplyCommand(
+	cmd *cobra.Command,
+	root string,
+	name string,
+	jsonMode bool,
+	runner omp.OMPModelCatalogRunner,
+	activate ompProfileActivator,
+) error {
+	payload, err := applyOMPProfile(cmd.Context(), root, name, runner, activate)
+	if err != nil {
+		if !jsonMode {
+			return err
+		}
+		return writeJSONResultAndExit(
+			cmd, jsonStatusError, err, "omp_profile_apply_failed",
+			map[string]any{"platform": "omp", "name": name, "status": "blocked"},
+			[]jsonMessage{{Code: "omp_profile_apply_failed", Message: err.Error()}}, nil,
+		)
+	}
+	if jsonMode {
+		return writeJSONResult(cmd, jsonStatusOK, payload, nil, []jsonCheck{{
+			ID: "omp.profile.activation", Severity: "info", Status: "pass", Detail: "omp_update",
+		}})
+	}
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(out, "OMP profile applied: %s\n", payload.Name)
+	_, _ = fmt.Fprintf(out, "Config: %s\nActivation: %s\n", payload.ConfigPath, payload.Activation)
+	_, _ = fmt.Fprintf(out, "Catalog: %s %s\n", payload.CatalogVersion, payload.CatalogFingerprint)
+	return nil
+}
+
+func applyOMPProfile(
+	ctx context.Context,
+	root string,
+	name string,
+	runner omp.OMPModelCatalogRunner,
+	activate ompProfileActivator,
+) (ompProfileApplyPayload, error) {
+	if !config.IsValidQualityPresetName(name) {
+		return ompProfileApplyPayload{}, ompProfilePlanError{reason: "profile_name_invalid"}
+	}
+	path, original, mode, err := readOwnedAutopusConfig(root)
+	if err != nil {
+		return ompProfileApplyPayload{}, err
+	}
+	cfg, err := config.LoadPreview(root)
+	if err != nil {
+		return ompProfileApplyPayload{}, errors.New("autopus_config_invalid")
+	}
+	if !containsOMPString(cfg.Platforms, "omp") {
+		return ompProfileApplyPayload{}, errors.New("omp_platform_not_configured")
+	}
+	if activate == nil {
+		return ompProfileApplyPayload{}, errors.New("omp_activation_path_unavailable")
+	}
+	probe, err := probeInstalledOMPCatalog(ctx, runner)
+	if err != nil {
+		return ompProfileApplyPayload{}, err
+	}
+
+	profile, exists := cfg.RoleModelPolicy.Profiles[name]
+	generated := !exists
+	if !exists {
+		proposal, proposalErr := buildOMPProfileProposal(name, probe.Catalog)
+		if proposalErr != nil {
+			return ompProfileApplyPayload{}, proposalErr
+		}
+		profile = proposal.profile
+	}
+	if err := preflightOMPProfile(name, profile, probe.Catalog); err != nil {
+		return ompProfileApplyPayload{}, err
+	}
+	if cfg.RoleModelPolicy.Profiles == nil {
+		cfg.RoleModelPolicy.Profiles = make(map[string]config.RoleModelProfileConf)
+	}
+	if cfg.RoleModelPolicy.Version == "" {
+		cfg.RoleModelPolicy.Version = config.RoleModelPolicyVersionV1
+	}
+	cfg.RoleModelPolicy.Profiles[name] = profile
+	cfg.RoleModelPolicy.Profile = name
+	if err := cfg.Validate(); err != nil {
+		return ompProfileApplyPayload{}, errors.New("omp_profile_validation_failed")
+	}
+
+	encoded, err := marshalAutopusConfig(original, cfg)
+	if err != nil {
+		return ompProfileApplyPayload{}, err
+	}
+	if err := verifyAutopusConfigSnapshot(path, original, mode); err != nil {
+		return ompProfileApplyPayload{}, err
+	}
+	if err := atomicWriteAutopusConfig(root, path, encoded, mode); err != nil {
+		return ompProfileApplyPayload{}, fmt.Errorf("persist OMP profile: %w", err)
+	}
+	if err := activate(ctx, root, cfg); err != nil {
+		if verifyErr := verifyAutopusConfigSnapshot(path, encoded, mode); verifyErr != nil {
+			return ompProfileApplyPayload{}, fmt.Errorf(
+				"activate OMP profile: %w; config rollback blocked: autopus_config_changed", err,
+			)
+		}
+		if rollbackErr := atomicWriteAutopusConfig(root, path, original, mode); rollbackErr != nil {
+			return ompProfileApplyPayload{}, fmt.Errorf(
+				"activate OMP profile: %w; config rollback failed: %v", err, rollbackErr,
+			)
+		}
+		return ompProfileApplyPayload{}, fmt.Errorf("activate OMP profile: %w", err)
+	}
+	if err := verifyAutopusConfigSnapshot(path, encoded, mode); err != nil {
+		return ompProfileApplyPayload{}, errors.New("autopus_config_changed_during_activation")
+	}
+	return ompProfileApplyPayload{
+		Platform: "omp", Name: name, Status: "applied", Generated: generated,
+		ConfigPath: "autopus.yaml", Activation: "omp_update",
+		CatalogVersion:     safeOMPOperatorVersion(probe.Version),
+		CatalogFingerprint: probe.Catalog.Fingerprint,
+		Capabilities:       profileCapabilityPayloads(profile),
+	}, nil
+}
+
+func preflightOMPProfile(
+	name string,
+	profile config.RoleModelProfileConf,
+	catalog omp.OMPModelCatalog,
+) error {
+	policy := config.RoleModelPolicyConf{
+		Version:  config.RoleModelPolicyVersionV1,
+		Profile:  name,
+		Profiles: map[string]config.RoleModelProfileConf{name: profile},
+	}
+	if err := policy.Validate(); err != nil {
+		return errors.New("omp_profile_validation_failed")
+	}
+	if !profile.FamilyDiversity.Enabled {
+		return errors.New("family_diversity_required")
+	}
+	compilation := compileOMPModelDoctorRouting(profile, catalog)
+	if len(compilation.Resolutions) != len(config.OMPAgentRoleMapping()) {
+		return errors.New("omp_profile_projection_incomplete")
+	}
+	for _, resolution := range compilation.Resolutions {
+		if resolution.Status != "selected" {
+			return fmt.Errorf(
+				"omp_profile_candidate_unavailable: agent=%s reason=%s",
+				safeOMPOperatorToken(resolution.Agent), safeOMPOperatorReason(resolution.Reason),
+			)
+		}
+	}
+	return nil
+}
+
+func profileCapabilityPayloads(profile config.RoleModelProfileConf) []ompProfileCapabilityPayload {
+	rows := make([]ompProfileCapabilityPayload, 0, len(config.OMPProviderNeutralCapabilities()))
+	for _, capability := range config.OMPProviderNeutralCapabilities() {
+		route := profile.Capabilities[capability]
+		row := ompProfileCapabilityPayload{Capability: capability, Required: route.Required}
+		for _, candidate := range route.Candidates {
+			row.Candidates = append(row.Candidates, ompProfileCandidatePayload(candidate))
+		}
+		if row.Candidates == nil {
+			row.Candidates = []ompProfileCandidatePayload{}
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}

--- a/internal/cli/platform_omp_profile_plan.go
+++ b/internal/cli/platform_omp_profile_plan.go
@@ -1,0 +1,230 @@
+package cli
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/insajin/autopus-adk/pkg/adapter/omp"
+	"github.com/insajin/autopus-adk/pkg/config"
+)
+
+type ompProfileCandidatePayload struct {
+	Selector string `json:"selector" yaml:"selector"`
+	Thinking string `json:"thinking" yaml:"thinking"`
+	Family   string `json:"family" yaml:"family"`
+}
+
+type ompProfileCapabilityPayload struct {
+	Capability string                       `json:"capability" yaml:"capability"`
+	Required   bool                         `json:"required" yaml:"required"`
+	Candidates []ompProfileCandidatePayload `json:"candidates" yaml:"candidates"`
+}
+type ompProfileFamilyDiversityPayload struct {
+	Enabled bool     `json:"enabled" yaml:"enabled"`
+	Roles   []string `json:"roles" yaml:"roles"`
+}
+
+type ompProfilePlanPayload struct {
+	Platform           string                           `json:"platform" yaml:"platform"`
+	Name               string                           `json:"name" yaml:"name"`
+	Mode               string                           `json:"mode" yaml:"mode"`
+	Writes             []string                         `json:"writes" yaml:"writes"`
+	CatalogVersion     string                           `json:"catalog_version" yaml:"catalog_version"`
+	CatalogFingerprint string                           `json:"catalog_fingerprint" yaml:"catalog_fingerprint"`
+	ConfigMode         string                           `json:"config_mode" yaml:"config_mode"`
+	Capabilities       []ompProfileCapabilityPayload    `json:"capabilities" yaml:"capabilities"`
+	FamilyDiversity    ompProfileFamilyDiversityPayload `json:"family_diversity" yaml:"family_diversity"`
+}
+
+type ompProfileProposal struct {
+	name         string
+	profile      config.RoleModelProfileConf
+	capabilities []ompProfileCapabilityPayload
+}
+
+type ompProfilePlanError struct {
+	reason string
+}
+
+func (e ompProfilePlanError) Error() string {
+	return "OMP profile plan invalid: " + e.reason
+}
+
+func runOMPProfileInitCommand(
+	cmd *cobra.Command,
+	_ string,
+	name string,
+	plan bool,
+	jsonMode bool,
+	runner omp.OMPModelCatalogRunner,
+) error {
+	if !config.IsValidQualityPresetName(name) {
+		return writeOMPProfilePlanFailure(cmd, jsonMode, ompProfilePlanError{reason: "profile_name_invalid"})
+	}
+	probe, err := probeInstalledOMPCatalog(cmd.Context(), runner)
+	if err != nil {
+		return writeOMPProfilePlanFailure(cmd, jsonMode, err)
+	}
+	proposal, err := buildOMPProfileProposal(name, probe.Catalog)
+	if err != nil {
+		return writeOMPProfilePlanFailure(cmd, jsonMode, err)
+	}
+	mode := "proposal"
+	if plan {
+		mode = "plan"
+	}
+	payload := profilePlanPayload(proposal, probe, mode)
+	if jsonMode {
+		return writeJSONResult(cmd, jsonStatusOK, payload, nil, []jsonCheck{{
+			ID: "omp.profile.plan", Severity: "info", Status: "pass", Detail: "zero_writes",
+		}})
+	}
+	return renderOMPProfilePlanText(cmd, payload, proposal.profile)
+}
+
+func buildOMPProfileProposal(name string, catalog omp.OMPModelCatalog) (ompProfileProposal, error) {
+	if !config.IsValidQualityPresetName(name) {
+		return ompProfileProposal{}, ompProfilePlanError{reason: "profile_name_invalid"}
+	}
+	profile := config.RoleModelProfileConf{
+		ConfigMode:   config.RoleModelConfigModeOverlay,
+		Capabilities: make(map[string]config.RoleCapabilityRouteConf),
+		FamilyDiversity: config.FamilyDiversityPolicyConf{
+			Enabled: true,
+			Roles:   []string{config.OMPRoleAdvisor},
+		},
+	}
+	rows := make([]ompProfileCapabilityPayload, 0, len(config.OMPProviderNeutralCapabilities()))
+	for _, capability := range config.OMPProviderNeutralCapabilities() {
+		route, row := proposeOMPCapabilityRoute(capability, catalog.Models)
+		if len(route.Candidates) == 0 {
+			return ompProfileProposal{}, ompProfilePlanError{reason: "capability_unavailable:" + capability}
+		}
+		profile.Capabilities[capability] = route
+		rows = append(rows, row)
+	}
+	policy := config.RoleModelPolicyConf{
+		Version:  config.RoleModelPolicyVersionV1,
+		Profile:  name,
+		Profiles: map[string]config.RoleModelProfileConf{name: profile},
+	}
+	if err := policy.Validate(); err != nil {
+		return ompProfileProposal{}, ompProfilePlanError{reason: "profile_validation_failed"}
+	}
+	return ompProfileProposal{name: name, profile: profile, capabilities: rows}, nil
+}
+
+func proposeOMPCapabilityRoute(
+	capability string,
+	models []omp.OMPModelMetadata,
+) (config.RoleCapabilityRouteConf, ompProfileCapabilityPayload) {
+	models = append([]omp.OMPModelMetadata(nil), models...)
+	sort.Slice(models, func(i, j int) bool {
+		left := models[i].Provider + "/" + models[i].Model
+		right := models[j].Provider + "/" + models[j].Model
+		return left < right
+	})
+	route := config.RoleCapabilityRouteConf{Required: true}
+	row := ompProfileCapabilityPayload{Capability: capability, Required: true}
+	for _, model := range models {
+		if ompModelAvailability(model) != "available" || !containsOMPString(model.Capabilities, capability) {
+			continue
+		}
+		thinking := preferredOMPThinking(capability, model.Thinking)
+		if thinking == "" {
+			continue
+		}
+		candidate := config.RoleModelCandidateConf{
+			Selector: model.Provider + "/" + model.Model,
+			Thinking: thinking,
+			Family:   model.Family,
+		}
+		route.Candidates = append(route.Candidates, candidate)
+		row.Candidates = append(row.Candidates, ompProfileCandidatePayload(candidate))
+	}
+	if row.Candidates == nil {
+		row.Candidates = []ompProfileCandidatePayload{}
+	}
+	return route, row
+}
+
+func preferredOMPThinking(capability string, supported []string) string {
+	preferences := map[string][]string{
+		config.CapabilityDeepReasoning:          {"xhigh", "max", "high", "medium", "auto", "low", "minimal", "none", "off"},
+		config.CapabilityCodingToolUse:          {"high", "xhigh", "medium", "auto", "low", "minimal", "none", "off", "max"},
+		config.CapabilityFastValidation:         {"low", "minimal", "medium", "none", "off", "auto", "high", "xhigh", "max"},
+		config.CapabilityVisionDesign:           {"high", "xhigh", "medium", "auto", "low", "minimal", "none", "off", "max"},
+		config.CapabilityIndependentDissent:     {"high", "xhigh", "medium", "auto", "low", "minimal", "none", "off", "max"},
+		config.CapabilityDeterministicTransform: {"low", "minimal", "medium", "none", "off", "auto", "high", "xhigh", "max"},
+	}
+	for _, candidate := range preferences[capability] {
+		if containsOMPString(supported, candidate) {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func containsOMPString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func profilePlanPayload(
+	proposal ompProfileProposal,
+	probe omp.OMPModelCatalogProbeResult,
+	mode string,
+) ompProfilePlanPayload {
+	return ompProfilePlanPayload{
+		Platform: "omp", Name: proposal.name, Mode: mode, Writes: []string{},
+		CatalogVersion:     safeOMPOperatorVersion(probe.Version),
+		CatalogFingerprint: probe.Catalog.Fingerprint,
+		ConfigMode:         proposal.profile.ConfigMode,
+		Capabilities:       append([]ompProfileCapabilityPayload(nil), proposal.capabilities...),
+		FamilyDiversity: ompProfileFamilyDiversityPayload{
+			Enabled: proposal.profile.FamilyDiversity.Enabled,
+			Roles:   append([]string(nil), proposal.profile.FamilyDiversity.Roles...),
+		},
+	}
+}
+
+func writeOMPProfilePlanFailure(cmd *cobra.Command, jsonMode bool, err error) error {
+	if !jsonMode {
+		return err
+	}
+	return writeJSONResultAndExit(
+		cmd, jsonStatusError, err, "omp_profile_invalid", map[string]any{"platform": "omp"},
+		[]jsonMessage{{Code: "omp_profile_invalid", Message: err.Error()}}, nil,
+	)
+}
+
+func renderOMPProfilePlanText(
+	cmd *cobra.Command,
+	payload ompProfilePlanPayload,
+	profile config.RoleModelProfileConf,
+) error {
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintln(out, "OMP model profile proposal")
+	_, _ = fmt.Fprintf(out, "Name: %s\nMode: %s\nWrites: 0\n", payload.Name, payload.Mode)
+	_, _ = fmt.Fprintf(out, "Catalog: %s %s\n", payload.CatalogVersion, payload.CatalogFingerprint)
+	policy := config.RoleModelPolicyConf{
+		Version:  config.RoleModelPolicyVersionV1,
+		Profile:  payload.Name,
+		Profiles: map[string]config.RoleModelProfileConf{payload.Name: profile},
+	}
+	encoded, err := yaml.Marshal(map[string]any{"role_model_policy": policy})
+	if err != nil {
+		return fmt.Errorf("marshal OMP profile proposal: %w", err)
+	}
+	_, _ = fmt.Fprint(out, strings.TrimSpace(string(encoded))+"\n")
+	_, _ = fmt.Fprintf(out, "Next: auto platform omp profile apply %s\n", payload.Name)
+	return nil
+}

--- a/internal/cli/platform_omp_projection_build.go
+++ b/internal/cli/platform_omp_projection_build.go
@@ -1,0 +1,209 @@
+package cli
+
+import (
+	"context"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/adapter/omp"
+	"github.com/insajin/autopus-adk/pkg/config"
+)
+
+func buildOMPPlatformProjection(
+	ctx context.Context,
+	root string,
+	runner omp.OMPModelCatalogRunner,
+	now time.Time,
+) ompPlatformProjection {
+	projection := defaultOMPPlatformProjection()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	} else {
+		now = now.UTC()
+	}
+	if !config.Exists(root) {
+		projection.Reason = "autopus_config_missing"
+		projection.Blockers = []string{"config:missing"}
+		return projection
+	}
+	cfg, err := config.LoadPreview(root)
+	if err != nil {
+		projection.Reason = "autopus_config_invalid"
+		projection.Blockers = []string{"config:invalid"}
+		return projection
+	}
+	if !containsOMPString(cfg.Platforms, "omp") {
+		projection.Reason = "omp_platform_not_configured"
+		projection.Blockers = []string{"platform:not_configured"}
+		return projection
+	}
+	projection.Configured = true
+	projection.Models = buildOMPModelOperatorProjection(ctx, root, cfg, runner)
+	projection.Context = buildOMPContextOperatorProjection(ctx, root, cfg, runner, now)
+	projection.ChildRuntime.EvidenceSource = projection.Context.EvidenceSource
+	projection.ReceiptVerification = ompReceiptVerificationProjection{
+		ModelStatus: projection.Models.ReceiptStatus, ModelVerified: projection.Models.ReceiptVerified,
+		ModelReason:   projection.Models.Reason,
+		ContextStatus: projection.Context.ReceiptStatus, ContextVerified: projection.Context.ReceiptVerified,
+		ContextReason: projection.Context.Reason,
+	}
+	projection.Blockers = collectOMPOperatorBlockers(projection)
+	projection.Status, projection.Reason = summarizeOMPOperatorStatus(projection)
+	return projection
+}
+
+func buildOMPModelOperatorProjection(
+	ctx context.Context,
+	root string,
+	cfg *config.HarnessConfig,
+	runner omp.OMPModelCatalogRunner,
+) ompModelOperatorProjection {
+	result := ompModelOperatorProjection{
+		Status: "disabled", Reason: "profile_not_selected", CatalogStatus: "not_probed",
+		CatalogReason: "profile_not_selected", ReceiptStatus: "not_applicable",
+		Models: []ompEffectiveModelProjection{},
+	}
+	profileName, profile, selected := cfg.RoleModelPolicy.SelectedRoleModelProfile()
+	if !selected {
+		return result
+	}
+	result.Enabled = true
+	result.Profile = safeOMPOperatorToken(profileName)
+	input := buildOMPModelDoctorInput(ctx, root, cfg, runner)
+	report := omp.CheckOMPModelRoutingDoctor(input)
+	result.Status = safeOMPOperatorReason(report.Status)
+	if result.Status == "not_available" {
+		result.Status = "blocked"
+	}
+	result.Reason = safeOMPOperatorReason(report.Reason)
+	result.CatalogStatus = safeOMPOperatorReason(input.Probe.Status)
+	result.CatalogReason = safeOMPOperatorReason(input.Probe.Reason)
+	result.CatalogVersion = safeOMPOperatorVersion(input.Probe.Version)
+	result.CatalogFingerprint = input.Probe.Catalog.Fingerprint
+	result.ReceiptStatus = safeOMPOperatorReason(report.ReceiptStatus)
+	result.ReceiptVerified = result.ReceiptStatus == "valid" && result.Status != "blocked"
+	result.Models = projectOMPEffectiveModels(input.Compilation.Resolutions, profile, result.ReceiptVerified)
+	return result
+}
+
+func projectOMPEffectiveModels(
+	resolutions []omp.OMPModelRouteResolution,
+	profile config.RoleModelProfileConf,
+	receiptVerified bool,
+) []ompEffectiveModelProjection {
+	rows := make([]ompEffectiveModelProjection, 0, len(resolutions))
+	for _, resolution := range resolutions {
+		row := ompEffectiveModelProjection{
+			Agent:      safeOMPOperatorToken(resolution.Agent),
+			Role:       safeOMPOperatorToken(resolution.RequestedRole),
+			Capability: safeOMPOperatorToken(resolution.Capability),
+			Source:     "autopus.yaml", ConfigSource: safeOMPOperatorToken(profile.ConfigMode),
+			Status: safeOMPOperatorReason(resolution.Status), Reason: safeOMPOperatorReason(resolution.Reason),
+			Verified:         receiptVerified && resolution.Status == "selected",
+			FallbackAttempts: []ompFallbackProjection{},
+		}
+		if resolution.Status == "selected" {
+			row.Provider = safeOMPOperatorToken(resolution.EffectiveProvider)
+			row.Model = safeOMPOperatorToken(resolution.EffectiveModel)
+			row.Thinking = safeOMPOperatorToken(resolution.Thinking)
+		}
+		for _, attempt := range resolution.FallbackAttempts {
+			row.FallbackAttempts = append(row.FallbackAttempts, ompFallbackProjection{
+				Index: attempt.Index, Selector: safeOMPOperatorToken(attempt.Selector),
+				Status: safeOMPOperatorReason(attempt.Status), Reason: safeOMPOperatorReason(attempt.Reason),
+			})
+			if attempt.Status == "selected" && attempt.Index > 0 {
+				row.FallbackUsed = true
+			}
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func buildOMPContextOperatorProjection(
+	ctx context.Context,
+	root string,
+	cfg *config.HarnessConfig,
+	runner ompContextDoctorRunner,
+	now time.Time,
+) ompContextOperatorProjection {
+	result := ompContextOperatorProjection{
+		Status: "disabled", Reason: "profile_not_selected", PromotionFreshness: "not_applicable",
+		ReceiptStatus: "not_applicable", ReceiptFreshness: "not_applicable", EvidenceSource: "not_available",
+	}
+	policy, selected, err := workflowContextPolicyFromConfig(cfg)
+	if err != nil || !selected {
+		if err != nil {
+			result.Status, result.Reason = "blocked", "context_profile_invalid"
+		}
+		return result
+	}
+	input := ompContextDoctorInput{
+		Enabled: true, Profile: policy.Profile, RequestedHistoryMode: policy.HistoryMode,
+		RequestedMemoryMode: policy.MemoryMode, FallbackMode: policy.Fallback,
+		RuntimeRootPolicy: policy.RuntimeRootPolicy,
+		Current:           probeOMPContextCurrentRuntime(ctx, runner), Receipt: readOMPContextDoctorReceipt(root, now),
+	}
+	report := checkOMPContextDoctor(input)
+	result.Enabled = true
+	result.Profile = safeOMPOperatorToken(report.Profile)
+	result.Status = safeOMPOperatorReason(report.Status)
+	result.Reason = safeOMPOperatorReason(report.Reason)
+	result.RequestedHistoryMode = safeOMPOperatorToken(report.RequestedHistoryMode)
+	result.EffectiveHistoryMode = safeOMPOperatorToken(report.EffectiveHistoryMode)
+	result.RequestedMemoryMode = safeOMPOperatorToken(report.RequestedMemoryMode)
+	result.EffectiveMemoryMode = safeOMPOperatorToken(report.EffectiveMemoryMode)
+	result.FallbackMode = safeOMPOperatorToken(report.FallbackMode)
+	result.FallbackReason = safeOMPOperatorReason(report.FallbackReason)
+	result.ReceiptStatus = safeOMPOperatorReason(report.ReceiptStatus)
+	result.ReceiptFreshness = safeOMPOperatorReason(report.ReceiptFreshness)
+	result.ReceiptVerified = result.ReceiptStatus == "valid" && result.ReceiptFreshness == "fresh"
+	if input.Receipt.Status == "valid" {
+		result.EvidenceSource = safeOMPOperatorToken(input.Receipt.Receipt.Capabilities.ProbeSource)
+		result.PromotionFreshness = ompPromotionFreshness(
+			input.Receipt.Receipt.PromotionCheckedAt, input.Receipt.Freshness, now,
+		)
+	} else {
+		result.PromotionFreshness = result.ReceiptFreshness
+	}
+	return result
+}
+
+func collectOMPOperatorBlockers(projection ompPlatformProjection) []string {
+	var blockers []string
+	if projection.Models.Enabled {
+		if projection.Models.CatalogStatus != "ready" || projection.Models.CatalogReason != "catalog_ready" {
+			blockers = appendUniqueOMPBlocker(blockers, "models:"+projection.Models.CatalogReason)
+		}
+		if projection.Models.Status == "blocked" {
+			blockers = appendUniqueOMPBlocker(blockers, "models:"+projection.Models.Reason)
+		}
+		for _, row := range projection.Models.Models {
+			if row.Status == "blocked" {
+				blockers = appendUniqueOMPBlocker(blockers, "models:"+row.Capability+":"+row.Reason)
+			}
+		}
+	}
+	if projection.Context.Enabled && projection.Context.Status != "supported" {
+		blockers = appendUniqueOMPBlocker(blockers, "context:"+projection.Context.Reason)
+	}
+	return sortOMPBlockers(blockers)
+}
+
+func summarizeOMPOperatorStatus(projection ompPlatformProjection) (string, string) {
+	if projection.Models.Enabled && projection.Models.Status == "blocked" ||
+		projection.Context.Enabled && projection.Context.Status == "blocked" {
+		if len(projection.Blockers) != 0 {
+			return "blocked", projection.Blockers[0]
+		}
+		return "blocked", "operator_check_blocked"
+	}
+	if projection.Models.Enabled && projection.Models.Status == "degraded" ||
+		projection.Context.Enabled && projection.Context.Status == "degraded" {
+		if len(projection.Blockers) != 0 {
+			return "degraded", projection.Blockers[0]
+		}
+		return "degraded", "operator_check_degraded"
+	}
+	return "ready", "ready"
+}

--- a/internal/cli/platform_omp_projection_types.go
+++ b/internal/cli/platform_omp_projection_types.go
@@ -1,0 +1,203 @@
+package cli
+
+import (
+	"sort"
+	"strings"
+	"time"
+)
+
+const ompLiveStateLimitation = "Live child state is only available through the OMP hub; Autopus does not read user-owned OMP session roots."
+const ompLiveStateNextCommand = "In the active OMP session, call hub with {\"op\":\"jobs\"}."
+
+type ompFallbackProjection struct {
+	Index    int    `json:"index"`
+	Selector string `json:"selector"`
+	Status   string `json:"status"`
+	Reason   string `json:"reason"`
+}
+
+type ompEffectiveModelProjection struct {
+	Agent            string                  `json:"agent"`
+	Role             string                  `json:"role"`
+	Capability       string                  `json:"capability"`
+	Provider         string                  `json:"provider,omitempty"`
+	Model            string                  `json:"model,omitempty"`
+	Thinking         string                  `json:"thinking,omitempty"`
+	Source           string                  `json:"source"`
+	ConfigSource     string                  `json:"config_source"`
+	Status           string                  `json:"status"`
+	Reason           string                  `json:"reason"`
+	Verified         bool                    `json:"verified"`
+	FallbackUsed     bool                    `json:"fallback_used"`
+	FallbackAttempts []ompFallbackProjection `json:"fallback_attempts"`
+}
+
+type ompModelOperatorProjection struct {
+	Enabled            bool                          `json:"enabled"`
+	Profile            string                        `json:"profile,omitempty"`
+	Status             string                        `json:"status"`
+	Reason             string                        `json:"reason"`
+	CatalogStatus      string                        `json:"catalog_status"`
+	CatalogReason      string                        `json:"catalog_reason"`
+	CatalogVersion     string                        `json:"catalog_version,omitempty"`
+	CatalogFingerprint string                        `json:"catalog_fingerprint,omitempty"`
+	ReceiptStatus      string                        `json:"receipt_status"`
+	ReceiptVerified    bool                          `json:"receipt_verified"`
+	Models             []ompEffectiveModelProjection `json:"models"`
+}
+
+type ompContextOperatorProjection struct {
+	Enabled              bool   `json:"enabled"`
+	Profile              string `json:"profile,omitempty"`
+	Status               string `json:"status"`
+	Reason               string `json:"reason"`
+	RequestedHistoryMode string `json:"requested_history_mode,omitempty"`
+	EffectiveHistoryMode string `json:"effective_history_mode,omitempty"`
+	RequestedMemoryMode  string `json:"requested_memory_mode,omitempty"`
+	EffectiveMemoryMode  string `json:"effective_memory_mode,omitempty"`
+	FallbackMode         string `json:"fallback_mode,omitempty"`
+	FallbackReason       string `json:"fallback_reason,omitempty"`
+	PromotionFreshness   string `json:"promotion_freshness"`
+	ReceiptStatus        string `json:"receipt_status"`
+	ReceiptFreshness     string `json:"receipt_freshness"`
+	ReceiptVerified      bool   `json:"receipt_verified"`
+	EvidenceSource       string `json:"evidence_source"`
+}
+
+type ompDAGOperatorProjection struct {
+	ContractOwner  string `json:"contract_owner"`
+	EffectiveOwner string `json:"effective_owner"`
+	ReceiptStatus  string `json:"receipt_status"`
+	Source         string `json:"source"`
+	Reason         string `json:"reason"`
+}
+
+type ompChildRuntimeProjection struct {
+	Status         string `json:"status"`
+	Source         string `json:"source"`
+	EvidenceSource string `json:"evidence_source"`
+	Reason         string `json:"reason"`
+	Limitation     string `json:"limitation"`
+	NextCommand    string `json:"next_command"`
+}
+
+type ompReceiptVerificationProjection struct {
+	ModelStatus     string `json:"model_status"`
+	ModelVerified   bool   `json:"model_verified"`
+	ModelReason     string `json:"model_reason"`
+	ContextStatus   string `json:"context_status"`
+	ContextVerified bool   `json:"context_verified"`
+	ContextReason   string `json:"context_reason"`
+}
+
+type ompPlatformProjection struct {
+	Platform            string                           `json:"platform"`
+	Configured          bool                             `json:"configured"`
+	Status              string                           `json:"status"`
+	Reason              string                           `json:"reason"`
+	DAG                 ompDAGOperatorProjection         `json:"dag"`
+	Models              ompModelOperatorProjection       `json:"models"`
+	Context             ompContextOperatorProjection     `json:"context"`
+	ChildRuntime        ompChildRuntimeProjection        `json:"child_runtime"`
+	ReceiptVerification ompReceiptVerificationProjection `json:"receipt_verification"`
+	Blockers            []string                         `json:"blockers"`
+}
+
+func defaultOMPPlatformProjection() ompPlatformProjection {
+	return ompPlatformProjection{
+		Platform: "omp", Status: "blocked", Reason: "not_evaluated",
+		DAG: ompDAGOperatorProjection{
+			ContractOwner: "omp-local", EffectiveOwner: "unverified",
+			ReceiptStatus: "hub_only", Source: "generated_omp_workflow_contract",
+			Reason: "live_child_state_hub_only",
+		},
+		Models: ompModelOperatorProjection{
+			Status: "disabled", Reason: "profile_not_selected", CatalogStatus: "not_probed",
+			CatalogReason: "profile_not_selected", ReceiptStatus: "not_applicable",
+			Models: []ompEffectiveModelProjection{},
+		},
+		Context: ompContextOperatorProjection{
+			Status: "disabled", Reason: "profile_not_selected", PromotionFreshness: "not_applicable",
+			ReceiptStatus: "not_applicable", ReceiptFreshness: "not_applicable", EvidenceSource: "not_available",
+		},
+		ChildRuntime: ompChildRuntimeProjection{
+			Status: "unavailable", Source: "omp_hub", EvidenceSource: "not_available",
+			Reason: "live_child_state_hub_only", Limitation: ompLiveStateLimitation,
+			NextCommand: ompLiveStateNextCommand,
+		},
+		ReceiptVerification: ompReceiptVerificationProjection{
+			ModelStatus: "not_applicable", ModelReason: "profile_not_selected",
+			ContextStatus: "not_applicable", ContextReason: "profile_not_selected",
+		},
+		Blockers: []string{},
+	}
+}
+
+func safeOMPOperatorToken(value string) string {
+	if value == "" || len(value) > 256 || strings.TrimSpace(value) != value {
+		return "not_available"
+	}
+	lower := strings.ToLower(value)
+	for _, marker := range []string{"authorization", "bearer ", "api_key", "api-key", "password", "secret", "access_token", "refresh_token"} {
+		if strings.Contains(lower, marker) {
+			return "redacted"
+		}
+	}
+	for _, char := range value {
+		if char >= 'a' && char <= 'z' || char >= 'A' && char <= 'Z' || char >= '0' && char <= '9' ||
+			strings.ContainsRune("._-/:=", char) {
+			continue
+		}
+		return "redacted"
+	}
+	return value
+}
+
+func safeOMPOperatorReason(value string) string {
+	return safeOMPOperatorToken(value)
+}
+
+func safeOMPOperatorVersion(value string) string {
+	if !ompDoctorVersion.MatchString(value) {
+		return "not_available"
+	}
+	return value
+}
+
+func appendUniqueOMPBlocker(blockers []string, value string) []string {
+	value = safeOMPOperatorToken(value)
+	if value == "not_available" || value == "redacted" {
+		return blockers
+	}
+	for _, existing := range blockers {
+		if existing == value {
+			return blockers
+		}
+	}
+	return append(blockers, value)
+}
+
+func sortOMPBlockers(blockers []string) []string {
+	sort.Strings(blockers)
+	if blockers == nil {
+		return []string{}
+	}
+	return blockers
+}
+
+func ompPromotionFreshness(raw string, receiptFreshness string, now time.Time) string {
+	if receiptFreshness != "fresh" {
+		return receiptFreshness
+	}
+	if raw == "" {
+		return "missing"
+	}
+	checkedAt, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil || checkedAt.After(now.Add(5*time.Minute)) {
+		return "invalid"
+	}
+	if now.Sub(checkedAt) > 24*time.Hour {
+		return "stale"
+	}
+	return "fresh"
+}

--- a/internal/cli/platform_omp_runner.go
+++ b/internal/cli/platform_omp_runner.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+
+	"github.com/insajin/autopus-adk/pkg/adapter/omp"
+)
+
+type ompOperatorExecRunner struct {
+	process *omp.OMPModelProbeProcess
+	pinErr  error
+}
+
+func newOMPOperatorExecRunner() *ompOperatorExecRunner {
+	process, err := omp.NewOMPInstalledModelProbeProcess("omp", ompModelDoctorProbeOutput)
+	return &ompOperatorExecRunner{process: process, pinErr: err}
+}
+
+func (runner ompOperatorExecRunner) Run(
+	ctx context.Context,
+	executable string,
+	args ...string,
+) ([]byte, error) {
+	if executable != "omp" || !safeOMPOperatorProbeArgs(args) {
+		return nil, errors.New("unsafe OMP operator command")
+	}
+	if runner.pinErr != nil {
+		return nil, runner.pinErr
+	}
+	return runner.process.Run(ctx, args...)
+}
+
+func safeOMPOperatorProbeArgs(args []string) bool {
+	joined := strings.Join(args, " ")
+	if joined == "--version" || joined == "models --json --no-extensions" ||
+		joined == "config list --json" {
+		return true
+	}
+	keyIndex := 2
+	if len(args) == 6 && args[0] == "--config" && filepath.IsAbs(args[1]) &&
+		!strings.ContainsAny(args[1], "\x00\r\n") {
+		keyIndex = 4
+	}
+	if len(args) != keyIndex+2 || args[keyIndex-2] != "config" ||
+		args[keyIndex-1] != "get" || args[keyIndex+1] != "--json" {
+		return false
+	}
+	allowed := map[string]bool{
+		"modelRoles": true, "retry.fallbackChains": true, "retry.modelFallback": true,
+		"tools.approvalMode": true, "task.isolation.mode": true,
+	}
+	return allowed[args[keyIndex]]
+}

--- a/internal/cli/platform_omp_status.go
+++ b/internal/cli/platform_omp_status.go
@@ -1,0 +1,213 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func runOMPPlatformStatus(
+	cmd *cobra.Command,
+	root string,
+	jsonMode bool,
+	deps ompPlatformDependencies,
+) error {
+	deps = normalizeOMPPlatformDependencies(deps)
+	projection := buildOMPPlatformProjection(cmd.Context(), root, deps.newRunner(), deps.now())
+	return renderOMPPlatformStatus(cmd, projection, jsonMode)
+}
+
+func renderOMPPlatformStatus(
+	cmd *cobra.Command,
+	projection ompPlatformProjection,
+	jsonMode bool,
+) error {
+	if jsonMode {
+		return writeJSONResult(
+			cmd,
+			ompProjectionEnvelopeStatus(projection.Status),
+			projection,
+			ompProjectionWarnings(projection.Blockers),
+			ompProjectionChecks(projection),
+		)
+	}
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintln(out, "OMP operator status")
+	_, _ = fmt.Fprintf(out, "Platform: configured=%t status=%s reason=%s\n", projection.Configured, projection.Status, projection.Reason)
+	_, _ = fmt.Fprintf(
+		out, "DAG: contract_owner=%s effective_owner=%s receipt=%s source=%s\n",
+		projection.DAG.ContractOwner, projection.DAG.EffectiveOwner,
+		projection.DAG.ReceiptStatus, projection.DAG.Source,
+	)
+	_, _ = fmt.Fprintf(
+		out, "Models: enabled=%t profile=%s status=%s reason=%s catalog=%s receipt=%s verified=%t\n",
+		projection.Models.Enabled, valueOrDash(projection.Models.Profile), projection.Models.Status,
+		projection.Models.Reason, projection.Models.CatalogReason,
+		projection.Models.ReceiptStatus, projection.Models.ReceiptVerified,
+	)
+	for _, row := range projection.Models.Models {
+		_, _ = fmt.Fprintf(
+			out, "  %s role=%s capability=%s model=%s/%s thinking=%s source=%s:%s status=%s reason=%s fallback=%t verified=%t\n",
+			row.Agent, row.Role, row.Capability, valueOrDash(row.Provider), valueOrDash(row.Model),
+			valueOrDash(row.Thinking), row.Source, row.ConfigSource, row.Status, row.Reason,
+			row.FallbackUsed, row.Verified,
+		)
+	}
+	_, _ = fmt.Fprintf(
+		out, "Context: enabled=%t profile=%s status=%s reason=%s history=%s->%s memory=%s->%s fallback=%s:%s promotion=%s\n",
+		projection.Context.Enabled, valueOrDash(projection.Context.Profile), projection.Context.Status,
+		projection.Context.Reason, valueOrDash(projection.Context.RequestedHistoryMode),
+		valueOrDash(projection.Context.EffectiveHistoryMode), valueOrDash(projection.Context.RequestedMemoryMode),
+		valueOrDash(projection.Context.EffectiveMemoryMode), valueOrDash(projection.Context.FallbackMode),
+		valueOrDash(projection.Context.FallbackReason), projection.Context.PromotionFreshness,
+	)
+	_, _ = fmt.Fprintf(
+		out, "Receipts: model=%s verified=%t context=%s/%s verified=%t\n",
+		projection.ReceiptVerification.ModelStatus, projection.ReceiptVerification.ModelVerified,
+		projection.ReceiptVerification.ContextStatus, projection.Context.ReceiptFreshness,
+		projection.ReceiptVerification.ContextVerified,
+	)
+	_, _ = fmt.Fprintf(out, "Child runtime: %s source=%s reason=%s\n", projection.ChildRuntime.Status, projection.ChildRuntime.Source, projection.ChildRuntime.Reason)
+	_, _ = fmt.Fprintln(out, projection.ChildRuntime.Limitation)
+	_, _ = fmt.Fprintln(out, "Next: "+projection.ChildRuntime.NextCommand)
+	renderOMPOperatorBlockers(out, projection.Blockers)
+	return nil
+}
+
+func renderOMPExplain(
+	cmd *cobra.Command,
+	projection ompPlatformProjection,
+	jsonMode bool,
+) error {
+	data := struct {
+		Platform string                     `json:"platform"`
+		Status   string                     `json:"status"`
+		Reason   string                     `json:"reason"`
+		Models   ompModelOperatorProjection `json:"models"`
+		Blockers []string                   `json:"blockers"`
+	}{
+		Platform: projection.Platform, Status: projection.Status, Reason: projection.Reason,
+		Models: projection.Models, Blockers: projection.Blockers,
+	}
+	if jsonMode {
+		return writeJSONResult(
+			cmd, ompProjectionEnvelopeStatus(projection.Status), data,
+			ompProjectionWarnings(projection.Blockers), ompProjectionChecks(projection),
+		)
+	}
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintln(out, "OMP model routing explanation")
+	_, _ = fmt.Fprintf(
+		out, "Profile: %s enabled=%t status=%s reason=%s\nCatalog: %s %s\nReceipt: %s verified=%t\n",
+		valueOrDash(projection.Models.Profile), projection.Models.Enabled,
+		projection.Models.Status, projection.Models.Reason,
+		valueOrDash(projection.Models.CatalogVersion), valueOrDash(projection.Models.CatalogFingerprint),
+		projection.Models.ReceiptStatus, projection.Models.ReceiptVerified,
+	)
+	for _, row := range projection.Models.Models {
+		_, _ = fmt.Fprintf(
+			out, "- agent=%s capability=%s role=%s provider=%s model=%s thinking=%s source=%s:%s status=%s reason=%s verified=%t\n",
+			row.Agent, row.Capability, row.Role, valueOrDash(row.Provider), valueOrDash(row.Model),
+			valueOrDash(row.Thinking), row.Source, row.ConfigSource, row.Status, row.Reason, row.Verified,
+		)
+		for _, attempt := range row.FallbackAttempts {
+			_, _ = fmt.Fprintf(
+				out, "    fallback[%d]=%s status=%s reason=%s\n",
+				attempt.Index, attempt.Selector, attempt.Status, attempt.Reason,
+			)
+		}
+	}
+	renderOMPOperatorBlockers(out, projection.Blockers)
+	return nil
+}
+
+func renderOMPOperatorBlockers(out interface{ Write([]byte) (int, error) }, blockers []string) {
+	if len(blockers) == 0 {
+		_, _ = fmt.Fprintln(out, "Blockers: none")
+		return
+	}
+	_, _ = fmt.Fprintln(out, "Blockers:")
+	for _, blocker := range blockers {
+		_, _ = fmt.Fprintln(out, "- "+blocker)
+	}
+}
+
+func ompProjectionEnvelopeStatus(status string) jsonEnvelopeStatus {
+	if status == "ready" {
+		return jsonStatusOK
+	}
+	return jsonStatusWarn
+}
+
+func ompProjectionWarnings(blockers []string) []jsonMessage {
+	warnings := make([]jsonMessage, 0, len(blockers))
+	for _, blocker := range blockers {
+		warnings = append(warnings, jsonMessage{Code: "omp_operator_blocker", Message: blocker})
+	}
+	return warnings
+}
+
+func ompProjectionChecks(projection ompPlatformProjection) []jsonCheck {
+	checks := []jsonCheck{
+		{ID: "omp.platform", Severity: projectionCheckSeverity(projection.Configured), Status: projectionCheckStatus(projection.Configured), Detail: projection.Reason},
+		{ID: "omp.models", Severity: projectionStatusSeverity(projection.Models.Status), Status: projectionStatusCheck(projection.Models.Status), Detail: projection.Models.Reason},
+		{ID: "omp.context", Severity: projectionStatusSeverity(projection.Context.Status), Status: projectionStatusCheck(projection.Context.Status), Detail: projection.Context.Reason},
+		receiptProjectionCheck("omp.receipt.models", projection.Models.Enabled, projection.Models.ReceiptVerified, projection.Models.ReceiptStatus),
+		receiptProjectionCheck("omp.receipt.context", projection.Context.Enabled, projection.Context.ReceiptVerified, projection.Context.ReceiptStatus),
+		{ID: "omp.child_runtime", Severity: "info", Status: "skip", Detail: "live_child_state_hub_only"},
+	}
+	return checks
+}
+
+func receiptProjectionCheck(id string, enabled, verified bool, detail string) jsonCheck {
+	if !enabled {
+		return jsonCheck{ID: id, Severity: "info", Status: "skip", Detail: detail}
+	}
+	return jsonCheck{
+		ID: id, Severity: projectionCheckSeverity(verified),
+		Status: projectionCheckStatus(verified), Detail: detail,
+	}
+}
+
+func projectionCheckSeverity(pass bool) string {
+	if pass {
+		return "info"
+	}
+	return "warning"
+}
+
+func projectionCheckStatus(pass bool) string {
+	if pass {
+		return "pass"
+	}
+	return "fail"
+}
+
+func projectionStatusSeverity(status string) string {
+	if status == "blocked" {
+		return "error"
+	}
+	if status == "degraded" {
+		return "warning"
+	}
+	return "info"
+}
+
+func projectionStatusCheck(status string) string {
+	switch status {
+	case "supported", "ready":
+		return "pass"
+	case "disabled":
+		return "skip"
+	default:
+		return "fail"
+	}
+}
+
+func valueOrDash(value string) string {
+	if strings.TrimSpace(value) == "" || value == "not_available" {
+		return "-"
+	}
+	return value
+}

--- a/internal/cli/platform_omp_test.go
+++ b/internal/cli/platform_omp_test.go
@@ -1,0 +1,447 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/adapter/omp"
+	"github.com/insajin/autopus-adk/pkg/config"
+)
+
+type ompCLIJSONEnvelope struct {
+	Status jsonEnvelopeStatus `json:"status"`
+	Data   json.RawMessage    `json:"data"`
+}
+
+type ompCLIFakeRunner struct {
+	catalog []byte
+	fail    bool
+	calls   []string
+}
+
+func (runner *ompCLIFakeRunner) Run(_ context.Context, executable string, args ...string) ([]byte, error) {
+	runner.calls = append(runner.calls, executable+" "+strings.Join(args, " "))
+	if runner.fail {
+		return nil, errors.New("fixture unavailable")
+	}
+	switch strings.Join(args, " ") {
+	case "--version":
+		return []byte("omp/17.1.8\n"), nil
+	case "models --json --no-extensions":
+		return append([]byte(nil), runner.catalog...), nil
+	case "config list --json":
+		return []byte(`{"compaction":{},"memory":{}}`), nil
+	default:
+		if len(args) >= 4 && args[len(args)-1] == "--json" && args[len(args)-3] == "config" && args[len(args)-2] == "get" {
+			return []byte(`{}`), nil
+		}
+		return nil, fmt.Errorf("unexpected fixture args: %s", strings.Join(args, " "))
+	}
+}
+
+func TestPlatformOMPHelpSurfacesCommandsAndExactFlags(t *testing.T) {
+	assertCommandHelpContains(t, []string{"platform", "omp", "--help"}, "models", "profile", "explain", "--dir")
+	assertCommandHelpContains(t, []string{"platform", "omp", "models", "--help"}, "--json", "--format")
+	assertCommandHelpContains(t, []string{"platform", "omp", "profile", "init", "--help"}, "--name", "--plan", "--json", "--format")
+	assertCommandHelpContains(t, []string{"platform", "omp", "profile", "apply", "--help"}, "apply <name>", "--json", "--format")
+	assertCommandHelpContains(t, []string{"platform", "omp", "explain", "--help"}, "--json", "--format")
+	assertCommandHelpContains(t, []string{"status", "--help"}, "--platform", "--dir", "--json", "--format")
+}
+
+func TestPlatformOMPModelsReadyTextAndJSON(t *testing.T) {
+	runner := &ompCLIFakeRunner{catalog: ompCLIReadyCatalogJSON()}
+	dir := t.TempDir()
+	deps := ompPlatformDependencies{newRunner: func() omp.OMPModelCatalogRunner { return runner }}
+
+	text := executeOMPSubcommand(t, newPlatformOMPModelsCmd(&dir, normalizeOMPPlatformDependencies(deps)))
+	assert.Contains(t, text, "OMP installed model catalog")
+	assert.Contains(t, text, "anthropic/alpha-reasoner")
+	assert.NotContains(t, strings.ToLower(text), "secret")
+
+	encoded := executeOMPSubcommand(t, newPlatformOMPModelsCmd(&dir, normalizeOMPPlatformDependencies(deps)), "--json")
+	var envelope ompCLIJSONEnvelope
+	require.NoError(t, json.Unmarshal([]byte(encoded), &envelope))
+	assert.Equal(t, jsonStatusOK, envelope.Status)
+	var payload ompCatalogPayload
+	require.NoError(t, json.Unmarshal(envelope.Data, &payload))
+	assert.Equal(t, "catalog_ready", payload.Reason)
+	assert.Len(t, payload.Models, 5)
+}
+
+func TestPlatformOMPProfileInitPlanWritesNothingAndHasSixCapabilities(t *testing.T) {
+	root := t.TempDir()
+	sentinelPath := filepath.Join(root, "autopus.yaml")
+	sentinel := []byte("sentinel: unchanged\n")
+	require.NoError(t, os.WriteFile(sentinelPath, sentinel, 0o640))
+	runner := &ompCLIFakeRunner{catalog: ompCLIReadyCatalogJSON()}
+	deps := normalizeOMPPlatformDependencies(ompPlatformDependencies{
+		newRunner: func() omp.OMPModelCatalogRunner { return runner },
+	})
+
+	encoded := executeOMPSubcommand(
+		t, newPlatformOMPProfileInitCmd(&root, deps), "--name", "balanced", "--plan", "--json",
+	)
+	var envelope ompCLIJSONEnvelope
+	require.NoError(t, json.Unmarshal([]byte(encoded), &envelope))
+	var payload ompProfilePlanPayload
+	require.NoError(t, json.Unmarshal(envelope.Data, &payload))
+	assert.Equal(t, "plan", payload.Mode)
+	assert.Empty(t, payload.Writes)
+	assert.Len(t, payload.Capabilities, 6)
+	after, err := os.ReadFile(sentinelPath)
+	require.NoError(t, err)
+	assert.Equal(t, sentinel, after)
+	entries, err := os.ReadDir(root)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+}
+
+func TestPlatformOMPProfileApplyPersistsAndRollsBackAtomically(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.DefaultFullConfig("omp-apply")
+	cfg.Platforms = []string{"omp"}
+	require.NoError(t, config.Save(root, cfg))
+	configPath := filepath.Join(root, "autopus.yaml")
+	original, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	original = append(original, []byte("operator_extension:\n  credential_ref: ${OMP_SECRET}\n")...)
+	require.NoError(t, os.WriteFile(configPath, original, 0o640))
+	require.NoError(t, os.Chmod(configPath, 0o640))
+	runner := &ompCLIFakeRunner{catalog: ompCLIReadyCatalogJSON()}
+	activated := false
+	deps := normalizeOMPPlatformDependencies(ompPlatformDependencies{
+		newRunner: func() omp.OMPModelCatalogRunner { return runner },
+		activate: func(_ context.Context, _ string, applied *config.HarnessConfig) error {
+			activated = true
+			name, profile, ok := applied.RoleModelPolicy.SelectedRoleModelProfile()
+			require.True(t, ok)
+			assert.Equal(t, "balanced", name)
+			return preflightOMPProfile(name, profile, mustOMPCatalog(t, runner.catalog))
+		},
+	})
+	dir := root
+	executeOMPSubcommand(t, newPlatformOMPProfileApplyCmd(&dir, deps), "balanced")
+	assert.True(t, activated)
+	loaded, err := config.LoadPreview(root)
+	require.NoError(t, err)
+	name, _, selected := loaded.RoleModelPolicy.SelectedRoleModelProfile()
+	assert.True(t, selected)
+	assert.Equal(t, "balanced", name)
+	persisted, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(persisted), "credential_ref: ${OMP_SECRET}")
+	assert.Equal(t, os.FileMode(0o640), mustFileMode(t, configPath))
+
+	before, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	_, err = applyOMPProfile(
+		context.Background(), root, "second", runner,
+		func(context.Context, string, *config.HarnessConfig) error { return errors.New("activation failed") },
+	)
+	require.Error(t, err)
+	after, readErr := os.ReadFile(configPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, before, after)
+}
+
+func TestPlatformOMPExplainShowsDisabledUnauthorizedAndMissingFallbacks(t *testing.T) {
+	root, runner, profile := writeSelectedOMPProfile(t)
+	route := profile.Capabilities[config.CapabilityCodingToolUse]
+	route.Candidates = []config.RoleModelCandidateConf{
+		{Selector: "openai/disabled-coder", Thinking: "high", Family: "openai"},
+		{Selector: "openai/unauthorized-coder", Thinking: "high", Family: "openai"},
+		{Selector: "openai/missing-coder", Thinking: "high", Family: "openai"},
+		{Selector: "openai/beta-coder", Thinking: "high", Family: "openai"},
+	}
+	profile.Capabilities[config.CapabilityCodingToolUse] = route
+	cfg, err := config.LoadPreview(root)
+	require.NoError(t, err)
+	cfg.RoleModelPolicy.Profiles["balanced"] = profile
+	require.NoError(t, config.Save(root, cfg))
+	deps := normalizeOMPPlatformDependencies(ompPlatformDependencies{
+		newRunner: func() omp.OMPModelCatalogRunner { return runner },
+	})
+	dir := root
+
+	text := executeOMPSubcommand(t, newPlatformOMPExplainCmd(&dir, deps))
+	for _, reason := range []string{"disabled", "unauthorized", "model_unknown", "selected"} {
+		assert.Contains(t, text, "reason="+reason)
+	}
+	encoded := executeOMPSubcommand(t, newPlatformOMPExplainCmd(&dir, deps), "--json")
+	var explainEnvelope struct {
+		Data struct {
+			Models ompModelOperatorProjection `json:"models"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(encoded), &explainEnvelope))
+	reasons := map[string]bool{}
+	for _, model := range explainEnvelope.Data.Models.Models {
+		for _, attempt := range model.FallbackAttempts {
+			reasons[attempt.Reason] = true
+		}
+	}
+	for _, reason := range []string{"disabled", "unauthorized", "model_unknown"} {
+		assert.True(t, reasons[reason], reason)
+	}
+	assert.NotContains(t, strings.ToLower(encoded), "api_key")
+}
+
+func TestOMPStatusProjectionReportsStaleCatalogAndMissingReceipt(t *testing.T) {
+	root, runner, _ := writeSelectedOMPProfile(t)
+	missing := buildOMPPlatformProjection(context.Background(), root, runner, time.Now().UTC())
+	assert.Equal(t, "blocked", missing.Models.Status)
+	assert.Equal(t, "receipt_missing", missing.Models.Reason)
+	assert.Contains(t, missing.Blockers, "models:receipt_missing")
+	var missingText bytes.Buffer
+	missingTextCmd := &cobra.Command{Use: "status"}
+	missingTextCmd.SetOut(&missingText)
+	require.NoError(t, renderOMPPlatformStatus(missingTextCmd, missing, false))
+	assert.Contains(t, missingText.String(), "reason=receipt_missing")
+
+	var missingJSON bytes.Buffer
+	missingJSONCmd := &cobra.Command{Use: "status"}
+	missingJSONCmd.SetOut(&missingJSON)
+	require.NoError(t, renderOMPPlatformStatus(missingJSONCmd, missing, true))
+	var missingEnvelope struct {
+		Data ompPlatformProjection `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(missingJSON.Bytes(), &missingEnvelope))
+	assert.Equal(t, "receipt_missing", missingEnvelope.Data.Models.Reason)
+
+	writeStaleOMPModelReceipt(t, root)
+	stale := buildOMPPlatformProjection(context.Background(), root, runner, time.Now().UTC())
+	assert.Equal(t, "catalog_stale", stale.Models.Reason)
+	assert.False(t, stale.Models.ReceiptVerified)
+	assert.Contains(t, stale.Blockers, "models:catalog_stale")
+	var staleText bytes.Buffer
+	staleTextCmd := &cobra.Command{Use: "status"}
+	staleTextCmd.SetOut(&staleText)
+	require.NoError(t, renderOMPPlatformStatus(staleTextCmd, stale, false))
+	assert.Contains(t, staleText.String(), "reason=catalog_stale")
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{Use: "status"}
+	cmd.SetOut(&out)
+	require.NoError(t, renderOMPPlatformStatus(cmd, stale, true))
+	var statusEnvelope struct {
+		Data ompPlatformProjection `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &statusEnvelope))
+	assert.Equal(t, "catalog_stale", statusEnvelope.Data.Models.Reason)
+	assert.False(t, statusEnvelope.Data.ReceiptVerification.ModelVerified)
+}
+
+func TestOMPProfileProposalRejectsInvalidMissingCapability(t *testing.T) {
+	catalog := mustOMPCatalog(t, ompCLIReadyCatalogJSON())
+	filtered := catalog.Models[:0]
+	for _, model := range catalog.Models {
+		if !containsOMPString(model.Capabilities, config.CapabilityVisionDesign) {
+			filtered = append(filtered, model)
+		}
+	}
+	catalog.Models = filtered
+	_, err := buildOMPProfileProposal("balanced", catalog)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "capability_unavailable:vision_design")
+}
+
+func TestOMPProfileInvalidNameFailsClosedInTextAndJSON(t *testing.T) {
+	root := t.TempDir()
+	runner := &ompCLIFakeRunner{catalog: ompCLIReadyCatalogJSON()}
+	deps := normalizeOMPPlatformDependencies(ompPlatformDependencies{
+		newRunner: func() omp.OMPModelCatalogRunner { return runner },
+	})
+	textCmd := newPlatformOMPProfileInitCmd(&root, deps)
+	textCmd.SilenceErrors = true
+	textCmd.SilenceUsage = true
+	textCmd.SetArgs([]string{"--name", "invalid/name"})
+	err := textCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "profile_name_invalid")
+	assert.Empty(t, runner.calls)
+
+	jsonCmd := newPlatformOMPProfileInitCmd(&root, deps)
+	var out bytes.Buffer
+	jsonCmd.SetOut(&out)
+	jsonCmd.SetErr(&out)
+	jsonCmd.SilenceErrors = true
+	jsonCmd.SilenceUsage = true
+	jsonCmd.SetArgs([]string{"--name", "invalid/name", "--json"})
+	err = jsonCmd.Execute()
+	require.Error(t, err)
+	var envelope struct {
+		Status jsonEnvelopeStatus `json:"status"`
+		Error  jsonErrorPayload   `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &envelope))
+	assert.Equal(t, jsonStatusError, envelope.Status)
+	assert.Equal(t, "omp_profile_invalid", envelope.Error.Code)
+	assert.Contains(t, envelope.Error.Message, "profile_name_invalid")
+	assert.Empty(t, runner.calls)
+}
+
+func TestOMPStatusNoOptInIsReadyHubLimitedAndBareStatusIsCompatible(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.DefaultFullConfig("omp-status")
+	cfg.Platforms = []string{"omp"}
+	require.NoError(t, config.Save(root, cfg))
+	runner := &ompCLIFakeRunner{catalog: ompCLIReadyCatalogJSON()}
+	deps := normalizeOMPPlatformDependencies(ompPlatformDependencies{
+		newRunner: func() omp.OMPModelCatalogRunner { return runner },
+		now:       func() time.Time { return time.Now().UTC() },
+	})
+	status := newStatusCmdWithOMPDependencies(deps)
+	var operatorOut bytes.Buffer
+	status.SetOut(&operatorOut)
+	status.SetErr(&operatorOut)
+	status.SetArgs([]string{"--dir", root, "--platform", "omp"})
+	require.NoError(t, status.Execute())
+	assert.Contains(t, operatorOut.String(), "status=ready")
+	assert.Contains(t, operatorOut.String(), ompLiveStateLimitation)
+	assert.Contains(t, operatorOut.String(), ompLiveStateNextCommand)
+	assert.Empty(t, runner.calls, "no opt-in must not probe OMP")
+	jsonStatusCmd := newStatusCmdWithOMPDependencies(deps)
+	var jsonOut bytes.Buffer
+	jsonStatusCmd.SetOut(&jsonOut)
+	jsonStatusCmd.SetErr(&jsonOut)
+	jsonStatusCmd.SetArgs([]string{"--dir", root, "--platform", "omp", "--json"})
+	require.NoError(t, jsonStatusCmd.Execute())
+	var statusEnvelope ompCLIJSONEnvelope
+	require.NoError(t, json.Unmarshal(jsonOut.Bytes(), &statusEnvelope))
+	assert.Equal(t, jsonStatusOK, statusEnvelope.Status)
+	var statusPayload ompPlatformProjection
+	require.NoError(t, json.Unmarshal(statusEnvelope.Data, &statusPayload))
+	assert.Equal(t, "ready", statusPayload.Status)
+	assert.Equal(t, ompLiveStateLimitation, statusPayload.ChildRuntime.Limitation)
+	assert.Empty(t, runner.calls, "JSON no opt-in must not probe OMP")
+
+	var want bytes.Buffer
+	legacy := &cobra.Command{Use: "status"}
+	legacy.SetOut(&want)
+	require.NoError(t, runStatusText(legacy, root))
+	bare := newStatusCmdWithOMPDependencies(deps)
+	var got bytes.Buffer
+	bare.SetOut(&got)
+	bare.SetErr(&got)
+	bare.SetArgs([]string{"--dir", root})
+	require.NoError(t, bare.Execute())
+	assert.Equal(t, want.String(), got.String())
+}
+
+func TestOMPModelsMissingExecutableFailsClosedInJSON(t *testing.T) {
+	root := t.TempDir()
+	runner := &ompCLIFakeRunner{fail: true}
+	deps := normalizeOMPPlatformDependencies(ompPlatformDependencies{
+		newRunner: func() omp.OMPModelCatalogRunner { return runner },
+	})
+	cmd := newPlatformOMPModelsCmd(&root, deps)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--json"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	var envelope struct {
+		Status jsonEnvelopeStatus `json:"status"`
+		Data   ompCatalogPayload  `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(out.Bytes(), &envelope))
+	assert.Equal(t, jsonStatusError, envelope.Status)
+	assert.Equal(t, "identity_unverified", envelope.Data.Reason)
+}
+
+func writeSelectedOMPProfile(t *testing.T) (string, *ompCLIFakeRunner, config.RoleModelProfileConf) {
+	t.Helper()
+	root := t.TempDir()
+	runner := &ompCLIFakeRunner{catalog: ompCLIReadyCatalogJSON()}
+	catalog := mustOMPCatalog(t, runner.catalog)
+	proposal, err := buildOMPProfileProposal("balanced", catalog)
+	require.NoError(t, err)
+	cfg := config.DefaultFullConfig("omp-selected")
+	cfg.Platforms = []string{"omp"}
+	cfg.RoleModelPolicy = config.RoleModelPolicyConf{
+		Version: config.RoleModelPolicyVersionV1, Profile: "balanced",
+		Profiles: map[string]config.RoleModelProfileConf{"balanced": proposal.profile},
+	}
+	require.NoError(t, config.Save(root, cfg))
+	return root, runner, proposal.profile
+}
+
+func writeStaleOMPModelReceipt(t *testing.T, root string) {
+	t.Helper()
+	hash := "sha256:" + strings.Repeat("a", 64)
+	receipt := omp.OMPModelResolutionReceipt{
+		OMPVersion: "omp/17.1.8", CatalogFingerprint: hash, Profile: "balanced", ConfigSource: "overlay",
+		Activation: omp.OMPModelActivationReceipt{Argv: []string{"omp"}, ConfigHash: hash, ReadbackHash: hash},
+		Roles: []omp.OMPModelRoleReceipt{{
+			Agent: "executor", Profile: "balanced", ConfigSource: "overlay", RequestedRole: "task", EffectiveRole: "task",
+			Capability: config.CapabilityCodingToolUse, Provider: "openai", Model: "beta-coder",
+			Selector: "openai/beta-coder", Thinking: "high",
+			FamilyDiversity: omp.OMPModelFamilyDiversityReceipt{Status: "not_applicable"}, SafetySource: "user_effective",
+		}},
+		GeneratedAt: time.Now().UTC(),
+	}
+	_, err := omp.WriteOMPModelResolutionReceipt(omp.OMPModelReceiptWriteInput{WorkspaceRoot: root, Receipt: receipt})
+	require.NoError(t, err)
+}
+
+func mustOMPCatalog(t *testing.T, data []byte) omp.OMPModelCatalog {
+	t.Helper()
+	catalog, reason := omp.NormalizeOMPModelCatalog(data, 1<<20)
+	require.Equal(t, "catalog_ready", reason)
+	return catalog
+}
+
+func ompCLIReadyCatalogJSON() []byte {
+	return []byte(`{"models":[
+		{"provider":"anthropic","id":"alpha-reasoner","family":"anthropic","capabilities":["deep_reasoning","independent_dissent"],"thinking":["high","xhigh"],"auth_enabled":true,"keyless":false,"disabled":false},
+		{"provider":"openai","id":"beta-coder","family":"openai","capabilities":["coding_tool_use","fast_validation","independent_dissent","deterministic_transform"],"thinking":["low","medium","high"],"auth_enabled":true,"keyless":false,"disabled":false},
+		{"provider":"google","id":"gamma-vision","family":"google","capabilities":["vision_design"],"thinking":["high"],"auth_enabled":true,"keyless":false,"disabled":false},
+		{"provider":"openai","id":"disabled-coder","family":"openai","capabilities":["coding_tool_use"],"thinking":["high"],"auth_enabled":true,"keyless":false,"disabled":true},
+		{"provider":"openai","id":"unauthorized-coder","family":"openai","capabilities":["coding_tool_use"],"thinking":["high"],"auth_enabled":false,"keyless":false,"disabled":false}
+	]}`)
+}
+
+func executeOMPSubcommand(t *testing.T, cmd *cobra.Command, args ...string) string {
+	t.Helper()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	require.NoError(t, cmd.Execute(), out.String())
+	return out.String()
+}
+
+func mustFileMode(t *testing.T, path string) os.FileMode {
+	t.Helper()
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	return info.Mode().Perm()
+}
+
+func assertCommandHelpContains(t *testing.T, args []string, expected ...string) {
+	t.Helper()
+	root := NewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs(args)
+	require.NoError(t, root.Execute())
+	for _, value := range expected {
+		assert.Contains(t, out.String(), value)
+	}
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -143,8 +143,13 @@ func scanSpecs(specsDir string) ([]specEntry, error) {
 }
 
 func newStatusCmd() *cobra.Command {
+	return newStatusCmdWithOMPDependencies(defaultOMPPlatformDependencies())
+}
+
+func newStatusCmdWithOMPDependencies(deps ompPlatformDependencies) *cobra.Command {
 	var (
 		dir        string
+		platform   string
 		jsonOutput bool
 		format     string
 	)
@@ -186,6 +191,20 @@ func newStatusCmd() *cobra.Command {
 					return fmt.Errorf("현재 디렉터리를 가져올 수 없음: %w", err)
 				}
 			}
+			selectedPlatform := strings.ToLower(strings.TrimSpace(platform))
+			if selectedPlatform != "" {
+				if selectedPlatform != "omp" {
+					err := fmt.Errorf("unsupported status platform %q: must be omp", platform)
+					if jsonMode {
+						return writeJSONResultAndExit(
+							cmd, jsonStatusError, err, "unsupported_platform",
+							map[string]any{"platform": selectedPlatform}, nil, nil,
+						)
+					}
+					return err
+				}
+				return runOMPPlatformStatus(cmd, dir, jsonMode, deps)
+			}
 
 			if jsonMode {
 				return runStatusJSON(cmd, dir)
@@ -195,6 +214,7 @@ func newStatusCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&dir, "dir", "", "프로젝트 루트 디렉터리 (기본값: 현재 디렉터리)")
+	cmd.Flags().StringVar(&platform, "platform", "", "Platform operator view (omp)")
 	addJSONFlags(cmd, &jsonOutput, &format)
 	return cmd
 }

--- a/internal/cli/workflow_context_runtime_implementation_identity_test.go
+++ b/internal/cli/workflow_context_runtime_implementation_identity_test.go
@@ -18,7 +18,7 @@ func TestWorkflowContextImplementationIdentityCommand(t *testing.T) {
 	var identity workflowContextImplementationIdentityV1
 	require.NoError(t, json.Unmarshal(output.Bytes(), &identity))
 	require.Equal(t, workflowContextImplementationIdentitySchemaV1, identity.SchemaVersion)
-	require.Equal(t, "sha256:031aae19565b060edd913ad1a5479e62b783f4efe20724ff7260bc061c118b5c",
+	require.Equal(t, "sha256:dd7be49d3342e54abffde9c8c3256cec68db5340d003267230f856774ad7ee0a",
 		identity.PipelineImplementationDigest)
 	require.Equal(t, "autopus.omp-pipeline-managed-rpc.v3", identity.RPCIdentity)
 	require.Equal(t, pipelineOMPActivePolicyIdentity, identity.PolicyIdentity)

--- a/internal/cli/workflow_context_runtime_implementation_identity_test.go
+++ b/internal/cli/workflow_context_runtime_implementation_identity_test.go
@@ -18,7 +18,7 @@ func TestWorkflowContextImplementationIdentityCommand(t *testing.T) {
 	var identity workflowContextImplementationIdentityV1
 	require.NoError(t, json.Unmarshal(output.Bytes(), &identity))
 	require.Equal(t, workflowContextImplementationIdentitySchemaV1, identity.SchemaVersion)
-	require.Equal(t, "sha256:10a9a0bb08f77eae34e67c1127c3b2dda42fdbcf4e79edad16c7e89b0089aa7b",
+	require.Equal(t, "sha256:031aae19565b060edd913ad1a5479e62b783f4efe20724ff7260bc061c118b5c",
 		identity.PipelineImplementationDigest)
 	require.Equal(t, "autopus.omp-pipeline-managed-rpc.v3", identity.RPCIdentity)
 	require.Equal(t, pipelineOMPActivePolicyIdentity, identity.PolicyIdentity)

--- a/internal/cli/workflow_context_runtime_observe_session_command.go
+++ b/internal/cli/workflow_context_runtime_observe_session_command.go
@@ -11,7 +11,7 @@ import (
 func newWorkflowContextObserveSessionCmd() *cobra.Command {
 	var input, output, format string
 	var explicitLive, inheritParentSandbox bool
-	options := workflowContextObserveSessionOptions{}
+	options := workflowContextObserveSessionOptions{ModelContextWindow: pipelineOMPActiveDefaultContextWindow}
 	cmd := &cobra.Command{
 		Use:   "observe-session",
 		Short: "Run a production explicit-live OMP cohort and write body-free promotion evidence",
@@ -21,7 +21,8 @@ func newWorkflowContextObserveSessionCmd() *cobra.Command {
 			"The report remains inactive until a trusted promotion-attestation.v2 and release lineage are installed.",
 		Example: "  auto workflow context-runtime observe-session --explicit-live --input-jsonl - --output - --format jsonl \\\n" +
 			"    --project-dir . --spec-id SPEC-OMP-004 --provider openai --model gpt-5.6-sol \\\n" +
-			"    --endpoint http://127.0.0.1:43123 --credential-locator AUTOPUS_OMP_CONTEXT_PROVIDER_OPENAI \\\n" +
+			"    --model-context-window 272000 --endpoint http://127.0.0.1:43123 \\\n" +
+			"    --credential-locator AUTOPUS_OMP_CONTEXT_PROVIDER_OPENAI \\\n" +
 			"    --producer-repository org/omp-evals --producer-workflow-ref refs/heads/main@REV \\\n" +
 			"    --producer-run-id 123 --producer-run-attempt 1 --candidate-repository org/autopus-adk \\\n" +
 			"    --policy-id omp-context-active-v1 --oracle-policy-digest sha256:DIGEST --target-git-commit REV",
@@ -53,6 +54,8 @@ func newWorkflowContextObserveSessionCmd() *cobra.Command {
 	cmd.Flags().StringVar(&options.SpecID, "spec-id", "", "SPEC identity")
 	cmd.Flags().StringVar(&options.Provider, "provider", "", "Signed cohort provider identity")
 	cmd.Flags().StringVar(&options.Model, "model", "", "Signed cohort model identity")
+	cmd.Flags().IntVar(&options.ModelContextWindow, "model-context-window",
+		pipelineOMPActiveDefaultContextWindow, "Provider model context window bound into runtime authority")
 	cmd.Flags().StringVar(&options.Endpoint, "endpoint", "", "Task-owned loopback broker endpoint")
 	cmd.Flags().StringVar(&options.CredentialLocator, "credential-locator", "", "Dedicated credential environment key")
 	cmd.Flags().StringVar(&options.Executable, "omp", "omp", "OMP executable")

--- a/internal/cli/workflow_context_runtime_observe_session_command.go
+++ b/internal/cli/workflow_context_runtime_observe_session_command.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -12,9 +13,18 @@ func newWorkflowContextObserveSessionCmd() *cobra.Command {
 	var explicitLive, inheritParentSandbox bool
 	options := workflowContextObserveSessionOptions{}
 	cmd := &cobra.Command{
-		Use:           "observe-session",
-		Short:         "Run a production-equivalent explicit-live OMP observation session",
-		Args:          cobra.NoArgs,
+		Use:   "observe-session",
+		Short: "Run a production explicit-live OMP cohort and write body-free promotion evidence",
+		Long: "Run exactly 20 balanced AB/BA task pairs through two reusable installed OMP sessions. " +
+			"The endpoint must be an exact loopback gateway; the upstream credential stays in the named environment variable. " +
+			"On success the command writes .autopus/runtime/omp-context/promotion-report-v1.json and evidence-v1.json. " +
+			"The report remains inactive until a trusted promotion-attestation.v2 and release lineage are installed.",
+		Example: "  auto workflow context-runtime observe-session --explicit-live --input-jsonl - --output - --format jsonl \\\n" +
+			"    --project-dir . --spec-id SPEC-OMP-004 --provider openai --model gpt-5.6-sol \\\n" +
+			"    --endpoint http://127.0.0.1:43123 --credential-locator AUTOPUS_OMP_CONTEXT_PROVIDER_OPENAI \\\n" +
+			"    --producer-repository org/omp-evals --producer-workflow-ref refs/heads/main@REV \\\n" +
+			"    --producer-run-id 123 --producer-run-attempt 1 --candidate-repository org/autopus-adk \\\n" +
+			"    --policy-id omp-context-active-v1 --oracle-policy-digest sha256:DIGEST --target-git-commit REV",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -23,6 +33,9 @@ func newWorkflowContextObserveSessionCmd() *cobra.Command {
 			}
 			if input != "-" || output != "-" || strings.ToLower(strings.TrimSpace(format)) != "jsonl" {
 				return errors.New("workflow context-runtime observe-session requires --input-jsonl - --output - --format jsonl")
+			}
+			if err := populateWorkflowContextObserveSessionPolicy(&options); err != nil {
+				return err
 			}
 			options.SandboxMode = workflowContextObserveSessionSandboxMode(inheritParentSandbox)
 			if err := validateWorkflowContextObserveSessionOptions(options); err != nil {
@@ -44,6 +57,14 @@ func newWorkflowContextObserveSessionCmd() *cobra.Command {
 	cmd.Flags().StringVar(&options.CredentialLocator, "credential-locator", "", "Dedicated credential environment key")
 	cmd.Flags().StringVar(&options.Executable, "omp", "omp", "OMP executable")
 	cmd.Flags().StringVar(&options.TargetGitCommit, "target-git-commit", "", "Exact target project commit")
+	cmd.Flags().StringVar(&options.ProducerRepository, "producer-repository", "", "Authorized evidence producer repository")
+	cmd.Flags().StringVar(&options.ProducerWorkflowRef, "producer-workflow-ref", "", "Immutable evidence workflow reference")
+	cmd.Flags().StringVar(&options.ProducerRunID, "producer-run-id", "", "Authorized evidence workflow run ID")
+	cmd.Flags().IntVar(&options.ProducerRunAttempt, "producer-run-attempt", 0, "Authorized evidence workflow run attempt")
+	cmd.Flags().StringVar(&options.CandidateRepository, "candidate-repository", "", "Candidate source repository")
+	cmd.Flags().StringVar(&options.PolicyID, "policy-id", "", "Signed active-history policy identity")
+	cmd.Flags().StringVar(&options.OraclePolicyDigest, "oracle-policy-digest", "", "Body-free quality/security oracle digest")
+	cmd.Flags().DurationVar(&options.EvidenceValidFor, "evidence-valid-for", time.Hour, "Current-run evidence validity window")
 	return cmd
 }
 

--- a/internal/cli/workflow_context_runtime_observe_session_evidence.go
+++ b/internal/cli/workflow_context_runtime_observe_session_evidence.go
@@ -90,10 +90,12 @@ func verifyWorkflowContextObserveSessionReadback(
 	fullCalls int,
 	optimizedCalls int,
 ) error {
+	maxCompactions := max(optimizedCalls-1, 0)
 	if setup == nil || setup.full == nil || setup.optimized == nil || setup.full.PID() <= 0 ||
 		setup.optimized.PID() <= 0 || setup.full.PID() == setup.optimized.PID() ||
 		setup.full.sequence != fullCalls || setup.optimized.sequence != optimizedCalls ||
-		setup.full.compactions != 0 || setup.optimized.compactions != optimizedCalls {
+		setup.full.compactions != 0 || setup.optimized.compactions < 0 ||
+		setup.optimized.compactions > maxCompactions {
 		return errors.New("observe-session reusable session readback is invalid")
 	}
 	for _, session := range []*pipelineOMPActiveEvaluatorSession{setup.full, setup.optimized} {
@@ -183,10 +185,7 @@ func buildWorkflowContextObserveSessionReport(
 			call.response.OutputDigest, call.response.SessionDigest, call.response.ProviderAuthorityDigest,
 			workflowContextRuntimeHash(string(usageBody)), call.providerPromptHash,
 		})
-		compactionCalls := 0
-		if call.command.Variant == "B" {
-			compactionCalls = 1
-		}
+		compactionCalls := call.response.CompactionCycles
 		report.Observations = append(report.Observations, promptlayer.OMPContextPromotionObservationV1{
 			Sequence: call.command.Sequence, TaskIDDigest: call.command.TaskIDDigest, Variant: call.command.Variant,
 			SessionReceiptDigest: call.response.SessionDigest, SessionSequence: sessionSequence[call.command.Variant],

--- a/internal/cli/workflow_context_runtime_observe_session_evidence.go
+++ b/internal/cli/workflow_context_runtime_observe_session_evidence.go
@@ -1,0 +1,264 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/promptlayer"
+)
+
+type workflowContextObserveSessionPrepare func(
+	context.Context,
+	workflowContextObserveSessionOptions,
+	string,
+) (workflowContextObserveSessionSetup, error)
+
+type workflowContextObserveSessionPrepareKey struct{}
+
+type workflowContextObserveSessionCallEvidence struct {
+	command            workflowContextObserveSessionCommand
+	response           workflowContextObserveSessionResponse
+	providerPromptHash string
+	startedAt          time.Time
+	endedAt            time.Time
+}
+
+func prepareWorkflowContextObserveSessionForRun(
+	ctx context.Context,
+	options workflowContextObserveSessionOptions,
+	challenge string,
+) (workflowContextObserveSessionSetup, error) {
+	if injected, ok := ctx.Value(workflowContextObserveSessionPrepareKey{}).(workflowContextObserveSessionPrepare); ok && injected != nil {
+		return injected(ctx, options, challenge)
+	}
+	return prepareWorkflowContextObserveSession(ctx, options, challenge)
+}
+
+func populateWorkflowContextObserveSessionPolicy(options *workflowContextObserveSessionOptions) error {
+	if options == nil {
+		return errors.New("observe-session policy target is unavailable")
+	}
+	cfg, err := loadHarnessConfigForDir(options.ProjectDir, globalFlags{})
+	if err != nil {
+		return fmt.Errorf("observe-session load active policy: %w", err)
+	}
+	policy, selected, err := workflowContextPolicyFromConfig(cfg)
+	if err != nil || !selected {
+		return errors.New("observe-session selected active policy is unavailable")
+	}
+	options.WorkspaceID = cfg.ProjectName
+	options.PromotionPolicy = promptlayer.OMPContextPromotionPolicyV1{
+		Profile: policy.Profile, HistoryMode: policy.HistoryMode, MemoryMode: policy.MemoryMode,
+		HistoryTargetTokens: policy.HistoryTargetTokens, Fallback: policy.Fallback,
+		CapabilityPolicy: policy.CapabilityPolicy, RuntimeRootPolicy: policy.RuntimeRootPolicy,
+		MutationScope: policy.MutationScope,
+	}
+	return nil
+}
+
+func workflowContextObserveCurrentExecutableSHA256() (string, error) {
+	digest, err := pipelineOMPActiveCurrentAutoExecutableSHA256()
+	if err != nil {
+		return "", errors.New("observe-session auto executable identity is unavailable")
+	}
+	return digest, nil
+}
+
+func (setup workflowContextObserveSessionSetup) sealPrompt(task string) (string, string, error) {
+	delivery, err := promptlayer.BuildContextDelivery(setup.deliveryOptions)
+	if err != nil || promptlayer.VerifyContextDeliveryForOptions(setup.deliveryOptions, delivery) != nil ||
+		delivery.SnapshotHash != setup.delivery.SnapshotHash ||
+		delivery.PromptManifestHash != setup.delivery.PromptManifestHash ||
+		workflowContextRuntimeHash(delivery.Prompt) != setup.canonicalPromptHash ||
+		delivery.Prompt != setup.delivery.Prompt {
+		return "", "", errors.New("observe-session canonical context changed before provider admission")
+	}
+	sealed := delivery.Prompt + "\n\n--- BEGIN IDENTICAL EVALUATION TASK ---\n" +
+		task + "\n--- END IDENTICAL EVALUATION TASK ---"
+	return sealed, workflowContextRuntimeHash(sealed), nil
+}
+
+func verifyWorkflowContextObserveSessionReadback(
+	ctx context.Context,
+	setup *workflowContextObserveSessionSetup,
+	fullCalls int,
+	optimizedCalls int,
+) error {
+	if setup == nil || setup.full == nil || setup.optimized == nil || setup.full.PID() <= 0 ||
+		setup.optimized.PID() <= 0 || setup.full.PID() == setup.optimized.PID() ||
+		setup.full.sequence != fullCalls || setup.optimized.sequence != optimizedCalls ||
+		setup.full.compactions != 0 || setup.optimized.compactions != optimizedCalls {
+		return errors.New("observe-session reusable session readback is invalid")
+	}
+	for _, session := range []*pipelineOMPActiveEvaluatorSession{setup.full, setup.optimized} {
+		state, err := session.protocol.readIdleState(ctx, "observe-session-readback")
+		if err != nil || state.SessionID != session.sessionID || state.AutoCompactionEnabled == nil ||
+			*state.AutoCompactionEnabled {
+			return errors.New("observe-session effective rollback readback is invalid")
+		}
+	}
+	return nil
+}
+
+func safeWorkflowContextObserveSessionOutput(
+	setup workflowContextObserveSessionSetup,
+	assistant string,
+) bool {
+	if strings.TrimSpace(assistant) == "" || workflowContextSecretPattern.MatchString(assistant) {
+		return false
+	}
+	for _, forbidden := range []string{setup.credential, setup.endpoint, setup.projectDir, setup.taskRoot} {
+		if forbidden != "" && strings.Contains(assistant, forbidden) {
+			return false
+		}
+	}
+	return true
+}
+
+func buildWorkflowContextObserveSessionReport(
+	options workflowContextObserveSessionOptions,
+	setup workflowContextObserveSessionSetup,
+	challenge string,
+	calls []workflowContextObserveSessionCallEvidence,
+) (promptlayer.OMPContextPromotionReportV1, []byte, []promptlayer.OMPContextCanaryRowV1, error) {
+	if len(calls) != 40 {
+		return promptlayer.OMPContextPromotionReportV1{}, nil, nil, errors.New("observe-session cohort is incomplete")
+	}
+	policyDigest, err := promptlayer.OMPContextPromotionPolicyDigestV1(options.PromotionPolicy)
+	if err != nil {
+		return promptlayer.OMPContextPromotionReportV1{}, nil, nil, err
+	}
+	report := promptlayer.OMPContextPromotionReportV1{
+		SchemaVersion:   promptlayer.OMPContextPromotionReportSchemaV1,
+		ChallengeDigest: challenge,
+		Producer: promptlayer.OMPContextPromotionProducerV1{
+			Repository: options.ProducerRepository, WorkflowRef: options.ProducerWorkflowRef,
+			RunID: options.ProducerRunID, RunAttempt: options.ProducerRunAttempt,
+		},
+		Candidate: promptlayer.OMPContextPromotionCandidateV1{
+			Repository: options.CandidateRepository, Revision: options.TargetGitCommit,
+			TreeSHA: setup.candidateTree, ArtifactSHA256: setup.autoExecutableSHA256,
+		},
+		Policy: promptlayer.OMPContextPromotionPolicyReportV1{
+			PolicyID: options.PolicyID, PolicyDigest: policyDigest, HistoryMode: "active", MemoryMode: "off",
+			MinPairCount: 20, MinReductionBasisPoints: 2000,
+		},
+		Runtime: promptlayer.OMPContextPromotionRuntimeV1{
+			AutoVersion: setup.autoVersion, AutoBinarySHA256: setup.autoExecutableSHA256,
+			OMPVersion: setup.ompVersion, OMPExecutableSHA256: setup.ompExecutableSHA256,
+			ExecutionClass: "external-live", ProductionPathEquivalent: true,
+			RuntimeKind: "omp-pipeline-managed-rpc", PipelineImplementationDigest: pipelineOMPActiveImplementationDigest(),
+		},
+		SessionFacts: promptlayer.OMPContextPromotionSessionFactsV1{
+			FullProcessStarts: 1, OptimizedProcessStarts: 1, FullSessionCount: 1,
+			OptimizedSessionCount: 1, MaxConcurrency: 1, CrossSessionContamination: 0,
+		},
+		Provider: options.Provider, ModelScopeDigest: setup.candidate.ModelScopeDigest,
+		OraclePolicyDigest: options.OraclePolicyDigest,
+	}
+	sessionSequence := map[string]int{"A": 0, "B": 0}
+	for index, call := range calls {
+		if index%2 == 0 {
+			report.Tasks = append(report.Tasks, promptlayer.OMPContextPromotionTaskV1{
+				TaskIDDigest: call.command.TaskIDDigest,
+				Order:        call.command.Variant + calls[index+1].command.Variant,
+			})
+		}
+		sessionSequence[call.command.Variant]++
+		usageBody, _ := json.Marshal(struct {
+			Sequence int                                 `json:"sequence"`
+			Usage    *workflowContextObserveSessionUsage `json:"usage"`
+		}{call.command.Sequence, call.response.Usage})
+		observationBody, _ := json.Marshal(struct {
+			Sequence, PairSequence                                                    int
+			Task, Variant, Output, Session, ProviderAuthority, Usage, CanonicalPrompt string
+		}{
+			call.command.Sequence, call.command.PairSequence, call.command.TaskIDDigest, call.command.Variant,
+			call.response.OutputDigest, call.response.SessionDigest, call.response.ProviderAuthorityDigest,
+			workflowContextRuntimeHash(string(usageBody)), call.providerPromptHash,
+		})
+		compactionCalls := 0
+		if call.command.Variant == "B" {
+			compactionCalls = 1
+		}
+		report.Observations = append(report.Observations, promptlayer.OMPContextPromotionObservationV1{
+			Sequence: call.command.Sequence, TaskIDDigest: call.command.TaskIDDigest, Variant: call.command.Variant,
+			SessionReceiptDigest: call.response.SessionDigest, SessionSequence: sessionSequence[call.command.Variant],
+			ProcessReused: call.response.ProcessReused, Provider: options.Provider,
+			ModelScopeDigest: setup.candidate.ModelScopeDigest, EndpointClass: "external-provider",
+			Transport: "provider-api", CredentialMode: "locator-only",
+			ProviderAuthorityDigest: setup.providerAuthorityDigest, ExecutionMode: "external-live",
+			StartedAt: call.startedAt.UTC().Format(time.RFC3339Nano), CompletedAt: call.endedAt.UTC().Format(time.RFC3339Nano),
+			InputTokens: call.response.Usage.PrimaryInputTokens, OutputTokens: call.response.Usage.PrimaryOutputTokens,
+			TotalTokens:           call.response.Usage.PrimaryInputTokens + call.response.Usage.PrimaryOutputTokens,
+			SetupProviderRequests: 0, CompactionProviderRequests: compactionCalls,
+			PrimaryProviderRequests: 1, TotalProviderRequests: 1 + compactionCalls,
+			PreCompactionACKs: call.response.PreCompactionACKs, PostCompactionACKs: call.response.PostCompactionACKs,
+			CanonicalReadmissions: call.response.CanonicalReadmissions,
+			EphemeralReadmissions: call.response.EphemeralReadmissions,
+			ObservationDigest:     workflowContextRuntimeHash(string(observationBody)),
+			UsageDigest:           workflowContextRuntimeHash(string(usageBody)), IntegrityPassed: true, SecurityPassed: true,
+			QualityScore: 10000, FallbackVerified: true, RollbackVerified: true, CleanupVerified: true,
+			RetryCount: 0, MaxConcurrency: 1,
+		})
+	}
+	report, body, err := promptlayer.BuildOMPContextPromotionReportV1(report)
+	if err != nil {
+		return report, nil, nil, err
+	}
+	rows, err := promptlayer.OMPContextPromotionReportCanaryRowsV1(report)
+	return report, body, rows, err
+}
+
+func writeWorkflowContextObserveSessionEvidence(
+	options workflowContextObserveSessionOptions,
+	setup workflowContextObserveSessionSetup,
+	challenge string,
+	calls []workflowContextObserveSessionCallEvidence,
+	checkedAt time.Time,
+) (string, string, error) {
+	report, body, rows, err := buildWorkflowContextObserveSessionReport(options, setup, challenge, calls)
+	if err != nil {
+		return "", "", err
+	}
+	for _, forbidden := range []string{setup.credential, setup.endpoint, setup.projectDir, setup.taskRoot} {
+		if forbidden != "" && bytes.Contains(body, []byte(forbidden)) {
+			return "", "", errors.New("observe-session promotion report contains private material")
+		}
+	}
+	for _, call := range calls {
+		for _, privateBody := range []string{call.command.Prompt, call.response.AssistantText} {
+			if len(privateBody) >= 16 && bytes.Contains(body, []byte(privateBody)) {
+				return "", "", errors.New("observe-session promotion report contains request or response bodies")
+			}
+		}
+	}
+	for _, key := range []string{"credential_locator", "credential_value", "assistant_text", "prompt_body", "project_dir"} {
+		if bytes.Contains(body, []byte(key)) {
+			return "", "", errors.New("observe-session promotion report contains body-bearing fields")
+		}
+	}
+	if filepath.IsAbs(options.ProducerRepository) || filepath.IsAbs(options.CandidateRepository) {
+		return "", "", errors.New("observe-session promotion report contains an absolute coordinate")
+	}
+	if err := promptlayer.WriteOMPContextPromotionReportV1(setup.projectDir, body); err != nil {
+		return "", "", err
+	}
+	if err := promptlayer.WriteOMPContextEvidenceStoreV1(setup.projectDir, promptlayer.OMPContextEvidenceStoreV1{
+		Binding: promptlayer.OMPContextEvidenceStoreBindingV1{
+			WorkspaceID: options.WorkspaceID, SpecID: options.SpecID,
+			SnapshotHash: setup.candidate.Snapshot.SnapshotHash, GitCommitHash: options.TargetGitCommit,
+			RuntimeVersion: setup.ompVersion, CheckedAt: checkedAt.UTC(), ValidFor: options.EvidenceValidFor,
+		},
+		Policy: options.PromotionPolicy, CanaryRows: rows,
+	}); err != nil {
+		return "", "", err
+	}
+	return report.EvidenceID, workflowContextRuntimeHash(string(body)), nil
+}

--- a/internal/cli/workflow_context_runtime_observe_session_evidence_test.go
+++ b/internal/cli/workflow_context_runtime_observe_session_evidence_test.go
@@ -1,0 +1,319 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/config"
+	"github.com/insajin/autopus-adk/pkg/pipeline"
+	"github.com/insajin/autopus-adk/pkg/promptlayer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWorkflowContextObserveSession_WritesObservedBodyFreePromotionEvidence(t *testing.T) {
+	requireDarwinManagedOMPSandboxForTest(t)
+	challenge := workflowContextRuntimeHash("observe-session-challenge")
+	setup, options, logPath := workflowContextObserveEvidenceFixture(t, challenge)
+	input, taskBodies := workflowContextObserveEvidenceInput(t, challenge)
+	var output bytes.Buffer
+	prepared := &setup
+	ctx := context.WithValue(context.Background(), workflowContextObserveSessionPrepareKey{},
+		workflowContextObserveSessionPrepare(func(_ context.Context, got workflowContextObserveSessionOptions, gotChallenge string) (workflowContextObserveSessionSetup, error) {
+			require.Equal(t, options, got)
+			require.Equal(t, challenge, gotChallenge)
+			return *prepared, nil
+		}))
+
+	require.NoError(t, RunWorkflowContextObserveSession(ctx, input, &output, options))
+	responses := decodeWorkflowContextObserveResponses(t, output.Bytes())
+	require.Len(t, responses, 42)
+	shutdown := responses[len(responses)-1]
+	assert.Equal(t, "shutdown", shutdown.Type)
+	assert.Equal(t, 40, shutdown.CallsCompleted)
+	assert.Equal(t, 20, shutdown.CompactionCycles)
+	assert.True(t, shutdown.CleanupVerified)
+	assert.NotEmpty(t, shutdown.EvidenceID)
+	assert.NotEmpty(t, shutdown.ReportDigest)
+	assert.Zero(t, shutdown.OwnedRootsRemaining)
+	assert.Zero(t, shutdown.ProcessesRemaining)
+
+	require.Zero(t, prepared.full.PID())
+	require.Zero(t, prepared.optimized.PID())
+	_, err := os.Lstat(prepared.taskRoot)
+	require.ErrorIs(t, err, os.ErrNotExist)
+
+	reportPath := promptlayer.OMPContextPromotionReportPathV1(options.ProjectDir)
+	reportBody, err := os.ReadFile(reportPath)
+	require.NoError(t, err)
+	for _, forbidden := range append([]string{
+		prepared.credential, prepared.endpoint, prepared.projectDir, prepared.taskRoot,
+		"credential_locator", "assistant_text", "safe assistant output", "/Users/",
+	}, taskBodies...) {
+		assert.NotContains(t, string(reportBody), forbidden)
+	}
+	var report promptlayer.OMPContextPromotionReportV1
+	require.NoError(t, json.Unmarshal(reportBody, &report))
+	assert.Equal(t, shutdown.EvidenceID, report.EvidenceID)
+	assert.Equal(t, challenge, report.ChallengeDigest)
+	assert.Len(t, report.Tasks, 20)
+	assert.Len(t, report.Observations, 40)
+	assert.Equal(t, 10, countWorkflowContextObserveOrders(report.Tasks, "AB"))
+	assert.Equal(t, 10, countWorkflowContextObserveOrders(report.Tasks, "BA"))
+	rows, err := promptlayer.OMPContextPromotionReportCanaryRowsV1(report)
+	require.NoError(t, err)
+	require.Len(t, rows, 40)
+	for index := 0; index < len(rows); index += 2 {
+		full, optimized := rows[index], rows[index+1]
+		if full.Variant == promptlayer.OMPContextCanaryVariantOptimizedV1 {
+			full, optimized = optimized, full
+		}
+		assert.Equal(t, int64(100), full.Tokens)
+		assert.Equal(t, int64(40), optimized.Tokens)
+		assert.True(t, optimized.FallbackVerified)
+		assert.True(t, optimized.RollbackVerified)
+	}
+
+	storeBody, err := os.ReadFile(promptlayer.OMPContextEvidenceStorePath(options.ProjectDir))
+	require.NoError(t, err)
+	assert.NotContains(t, string(storeBody), prepared.credential)
+	assert.NotContains(t, string(storeBody), prepared.projectDir)
+	var store promptlayer.OMPContextEvidenceStoreV1
+	require.NoError(t, json.Unmarshal(storeBody, &store))
+	assert.Equal(t, options.WorkspaceID, store.Binding.WorkspaceID)
+	assert.Equal(t, prepared.candidate.Snapshot.SnapshotHash, store.Binding.SnapshotHash)
+	assert.Len(t, store.CanaryRows, 40)
+	assert.Empty(t, store.HistoryRefs)
+
+	verifyWorkflowContextObserveProviderLog(t, logPath, taskBodies)
+}
+
+func TestWorkflowContextObserveSessionHelp_DocumentsExplicitLiveLoopbackCanary(t *testing.T) {
+	cmd := newWorkflowContextObserveSessionCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"--help"})
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, output.String(), "http://127.0.0.1:43123")
+	assert.Contains(t, output.String(), "--explicit-live")
+	assert.Contains(t, output.String(), "promotion-report-v1.json")
+}
+
+func TestWorkflowContextObserveSessionCommand_RequiresExplicitLiveAcknowledgement(t *testing.T) {
+	cmd := newWorkflowContextObserveSessionCmd()
+	cmd.SetArgs(nil)
+	err := cmd.Execute()
+	require.ErrorContains(t, err, "requires --explicit-live")
+}
+
+func workflowContextObserveEvidenceFixture(t *testing.T, challenge string) (
+	workflowContextObserveSessionSetup,
+	workflowContextObserveSessionOptions,
+	string,
+) {
+	t.Helper()
+	backend, _ := pipelineOMPBackendTestConfig(t)
+	writeWorkflowContextObserveCanonicalDocuments(t, backend.ProjectDir, backend.SpecID)
+	deliveryOptions := promptlayer.ContextDeliveryOptions{
+		Root: backend.ProjectDir, Command: "go",
+		SpecDir: filepath.ToSlash(filepath.Join(".autopus", "specs", backend.SpecID)),
+	}
+	delivery, err := promptlayer.BuildContextDelivery(deliveryOptions)
+	require.NoError(t, err)
+	require.NoError(t, promptlayer.VerifyContextDeliveryForOptions(deliveryOptions, delivery))
+	snapshotHash, err := pipeline.SpecSnapshotHash(backend.SpecDir)
+	require.NoError(t, err)
+	taskRoot, err := os.MkdirTemp("", "autopus-observe-evidence-test-")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(taskRoot) })
+	runtimeBase := filepath.Join(taskRoot, "runtime")
+	require.NoError(t, os.Mkdir(runtimeBase, 0o700))
+	commit, tree := strings.Repeat("b", 40), strings.Repeat("c", 40)
+	endpoint, credential := "http://127.0.0.1:43123", "fixture-provider-token-value-123456"
+	backend.Executable = os.Args[0]
+	backend.RuntimeBase, backend.SnapshotHash, backend.GitCommitHash = runtimeBase, snapshotHash, commit
+	backend.PhaseModels = workflowContextObserveSessionPhaseModels("openai/model-a")
+	backend.Environment = append(backend.Environment,
+		pipelineOMPActiveEndpointKey+"="+endpoint,
+		pipelineOMPActiveCredentialKey+"="+credential,
+	)
+	backend, err = normalizePipelineOMPBackendConfig(backend)
+	require.NoError(t, err)
+	snapshot := pipeline.OMPExecutionSnapshot{
+		ProjectDir: backend.ProjectDir, SpecID: backend.SpecID, SpecDir: backend.SpecDir,
+		SnapshotHash: snapshotHash, GitCommitHash: commit, PhaseID: pipeline.PhaseImplement,
+		Attempt: 1, Prompt: "observe-session", ActivePrompt: "observe-session",
+	}
+	candidate, err := newPipelineOMPManagedActiveCandidate(
+		snapshot, backend.PhaseModels[pipeline.PhaseImplement], backend.PhaseModels,
+	)
+	require.NoError(t, err)
+	candidate.AutoSourceCommit, candidate.AutoSourceTree = commit, tree
+	policy := promptlayer.OMPContextPromotionPolicyV1{
+		Profile: "active", HistoryMode: config.OMPContextHistoryActive, MemoryMode: config.OMPContextMemoryOff,
+		HistoryTargetTokens: 1000, Fallback: config.OMPContextFallbackCanonicalFull,
+		CapabilityPolicy:  config.OMPContextCapabilityProbeRequired,
+		RuntimeRootPolicy: config.OMPContextRuntimeIsolatedTaskOwned,
+		MutationScope:     config.OMPContextMutationSessionOverlay,
+	}
+	policyDigest, err := promptlayer.OMPContextPromotionPolicyDigestV1(policy)
+	require.NoError(t, err)
+	autoSHA := workflowContextRuntimeHash("installed-auto-binary")
+	setup := workflowContextObserveSessionSetup{
+		taskRoot: taskRoot, projectDir: backend.ProjectDir, endpoint: endpoint, credential: credential,
+		backend: backend, candidate: candidate,
+		prepared: pipelineOMPManagedActivePrepared{Binding: pipelineOMPActiveLeaseBinding{
+			GrantDigest: challenge, PolicyDigest: policyDigest, WorkspaceID: "autopus-adk", SpecID: backend.SpecID,
+			GitCommitHash: commit, AutoSourceCommit: commit, AutoSourceTree: tree,
+			ModelScopeDigest: candidate.ModelScopeDigest,
+		}},
+		deliveryOptions: deliveryOptions, delivery: delivery, canonicalPromptHash: workflowContextRuntimeHash(delivery.Prompt),
+		ompVersion: "omp/17.2.7", ompExecutableSHA256: fmt.Sprintf("sha256:%x", backend.executableID.digest[:]),
+		autoVersion: "0.50.93", autoExecutableSHA256: autoSHA, candidateTree: tree,
+		sandboxMode: pipelineOMPActiveSandboxManaged,
+	}
+	options := workflowContextObserveSessionOptions{
+		ProjectDir: backend.ProjectDir, SpecID: backend.SpecID, Provider: "openai", Model: "model-a",
+		Endpoint: endpoint, CredentialLocator: "AUTOPUS_TEST_PROVIDER_TOKEN", Executable: os.Args[0],
+		TargetGitCommit: commit, SandboxMode: pipelineOMPActiveSandboxManaged,
+		WorkspaceID: "autopus-adk", ProducerRepository: "insajin/omp-evals",
+		ProducerWorkflowRef: "refs/heads/main@" + commit, ProducerRunID: "123456", ProducerRunAttempt: 1,
+		CandidateRepository: "insajin/autopus-adk", PolicyID: "omp-context-active-v1",
+		OraclePolicyDigest: workflowContextRuntimeHash("quality-security-oracle"), PromotionPolicy: policy,
+		EvidenceValidFor: time.Hour,
+	}
+	return setup, options, filepath.Join(backend.ProjectDir, "active-native-rpc.jsonl")
+}
+
+func workflowContextObserveEvidenceInput(t *testing.T, challenge string) (*bytes.Buffer, []string) {
+	t.Helper()
+	var input bytes.Buffer
+	encoder := json.NewEncoder(&input)
+	require.NoError(t, encoder.Encode(workflowContextObserveSessionCommand{
+		SchemaVersion: workflowContextObserveSessionCommandSchema, Type: "handshake", ChallengeDigest: challenge,
+	}))
+	tasks := make([]string, 0, 20)
+	sequence := 0
+	for pair := range 20 {
+		taskDigest := workflowContextRuntimeHash(fmt.Sprintf("observed-task-%02d", pair))
+		prompt := fmt.Sprintf("identical evaluation task %02d requiring safe deterministic output", pair)
+		tasks = append(tasks, prompt)
+		order := []string{"A", "B"}
+		if pair%2 == 1 {
+			order = []string{"B", "A"}
+		}
+		for pairIndex, variant := range order {
+			sequence++
+			require.NoError(t, encoder.Encode(workflowContextObserveSessionCommand{
+				SchemaVersion: workflowContextObserveSessionCommandSchema, Type: "call",
+				TaskIDDigest: taskDigest, Variant: variant, Sequence: sequence,
+				PairSequence: pairIndex + 1, Prompt: prompt,
+			}))
+		}
+	}
+	require.NoError(t, encoder.Encode(workflowContextObserveSessionCommand{
+		SchemaVersion: workflowContextObserveSessionCommandSchema, Type: "shutdown",
+	}))
+	return &input, tasks
+}
+
+func writeWorkflowContextObserveCanonicalDocuments(t *testing.T, root, specID string) {
+	t.Helper()
+	files := map[string]string{
+		"AGENTS.md":                     "CANONICAL-AGENT-DOCUMENT\n",
+		"ARCHITECTURE.md":               "CANONICAL-ARCHITECTURE-DOCUMENT\n",
+		".autopus/project/workspace.md": "CANONICAL-WORKSPACE-DOCUMENT\n",
+		".autopus/project/product.md":   "CANONICAL-PRODUCT-DOCUMENT\n",
+		".autopus/project/structure.md": "CANONICAL-STRUCTURE-DOCUMENT\n",
+		".autopus/project/tech.md":      "CANONICAL-TECH-DOCUMENT\n",
+		filepath.ToSlash(filepath.Join(".autopus", "specs", specID, "spec.md")):       "# " + specID + "\nCANONICAL-SPEC-DOCUMENT\n",
+		filepath.ToSlash(filepath.Join(".autopus", "specs", specID, "plan.md")):       "CANONICAL-PLAN-DOCUMENT\n",
+		filepath.ToSlash(filepath.Join(".autopus", "specs", specID, "acceptance.md")): "CANONICAL-ACCEPTANCE-DOCUMENT\n",
+	}
+	for name, body := range files {
+		path := filepath.Join(root, filepath.FromSlash(name))
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+		require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+	}
+}
+
+func decodeWorkflowContextObserveResponses(t *testing.T, body []byte) []workflowContextObserveSessionResponse {
+	t.Helper()
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	var responses []workflowContextObserveSessionResponse
+	for decoder.More() {
+		var response workflowContextObserveSessionResponse
+		require.NoError(t, decoder.Decode(&response))
+		responses = append(responses, response)
+	}
+	return responses
+}
+
+func countWorkflowContextObserveOrders(tasks []promptlayer.OMPContextPromotionTaskV1, order string) int {
+	count := 0
+	for _, task := range tasks {
+		if task.Order == order {
+			count++
+		}
+	}
+	return count
+}
+
+func verifyWorkflowContextObserveProviderLog(t *testing.T, path string, taskBodies []string) {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	require.NoError(t, err)
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	starts := map[int]bool{}
+	compactions := map[int]int{}
+	pendingCompaction := map[int]bool{}
+	var prompts []pipelineOMPRPCRecord
+	for decoder.More() {
+		var record pipelineOMPRPCRecord
+		require.NoError(t, decoder.Decode(&record))
+		if record.Kind == "start" {
+			starts[record.PID] = true
+		}
+		if record.Kind != "command" {
+			continue
+		}
+		switch record.Type {
+		case "compact":
+			compactions[record.PID]++
+			pendingCompaction[record.PID] = true
+		case "prompt":
+			prompts = append(prompts, record)
+			assert.Contains(t, record.Message, "CANONICAL-AGENT-DOCUMENT")
+			assert.Contains(t, record.Message, "CANONICAL-SPEC-DOCUMENT")
+			assert.Contains(t, record.Message, "CANONICAL-PLAN-DOCUMENT")
+			assert.Contains(t, record.Message, "CANONICAL-ACCEPTANCE-DOCUMENT")
+			assert.Contains(t, record.Message, "CANONICAL-WORKSPACE-DOCUMENT")
+			if compactions[record.PID] > 0 {
+				assert.True(t, pendingCompaction[record.PID], "optimized prompt was not admitted after compaction")
+				pendingCompaction[record.PID] = false
+			}
+		}
+	}
+	assert.Len(t, starts, 2)
+	assert.Len(t, prompts, 40)
+	optimizedPIDs := 0
+	for _, count := range compactions {
+		if count > 0 {
+			optimizedPIDs++
+			assert.Equal(t, 20, count)
+		}
+	}
+	assert.Equal(t, 1, optimizedPIDs)
+	for pair := range 20 {
+		assert.Equal(t, prompts[pair*2].Message, prompts[pair*2+1].Message)
+		assert.Contains(t, prompts[pair*2].Message, taskBodies[pair])
+	}
+}

--- a/internal/cli/workflow_context_runtime_observe_session_evidence_test.go
+++ b/internal/cli/workflow_context_runtime_observe_session_evidence_test.go
@@ -38,7 +38,7 @@ func TestWorkflowContextObserveSession_WritesObservedBodyFreePromotionEvidence(t
 	shutdown := responses[len(responses)-1]
 	assert.Equal(t, "shutdown", shutdown.Type)
 	assert.Equal(t, 40, shutdown.CallsCompleted)
-	assert.Equal(t, 20, shutdown.CompactionCycles)
+	assert.Equal(t, 19, shutdown.CompactionCycles)
 	assert.True(t, shutdown.CleanupVerified)
 	assert.NotEmpty(t, shutdown.EvidenceID)
 	assert.NotEmpty(t, shutdown.ReportDigest)
@@ -76,7 +76,11 @@ func TestWorkflowContextObserveSession_WritesObservedBodyFreePromotionEvidence(t
 			full, optimized = optimized, full
 		}
 		assert.Equal(t, int64(100), full.Tokens)
-		assert.Equal(t, int64(40), optimized.Tokens)
+		expectedOptimizedTokens := int64(40)
+		if index == 0 {
+			expectedOptimizedTokens = 100
+		}
+		assert.Equal(t, expectedOptimizedTokens, optimized.Tokens)
 		assert.True(t, optimized.FallbackVerified)
 		assert.True(t, optimized.RollbackVerified)
 	}
@@ -182,7 +186,8 @@ func workflowContextObserveEvidenceFixture(t *testing.T, challenge string) (
 	}
 	options := workflowContextObserveSessionOptions{
 		ProjectDir: backend.ProjectDir, SpecID: backend.SpecID, Provider: "openai", Model: "model-a",
-		Endpoint: endpoint, CredentialLocator: "AUTOPUS_TEST_PROVIDER_TOKEN", Executable: os.Args[0],
+		ModelContextWindow: pipelineOMPActiveDefaultContextWindow,
+		Endpoint:           endpoint, CredentialLocator: "AUTOPUS_TEST_PROVIDER_TOKEN", Executable: os.Args[0],
 		TargetGitCommit: commit, SandboxMode: pipelineOMPActiveSandboxManaged,
 		WorkspaceID: "autopus-adk", ProducerRepository: "insajin/omp-evals",
 		ProducerWorkflowRef: "refs/heads/main@" + commit, ProducerRunID: "123456", ProducerRunAttempt: 1,
@@ -308,7 +313,7 @@ func verifyWorkflowContextObserveProviderLog(t *testing.T, path string, taskBodi
 	for _, count := range compactions {
 		if count > 0 {
 			optimizedPIDs++
-			assert.Equal(t, 20, count)
+			assert.Equal(t, 19, count)
 		}
 	}
 	assert.Equal(t, 1, optimizedPIDs)

--- a/internal/cli/workflow_context_runtime_observe_session_run.go
+++ b/internal/cli/workflow_context_runtime_observe_session_run.go
@@ -51,6 +51,8 @@ func RunWorkflowContextObserveSession(
 	seenTasks := make(map[string]struct{}, 20)
 	variantCalls := map[string]int{"A": 0, "B": 0}
 	sessionBindings := map[string]string{"A": "", "B": ""}
+	compactionCycles, preCompactionACKs := 0, 0
+	postCompactionACKs, canonicalReadmissions, ephemeralReadmissions := 0, 0, 0
 	providerAuthority := setup.providerAuthorityDigest
 	if !validPipelineOMPActiveHash(providerAuthority) {
 		return errors.New("observe-session provider authority binding is unstable")
@@ -126,16 +128,26 @@ func RunWorkflowContextObserveSession(
 		} else if prior != receipt.SessionBindingHash {
 			lifecycleValid = false
 		}
+		expectedCompactions := response.CompactionCycles
+		freshOptimized := command.Variant == "B" && variantCalls["B"] == 0
 		variantCalls[command.Variant]++
-		fullValid := command.Variant == "A" && response.CompactionCycles == 0 &&
+		fullValid := command.Variant == "A" && expectedCompactions == 0 &&
 			response.PreCompactionACKs == 0 && response.PostCompactionACKs == 0 &&
 			response.CanonicalReadmissions == 0 && response.EphemeralReadmissions == 0
-		optimizedValid := command.Variant == "B" && response.CompactionCycles == 1 &&
-			response.PreCompactionACKs == 1 && response.PostCompactionACKs == 1 &&
-			response.CanonicalReadmissions == 1 && response.EphemeralReadmissions == 1
+		optimizedValid := command.Variant == "B" && expectedCompactions >= 0 && expectedCompactions <= 1 &&
+			(!freshOptimized || expectedCompactions == 0) &&
+			response.PreCompactionACKs == expectedCompactions &&
+			response.PostCompactionACKs == expectedCompactions &&
+			response.CanonicalReadmissions == expectedCompactions &&
+			response.EphemeralReadmissions == expectedCompactions
 		if !lifecycleValid || !fullValid && !optimizedValid {
 			return fmt.Errorf("observe-session call %d process lifecycle changed", sequence)
 		}
+		compactionCycles += response.CompactionCycles
+		preCompactionACKs += response.PreCompactionACKs
+		postCompactionACKs += response.PostCompactionACKs
+		canonicalReadmissions += response.CanonicalReadmissions
+		ephemeralReadmissions += response.EphemeralReadmissions
 		calls = append(calls, workflowContextObserveSessionCallEvidence{
 			command: command, response: response, providerPromptHash: providerPromptHash,
 			startedAt: startedAt, endedAt: endedAt,
@@ -153,7 +165,7 @@ func RunWorkflowContextObserveSession(
 		}
 	}
 	if len(seenTasks) != 20 || variantCalls["A"] != 20 || variantCalls["B"] != 20 ||
-		sessionBindings["A"] == "" || sessionBindings["B"] == "" ||
+		compactionCycles < 2 || sessionBindings["A"] == "" || sessionBindings["B"] == "" ||
 		sessionBindings["A"] == sessionBindings["B"] {
 		return errors.New("observe-session task or reusable-session cardinality is invalid")
 	}
@@ -184,11 +196,11 @@ func RunWorkflowContextObserveSession(
 	response.ProviderAuthorityDigest = providerAuthority
 	response.EvidenceID, response.ReportDigest = evidenceID, reportDigest
 	response.CleanupVerified = true
-	response.CompactionCycles = variantCalls["B"]
-	response.PreCompactionACKs = variantCalls["B"]
-	response.PostCompactionACKs = variantCalls["B"]
-	response.CanonicalReadmissions = variantCalls["B"]
-	response.EphemeralReadmissions = variantCalls["B"]
+	response.CompactionCycles = compactionCycles
+	response.PreCompactionACKs = preCompactionACKs
+	response.PostCompactionACKs = postCompactionACKs
+	response.CanonicalReadmissions = canonicalReadmissions
+	response.EphemeralReadmissions = ephemeralReadmissions
 	return encoder.Encode(response)
 }
 

--- a/internal/cli/workflow_context_runtime_observe_session_run.go
+++ b/internal/cli/workflow_context_runtime_observe_session_run.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/insajin/autopus-adk/pkg/version"
 )
@@ -29,7 +30,7 @@ func RunWorkflowContextObserveSession(
 	if err != nil || !validWorkflowContextObserveHandshake(first) {
 		return errors.New("observe-session handshake is invalid")
 	}
-	setup, err := prepareWorkflowContextObserveSession(ctx, options, first.ChallengeDigest)
+	setup, err := prepareWorkflowContextObserveSessionForRun(ctx, options, first.ChallengeDigest)
 	if err != nil {
 		return err
 	}
@@ -54,8 +55,11 @@ func RunWorkflowContextObserveSession(
 	if !validPipelineOMPActiveHash(providerAuthority) {
 		return errors.New("observe-session provider authority binding is unstable")
 	}
-	var pairTask, pairPromptHash string
-	for sequence := 1; sequence <= 40; sequence++ {
+	calls := make([]workflowContextObserveSessionCallEvidence, 0, 40)
+	var pairTask, pairPromptHash, pairOutputDigest string
+	var lastCompleted time.Time
+	for index := range 40 {
+		sequence := index + 1
 		command, err := nextWorkflowContextObserveSessionCommand(scanner)
 		if err != nil || validateWorkflowContextObserveSessionCall(command, sequence) != nil {
 			return fmt.Errorf("observe-session call %d is invalid", sequence)
@@ -73,14 +77,34 @@ func RunWorkflowContextObserveSession(
 		if command.Variant == "B" {
 			session, expectedPID = setup.optimized, optimizedPID
 		}
-		assistant, receipt, err := session.Execute(ctx, command.Prompt)
+		providerPrompt, providerPromptHash, err := setup.sealPrompt(command.Prompt)
+		if err != nil {
+			return fmt.Errorf("observe-session call %d canonical admission failed: %w", sequence, err)
+		}
+		startedAt := time.Now().UTC()
+		if !lastCompleted.IsZero() && !startedAt.After(lastCompleted) {
+			startedAt = lastCompleted.Add(time.Nanosecond)
+		}
+		assistant, receipt, err := session.Execute(ctx, providerPrompt)
+		endedAt := time.Now().UTC()
+		if !endedAt.After(startedAt) {
+			endedAt = startedAt.Add(time.Nanosecond)
+		}
 		if err != nil {
 			return fmt.Errorf("observe-session call %d failed closed: %w", sequence, err)
+		}
+		if !safeWorkflowContextObserveSessionOutput(setup, assistant) {
+			return fmt.Errorf("observe-session call %d returned private or unsafe output", sequence)
 		}
 		response := workflowContextObserveSessionBaseResponse("call", setup.candidate.ModelScopeDigest)
 		response.Sequence, response.PairSequence = command.Sequence, command.PairSequence
 		response.TaskIDDigest, response.Variant = command.TaskIDDigest, command.Variant
 		response.AssistantText, response.OutputDigest = assistant, workflowContextRuntimeHash(assistant)
+		if command.PairSequence == 1 {
+			pairOutputDigest = response.OutputDigest
+		} else if response.OutputDigest != pairOutputDigest {
+			return fmt.Errorf("observe-session call %d quality oracle changed across the pair", sequence)
+		}
 		response.SessionDigest = receipt.SessionBindingHash
 		response.ProviderAuthorityDigest = providerAuthority
 		response.ProcessReused = variantCalls[command.Variant] > 0
@@ -96,7 +120,7 @@ func RunWorkflowContextObserveSession(
 		}
 		lifecycleValid := session.PID() == expectedPID && receipt.SameProcess && receipt.SameSession &&
 			receipt.TerminalIdle && receipt.SessionBindingHash != "" &&
-			receipt.BridgeBindingHash == providerAuthority
+			receipt.BridgeBindingHash == session.binding.BindingHash
 		if prior := sessionBindings[command.Variant]; prior == "" {
 			sessionBindings[command.Variant] = receipt.SessionBindingHash
 		} else if prior != receipt.SessionBindingHash {
@@ -111,6 +135,18 @@ func RunWorkflowContextObserveSession(
 			response.CanonicalReadmissions == 1 && response.EphemeralReadmissions == 1
 		if !lifecycleValid || !fullValid && !optimizedValid {
 			return fmt.Errorf("observe-session call %d process lifecycle changed", sequence)
+		}
+		calls = append(calls, workflowContextObserveSessionCallEvidence{
+			command: command, response: response, providerPromptHash: providerPromptHash,
+			startedAt: startedAt, endedAt: endedAt,
+		})
+		lastCompleted = endedAt
+		if command.PairSequence == 2 {
+			if err := verifyWorkflowContextObserveSessionReadback(
+				ctx, &setup, variantCalls["A"], variantCalls["B"],
+			); err != nil {
+				return fmt.Errorf("observe-session pair %d failed readback: %w", (sequence+1)/2, err)
+			}
 		}
 		if err := encoder.Encode(response); err != nil {
 			return err
@@ -128,13 +164,26 @@ func RunWorkflowContextObserveSession(
 	if scanner.Scan() || scanner.Err() != nil {
 		return errors.New("observe-session input continued after shutdown")
 	}
+	evidenceSetup := setup
 	if err := setup.close(); err != nil {
 		return err
 	}
 	setup.taskRoot = ""
+	checkedAt := time.Now().UTC()
+	if !checkedAt.After(lastCompleted) {
+		checkedAt = lastCompleted.Add(time.Nanosecond)
+	}
+	evidenceID, reportDigest, err := writeWorkflowContextObserveSessionEvidence(
+		options, evidenceSetup, first.ChallengeDigest, calls, checkedAt,
+	)
+	if err != nil {
+		return err
+	}
 	response := workflowContextObserveSessionBaseResponse("shutdown", setup.candidate.ModelScopeDigest)
 	response.CallsCompleted = 40
 	response.ProviderAuthorityDigest = providerAuthority
+	response.EvidenceID, response.ReportDigest = evidenceID, reportDigest
+	response.CleanupVerified = true
 	response.CompactionCycles = variantCalls["B"]
 	response.PreCompactionACKs = variantCalls["B"]
 	response.PostCompactionACKs = variantCalls["B"]

--- a/internal/cli/workflow_context_runtime_observe_session_setup.go
+++ b/internal/cli/workflow_context_runtime_observe_session_setup.go
@@ -10,29 +10,57 @@ import (
 	"strings"
 	"time"
 
+	"github.com/insajin/autopus-adk/pkg/config"
 	"github.com/insajin/autopus-adk/pkg/pipeline"
+	"github.com/insajin/autopus-adk/pkg/promptlayer"
 	"github.com/insajin/autopus-adk/pkg/version"
 )
 
 type workflowContextObserveSessionSetup struct {
 	taskRoot                string
+	projectDir              string
+	endpoint                string
+	credential              string
 	backend                 pipelineOMPBackendConfig
 	candidate               pipelineOMPManagedActiveCandidate
 	prepared                pipelineOMPManagedActivePrepared
 	full                    *pipelineOMPActiveEvaluatorSession
+	deliveryOptions         promptlayer.ContextDeliveryOptions
+	delivery                promptlayer.ContextDeliveryResult
+	canonicalPromptHash     string
 	optimized               *pipelineOMPActiveEvaluatorSession
 	ompVersion              string
 	ompExecutableSHA256     string
+	autoVersion             string
+	autoExecutableSHA256    string
+	candidateTree           string
 	providerAuthorityDigest string
 	sandboxMode             pipelineOMPActiveSandboxMode
 }
 
 func validateWorkflowContextObserveSessionOptions(options workflowContextObserveSessionOptions) error {
+	_, policyErr := promptlayer.OMPContextPromotionPolicyDigestV1(options.PromotionPolicy)
+	metadata := []string{
+		options.WorkspaceID, options.ProducerRepository, options.ProducerWorkflowRef,
+		options.CandidateRepository, options.PolicyID,
+	}
+	metadataValid := true
+	for _, value := range metadata {
+		if strings.TrimSpace(value) == "" || strings.TrimSpace(value) != value ||
+			len(value) > 256 || strings.ContainsRune(value, 0) {
+			metadataValid = false
+		}
+	}
 	if !workflowContextObserveProviderPattern.MatchString(options.Provider) ||
 		!workflowContextObserveProviderPattern.MatchString(options.Model) ||
 		!workflowContextMetadataPattern.MatchString(options.SpecID) ||
 		!pipelineOMPContextCohortLocatorPattern.MatchString(options.CredentialLocator) ||
-		!validPipelineOMPActiveGitHash(options.TargetGitCommit) ||
+		!pipelineOMPContextObservationRunID.MatchString(options.ProducerRunID) ||
+		options.ProducerRunAttempt <= 0 || !metadataValid || !validPipelineOMPActiveHash(options.OraclePolicyDigest) ||
+		!validPipelineOMPActiveGitHash(options.TargetGitCommit) || policyErr != nil ||
+		options.PromotionPolicy.HistoryMode != config.OMPContextHistoryActive ||
+		options.PromotionPolicy.MemoryMode != config.OMPContextMemoryOff ||
+		options.EvidenceValidFor <= 0 || options.EvidenceValidFor > 24*time.Hour ||
 		(options.SandboxMode != pipelineOMPActiveSandboxManaged &&
 			options.SandboxMode != pipelineOMPActiveSandboxInheritedParent) ||
 		strings.TrimSpace(options.Endpoint) == "" || strings.TrimSpace(options.Executable) == "" {
@@ -57,7 +85,8 @@ func prepareWorkflowContextObserveSession(
 		return workflowContextObserveSessionSetup{}, errors.New("observe-session endpoint is invalid")
 	}
 	credential, found := os.LookupEnv(options.CredentialLocator)
-	if !found || strings.TrimSpace(credential) == "" || strings.ContainsRune(credential, 0) {
+	if !found || strings.TrimSpace(credential) == "" || len(credential) > pipelineOMPActiveCredentialMaxBytes ||
+		strings.ContainsRune(credential, 0) {
 		return workflowContextObserveSessionSetup{}, errors.New("observe-session credential is unavailable")
 	}
 	executable, err := exec.LookPath(options.Executable)
@@ -68,14 +97,40 @@ func prepareWorkflowContextObserveSession(
 	if err != nil {
 		return workflowContextObserveSessionSetup{}, err
 	}
-	if !validPipelineOMPActiveGitHash(version.SourceCommit()) || !validPipelineOMPActiveGitHash(version.SourceTree()) {
+	if !validPipelineOMPActiveGitHash(version.SourceCommit()) || !validPipelineOMPActiveGitHash(version.SourceTree()) ||
+		options.TargetGitCommit != version.SourceCommit() {
 		return workflowContextObserveSessionSetup{}, errors.New("observe-session candidate build provenance is unavailable")
+	}
+	autoExecutableSHA256, err := workflowContextObserveCurrentExecutableSHA256()
+	if err != nil {
+		return workflowContextObserveSessionSetup{}, err
+	}
+	policyDigest, err := promptlayer.OMPContextPromotionPolicyDigestV1(options.PromotionPolicy)
+	if err != nil {
+		return workflowContextObserveSessionSetup{}, err
+	}
+	specDirRef := filepath.ToSlash(filepath.Join(".autopus", "specs", options.SpecID))
+	specDir := filepath.Join(projectDir, filepath.FromSlash(specDirRef))
+	snapshotHash, err := pipeline.SpecSnapshotHash(specDir)
+	if err != nil {
+		return workflowContextObserveSessionSetup{}, errors.New("observe-session SPEC snapshot is unavailable")
+	}
+	deliveryOptions := promptlayer.ContextDeliveryOptions{
+		Root: projectDir, Command: "go", SpecDir: specDirRef,
+	}
+	delivery, err := promptlayer.BuildContextDelivery(deliveryOptions)
+	if err != nil || promptlayer.VerifyContextDeliveryForOptions(deliveryOptions, delivery) != nil {
+		return workflowContextObserveSessionSetup{}, errors.New("observe-session canonical context is unavailable")
 	}
 	taskRoot, err := os.MkdirTemp("", "autopus-omp-observe-session-")
 	if err != nil {
 		return workflowContextObserveSessionSetup{}, err
 	}
-	setup := workflowContextObserveSessionSetup{taskRoot: taskRoot}
+	setup := workflowContextObserveSessionSetup{
+		taskRoot: taskRoot, projectDir: projectDir, endpoint: endpoint, credential: credential,
+		deliveryOptions: deliveryOptions, delivery: delivery,
+		canonicalPromptHash: workflowContextRuntimeHash(delivery.Prompt),
+	}
 	failed := true
 	defer func() {
 		if failed {
@@ -92,8 +147,8 @@ func prepareWorkflowContextObserveSession(
 	phaseModels := workflowContextObserveSessionPhaseModels(options.Provider + "/" + options.Model)
 	backend, err := normalizePipelineOMPBackendConfig(pipelineOMPBackendConfig{
 		Executable: executable, executableID: executableID, ProjectDir: projectDir,
-		SpecID: options.SpecID, SpecDir: filepath.Join(projectDir, ".autopus", "specs", options.SpecID),
-		SnapshotHash: challenge, GitCommitHash: options.TargetGitCommit, RuntimeBase: runtimeBase,
+		SpecID: options.SpecID, SpecDir: specDir,
+		SnapshotHash: snapshotHash, GitCommitHash: options.TargetGitCommit, RuntimeBase: runtimeBase,
 		Environment: []string{
 			"PATH=" + os.Getenv("PATH"), pipelineOMPActiveEndpointKey + "=" + endpoint,
 			pipelineOMPActiveCredentialKey + "=" + credential,
@@ -111,22 +166,24 @@ func prepareWorkflowContextObserveSession(
 	}
 	snapshot := pipeline.OMPExecutionSnapshot{
 		ProjectDir: projectDir, SpecID: options.SpecID, SpecDir: backend.SpecDir,
-		SnapshotHash: challenge, GitCommitHash: options.TargetGitCommit, PhaseID: pipeline.PhasePlan,
+		SnapshotHash: snapshotHash, GitCommitHash: options.TargetGitCommit, PhaseID: pipeline.PhaseImplement,
 		Attempt: 1, Prompt: "observe-session", ActivePrompt: "observe-session",
 	}
-	candidate, err := newPipelineOMPManagedActiveCandidate(snapshot, phaseModels[pipeline.PhasePlan], phaseModels)
+	candidate, err := newPipelineOMPManagedActiveCandidate(snapshot, phaseModels[pipeline.PhaseImplement], phaseModels)
 	if err != nil {
 		return setup, err
 	}
 	prepared := pipelineOMPManagedActivePrepared{Binding: pipelineOMPActiveLeaseBinding{
-		GrantDigest: challenge, PolicyDigest: workflowContextRuntimeHash("observe-session-policy-v1"),
-		WorkspaceID: filepath.Base(projectDir), SpecID: options.SpecID,
+		GrantDigest: challenge, PolicyDigest: policyDigest,
+		WorkspaceID: options.WorkspaceID, SpecID: options.SpecID,
 		GitCommitHash: options.TargetGitCommit, AutoSourceCommit: candidate.AutoSourceCommit,
 		AutoSourceTree: candidate.AutoSourceTree, ModelScopeDigest: candidate.ModelScopeDigest,
 	}}
 	setup.backend, setup.candidate, setup.prepared = backend, candidate, prepared
 	setup.ompVersion = ompVersion
 	setup.ompExecutableSHA256 = fmt.Sprintf("sha256:%x", executableID.digest[:])
+	setup.autoVersion, setup.autoExecutableSHA256 = version.Version(), autoExecutableSHA256
+	setup.candidateTree = version.SourceTree()
 	setup.sandboxMode = options.SandboxMode
 	failed = false
 	return setup, nil

--- a/internal/cli/workflow_context_runtime_observe_session_setup.go
+++ b/internal/cli/workflow_context_runtime_observe_session_setup.go
@@ -38,6 +38,8 @@ type workflowContextObserveSessionSetup struct {
 	sandboxMode             pipelineOMPActiveSandboxMode
 }
 
+const workflowContextObserveSessionMaxTime = 30 * time.Minute
+
 func validateWorkflowContextObserveSessionOptions(options workflowContextObserveSessionOptions) error {
 	_, policyErr := promptlayer.OMPContextPromotionPolicyDigestV1(options.PromotionPolicy)
 	metadata := []string{
@@ -56,8 +58,9 @@ func validateWorkflowContextObserveSessionOptions(options workflowContextObserve
 		!workflowContextMetadataPattern.MatchString(options.SpecID) ||
 		!pipelineOMPContextCohortLocatorPattern.MatchString(options.CredentialLocator) ||
 		!pipelineOMPContextObservationRunID.MatchString(options.ProducerRunID) ||
-		options.ProducerRunAttempt <= 0 || !metadataValid || !validPipelineOMPActiveHash(options.OraclePolicyDigest) ||
-		!validPipelineOMPActiveGitHash(options.TargetGitCommit) || policyErr != nil ||
+		options.ProducerRunAttempt <= 0 || options.ModelContextWindow < 8192 ||
+		options.ModelContextWindow > 1<<30 || !metadataValid || policyErr != nil ||
+		!validPipelineOMPActiveHash(options.OraclePolicyDigest) ||
 		options.PromotionPolicy.HistoryMode != config.OMPContextHistoryActive ||
 		options.PromotionPolicy.MemoryMode != config.OMPContextMemoryOff ||
 		options.EvidenceValidFor <= 0 || options.EvidenceValidFor > 24*time.Hour ||
@@ -149,11 +152,12 @@ func prepareWorkflowContextObserveSession(
 		Executable: executable, executableID: executableID, ProjectDir: projectDir,
 		SpecID: options.SpecID, SpecDir: specDir,
 		SnapshotHash: snapshotHash, GitCommitHash: options.TargetGitCommit, RuntimeBase: runtimeBase,
+		ModelContextWindow: options.ModelContextWindow,
 		Environment: []string{
 			"PATH=" + os.Getenv("PATH"), pipelineOMPActiveEndpointKey + "=" + endpoint,
 			pipelineOMPActiveCredentialKey + "=" + credential,
 		},
-		PhaseModels: phaseModels, MaxTime: 10 * time.Minute,
+		PhaseModels: phaseModels, MaxTime: workflowContextObserveSessionMaxTime,
 	})
 	if err != nil {
 		return setup, err

--- a/internal/cli/workflow_context_runtime_observe_session_setup_test.go
+++ b/internal/cli/workflow_context_runtime_observe_session_setup_test.go
@@ -38,6 +38,11 @@ func TestWorkflowContextObserveSessionPhaseModels_BindsAllCanonicalPhases(t *tes
 	assert.Equal(t, "sha256:386816349ebf9b5c2a113889fb3160662121a4fd4fa4085d2bdef97660142adf", digest)
 }
 
+func TestWorkflowContextObserveSession_RuntimeBudgetCoversFullCohort(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, 30*time.Minute, workflowContextObserveSessionMaxTime)
+}
+
 func TestWorkflowContextObserveSessionCommand_InheritedParentSandboxIsExplicitOptIn(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, pipelineOMPActiveSandboxManaged, workflowContextObserveSessionSandboxMode(false))
@@ -45,10 +50,13 @@ func TestWorkflowContextObserveSessionCommand_InheritedParentSandboxIsExplicitOp
 	flag := newWorkflowContextObserveSessionCmd().Flags().Lookup("inherit-parent-sandbox")
 	require.NotNil(t, flag)
 	assert.Equal(t, "false", flag.DefValue)
+	contextWindow := newWorkflowContextObserveSessionCmd().Flags().Lookup("model-context-window")
+	require.NotNil(t, contextWindow)
+	assert.Equal(t, "262144", contextWindow.DefValue)
 	assert.Nil(t, newWorkflowContextObserveCallCmd().Flags().Lookup("inherit-parent-sandbox"))
 
 	options := workflowContextObserveSessionOptions{
-		Provider: "openai", Model: "gpt-5.6-sol", SpecID: "SPEC-OMP-004",
+		Provider: "openai", Model: "gpt-5.6-sol", ModelContextWindow: 272000, SpecID: "SPEC-OMP-004",
 		CredentialLocator: "AUTOPUS_OMP_CONTEXT_PROVIDER_OPENAI", TargetGitCommit: strings.Repeat("a", 40),
 		Endpoint: "http://127.0.0.1:43123", Executable: "omp", WorkspaceID: "autopus-adk",
 		ProducerRepository:  "insajin/omp-evals",

--- a/internal/cli/workflow_context_runtime_observe_session_setup_test.go
+++ b/internal/cli/workflow_context_runtime_observe_session_setup_test.go
@@ -10,7 +10,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/insajin/autopus-adk/pkg/config"
 	"github.com/insajin/autopus-adk/pkg/pipeline"
+	"github.com/insajin/autopus-adk/pkg/promptlayer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -48,9 +50,49 @@ func TestWorkflowContextObserveSessionCommand_InheritedParentSandboxIsExplicitOp
 	options := workflowContextObserveSessionOptions{
 		Provider: "openai", Model: "gpt-5.6-sol", SpecID: "SPEC-OMP-004",
 		CredentialLocator: "AUTOPUS_OMP_CONTEXT_PROVIDER_OPENAI", TargetGitCommit: strings.Repeat("a", 40),
-		Endpoint: "http://127.0.0.1:43123", Executable: "omp",
+		Endpoint: "http://127.0.0.1:43123", Executable: "omp", WorkspaceID: "autopus-adk",
+		ProducerRepository:  "insajin/omp-evals",
+		ProducerWorkflowRef: "refs/heads/main@" + strings.Repeat("a", 40),
+		ProducerRunID:       "123456", ProducerRunAttempt: 1, CandidateRepository: "insajin/autopus-adk",
+		PolicyID: "omp-context-active-v1", OraclePolicyDigest: workflowContextRuntimeHash("oracle"),
+		PromotionPolicy: promptlayer.OMPContextPromotionPolicyV1{
+			Profile: "active", HistoryMode: config.OMPContextHistoryActive, MemoryMode: config.OMPContextMemoryOff,
+			HistoryTargetTokens: 1000, Fallback: config.OMPContextFallbackCanonicalFull,
+			CapabilityPolicy:  config.OMPContextCapabilityProbeRequired,
+			RuntimeRootPolicy: config.OMPContextRuntimeIsolatedTaskOwned,
+			MutationScope:     config.OMPContextMutationSessionOverlay,
+		},
+		EvidenceValidFor: time.Hour, SandboxMode: pipelineOMPActiveSandboxManaged,
 	}
 	require.NoError(t, validateWorkflowContextObserveSessionOptions(options))
+}
+
+func TestPopulateWorkflowContextObserveSessionPolicy_DoesNotInspectOrMutateUserOMPState(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.DefaultFullConfig("evidence-workspace")
+	cfg.OMPContextPolicy = config.OMPContextPolicyConf{
+		Profile: "active",
+		Profiles: map[string]config.OMPContextProfileConf{"active": {
+			HistoryMode: config.OMPContextHistoryActive, MemoryMode: config.OMPContextMemoryOff,
+			HistoryTargetTokens: 1000, Fallback: config.OMPContextFallbackCanonicalFull,
+			CapabilityPolicy:  config.OMPContextCapabilityProbeRequired,
+			RuntimeRootPolicy: config.OMPContextRuntimeIsolatedTaskOwned,
+			MutationScope:     config.OMPContextMutationSessionOverlay,
+		}},
+	}
+	require.NoError(t, config.Save(root, cfg))
+	userOMPPath := filepath.Join(root, ".omp", "config.yml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(userOMPPath), 0o700))
+	require.NoError(t, os.WriteFile(userOMPPath, []byte("USER-OWNED-OMP-CONFIG"), 0o600))
+
+	options := workflowContextObserveSessionOptions{ProjectDir: root}
+	require.NoError(t, populateWorkflowContextObserveSessionPolicy(&options))
+	assert.Equal(t, "evidence-workspace", options.WorkspaceID)
+	assert.Equal(t, config.OMPContextHistoryActive, options.PromotionPolicy.HistoryMode)
+	assert.Equal(t, config.OMPContextMemoryOff, options.PromotionPolicy.MemoryMode)
+	body, err := os.ReadFile(userOMPPath)
+	require.NoError(t, err)
+	assert.Equal(t, "USER-OWNED-OMP-CONFIG", string(body))
 }
 
 func TestWorkflowContextObserveVersion_InheritedModeUsesVerifiedPathWithoutInnerWrapper(t *testing.T) {

--- a/internal/cli/workflow_context_runtime_observe_session_types.go
+++ b/internal/cli/workflow_context_runtime_observe_session_types.go
@@ -1,5 +1,11 @@
 package cli
 
+import (
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/promptlayer"
+)
+
 const (
 	workflowContextObserveSessionCommandSchema  = "autopus.omp_context_observe_session_command.v1"
 	workflowContextObserveSessionResponseSchema = "autopus.omp_context_observe_session_response.v1"
@@ -38,6 +44,8 @@ type workflowContextObserveSessionResponse struct {
 	OMPExecutableSHA256      string                              `json:"omp_executable_sha256,omitempty"`
 	Sequence                 int                                 `json:"sequence,omitempty"`
 	PairSequence             int                                 `json:"pair_sequence,omitempty"`
+	EvidenceID               string                              `json:"evidence_id,omitempty"`
+	ReportDigest             string                              `json:"report_digest,omitempty"`
 	TaskIDDigest             string                              `json:"task_id_digest,omitempty"`
 	Variant                  string                              `json:"variant,omitempty"`
 	AssistantText            string                              `json:"assistant_text,omitempty"`
@@ -53,17 +61,28 @@ type workflowContextObserveSessionResponse struct {
 	Usage                    *workflowContextObserveSessionUsage `json:"usage,omitempty"`
 	CallsCompleted           int                                 `json:"calls_completed,omitempty"`
 	OwnedRootsRemaining      int                                 `json:"owned_roots_remaining,omitempty"`
+	CleanupVerified          bool                                `json:"cleanup_verified,omitempty"`
 	ProcessesRemaining       int                                 `json:"processes_remaining,omitempty"`
 }
 
 type workflowContextObserveSessionOptions struct {
-	ProjectDir        string
-	SpecID            string
-	Provider          string
-	Model             string
-	Endpoint          string
-	CredentialLocator string
-	Executable        string
-	TargetGitCommit   string
-	SandboxMode       pipelineOMPActiveSandboxMode
+	ProjectDir          string
+	SpecID              string
+	Provider            string
+	Model               string
+	Endpoint            string
+	CredentialLocator   string
+	Executable          string
+	TargetGitCommit     string
+	SandboxMode         pipelineOMPActiveSandboxMode
+	WorkspaceID         string
+	ProducerRepository  string
+	ProducerWorkflowRef string
+	ProducerRunID       string
+	ProducerRunAttempt  int
+	CandidateRepository string
+	PolicyID            string
+	OraclePolicyDigest  string
+	PromotionPolicy     promptlayer.OMPContextPromotionPolicyV1
+	EvidenceValidFor    time.Duration
 }

--- a/internal/cli/workflow_context_runtime_observe_session_types.go
+++ b/internal/cli/workflow_context_runtime_observe_session_types.go
@@ -70,6 +70,7 @@ type workflowContextObserveSessionOptions struct {
 	SpecID              string
 	Provider            string
 	Model               string
+	ModelContextWindow  int
 	Endpoint            string
 	CredentialLocator   string
 	Executable          string

--- a/internal/companionmanifest/release_ci_stability_test.go
+++ b/internal/companionmanifest/release_ci_stability_test.go
@@ -30,6 +30,7 @@ func TestCIWorkflow_StableChecksHaveBoundedTimeouts(t *testing.T) {
 	want := map[string]int{
 		"test": 35, "lineage-integration": 55, "e2e": 10, "lint": 10,
 		"static-contracts": 10, "macos-runtime": 15,
+		"omp-native-smoke": 5,
 	}
 	for id, timeout := range want {
 		job, ok := workflow.Jobs[id]

--- a/pkg/adapter/omp/omp_commands.go
+++ b/pkg/adapter/omp/omp_commands.go
@@ -52,7 +52,14 @@ func thinRouterCommandBody() string {
 
 func thinWorkflowCommandBody(name string) string {
 	subcommand := strings.TrimPrefix(name, "auto-")
-	return strings.TrimSpace(fmt.Sprintf("`$ARGUMENTS`\n\nTreat the text above as the full argument payload for `/%s`.\nLoad exact detail skill `%s`; this is the same target selected by `/auto %s ...`.\nPreserve `--model <provider/model>` and `--variant <value>` when present.\nDo not restate or expand the arguments unless needed for execution.", name, name, subcommand))
+	body := fmt.Sprintf("`$ARGUMENTS`\n\nTreat the text above as the full argument payload for `/%s`.\nLoad exact detail skill `%s`; this is the same target selected by `/auto %s ...`.\nPreserve `--model <provider/model>` and `--variant <value>` when present.\nDo not restate or expand the arguments unless needed for execution.", name, name, subcommand)
+	switch name {
+	case "auto-go":
+		body += "\nAccept at most one exact `--execution-owner omp|orca` pair; omission defaults to `omp`, with no aliases or fuzzy fallback."
+	case "auto-status":
+		body += "\nCombine the workspace execution-owner receipt with current-session OMP-native `hub` state; external `auto status` cannot inspect OMP user-session roots."
+	}
+	return strings.TrimSpace(body)
 }
 
 // ompCommandFrontmatter builds command frontmatter with the description escaped

--- a/pkg/adapter/omp/omp_context_bridge_test.go
+++ b/pkg/adapter/omp/omp_context_bridge_test.go
@@ -169,7 +169,7 @@ func TestOMPContextBridge_NoOptInPreservesExactPreparedFiles(t *testing.T) {
 	catalogFiles, err := adapterUnderTest.prepareFiles(context.Background(), catalogOnly)
 	require.NoError(t, err)
 
-	const priorPreparedFilesFingerprint = "5c3dc5888c4f0aa5866176dea90e14435bdb6c66fda117688a37e7172c661ad9"
+	const priorPreparedFilesFingerprint = "637c407b6541c185502687a7e72ed58155d4a793c10440193a0a37647102aced"
 	assert.Equal(t, priorPreparedFilesFingerprint, fingerprintOMPFileMappings(t, baselineFiles))
 	assert.Equal(t, fingerprintOMPFileMappings(t, baselineFiles), fingerprintOMPFileMappings(t, catalogFiles))
 	assert.NotContains(t, ompMappingTargets(baselineFiles), ".omp/extensions/autopus-context.ts")

--- a/pkg/adapter/omp/omp_native_pipeline_route.go
+++ b/pkg/adapter/omp/omp_native_pipeline_route.go
@@ -40,7 +40,7 @@ const SPEC_ID_PATTERN = /^SPEC-[A-Z0-9]+(?:-[A-Z0-9]+)+$/;
 const MAX_ARGUMENT_LENGTH = 512;
 const MAX_CAPTURE_LENGTH = 4096;
 const MAX_NOTICE_LENGTH = 320;
-const USAGE = "Usage: /autopus-pipeline go SPEC-ID [--continue] [--dry-run] [--strategy sequential] [--auto] [--loop] [--multi] [--quality balanced|ultra] [--effort low|medium|high|xhigh|max|ultra]";
+const USAGE = "Usage: /autopus-pipeline go SPEC-ID [--execution-owner omp|orca] [--continue] [--dry-run] [--strategy sequential] [--auto] [--loop] [--multi] [--quality balanced|ultra] [--effort low|medium|high|xhigh|max|ultra]";
 
 const BOOLEAN_FLAGS = new Set([
   "--continue",
@@ -52,6 +52,7 @@ const BOOLEAN_FLAGS = new Set([
 
 const VALUE_FLAGS = new Map<string, ReadonlySet<string>>([
   ["--strategy", new Set(["sequential"])],
+  ["--execution-owner", new Set(["omp", "orca"])],
   ["--quality", new Set(["balanced", "ultra"])],
   ["--effort", new Set(["low", "medium", "high", "xhigh", "max", "ultra"])],
 ]);

--- a/pkg/adapter/omp/omp_native_pipeline_route_test.go
+++ b/pkg/adapter/omp/omp_native_pipeline_route_test.go
@@ -28,6 +28,11 @@ func TestOMPNativePipelineRoute_MarkdownAutoOwnsInteractiveAndExplicitRouteOwnsH
 	require.NotContains(t, source, `registerCommand("auto"`)
 	require.Equal(t, 1, countLiteral(source, `registerCommand("autopus-pipeline"`))
 	require.Contains(t, source, `Usage: /autopus-pipeline go SPEC-ID`)
+	require.Contains(t, source, `[--execution-owner omp|orca]`)
+	require.Contains(t, source, `["--execution-owner", new Set(["omp", "orca"])]`)
+	require.NotContains(t, source, `"OMP"`)
+	require.NotContains(t, source, `"local"`)
+	require.NotContains(t, source, `"supervised"`)
 	require.Contains(t, source, `process.env.AUTOPUS_OMP_MANAGED_INNER === "1"`)
 	require.Equal(t, 1, countLiteral(source, `["pipeline", "run", specID, "--platform", "omp"]`))
 	require.Equal(t, 1, countLiteral(source, `spawn("auto", argv`))
@@ -95,6 +100,15 @@ const sequential = parseRoute("go SPEC-TEST-001 --strategy sequential");
 if (!sequential.ok) throw new Error("sequential headless strategy was rejected");
 const parallel = parseRoute("go SPEC-TEST-001 --strategy parallel");
 if (parallel.ok) throw new Error("parallel remained in the headless allowlist");
+const ompOwner = parseRoute("go SPEC-TEST-001 --execution-owner omp");
+if (!ompOwner.ok || ompOwner.forwardedFlags.join(" ") !== "--execution-owner omp") throw new Error("exact omp owner was not forwarded");
+const orcaOwner = parseRoute("go SPEC-TEST-001 --execution-owner orca");
+if (!orcaOwner.ok || orcaOwner.forwardedFlags.join(" ") !== "--execution-owner orca") throw new Error("exact orca owner was not forwarded");
+for (const invalidOwner of ["OMP", "Orca", "omp,orca", "local", "supervised"]) {
+  if (parseRoute("go SPEC-TEST-001 --execution-owner " + invalidOwner).ok) throw new Error("invalid owner was accepted: " + invalidOwner);
+}
+const mixedOwner = parseRoute("go SPEC-TEST-001 --execution-owner omp --execution-owner orca");
+if (mixedOwner.ok) throw new Error("mixed owner selection was accepted");
 registrations = 0;
 process.env.AUTOPUS_OMP_MANAGED_INNER = "1";
 autopusPipelineRoute(api as any);

--- a/pkg/adapter/omp/omp_native_task_hub_contract_test.go
+++ b/pkg/adapter/omp/omp_native_task_hub_contract_test.go
@@ -1,0 +1,263 @@
+package omp
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	ompNativeSmokeToken    = "AUTOPUS_OMP_NATIVE_TASK_HUB_SMOKE"
+	ompNativeCredential    = "AUTOPUS_NATIVE_CREDENTIAL_MUST_NOT_LEAK"
+	ompNativeAlphaID       = "NativeAlpha"
+	ompNativeBetaID        = "NativeBeta"
+	ompNativeSharedContext = "Read-only native lifecycle smoke. Do not modify files or use process or network tools. Return only the required five-field receipt through yield."
+	ompNativeAlphaTask     = "NATIVE_CHILD_ALPHA: inspect the generated explorer surface read-only and return its strict receipt without modifying anything."
+	ompNativeBetaTask      = "NATIVE_CHILD_BETA: inspect the generated reviewer surface read-only and return its strict receipt without modifying anything."
+)
+
+type ompNativeChildReceipt struct {
+	OwnedPaths       []string `json:"owned_paths"`
+	ChangedFiles     []string `json:"changed_files"`
+	Verification     []string `json:"verification"`
+	Blockers         []string `json:"blockers"`
+	NextRequiredStep string   `json:"next_required_step"`
+}
+
+func ompNativeReceiptSchema() map[string]any {
+	stringArray := func() map[string]any {
+		return map[string]any{"type": "array", "items": map[string]any{"type": "string"}}
+	}
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"owned_paths":        stringArray(),
+			"changed_files":      stringArray(),
+			"verification":       stringArray(),
+			"blockers":           stringArray(),
+			"next_required_step": map[string]any{"type": "string"},
+		},
+		"required": []string{
+			"owned_paths", "changed_files", "verification", "blockers", "next_required_step",
+		},
+	}
+}
+
+func ompNativeTaskArguments() map[string]any {
+	return map[string]any{
+		"i":       "Spawning read-only lifecycle probes",
+		"context": ompNativeSharedContext,
+		"tasks": []any{
+			map[string]any{
+				"name": ompNativeAlphaID, "agent": "explorer", "task": ompNativeAlphaTask,
+				"outputSchema": ompNativeReceiptSchema(), "schemaMode": "strict",
+			},
+			map[string]any{
+				"name": ompNativeBetaID, "agent": "reviewer", "task": ompNativeBetaTask,
+				"outputSchema": ompNativeReceiptSchema(), "schemaMode": "strict",
+			},
+		},
+	}
+}
+
+func ompNativeExpectedReceipt(id string) ompNativeChildReceipt {
+	switch id {
+	case ompNativeAlphaID:
+		return ompNativeChildReceipt{
+			OwnedPaths: []string{".omp/agents/explorer.md"}, ChangedFiles: []string{},
+			Verification: []string{"native-alpha-read-only"}, Blockers: []string{}, NextRequiredStep: "none",
+		}
+	case ompNativeBetaID:
+		return ompNativeChildReceipt{
+			OwnedPaths: []string{".omp/agents/reviewer.md"}, ChangedFiles: []string{},
+			Verification: []string{"native-beta-read-only"}, Blockers: []string{}, NextRequiredStep: "none",
+		}
+	default:
+		panic("unknown native child receipt " + id)
+	}
+}
+
+func validateOMPNativeTaskArguments(args any) error {
+	actual, err := json.Marshal(args)
+	if err != nil {
+		return fmt.Errorf("encode task arguments: %w", err)
+	}
+	expectedArgs := ompNativeTaskArguments()
+	delete(expectedArgs, "i")
+	expected, err := json.Marshal(expectedArgs)
+	if err != nil {
+		return fmt.Errorf("encode expected task arguments: %w", err)
+	}
+	if string(actual) != string(expected) {
+		return fmt.Errorf("task arguments drifted: %s", actual)
+	}
+	return nil
+}
+
+func validateOMPNativeParentTools(tools []json.RawMessage) error {
+	parameters, ok := ompNativeToolParameters(tools, "task")
+	if !ok {
+		return fmt.Errorf("task tool missing")
+	}
+	properties := ompNativeMap(parameters["properties"])
+	if !ompNativeExactKeys(properties, "context", "i", "tasks") ||
+		!ompNativeStringSet(parameters["required"], "context", "i", "tasks") {
+		encoded, _ := json.Marshal(properties)
+		return fmt.Errorf("task batch shape drifted: properties=%s", encoded)
+	}
+	tasks := ompNativeMap(properties["tasks"])
+	items := ompNativeMap(tasks["items"])
+	itemProperties := ompNativeMap(items["properties"])
+	if !ompNativeExactKeys(itemProperties, "agent", "name", "outputSchema", "schemaMode", "task") {
+		return fmt.Errorf("task item shape drifted")
+	}
+	taskDefinition := ompNativeToolDefinition(tools, "task")
+	if !strings.Contains(taskDefinition, "explorer") || !strings.Contains(taskDefinition, "reviewer") {
+		return fmt.Errorf("generated agents missing from task definition")
+	}
+	for _, forbidden := range []string{"effort", "model", "thinking", "isolated"} {
+		if _, exists := itemProperties[forbidden]; exists {
+			return fmt.Errorf("unexpected child override field %s", forbidden)
+		}
+	}
+	hub, ok := ompNativeToolParameters(tools, "hub")
+	if !ok {
+		return fmt.Errorf("hub tool missing")
+	}
+	hubOp, _ := json.Marshal(ompNativeMap(hub["properties"])["op"])
+	for _, op := range []string{"list", "jobs", "wait"} {
+		if !strings.Contains(string(hubOp), `"`+op+`"`) {
+			return fmt.Errorf("hub op %s missing", op)
+		}
+	}
+	return nil
+}
+
+func validateOMPNativeChildTools(tools []json.RawMessage) error {
+	names := ompNativeToolNames(tools)
+	for _, required := range []string{"bash", "glob", "grep", "hub", "read", "yield"} {
+		if !names[required] {
+			return fmt.Errorf("read-only child tool %s missing", required)
+		}
+	}
+	for _, forbidden := range []string{"edit", "task", "web_search", "write"} {
+		if names[forbidden] {
+			return fmt.Errorf("read-only child exposed %s", forbidden)
+		}
+	}
+	yieldParameters, ok := ompNativeToolParameters(tools, "yield")
+	if !ok {
+		return fmt.Errorf("yield tool missing")
+	}
+	if !ompNativeContainsReceiptSchema(yieldParameters) {
+		encoded, _ := json.Marshal(yieldParameters)
+		if len(encoded) > 4000 {
+			encoded = encoded[:4000]
+		}
+		return fmt.Errorf("strict five-field yield schema missing: %s", encoded)
+	}
+	return nil
+}
+
+func ompNativeToolNames(tools []json.RawMessage) map[string]bool {
+	result := make(map[string]bool, len(tools))
+	for _, raw := range tools {
+		var tool struct {
+			Function struct {
+				Name string `json:"name"`
+			} `json:"function"`
+		}
+		if json.Unmarshal(raw, &tool) == nil && tool.Function.Name != "" {
+			result[tool.Function.Name] = true
+		}
+	}
+	return result
+}
+func ompNativeToolDefinition(tools []json.RawMessage, name string) string {
+	for _, raw := range tools {
+		var tool struct {
+			Function struct {
+				Name string `json:"name"`
+			} `json:"function"`
+		}
+		if json.Unmarshal(raw, &tool) == nil && tool.Function.Name == name {
+			return string(raw)
+		}
+	}
+	return ""
+}
+
+func ompNativeToolParameters(tools []json.RawMessage, name string) (map[string]any, bool) {
+	for _, raw := range tools {
+		var tool struct {
+			Function struct {
+				Name       string         `json:"name"`
+				Parameters map[string]any `json:"parameters"`
+			} `json:"function"`
+		}
+		if json.Unmarshal(raw, &tool) == nil && tool.Function.Name == name {
+			return tool.Function.Parameters, true
+		}
+	}
+	return nil, false
+}
+
+func ompNativeContainsReceiptSchema(value any) bool {
+	switch typed := value.(type) {
+	case map[string]any:
+		properties := ompNativeMap(typed["properties"])
+		if ompNativeExactKeys(properties,
+			"blockers", "changed_files", "next_required_step", "owned_paths", "verification") &&
+			ompNativeStringSet(typed["required"],
+				"blockers", "changed_files", "next_required_step", "owned_paths", "verification") {
+			return true
+		}
+		for _, child := range typed {
+			if ompNativeContainsReceiptSchema(child) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range typed {
+			if ompNativeContainsReceiptSchema(child) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func ompNativeMap(value any) map[string]any {
+	result, _ := value.(map[string]any)
+	return result
+}
+
+func ompNativeExactKeys(values map[string]any, expected ...string) bool {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	sort.Strings(expected)
+	return strings.Join(keys, "\x00") == strings.Join(expected, "\x00")
+}
+
+func ompNativeStringSet(value any, expected ...string) bool {
+	items, ok := value.([]any)
+	if !ok || len(items) != len(expected) {
+		return false
+	}
+	actual := make([]string, 0, len(items))
+	for _, item := range items {
+		text, ok := item.(string)
+		if !ok {
+			return false
+		}
+		actual = append(actual, text)
+	}
+	sort.Strings(actual)
+	sort.Strings(expected)
+	return strings.Join(actual, "\x00") == strings.Join(expected, "\x00")
+}

--- a/pkg/adapter/omp/omp_native_task_hub_live_test.go
+++ b/pkg/adapter/omp/omp_native_task_hub_live_test.go
@@ -1,0 +1,245 @@
+package omp
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type ompNativeLiveReceipt struct {
+	Version              string   `json:"version"`
+	ChildIDs             []string `json:"child_ids"`
+	HubOps               []string `json:"hub_ops"`
+	LoopbackRequests     int      `json:"loopback_requests"`
+	ExternalRequests     int      `json:"external_network_requests"`
+	AuthHeaders          int      `json:"auth_headers"`
+	CredentialLeaks      int      `json:"credential_leaks"`
+	ResidualArtifacts    int      `json:"residual_artifacts"`
+	ChildOverridesAbsent bool     `json:"child_overrides_absent"`
+	Status               string   `json:"status"`
+}
+
+func TestOMPNativeTaskHubLiveSmoke(t *testing.T) {
+	if os.Getenv("AUTOPUS_OMP_NATIVE_LIVE") != "1" {
+		t.Skip("set AUTOPUS_OMP_NATIVE_LIVE=1 to run the isolated native task/hub smoke")
+	}
+	for _, key := range []string{
+		"ANTHROPIC_API_KEY", "AWS_SECRET_ACCESS_KEY", "GITHUB_TOKEN", "GOOGLE_APPLICATION_CREDENTIALS",
+		"OPENAI_API_KEY", "OMP_ACCESS_TOKEN", "PI_PROVIDER_TOKEN", "SSH_AUTH_SOCK",
+	} {
+		t.Setenv(key, ompNativeCredential)
+	}
+	executable := resolveOMPNativeLiveExecutable(t)
+	scratch := generateOMPOnly(t)
+	assertOMPNativeGeneratedAgentsInheritParent(t, scratch)
+	baseline := snapshotOMPNativeTree(t, scratch)
+
+	provider := newOMPNativeProvider(t)
+	profile := t.TempDir()
+	writeOMPLiveModelConfig(t, profile, provider.server.URL)
+	overlay := writeOMPNativeLiveOverlay(t, profile)
+	version := probeOMPLiveVersion(t, executable, profile, overlay)
+	require.Equal(t, "omp/17.2.7", version, "native task/hub schema is pinned to the supported OMP release")
+
+	sandboxCtx, cancelSandbox := context.WithTimeout(context.Background(), 5*time.Second)
+	sandboxEvidence, sandboxErr := probeOMPRPCNetworkSandbox(sandboxCtx, provider.server.URL)
+	cancelSandbox()
+	require.NoError(t, sandboxErr, "OS-level loopback-only sandbox is mandatory")
+	require.Equal(t, ompRPCNetworkSandboxEvidence{
+		AllowedEndpointConnections: 1, DeniedOtherLoopback: 1, DeniedNonLoopback: 2,
+	}, sandboxEvidence)
+
+	prompt := ompNativeSmokeToken + ": issue exactly one task batch with the two named read-only children, " +
+		"then observe them only through hub list, jobs, one wait per child, and final list before finishing."
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Second)
+	defer cancel()
+	trace, err := runActualOMPNativeRPC(
+		ctx, executable, scratch, profile, overlay, prompt, provider.server.URL, provider,
+	)
+	providerReceipt := provider.receipt()
+	require.NoError(t, err, "native RPC failed: provider=%+v", providerReceipt)
+	require.Empty(t, providerReceipt.Failure)
+	require.Equal(t, 10, providerReceipt.Requests)
+	require.Equal(t, 8, providerReceipt.ParentStages)
+	require.Equal(t, map[string]int{ompNativeAlphaID: 1, ompNativeBetaID: 1}, providerReceipt.ChildRequests)
+	require.Zero(t, providerReceipt.AuthHeaders)
+	require.Zero(t, providerReceipt.CredentialLeaks)
+	require.Zero(t, providerReceipt.UnexpectedEndpoints)
+	require.Equal(t, []string{
+		"task", "hub:list", "hub:jobs", "hub:wait", "hub:jobs", "hub:wait", "hub:list",
+	}, trace.toolSequence)
+	require.Equal(t, []string{"list", "jobs", "wait", "jobs", "wait", "list"}, trace.hubOps)
+	require.Equal(t, 7, trace.pairedCalls)
+
+	after := snapshotOMPNativeTree(t, scratch)
+	require.Equal(t, baseline, after, "native children must leave the generated project byte-identical")
+	residual := findOMPNativeResidualArtifacts(t, scratch, profile)
+	require.Empty(t, residual, "task/session/worktree artifacts must not survive process exit")
+
+	receipt := ompNativeLiveReceipt{
+		Version: version, ChildIDs: []string{ompNativeAlphaID, ompNativeBetaID}, HubOps: trace.hubOps,
+		LoopbackRequests: providerReceipt.Requests, ExternalRequests: 0,
+		AuthHeaders: providerReceipt.AuthHeaders, CredentialLeaks: providerReceipt.CredentialLeaks,
+		ResidualArtifacts: len(residual), ChildOverridesAbsent: true, Status: "completed",
+	}
+	encoded, marshalErr := json.Marshal(receipt)
+	require.NoError(t, marshalErr)
+	for _, forbidden := range []string{ompNativeCredential, executable, os.Getenv("HOME"), provider.server.URL} {
+		if forbidden != "" {
+			assert.NotContains(t, string(encoded), forbidden)
+		}
+	}
+	t.Logf("sanitized_native_task_hub_receipt=%s", encoded)
+}
+
+func resolveOMPNativeLiveExecutable(t *testing.T) string {
+	t.Helper()
+	if explicit := os.Getenv("AUTOPUS_OMP_LIVE_EXECUTABLE"); explicit != "" {
+		require.True(t, filepath.IsAbs(explicit), "explicit OMP live executable must be absolute")
+		info, err := os.Lstat(explicit)
+		require.NoError(t, err)
+		require.True(t, info.Mode().IsRegular() && info.Mode().Perm()&0o111 != 0,
+			"explicit OMP live executable must be a regular executable")
+		return explicit
+	}
+	executable, err := exec.LookPath(cliBinary)
+	require.NoError(t, err, "actual omp binary is required for the native live gate")
+	return executable
+}
+
+func assertOMPNativeGeneratedAgentsInheritParent(t *testing.T, root string) {
+	t.Helper()
+	for _, name := range []string{"explorer", "reviewer"} {
+		data, err := os.ReadFile(filepath.Join(root, ".omp", "agents", name+".md"))
+		require.NoError(t, err)
+		frontmatter, _ := splitEmittedFrontmatter(t, string(data))
+		require.NotContains(t, frontmatter, "model:", "%s must not override the parent model", name)
+		require.NotContains(t, frontmatter, "thinking:", "%s must not override parent thinking", name)
+		for _, tool := range []string{"bash", "glob", "grep", "read"} {
+			require.Contains(t, frontmatter, "  - "+tool)
+		}
+		for _, forbidden := range []string{"  - edit", "  - task", "  - write"} {
+			require.NotContains(t, frontmatter, forbidden)
+		}
+	}
+}
+
+func writeOMPNativeLiveOverlay(t *testing.T, profile string) string {
+	t.Helper()
+	path := filepath.Join(profile, "native-live-config.yml")
+	content := `skills:
+  enableCodexUser: false
+  enableClaudeUser: false
+  enableClaudeProject: false
+  enablePiUser: false
+  enablePiProject: false
+  enableAgentsUser: false
+  enableAgentsProject: true
+  enableSkillCommands: true
+  customDirectories: [.agents/skills]
+async:
+  enabled: true
+  maxJobs: 2
+  pollWaitDuration: 5s
+task:
+  batch: true
+  enableEffort: false
+  maxConcurrency: 2
+  maxRuntimeMs: 20000
+  agentIdleTtlMs: 60000
+  isolation:
+    mode: none
+tools:
+  approvalMode: yolo
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+func snapshotOMPNativeTree(t *testing.T, root string) map[string]string {
+	t.Helper()
+	result := make(map[string]string)
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == root {
+			return nil
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		key := filepath.ToSlash(relative)
+		switch {
+		case info.Mode().IsRegular():
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			result[key] = fmt.Sprintf("file:%o:%x", info.Mode().Perm(), sha256.Sum256(data))
+		case info.Mode()&os.ModeSymlink != 0:
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			result[key] = "symlink:" + target
+		case info.IsDir():
+			result[key] = fmt.Sprintf("dir:%o", info.Mode().Perm())
+		default:
+			result[key] = info.Mode().String()
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	return result
+}
+
+func findOMPNativeResidualArtifacts(t *testing.T, roots ...string) []string {
+	t.Helper()
+	var residual []string
+	for _, root := range roots {
+		err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if path == root {
+				return nil
+			}
+			relative, err := filepath.Rel(root, path)
+			if err != nil {
+				return err
+			}
+			normalized := strings.ToLower(filepath.ToSlash(relative))
+			base := strings.ToLower(entry.Name())
+			if strings.Contains(base, strings.ToLower(ompNativeAlphaID)) ||
+				strings.Contains(base, strings.ToLower(ompNativeBetaID)) ||
+				strings.HasSuffix(base, ".jsonl") || strings.HasSuffix(base, ".patch") ||
+				strings.Contains("/"+normalized+"/", "/sessions/") ||
+				strings.Contains("/"+normalized+"/", "/worktrees/") ||
+				strings.Contains("/"+normalized+"/", "/.omp/wt/") {
+				residual = append(residual, filepath.Join(root, relative))
+			}
+			return nil
+		})
+		require.NoError(t, err)
+	}
+	sort.Strings(residual)
+	return residual
+}

--- a/pkg/adapter/omp/omp_native_task_hub_process_test.go
+++ b/pkg/adapter/omp/omp_native_task_hub_process_test.go
@@ -1,0 +1,216 @@
+package omp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+)
+
+type ompNativeRPCTrace struct {
+	toolSequence []string
+	hubOps       []string
+	taskCalls    int
+	pairedCalls  int
+	starts       map[string]string
+	ended        map[string]bool
+}
+
+func runActualOMPNativeRPC(
+	ctx context.Context,
+	executable, scratch, profile, overlay, prompt, allowedEndpoint string,
+	provider *ompNativeProvider,
+) (ompNativeRPCTrace, error) {
+	trace := ompNativeRPCTrace{starts: make(map[string]string), ended: make(map[string]bool)}
+	cmd := exec.CommandContext(ctx, executable,
+		"--mode", "rpc",
+		"--no-session",
+		"--cwd", scratch,
+		"--model", "s7dummy/"+ompLiveModel,
+		"--config", overlay,
+		"--tools", "task,hub",
+		"--auto-approve",
+		"--no-extensions",
+		"--no-rules",
+		"--no-lsp",
+		"--no-pty",
+		"--max-time", "40s",
+	)
+	cmd.Dir = scratch
+	isolatedEnv, envErr := isolatedOMPLiveEnv(profile, overlay)
+	if envErr != nil {
+		return trace, fmt.Errorf("native_rpc_isolation_invalid")
+	}
+	cmd.Env = isolatedEnv
+	cmd.Stderr = io.Discard
+	cmd.WaitDelay = ompRPCWaitDelay
+	if err := configureOMPRPCNetworkSandbox(cmd, allowedEndpoint); err != nil {
+		return trace, fmt.Errorf("native_rpc_network_sandbox_unavailable: %w", err)
+	}
+	if err := configureOMPRPCProcessGroup(cmd); err != nil {
+		return trace, fmt.Errorf("native_rpc_process_group_unsupported")
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return trace, fmt.Errorf("native_rpc_stdin_pipe")
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return trace, fmt.Errorf("native_rpc_stdout_pipe")
+	}
+	if err := cmd.Start(); err != nil {
+		return trace, fmt.Errorf("native_rpc_start")
+	}
+	waited := false
+	completedCleanly := false
+	defer func() {
+		_ = stdin.Close()
+		if !completedCleanly {
+			provider.releaseAll()
+			_ = terminateOMPRPCProcessGroup(cmd)
+		}
+		if !waited {
+			_ = cmd.Wait()
+		}
+	}()
+
+	frames, scanDone := scanOMPRPCFrames(stdout)
+	ready := false
+	for !ready {
+		frame, readErr := nextOMPRPCFrame(ctx, frames, scanDone)
+		if readErr != nil {
+			return trace, readErr
+		}
+		ready = rpcFrameType(frame) == "ready"
+	}
+	encoder := json.NewEncoder(stdin)
+	for _, command := range []map[string]any{
+		{"id": "disable-retry", "type": "set_auto_retry", "enabled": false},
+		{"id": "disable-compaction", "type": "set_auto_compaction", "enabled": false},
+		{"id": "native-task-hub-prompt", "type": "prompt", "message": prompt},
+	} {
+		if encoder.Encode(command) != nil {
+			return trace, fmt.Errorf("native_rpc_write_command")
+		}
+	}
+
+	terminal := false
+	for !terminal {
+		frame, readErr := nextOMPRPCFrame(ctx, frames, scanDone)
+		if readErr != nil {
+			return trace, readErr
+		}
+		terminal, err = trace.consume(frame, provider)
+		if err != nil {
+			return trace, err
+		}
+	}
+	if err := stdin.Close(); err != nil {
+		return trace, fmt.Errorf("native_rpc_close_stdin")
+	}
+	waitErr := cmd.Wait()
+	waited = true
+	if waitErr != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return trace, fmt.Errorf("native_rpc_timeout")
+		}
+		return trace, fmt.Errorf("native_rpc_exit_nonzero")
+	}
+	completedCleanly = true
+	return trace, nil
+}
+
+func (trace *ompNativeRPCTrace) consume(frame []byte, provider *ompNativeProvider) (bool, error) {
+	var event struct {
+		Type       string          `json:"type"`
+		ToolCallID string          `json:"toolCallId"`
+		ToolName   string          `json:"toolName"`
+		Args       json.RawMessage `json:"args"`
+		IsError    bool            `json:"isError"`
+		Success    *bool           `json:"success"`
+		Message    struct {
+			Role       string `json:"role"`
+			StopReason string `json:"stopReason"`
+		} `json:"message"`
+	}
+	if json.Unmarshal(frame, &event) != nil {
+		return false, nil
+	}
+	if event.Type == "response" && event.Success != nil && !*event.Success {
+		return false, fmt.Errorf("native_rpc_response_failed")
+	}
+	switch event.Type {
+	case "tool_execution_start":
+		if event.ToolCallID == "" || event.ToolName == "" {
+			return false, fmt.Errorf("native_rpc_tool_start_invalid")
+		}
+		trace.starts[event.ToolCallID] = event.ToolName
+		switch event.ToolName {
+		case "task":
+			if trace.taskCalls != 0 {
+				return false, fmt.Errorf("native_rpc_task_repeated")
+			}
+			var args any
+			if err := json.Unmarshal(event.Args, &args); err != nil {
+				return false, fmt.Errorf("native_rpc_task_arguments_decode")
+			}
+			if err := validateOMPNativeTaskArguments(args); err != nil {
+				return false, fmt.Errorf("native_rpc_task_arguments_invalid:%w", err)
+			}
+			trace.taskCalls++
+			trace.toolSequence = append(trace.toolSequence, "task")
+		case "hub":
+			var args struct {
+				IDs       []string `json:"ids"`
+				Op        string   `json:"op"`
+				TimeoutMS int      `json:"timeoutMs"`
+			}
+			if json.Unmarshal(event.Args, &args) != nil || args.Op == "" {
+				return false, fmt.Errorf("native_rpc_hub_arguments_invalid")
+			}
+			expected := []string{"list", "jobs", "wait", "jobs", "wait", "list"}
+			if len(trace.hubOps) >= len(expected) || args.Op != expected[len(trace.hubOps)] {
+				return false, fmt.Errorf("native_rpc_hub_sequence_invalid")
+			}
+			trace.hubOps = append(trace.hubOps, args.Op)
+			trace.toolSequence = append(trace.toolSequence, "hub:"+args.Op)
+			if args.Op == "wait" {
+				expectedID := ompNativeAlphaID
+				if len(trace.hubOps) == 5 {
+					expectedID = ompNativeBetaID
+				}
+				if len(args.IDs) != 1 || args.IDs[0] != expectedID ||
+					args.TimeoutMS < 1 || args.TimeoutMS > 15_000 {
+					return false, fmt.Errorf("native_rpc_hub_wait_arguments_invalid")
+				}
+				provider.release(expectedID)
+			}
+		default:
+			return false, fmt.Errorf("native_rpc_unexpected_tool:%s", event.ToolName)
+		}
+	case "tool_execution_end":
+		name := trace.starts[event.ToolCallID]
+		if name == "" || event.IsError {
+			return false, fmt.Errorf("native_rpc_tool_end_invalid:%s", name)
+		}
+		if !trace.ended[event.ToolCallID] {
+			trace.ended[event.ToolCallID] = true
+			trace.pairedCalls++
+		}
+	case "message_end":
+		if event.Message.Role == "assistant" && event.Message.StopReason == "stop" {
+			want := []string{
+				"task", "hub:list", "hub:jobs", "hub:wait", "hub:jobs", "hub:wait", "hub:list",
+			}
+			if strings.Join(trace.toolSequence, "\x00") != strings.Join(want, "\x00") ||
+				trace.pairedCalls != 7 {
+				return false, fmt.Errorf("native_rpc_terminal_before_lifecycle")
+			}
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/pkg/adapter/omp/omp_native_task_hub_provider_test.go
+++ b/pkg/adapter/omp/omp_native_task_hub_provider_test.go
@@ -1,0 +1,299 @@
+package omp
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type ompNativeChatRequest struct {
+	Model    string            `json:"model"`
+	Stream   bool              `json:"stream"`
+	Tools    []json.RawMessage `json:"tools"`
+	Messages []json.RawMessage `json:"messages"`
+}
+
+type ompNativeProviderReceipt struct {
+	Requests            int
+	ParentStages        int
+	ChildRequests       map[string]int
+	AuthHeaders         int
+	CredentialLeaks     int
+	UnexpectedEndpoints int
+	Failure             string
+}
+
+type ompNativeProvider struct {
+	server *httptest.Server
+
+	mu                                sync.Mutex
+	parentStage                       int
+	childRequests                     map[string]int
+	requestCount                      int
+	authHeaders                       int
+	credentialLeaks                   int
+	unexpectedEndpoints               int
+	failure                           string
+	childrenReady                     chan struct{}
+	childrenReadyOnce                 sync.Once
+	alphaRelease, betaRelease         chan struct{}
+	alphaReleaseOnce, betaReleaseOnce sync.Once
+}
+
+func newOMPNativeProvider(t *testing.T) *ompNativeProvider {
+	t.Helper()
+	provider := &ompNativeProvider{
+		childRequests: map[string]int{ompNativeAlphaID: 0, ompNativeBetaID: 0},
+		childrenReady: make(chan struct{}),
+		alphaRelease:  make(chan struct{}),
+		betaRelease:   make(chan struct{}),
+	}
+	provider.server = httptest.NewServer(http.HandlerFunc(provider.handle))
+	t.Cleanup(provider.server.Close)
+	return provider
+}
+
+func (p *ompNativeProvider) handle(w http.ResponseWriter, r *http.Request) {
+	p.mu.Lock()
+	p.requestCount++
+	p.mu.Unlock()
+	if r.Method != http.MethodPost || r.URL.Path != "/v1/chat/completions" {
+		p.mu.Lock()
+		p.unexpectedEndpoints++
+		p.mu.Unlock()
+		p.reject(w, "unexpected_endpoint")
+		return
+	}
+	if ompNativeRequestHasAuth(r.Header) {
+		p.mu.Lock()
+		p.authHeaders++
+		p.mu.Unlock()
+		p.reject(w, "unexpected_auth_header")
+		return
+	}
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 8<<20))
+	if err != nil {
+		p.reject(w, "request_oversized")
+		return
+	}
+	if strings.Contains(string(body), ompNativeCredential) {
+		p.mu.Lock()
+		p.credentialLeaks++
+		p.mu.Unlock()
+		p.reject(w, "credential_leak")
+		return
+	}
+	var request ompNativeChatRequest
+	if json.Unmarshal(body, &request) != nil || request.Model != ompLiveModel || !request.Stream {
+		p.reject(w, "invalid_request_shape")
+		return
+	}
+	if _, parent := ompNativeToolParameters(request.Tools, "task"); parent {
+		p.handleParent(w, r, request, body)
+		return
+	}
+	p.handleChild(w, r, request, body)
+}
+
+func (p *ompNativeProvider) handleParent(
+	w http.ResponseWriter,
+	r *http.Request,
+	request ompNativeChatRequest,
+	body []byte,
+) {
+	p.mu.Lock()
+	stage := p.parentStage
+	p.mu.Unlock()
+	lastTool := ompNativeLastToolContent(request.Messages)
+	var validationErr error
+	switch stage {
+	case 0:
+		if !strings.Contains(string(body), ompNativeSmokeToken) {
+			validationErr = fmt.Errorf("smoke prompt missing")
+		} else {
+			validationErr = validateOMPNativeParentTools(request.Tools)
+		}
+	case 1:
+		validationErr = ompNativeRequireTokens(lastTool,
+			"Spawned 2 background agents", ompNativeAlphaID, ompNativeBetaID)
+		if validationErr == nil {
+			select {
+			case <-p.childrenReady:
+			case <-r.Context().Done():
+				validationErr = fmt.Errorf("children did not reach provider")
+			case <-time.After(8 * time.Second):
+				validationErr = fmt.Errorf("children did not start")
+			}
+		}
+	case 2:
+		validationErr = ompNativeRequireTokens(lastTool,
+			ompNativeAlphaID, ompNativeBetaID, "running")
+	case 3:
+		validationErr = ompNativeRequireTokens(lastTool,
+			"Still Running (2)", ompNativeAlphaID, ompNativeBetaID)
+	case 4:
+		validationErr = ompNativeRequireTokens(lastTool,
+			"Completed (1)", ompNativeAlphaID,
+			"owned_paths", "changed_files", "verification", "blockers", "next_required_step",
+			"native-alpha-read-only")
+	case 5:
+		validationErr = ompNativeRequireTokens(lastTool,
+			"Still Running (1)", ompNativeBetaID)
+	case 6:
+		validationErr = ompNativeRequireTokens(lastTool,
+			"Completed (1)", ompNativeBetaID,
+			"owned_paths", "changed_files", "verification", "blockers", "next_required_step",
+			"native-beta-read-only")
+	case 7:
+		validationErr = ompNativeRequireTokens(lastTool,
+			ompNativeAlphaID, ompNativeBetaID, "idle")
+	default:
+		validationErr = fmt.Errorf("parent request budget exceeded")
+	}
+	if validationErr != nil {
+		p.reject(w, fmt.Sprintf("parent_stage_%d:%v", stage, validationErr))
+		return
+	}
+	p.mu.Lock()
+	if p.parentStage != stage {
+		p.mu.Unlock()
+		p.reject(w, "parent_stage_race")
+		return
+	}
+	p.parentStage++
+	p.mu.Unlock()
+
+	switch stage {
+	case 0:
+		writeOMPNativeToolSSE(w, 1, "task", ompNativeTaskArguments())
+	case 1:
+		writeOMPNativeToolSSE(w, 2, "hub", map[string]any{
+			"i": "Listing child identities", "op": "list",
+		})
+	case 2:
+		writeOMPNativeToolSSE(w, 3, "hub", map[string]any{
+			"i": "Inspecting child jobs", "op": "jobs",
+		})
+	case 3:
+		writeOMPNativeToolSSE(w, 4, "hub", map[string]any{
+			"i": "Awaiting alpha receipt", "op": "wait",
+			"ids": []string{ompNativeAlphaID}, "timeoutMs": 15_000,
+		})
+	case 4:
+		writeOMPNativeToolSSE(w, 5, "hub", map[string]any{
+			"i": "Inspecting remaining child", "op": "jobs",
+		})
+	case 5:
+		writeOMPNativeToolSSE(w, 6, "hub", map[string]any{
+			"i": "Awaiting beta receipt", "op": "wait",
+			"ids": []string{ompNativeBetaID}, "timeoutMs": 15_000,
+		})
+	case 6:
+		writeOMPNativeToolSSE(w, 7, "hub", map[string]any{
+			"i": "Confirming child lifecycle", "op": "list",
+		})
+	case 7:
+		writeOMPNativeFinalSSE(w, 8, "native task hub lifecycle complete")
+	}
+}
+
+func (p *ompNativeProvider) handleChild(
+	w http.ResponseWriter,
+	r *http.Request,
+	request ompNativeChatRequest,
+	body []byte,
+) {
+	bodyText := string(body)
+	id := ""
+	if strings.Contains(bodyText, "NATIVE_CHILD_ALPHA") {
+		id = ompNativeAlphaID
+	}
+	if strings.Contains(bodyText, "NATIVE_CHILD_BETA") {
+		if id != "" {
+			p.reject(w, "child_assignment_ambiguous")
+			return
+		}
+		id = ompNativeBetaID
+	}
+	if id == "" {
+		p.reject(w, "unknown_child_assignment")
+		return
+	}
+	if err := validateOMPNativeChildTools(request.Tools); err != nil {
+		p.reject(w, "child_schema:"+err.Error())
+		return
+	}
+	p.mu.Lock()
+	p.childRequests[id]++
+	count := p.childRequests[id]
+	ready := p.childRequests[ompNativeAlphaID] == 1 && p.childRequests[ompNativeBetaID] == 1
+	p.mu.Unlock()
+	if count != 1 {
+		p.reject(w, "child_request_budget_exceeded:"+id)
+		return
+	}
+	if ready {
+		p.childrenReadyOnce.Do(func() { close(p.childrenReady) })
+	}
+	release := p.alphaRelease
+	if id == ompNativeBetaID {
+		release = p.betaRelease
+	}
+	select {
+	case <-release:
+	case <-r.Context().Done():
+		p.reject(w, "child_request_cancelled:"+id)
+		return
+	case <-time.After(20 * time.Second):
+		p.reject(w, "child_release_timeout:"+id)
+		return
+	}
+	writeOMPNativeToolSSE(w, 100+count, "yield", map[string]any{
+		"i":      "Submitting read-only receipt",
+		"type":   nil,
+		"result": map[string]any{"data": ompNativeExpectedReceipt(id)},
+	})
+}
+
+func (p *ompNativeProvider) release(id string) {
+	if id == ompNativeAlphaID {
+		p.alphaReleaseOnce.Do(func() { close(p.alphaRelease) })
+		return
+	}
+	p.betaReleaseOnce.Do(func() { close(p.betaRelease) })
+}
+
+func (p *ompNativeProvider) releaseAll() {
+	p.release(ompNativeAlphaID)
+	p.release(ompNativeBetaID)
+}
+
+func (p *ompNativeProvider) receipt() ompNativeProviderReceipt {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	children := make(map[string]int, len(p.childRequests))
+	for id, count := range p.childRequests {
+		children[id] = count
+	}
+	return ompNativeProviderReceipt{
+		Requests: p.requestCount, ParentStages: p.parentStage, ChildRequests: children,
+		AuthHeaders: p.authHeaders, CredentialLeaks: p.credentialLeaks,
+		UnexpectedEndpoints: p.unexpectedEndpoints, Failure: p.failure,
+	}
+}
+
+func (p *ompNativeProvider) reject(w http.ResponseWriter, reason string) {
+	p.mu.Lock()
+	if p.failure == "" {
+		p.failure = reason
+	}
+	p.mu.Unlock()
+	p.releaseAll()
+	http.Error(w, "native fixture rejected request", http.StatusBadRequest)
+}

--- a/pkg/adapter/omp/omp_native_task_hub_provider_wire_test.go
+++ b/pkg/adapter/omp/omp_native_task_hub_provider_wire_test.go
@@ -1,0 +1,80 @@
+package omp
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+func ompNativeRequestHasAuth(header http.Header) bool {
+	for name, values := range header {
+		lower := strings.ToLower(name)
+		if lower == "authorization" || strings.Contains(lower, "api-key") {
+			for _, value := range values {
+				if strings.TrimSpace(value) != "" {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func ompNativeLastToolContent(messages []json.RawMessage) string {
+	for index := len(messages) - 1; index >= 0; index-- {
+		var message struct {
+			Role    string `json:"role"`
+			Content any    `json:"content"`
+		}
+		if json.Unmarshal(messages[index], &message) == nil && message.Role == "tool" {
+			encoded, _ := json.Marshal(message.Content)
+			return string(encoded)
+		}
+	}
+	return ""
+}
+
+func ompNativeRequireTokens(value string, tokens ...string) error {
+	for _, token := range tokens {
+		if !strings.Contains(value, token) {
+			return fmt.Errorf("missing %q", token)
+		}
+	}
+	return nil
+}
+
+func writeOMPNativeToolSSE(w http.ResponseWriter, sequence int, name string, args any) {
+	arguments, _ := json.Marshal(args)
+	chunk := map[string]any{
+		"id": "chatcmpl-native", "object": "chat.completion.chunk", "created": sequence, "model": ompLiveModel,
+		"choices": []any{map[string]any{
+			"index": 0,
+			"delta": map[string]any{"role": "assistant", "tool_calls": []any{map[string]any{
+				"index": 0, "id": fmt.Sprintf("native-call-%d", sequence), "type": "function",
+				"function": map[string]any{"name": name, "arguments": string(arguments)},
+			}}},
+		}},
+	}
+	terminal := map[string]any{
+		"id": "chatcmpl-native", "object": "chat.completion.chunk", "created": sequence, "model": ompLiveModel,
+		"choices": []any{map[string]any{"index": 0, "delta": map[string]any{}, "finish_reason": "tool_calls"}},
+		"usage":   map[string]int{"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12},
+	}
+	writeOMPSSE(w, chunk, terminal)
+}
+
+func writeOMPNativeFinalSSE(w http.ResponseWriter, sequence int, content string) {
+	chunk := map[string]any{
+		"id": "chatcmpl-native", "object": "chat.completion.chunk", "created": sequence, "model": ompLiveModel,
+		"choices": []any{map[string]any{
+			"index": 0, "delta": map[string]any{"role": "assistant", "content": content},
+		}},
+	}
+	terminal := map[string]any{
+		"id": "chatcmpl-native", "object": "chat.completion.chunk", "created": sequence, "model": ompLiveModel,
+		"choices": []any{map[string]any{"index": 0, "delta": map[string]any{}, "finish_reason": "stop"}},
+		"usage":   map[string]int{"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12},
+	}
+	writeOMPSSE(w, chunk, terminal)
+}

--- a/pkg/adapter/omp/omp_skills.go
+++ b/pkg/adapter/omp/omp_skills.go
@@ -84,6 +84,7 @@ func (a *Adapter) renderTemplateWorkflowSkill(spec workflowSpec, cfg *config.Har
 		body = rendered
 	}
 	body = normalizeOMPWorkflowBody(body)
+	body = injectOMPExecutionOwnerControl(body, spec.Name)
 	body = injectOMPInvocation(body, spec.Name)
 	return buildMarkdown(ompSkillFrontmatter(spec.Name, spec.Description), body), nil
 }
@@ -135,6 +136,7 @@ func (a *Adapter) prepareExtendedSkillMappings(cfg *config.HarnessConfig) ([]ada
 			}
 			body = pkgcontent.NormalizeOMPSemanticReferences(string(raw))
 		}
+		body = normalizeOMPExecutionOwnerContract(body)
 		content := buildMarkdown(
 			ompSkillFrontmatter(skill.Name, skill.Description),
 			body,

--- a/pkg/adapter/omp/omp_workflow_contract_test.go
+++ b/pkg/adapter/omp/omp_workflow_contract_test.go
@@ -108,14 +108,15 @@ func ompWorkflowBodyContracts() []ompWorkflowBodyContract {
 	return []ompWorkflowBodyContract{
 		template("auto-setup", "codex/skills/auto-setup.md.tmpl",
 			[]string{"## Workspace Folder Boundary", "## 실행 순서", "## Completion Message"}, []string{"ARCHITECTURE.md", ".autopus/project/"}),
-		compact("auto-status", "SPEC lifecycle", "module 상태"),
+		compact("auto-status", "SPEC lifecycle", "module 상태", "execution-owner.json", "native `hub`", "user-session roots"),
 		compact("auto-goal", "goal surface", "persisted state"),
 		compact("auto-update", "harness surface", "source-of-truth 경계"),
 		template("auto-plan", "codex/skills/auto-plan.md.tmpl",
 			[]string{"## Context Profile: plan", "## 실행 순서", "## 요구사항 형식 (EARS)"}, []string{"Clarification Ledger", "auto spec validate"}),
 		template("auto-go", "codex/skills/auto-go.md.tmpl",
-			[]string{"## Context Profile: go", "## 구현 절차", "## 실행 계약", "## 품질 기준"},
-			[]string{"RED: 실패 테스트", ".agents/skills/agent-pipeline/SKILL.md", `"outputSchema"`, "single DAG owner invariant"}),
+			[]string{"## Context Profile: go", "## 구현 절차", "## 실행 계약", "## 품질 기준", "## Execution Owner Control Plane"},
+			[]string{"RED: 실패 테스트", ".agents/skills/agent-pipeline/SKILL.md", `"outputSchema"`, "single DAG owner invariant",
+				"--execution-owner omp|orca", "pipeline_execution_owner_receipt.v1", "pipeline_execution_owner_result.v1", "status=handoff_required"}),
 		template("auto-fix", "codex/skills/auto-fix.md.tmpl",
 			[]string{"## 절차", "## 규칙"}, []string{"버그 재현 테스트", "최소 코드 변경"}),
 		template("auto-review", "codex/skills/auto-review.md.tmpl",
@@ -189,10 +190,13 @@ func assertOMPNativeCoordinationContract(t *testing.T, body string) {
 	assert.Contains(t, body, `{"op":"init","list":[{"phase":"Implementation","items":["..."]}]}`)
 	assert.Contains(t, body, `{"op":"start","task":"<exact task content>"}`)
 	assert.Contains(t, body, "that same agent")
-	assert.Contains(t, body, "OMP-local")
-	assert.Contains(t, body, "Orca-supervised")
+	assert.Contains(t, body, "owner `omp`")
+	assert.Contains(t, body, "owner `orca`")
+	assert.Contains(t, body, "--execution-owner orca")
 	assert.Contains(t, body, "orca skills get orchestration --full")
 	assert.Contains(t, body, "single DAG owner invariant")
+	assert.NotContains(t, body, "OMP-local")
+	assert.NotContains(t, body, "Orca-supervised")
 }
 
 func ompIntentionalPlatformRootGlobs() []string {

--- a/pkg/adapter/omp/omp_workflow_parity_test.go
+++ b/pkg/adapter/omp/omp_workflow_parity_test.go
@@ -38,6 +38,7 @@ func TestOMP002_WorkflowParity_GenerateEmitsCanonicalCommandsAndSkills(t *testin
 	}
 
 	commands := map[string]bool{}
+	commandBodies := map[string]string{}
 	skills := map[string]string{}
 	seen := map[string]int{}
 	coordinationBodies := map[string]bool{
@@ -52,6 +53,7 @@ func TestOMP002_WorkflowParity_GenerateEmitsCanonicalCommandsAndSkills(t *testin
 			name := strings.TrimSuffix(strings.TrimPrefix(target, ".agents/commands/"), ".md")
 			if !strings.Contains(name, "/") {
 				commands[name] = true
+				commandBodies[name] = string(file.Content)
 			}
 		}
 		const skillPrefix, skillSuffix = ".agents/skills/", "/SKILL.md"
@@ -110,6 +112,7 @@ func TestOMP002_WorkflowParity_GenerateEmitsCanonicalCommandsAndSkills(t *testin
 	assert.Equal(t, want, commands, "command basenames must equal workflowSpecs")
 	assert.Equal(t, want, mappingContentKeys(skills),
 		"workflow skill basenames must equal workflowSpecs; extended skills are excluded")
+	assertOMPExecutionOwnerSurfaceParity(t, commandBodies, skills)
 
 	router, ok := skills["auto"]
 	if assert.True(t, ok, "the thin auto router skill must be emitted") {
@@ -128,6 +131,34 @@ func TestOMP002_WorkflowParity_GenerateEmitsCanonicalCommandsAndSkills(t *testin
 		assert.NotEmpty(t, strings.TrimSpace(body))
 		assert.Contains(t, body, "## ", "%s needs structured execution sections", spec.Name)
 		assert.NotContains(t, body, "# Autopus 명령 라우터")
+	}
+}
+
+func assertOMPExecutionOwnerSurfaceParity(t *testing.T, commands, skills map[string]string) {
+	t.Helper()
+	for _, surface := range []struct {
+		name string
+		body string
+	}{
+		{name: "auto router command", body: commands["auto"]},
+		{name: "auto router skill", body: skills["auto"]},
+		{name: "auto-go command", body: commands["auto-go"]},
+		{name: "auto-go skill", body: skills["auto-go"]},
+	} {
+		assert.Contains(t, surface.body, "--execution-owner omp|orca", "%s lost the exact owner flag", surface.name)
+		assert.NotContains(t, surface.body, "OMP-local", "%s retained a deprecated owner spelling", surface.name)
+		assert.NotContains(t, surface.body, "Orca-supervised", "%s retained a deprecated owner spelling", surface.name)
+	}
+	for _, surface := range []struct {
+		name string
+		body string
+	}{
+		{name: "auto-status command", body: commands["auto-status"]},
+		{name: "auto-status skill", body: skills["auto-status"]},
+	} {
+		assert.Contains(t, surface.body, "execution-owner", "%s lost receipt guidance", surface.name)
+		assert.Contains(t, surface.body, "`hub`", "%s lost OMP-native hub guidance", surface.name)
+		assert.Contains(t, surface.body, "user-session roots", "%s claims external session-root visibility", surface.name)
 	}
 }
 

--- a/pkg/adapter/omp/omp_workflow_render.go
+++ b/pkg/adapter/omp/omp_workflow_render.go
@@ -16,6 +16,7 @@ func ompRouterBody(prefix string) string {
 		"Treat the payload above as the complete text supplied after `/auto`.",
 		"Route to exactly one matching detail skill from this exact map: " + ompWorkflowTargets() + ".",
 		"Preserve `--model <provider/model>` and `--variant <value>` exactly as supplied.",
+		"For `go`, preserve at most one `--execution-owner omp|orca` pair exactly; omission defaults to `omp`, and aliases or fuzzy correction are forbidden.",
 		"Do not fuzzy-correct an unknown subcommand; report it as unsupported and show the exact map.",
 		"This is an emitted routing contract, not an OMP runtime parser or model-quality claim.",
 	}, "\n")
@@ -50,6 +51,7 @@ func normalizeOMPWorkflowBody(body string) string {
 		"@auto-", "/auto-",
 	).Replace(body)
 	body = pkgcontent.ReplacePlatformReferences(body, "omp")
+	body = normalizeOMPExecutionOwnerContract(body)
 	body = dedupeOMPReference(body, ".agents/skills/agent-pipeline/SKILL.md")
 	return strings.TrimSpace(body)
 }
@@ -62,6 +64,42 @@ func dedupeOMPReference(body, ref string) string {
 	head := body[:first+len(ref)]
 	tail := strings.ReplaceAll(body[first+len(ref):], ref, "the pipeline reference above")
 	return head + tail
+}
+
+func normalizeOMPExecutionOwnerContract(body string) string {
+	body = strings.NewReplacer(
+		"- Choose exactly one topology before dispatch: `OMP-local` or `Orca-supervised`.",
+		"- Choose exactly one DAG owner with `--execution-owner omp|orca` before dispatch; omission selects owner `omp`.",
+		"- `OMP-local` is the default. The current OMP session is the sole DAG owner and uses its native `task`, `hub`, and `todo` tools.",
+		"- Owner `omp` is the default. The current OMP session is the sole DAG owner and uses its native `task`, `hub`, and `todo` tools.",
+		"- `Orca-supervised` is allowed only when the user explicitly selects a supervised or durable topology. Before any Orca orchestration, run and read `orca skills get orchestration --full`.",
+		"- Owner `orca` is allowed only when `--execution-owner orca` is explicit. Before any Orca orchestration, run and read `orca skills get orchestration --full`.",
+		"- The single DAG owner invariant is mandatory: when Orca owns the DAG, the OMP session does not dispatch a competing DAG; when OMP owns it, Orca does not dispatch one.",
+		"- The single DAG owner invariant is mandatory: owner `orca` creates no OMP task DAG, and owner `omp` creates no Orca Run.",
+	).Replace(body)
+	return strings.NewReplacer(
+		"`OMP-local`", "owner `omp`",
+		"`Orca-supervised`", "owner `orca`",
+		"OMP-local", "owner `omp`",
+		"Orca-supervised", "owner `orca`",
+	).Replace(body)
+}
+
+func injectOMPExecutionOwnerControl(body, name string) string {
+	if name != "auto-go" {
+		return body
+	}
+	block := strings.Join([]string{
+		"## Execution Owner Control Plane",
+		"",
+		"- Invocation: `/auto go SPEC-ID [--execution-owner omp|orca]`. Omission selects `omp` with receipt source `default`; a supplied exact value has source `explicit`.",
+		"- Parse the flag exactly once before any `task`, DAG-owning `todo`, OMP subprocess, or Orca Run effect. Reject repeated, mixed, case-shifted, whitespace-padded, or aliased values without fallback.",
+		"- Persist the body-free receipt `.autopus/pipeline-state/<SPEC-ID>.execution-owner.json` with schema `pipeline_execution_owner_receipt.v1` and only owner, source, reason, SPEC/run identity, `checked_at`, and `verification_status` evidence.",
+		"- Owner `omp`: the current OMP session is the sole DAG owner, uses native `task`, `hub`, and `todo`, and must not create an Orca Run.",
+		"- Owner `orca`: do not initialize an OMP task/todo DAG or call `task`. Run and read `orca skills get orchestration --full`, then use its supervised durable cross-worktree Run contract.",
+		"- At `auto pipeline run SPEC-ID --platform omp --execution-owner <owner>`, owner `orca` returns `pipeline_execution_owner_result.v1` with `status=handoff_required` before any OMP process/task creation. Act on that result; never retry as owner `omp`.",
+	}, "\n")
+	return injectOMPAfterHeading(body, block)
 }
 
 func injectOMPInvocation(body, name string) string {
@@ -111,7 +149,7 @@ func renderOMPCompactWorkflowSkill(spec workflowSpec) string {
 func ompCompactWorkflowContract(name string) (string, string) {
 	switch name {
 	case "auto-status":
-		return "Bash tool로 `auto status`를 실행해 SPEC lifecycle과 module 상태를 수집합니다.", "SPEC별 status와 다음 실행 가능한 명령을 보고합니다."
+		return "Bash tool로 `auto status`를 실행해 SPEC lifecycle과 module 상태를 수집한 뒤 현재 workspace의 `.autopus/pipeline-state/<SPEC-ID>.execution-owner.json` receipt와 현재 OMP 세션의 native `hub` jobs 상태를 읽습니다. 외부 CLI가 OMP user-session roots를 검사할 수 있다고 가정하지 않습니다.", "receipt의 owner/source/verification과 OMP-native `hub` 상태를 결합해 단일 DAG owner 위반 여부, SPEC별 status, 다음 실행 가능한 명령을 보고합니다."
 	case "auto-update":
 		return "Bash tool로 `auto update`를 실행해 현재 repo 또는 meta workspace의 harness surface를 갱신합니다.", "변경된 generated surface와 source-of-truth 경계를 보고합니다."
 	case "auto-map":

--- a/pkg/promptlayer/omp_context_canary_attestation.go
+++ b/pkg/promptlayer/omp_context_canary_attestation.go
@@ -40,6 +40,13 @@ type OMPContextPromotionPolicyV1 struct {
 	MutationScope       string `json:"mutation_scope"`
 }
 
+func OMPContextPromotionPolicyDigestV1(policy OMPContextPromotionPolicyV1) (string, error) {
+	if err := validateOMPContextPromotionPolicyV1(policy); err != nil {
+		return "", err
+	}
+	return hashOMPContextPromotionValueV1(policy), nil
+}
+
 type OMPContextPromotionAttestationInputV1 struct {
 	Subject   OMPContextPromotionSubjectV1
 	Policy    OMPContextPromotionPolicyV1
@@ -148,6 +155,10 @@ func (attestation OMPContextPromotionAttestationV1) PolicyDigest() string {
 
 func (attestation OMPContextPromotionAttestationV1) CheckedAt() time.Time {
 	return attestation.checkedAt
+}
+
+func (attestation OMPContextPromotionAttestationV1) ExpiresAt() time.Time {
+	return attestation.expiresAt
 }
 
 func validateOMPContextPromotionSubjectV1(subject OMPContextPromotionSubjectV1) error {

--- a/pkg/promptlayer/omp_context_promotion_attestation_sign_v2.go
+++ b/pkg/promptlayer/omp_context_promotion_attestation_sign_v2.go
@@ -1,0 +1,90 @@
+package promptlayer
+
+import (
+	"crypto/ed25519"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
+// OMPContextPromotionAttestationSignInputV2 contains the exact report bytes and
+// canonical validity interval bound into a production promotion attestation.
+type OMPContextPromotionAttestationSignInputV2 struct {
+	ReportBytes []byte
+	IssuedAt    string
+	NotBefore   string
+	ExpiresAt   string
+}
+
+// SignOMPContextPromotionAttestationV2 validates a canonical promotion-report-v1
+// document and signs its fixed v2 statement with the committed production key.
+func SignOMPContextPromotionAttestationV2(
+	input OMPContextPromotionAttestationSignInputV2,
+	privateKey ed25519.PrivateKey,
+) ([]byte, error) {
+	report, err := decodeOMPContextPromotionReportV1(input.ReportBytes)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOMPContextPromotionInvalid, err)
+	}
+	issuedAt, issueErr := parseCanonicalOMPContextPromotionTimeV2(input.IssuedAt)
+	notBefore, beforeErr := parseCanonicalOMPContextPromotionTimeV2(input.NotBefore)
+	expiresAt, expiryErr := parseCanonicalOMPContextPromotionTimeV2(input.ExpiresAt)
+	if issueErr != nil || beforeErr != nil || expiryErr != nil || issuedAt.Before(notBefore) ||
+		issuedAt.Sub(notBefore) > ompContextPromotionFutureSkewV2 || !issuedAt.Before(expiresAt) ||
+		expiresAt.Sub(issuedAt) > ompContextPromotionMaxTTLV2 {
+		return nil, ErrOMPContextPromotionStale
+	}
+	if err := validateOMPContextPromotionCohortAttestationTimeV2(report, issuedAt); err != nil {
+		return nil, err
+	}
+	normalizedKey, err := validatedOMPContextPromotionSigningKeyV2(privateKey)
+	if err != nil {
+		return nil, err
+	}
+	defer clear(normalizedKey)
+
+	attestation := OMPContextPromotionAttestationV2{
+		SchemaVersion: OMPContextPromotionAttestationSchemaV2,
+		KeyID:         OMPContextPromotionKeyID2026Q3K1,
+		Algorithm:     "ed25519",
+		ReportSHA256:  promotionSHA256(input.ReportBytes),
+		IssuedAt:      input.IssuedAt,
+		NotBefore:     input.NotBefore,
+		ExpiresAt:     input.ExpiresAt,
+		TrustLane:     OMPContextPromotionTrustLaneV2,
+	}
+	message, err := ompContextPromotionAttestationMessageV2(attestation)
+	if err != nil {
+		return nil, fmt.Errorf("%w: statement", ErrOMPContextPromotionInvalid)
+	}
+	attestation.SignatureBase64 = base64.StdEncoding.EncodeToString(ed25519.Sign(normalizedKey, message))
+	body, err := json.Marshal(attestation)
+	if err != nil {
+		return nil, fmt.Errorf("%w: attestation encoding", ErrOMPContextPromotionInvalid)
+	}
+	return body, nil
+}
+
+func validatedOMPContextPromotionSigningKeyV2(privateKey ed25519.PrivateKey) (ed25519.PrivateKey, error) {
+	if len(privateKey) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("%w: signing key", ErrOMPContextPromotionInvalid)
+	}
+	seed := privateKey.Seed()
+	defer clear(seed)
+	normalizedKey := ed25519.NewKeyFromSeed(seed)
+	if subtle.ConstantTimeCompare(privateKey, normalizedKey) != 1 {
+		clear(normalizedKey)
+		return nil, fmt.Errorf("%w: signing key", ErrOMPContextPromotionInvalid)
+	}
+	trusted := committedOMPContextPromotionPublicKeysV2()
+	publicKey, present := trusted[OMPContextPromotionKeyID2026Q3K1]
+	derivedPublicKey := normalizedKey[ed25519.SeedSize:]
+	if !present || len(publicKey) != ed25519.PublicKeySize ||
+		ompContextPromotionRevokedKeysV2[OMPContextPromotionKeyID2026Q3K1] ||
+		subtle.ConstantTimeCompare(derivedPublicKey, publicKey) != 1 {
+		clear(normalizedKey)
+		return nil, fmt.Errorf("%w: signing key", ErrOMPContextPromotionInvalid)
+	}
+	return normalizedKey, nil
+}

--- a/pkg/promptlayer/omp_context_promotion_attestation_sign_v2_test.go
+++ b/pkg/promptlayer/omp_context_promotion_attestation_sign_v2_test.go
@@ -1,0 +1,133 @@
+package promptlayer
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestSignOMPContextPromotionAttestationV2_RoundTripsAgainstCommittedTrust(t *testing.T) {
+	fixture := newOMPContextPromotionV2Fixture(t)
+	withOMPContextPromotionV3FixtureKey(t, fixture.publicKey)
+	issuedAt := fixture.now.Add(-time.Minute)
+	body, err := SignOMPContextPromotionAttestationV2(
+		OMPContextPromotionAttestationSignInputV2{
+			ReportBytes: fixture.reportBytes,
+			IssuedAt:    issuedAt.Format(time.RFC3339Nano),
+			NotBefore:   issuedAt.Format(time.RFC3339Nano),
+			ExpiresAt:   issuedAt.Add(24 * time.Hour).Format(time.RFC3339Nano),
+		},
+		fixture.privateKey,
+	)
+	if err != nil {
+		t.Fatalf("sign promotion attestation: %v", err)
+	}
+	var attestation OMPContextPromotionAttestationV2
+	if err := json.Unmarshal(body, &attestation); err != nil {
+		t.Fatalf("decode produced attestation: %v", err)
+	}
+	canonical, err := json.Marshal(attestation)
+	if err != nil || !bytes.Equal(body, canonical) {
+		t.Fatalf("attestation is not canonical: marshal error=%v", err)
+	}
+	if attestation.SchemaVersion != OMPContextPromotionAttestationSchemaV2 ||
+		attestation.KeyID != OMPContextPromotionKeyID2026Q3K1 || attestation.Algorithm != "ed25519" ||
+		attestation.TrustLane != OMPContextPromotionTrustLaneV2 ||
+		attestation.ReportSHA256 != promotionSHA256(fixture.reportBytes) {
+		t.Fatalf("unexpected fixed attestation statement: %#v", attestation)
+	}
+	verified, err := verifyOMPContextPromotionArtifactV2At(
+		fixture.reportBytes,
+		body,
+		fixture.now,
+		fixture.expectation,
+	)
+	if err != nil || !verified.validAt(fixture.now) || verified.ReportDigest() != attestation.ReportSHA256 {
+		t.Fatalf("produced attestation did not verify: verified=%#v error=%v", verified, err)
+	}
+}
+
+func TestSignOMPContextPromotionAttestationV2_RejectsWrongOrMalformedKey(t *testing.T) {
+	fixture := newOMPContextPromotionV2Fixture(t)
+	withOMPContextPromotionV3FixtureKey(t, fixture.publicKey)
+	input := validOMPContextPromotionAttestationSignInputV2(fixture)
+	wrongSeed := sha256.Sum256([]byte("wrong-promotion-signing-key"))
+	wrongKey := ed25519.NewKeyFromSeed(wrongSeed[:])
+	inconsistentKey := append(ed25519.PrivateKey(nil), fixture.privateKey...)
+	inconsistentKey[len(inconsistentKey)-1] ^= 0xff
+	for _, privateKey := range []ed25519.PrivateKey{wrongKey, inconsistentKey, fixture.privateKey[:63]} {
+		if body, err := SignOMPContextPromotionAttestationV2(input, privateKey); err == nil || body != nil || !errors.Is(err, ErrOMPContextPromotionInvalid) {
+			t.Fatalf("invalid key result body=%q error=%v", body, err)
+		}
+	}
+}
+
+func TestSignOMPContextPromotionAttestationV2_RejectsNonCanonicalOrInvalidReport(t *testing.T) {
+	fixture := newOMPContextPromotionV2Fixture(t)
+	withOMPContextPromotionV3FixtureKey(t, fixture.publicKey)
+	duplicate := append([]byte(`{"schema_version":"autopus.omp_context_promotion_report.v1",`), fixture.reportBytes[1:]...)
+	wrongLane := replaceJSONField(t, fixture.reportBytes, "trust_lane", "other-lane")
+	for _, report := range [][]byte{
+		append(append([]byte(nil), fixture.reportBytes...), '\n'),
+		duplicate,
+		wrongLane,
+		[]byte(`{"schema_version":"autopus.omp_context_promotion_report.v1"}`),
+	} {
+		input := validOMPContextPromotionAttestationSignInputV2(fixture)
+		input.ReportBytes = report
+		if body, err := SignOMPContextPromotionAttestationV2(input, fixture.privateKey); err == nil || body != nil || !errors.Is(err, ErrOMPContextPromotionInvalid) {
+			t.Fatalf("invalid report result body=%q error=%v", body, err)
+		}
+	}
+}
+
+func TestSignOMPContextPromotionAttestationV2_RejectsInvalidTimes(t *testing.T) {
+	fixture := newOMPContextPromotionV2Fixture(t)
+	withOMPContextPromotionV3FixtureKey(t, fixture.publicKey)
+	valid := validOMPContextPromotionAttestationSignInputV2(fixture)
+	cases := []OMPContextPromotionAttestationSignInputV2{
+		withPromotionSignTime(valid, "issued", "2026-08-04T02:59:00+00:00"),
+		withPromotionSignTime(valid, "not-before", fixture.now.Add(time.Minute).Format(time.RFC3339Nano)),
+		withPromotionSignTime(valid, "not-before", fixture.now.Add(-10*time.Minute).Format(time.RFC3339Nano)),
+		withPromotionSignTime(valid, "expires", fixture.now.Add(-2*time.Minute).Format(time.RFC3339Nano)),
+		withPromotionSignTime(valid, "expires", fixture.now.Add(25*time.Hour).Format(time.RFC3339Nano)),
+		withPromotionSignTime(valid, "issued", fixture.now.Add(2*time.Hour).Format(time.RFC3339Nano)),
+	}
+	for _, input := range cases {
+		if body, err := SignOMPContextPromotionAttestationV2(input, fixture.privateKey); err == nil || body != nil || !errors.Is(err, ErrOMPContextPromotionStale) {
+			t.Fatalf("invalid time result body=%q error=%v input=%#v", body, err, input)
+		}
+	}
+}
+
+func validOMPContextPromotionAttestationSignInputV2(
+	fixture *ompContextPromotionV2Fixture,
+) OMPContextPromotionAttestationSignInputV2 {
+	issuedAt := fixture.now.Add(-time.Minute)
+	return OMPContextPromotionAttestationSignInputV2{
+		ReportBytes: fixture.reportBytes,
+		IssuedAt:    issuedAt.Format(time.RFC3339Nano),
+		NotBefore:   issuedAt.Format(time.RFC3339Nano),
+		ExpiresAt:   issuedAt.Add(time.Hour).Format(time.RFC3339Nano),
+	}
+}
+
+func withPromotionSignTime(
+	input OMPContextPromotionAttestationSignInputV2,
+	field,
+	value string,
+) OMPContextPromotionAttestationSignInputV2 {
+	switch field {
+	case "issued":
+		input.IssuedAt = value
+	case "not-before":
+		input.NotBefore = value
+	case "expires":
+		input.ExpiresAt = value
+	}
+	return input
+}

--- a/pkg/promptlayer/omp_context_promotion_attestation_v2.go
+++ b/pkg/promptlayer/omp_context_promotion_attestation_v2.go
@@ -53,15 +53,18 @@ type OMPContextPromotionExpectationV2 struct {
 // VerifiedOMPContextPromotion can only be populated after strict signature,
 // provenance, freshness, and cohort verification succeeds.
 type VerifiedOMPContextPromotion struct {
-	reportDigest     string
-	evidenceID       string
-	expiresAt        time.Time
-	producer         OMPContextPromotionProducerV1
-	candidate        OMPContextPromotionCandidateV1
-	policyDigest     string
-	runtime          OMPContextPromotionRuntimeV1
-	provider         string
-	modelScopeDigest string
+	reportDigest            string
+	evidenceID              string
+	expiresAt               time.Time
+	producer                OMPContextPromotionProducerV1
+	candidate               OMPContextPromotionCandidateV1
+	policyDigest            string
+	runtime                 OMPContextPromotionRuntimeV1
+	provider                string
+	modelScopeDigest        string
+	providerAuthorityDigest string
+	sessionAuthorityDigest  string
+	canaryRows              []OMPContextCanaryRowV1
 }
 
 // VerifiedOMPContextPromotionHistoricalProof proves an immutable artifact was
@@ -80,8 +83,10 @@ func (v VerifiedOMPContextPromotion) Valid() bool {
 }
 
 func (v VerifiedOMPContextPromotion) validAt(now time.Time) bool {
-	return v.reportDigest != "" && v.evidenceID != "" && !v.expiresAt.IsZero() &&
-		!now.IsZero() && now.Before(v.expiresAt)
+	return validOMPContextMemoryHashV1(v.reportDigest) && validOMPContextMemoryHashV1(v.evidenceID) &&
+		validOMPContextMemoryHashV1(v.providerAuthorityDigest) &&
+		validOMPContextMemoryHashV1(v.sessionAuthorityDigest) && len(v.canaryRows) == 40 &&
+		!v.expiresAt.IsZero() && !now.IsZero() && now.Before(v.expiresAt)
 }
 func (v VerifiedOMPContextPromotion) ReportDigest() string { return v.reportDigest }
 func (v VerifiedOMPContextPromotion) EvidenceID() string   { return v.evidenceID }
@@ -98,6 +103,29 @@ func (v VerifiedOMPContextPromotion) RuntimeCoordinates() OMPContextPromotionRun
 }
 func (v VerifiedOMPContextPromotion) ProviderScope() (string, string) {
 	return v.provider, v.modelScopeDigest
+}
+func (v VerifiedOMPContextPromotion) ProviderAuthorityDigest() string {
+	return v.providerAuthorityDigest
+}
+func (v VerifiedOMPContextPromotion) SessionAuthorityDigest() string {
+	return v.sessionAuthorityDigest
+}
+func (v VerifiedOMPContextPromotion) CanaryRows() []OMPContextCanaryRowV1 {
+	return append([]OMPContextCanaryRowV1(nil), v.canaryRows...)
+}
+func verifiedOMPContextPromotionFromReportV2(
+	report OMPContextPromotionReportV1,
+	reportDigest string,
+	expiresAt time.Time,
+) VerifiedOMPContextPromotion {
+	return VerifiedOMPContextPromotion{
+		reportDigest: reportDigest, evidenceID: report.EvidenceID, expiresAt: expiresAt,
+		producer: report.Producer, candidate: report.Candidate, policyDigest: report.Policy.PolicyDigest,
+		runtime: report.Runtime, provider: report.Provider, modelScopeDigest: report.ModelScopeDigest,
+		providerAuthorityDigest: ompContextPromotionProviderAuthorityDigestV1(report),
+		sessionAuthorityDigest:  ompContextPromotionSessionAuthorityDigestV1(report),
+		canaryRows:              ompContextPromotionCanaryRowsV1(report),
+	}
 }
 
 func (v VerifiedOMPContextPromotionHistoricalProof) Valid() bool {

--- a/pkg/promptlayer/omp_context_promotion_attestation_v2_fixture_test.go
+++ b/pkg/promptlayer/omp_context_promotion_attestation_v2_fixture_test.go
@@ -113,7 +113,7 @@ func validOMPContextPromotionReportV1() OMPContextPromotionReportV1 {
 			sequence := len(report.Observations) + 1
 			sessionSequences[variant]++
 			input, compactionRequests := int64(10000), 0
-			if variant == "B" {
+			if variant == "B" && sessionSequences[variant] > 1 {
 				input, compactionRequests = 7500, 1
 			}
 			began := start.Add(time.Duration(sequence*2) * time.Second)
@@ -137,7 +137,7 @@ func validOMPContextPromotionReportV1() OMPContextPromotionReportV1 {
 	taskBytes, _ := json.Marshal(report.Tasks)
 	report.CohortManifestDigest = promotionSHA256(taskBytes)
 	report.OrderSeed = report.CohortManifestDigest
-	report.Gates = expectedOMPContextPromotionGatesV1(2500)
+	report.Gates = expectedOMPContextPromotionGatesV1(2500, 19)
 	return report
 }
 

--- a/pkg/promptlayer/omp_context_promotion_attestation_v2_test.go
+++ b/pkg/promptlayer/omp_context_promotion_attestation_v2_test.go
@@ -118,18 +118,38 @@ func TestVerifyOMPContextPromotionArtifactV2_RejectsInvalidCohortFacts(t *testin
 			r.Observations[0].CompactionProviderRequests = 1
 			r.Observations[0].TotalProviderRequests++
 		}},
-		{name: "optimized compaction request missing", mutate: func(r *OMPContextPromotionReportV1) {
-			r.Observations[1].CompactionProviderRequests = 0
-			r.Observations[1].TotalProviderRequests--
+		{name: "fresh optimized compaction request", mutate: func(r *OMPContextPromotionReportV1) {
+			r.Observations[1].CompactionProviderRequests = 1
+			r.Observations[1].PreCompactionACKs = 1
+			r.Observations[1].PostCompactionACKs = 1
+			r.Observations[1].CanonicalReadmissions = 1
+			r.Observations[1].EphemeralReadmissions = 1
+			r.Observations[1].TotalProviderRequests++
+		}},
+		{name: "optimized compaction request overflow", mutate: func(r *OMPContextPromotionReportV1) {
+			r.Observations[2].CompactionProviderRequests = 2
+			r.Observations[2].TotalProviderRequests++
 		}},
 		{name: "optimized pre ACK missing", mutate: func(r *OMPContextPromotionReportV1) {
-			r.Observations[1].PreCompactionACKs = 0
+			r.Observations[2].PreCompactionACKs = 0
 		}},
 		{name: "optimized canonical readmission missing", mutate: func(r *OMPContextPromotionReportV1) {
-			r.Observations[1].CanonicalReadmissions = 0
+			r.Observations[2].CanonicalReadmissions = 0
 		}},
 		{name: "optimized ephemeral readmission missing", mutate: func(r *OMPContextPromotionReportV1) {
-			r.Observations[1].EphemeralReadmissions = 0
+			r.Observations[2].EphemeralReadmissions = 0
+		}},
+		{name: "insufficient multi-compaction evidence", mutate: func(r *OMPContextPromotionReportV1) {
+			for index := range r.Observations {
+				if r.Observations[index].Variant == "B" {
+					r.Observations[index].CompactionProviderRequests = 0
+					r.Observations[index].PreCompactionACKs = 0
+					r.Observations[index].PostCompactionACKs = 0
+					r.Observations[index].CanonicalReadmissions = 0
+					r.Observations[index].EphemeralReadmissions = 0
+					r.Observations[index].TotalProviderRequests = 1
+				}
+			}
 		}},
 		{name: "provider request total mismatch", mutate: func(r *OMPContextPromotionReportV1) { r.Observations[0].TotalProviderRequests++ }},
 		{name: "integrity failure", mutate: func(r *OMPContextPromotionReportV1) { r.Observations[0].IntegrityPassed = false }},

--- a/pkg/promptlayer/omp_context_promotion_attestation_verify_v2.go
+++ b/pkg/promptlayer/omp_context_promotion_attestation_verify_v2.go
@@ -68,11 +68,7 @@ func verifyOMPContextPromotionArtifactV2WithTrust(reportBytes, attestationBytes 
 	if err := validateOMPContextPromotionCohortAttestationTimeV2(report, issuedAt); err != nil {
 		return VerifiedOMPContextPromotion{}, err
 	}
-	return VerifiedOMPContextPromotion{
-		reportDigest: attestation.ReportSHA256, evidenceID: report.EvidenceID, expiresAt: expiresAt,
-		producer: report.Producer, candidate: report.Candidate, policyDigest: report.Policy.PolicyDigest,
-		runtime: report.Runtime, provider: report.Provider, modelScopeDigest: report.ModelScopeDigest,
-	}, nil
+	return verifiedOMPContextPromotionFromReportV2(report, attestation.ReportSHA256, expiresAt), nil
 }
 
 func verifyOMPContextPromotionHistoricalArtifactV2WithTrust(reportBytes, attestationBytes []byte,

--- a/pkg/promptlayer/omp_context_promotion_report_build.go
+++ b/pkg/promptlayer/omp_context_promotion_report_build.go
@@ -1,0 +1,91 @@
+package promptlayer
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	"github.com/insajin/autopus-adk/pkg/companionmanifest"
+)
+
+// BuildOMPContextPromotionReportV1 derives the canonical body-free fields and
+// re-enters the same strict verifier used by signed active admission.
+func BuildOMPContextPromotionReportV1(
+	report OMPContextPromotionReportV1,
+) (OMPContextPromotionReportV1, []byte, error) {
+	if report.SchemaVersion != "" && report.SchemaVersion != OMPContextPromotionReportSchemaV1 {
+		return report, nil, fmt.Errorf("OMP context promotion report schema is invalid")
+	}
+	if report.TrustLane != "" && report.TrustLane != OMPContextPromotionTrustLaneV2 {
+		return report, nil, fmt.Errorf("OMP context promotion report trust lane is invalid")
+	}
+	report.SchemaVersion = OMPContextPromotionReportSchemaV1
+	report.TrustLane = OMPContextPromotionTrustLaneV2
+	if len(report.Tasks) != 20 || len(report.Observations) != 40 {
+		return report, nil, fmt.Errorf("OMP context promotion cohort is incomplete")
+	}
+	taskBytes, err := json.Marshal(report.Tasks)
+	if err != nil {
+		return report, nil, fmt.Errorf("marshal OMP context promotion tasks: %w", err)
+	}
+	report.CohortManifestDigest = promotionSHA256(taskBytes)
+	report.OrderSeed = report.CohortManifestDigest
+	rows := ompContextPromotionCanaryRowsV1(report)
+	aggregate, err := ReduceOMPContextCanaryPairsV1(rows)
+	if err != nil {
+		return report, nil, fmt.Errorf("reduce OMP context promotion cohort: %w", err)
+	}
+	report.Gates = expectedOMPContextPromotionGatesV1(aggregate.MedianReductionBasisPoints)
+	report.EvidenceID, err = computeOMPContextPromotionEvidenceIDV1(report)
+	if err != nil {
+		return report, nil, fmt.Errorf("compute OMP context promotion evidence ID: %w", err)
+	}
+	body, err := json.Marshal(report)
+	if err != nil {
+		return report, nil, fmt.Errorf("marshal OMP context promotion report: %w", err)
+	}
+	verified, err := decodeOMPContextPromotionReportV1(body)
+	if err != nil {
+		return report, nil, err
+	}
+	return verified, body, nil
+}
+
+func OMPContextPromotionReportCanaryRowsV1(
+	report OMPContextPromotionReportV1,
+) ([]OMPContextCanaryRowV1, error) {
+	if err := validateOMPContextPromotionReportMetadataV1(report); err != nil {
+		return nil, err
+	}
+	if err := validateOMPContextPromotionCohortV1(report); err != nil {
+		return nil, err
+	}
+	return append([]OMPContextCanaryRowV1(nil), ompContextPromotionCanaryRowsV1(report)...), nil
+}
+
+func OMPContextPromotionProviderAuthorityDigestV1(report OMPContextPromotionReportV1) string {
+	return ompContextPromotionProviderAuthorityDigestV1(report)
+}
+
+func OMPContextPromotionSessionAuthorityDigestV1(report OMPContextPromotionReportV1) string {
+	return ompContextPromotionSessionAuthorityDigestV1(report)
+}
+
+func OMPContextPromotionReportPathV1(root string) string {
+	return filepath.Join(root, filepath.FromSlash(ompContextPromotionReportRelativePathV2))
+}
+
+func WriteOMPContextPromotionReportV1(root string, body []byte) error {
+	if _, err := decodeOMPContextPromotionReportV1(body); err != nil {
+		return err
+	}
+	evidencePath, err := prepareOMPContextEvidenceStorePathV1(root, true)
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(filepath.Dir(evidencePath), ompContextPromotionReportFileNameV2)
+	if err := companionmanifest.WriteAtomic(path, body); err != nil {
+		return fmt.Errorf("write OMP context promotion report: %w", err)
+	}
+	return verifyOMPContextEvidenceFileV1(path)
+}

--- a/pkg/promptlayer/omp_context_promotion_report_build.go
+++ b/pkg/promptlayer/omp_context_promotion_report_build.go
@@ -35,7 +35,10 @@ func BuildOMPContextPromotionReportV1(
 	if err != nil {
 		return report, nil, fmt.Errorf("reduce OMP context promotion cohort: %w", err)
 	}
-	report.Gates = expectedOMPContextPromotionGatesV1(aggregate.MedianReductionBasisPoints)
+	report.Gates = expectedOMPContextPromotionGatesV1(
+		aggregate.MedianReductionBasisPoints,
+		ompContextPromotionCompactionCountV1(report),
+	)
 	report.EvidenceID, err = computeOMPContextPromotionEvidenceIDV1(report)
 	if err != nil {
 		return report, nil, fmt.Errorf("compute OMP context promotion evidence ID: %w", err)

--- a/pkg/promptlayer/omp_context_promotion_report_build_test.go
+++ b/pkg/promptlayer/omp_context_promotion_report_build_test.go
@@ -1,0 +1,66 @@
+package promptlayer
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestBuildOMPContextPromotionReportV1_DerivesCanonicalBodyFreeIdentity(t *testing.T) {
+	report := validOMPContextPromotionReportV1()
+	report.EvidenceID = ""
+	report.TrustLane = ""
+
+	built, body, err := BuildOMPContextPromotionReportV1(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := decodeOMPContextPromotionReportV1(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decoded.EvidenceID != built.EvidenceID || decoded.TrustLane != OMPContextPromotionTrustLaneV2 {
+		t.Fatalf("canonical identity mismatch: %#v", decoded)
+	}
+	for _, forbidden := range [][]byte{[]byte("prompt_body"), []byte("assistant_text"), []byte("credential_locator")} {
+		if bytes.Contains(body, forbidden) {
+			t.Fatalf("body-bearing field leaked: %q", forbidden)
+		}
+	}
+	if got := ompContextPromotionProviderAuthorityDigestV1(built); got == "" {
+		t.Fatal("provider authority digest missing")
+	}
+	if got := ompContextPromotionSessionAuthorityDigestV1(built); got == "" {
+		t.Fatal("session authority digest missing")
+	}
+	rows, err := OMPContextPromotionReportCanaryRowsV1(built)
+	if err != nil || len(rows) != 40 {
+		t.Fatalf("canary projection failed: rows=%d err=%v", len(rows), err)
+	}
+}
+
+func TestBuildOMPContextPromotionReportV1_RejectsIncompleteObservedCohort(t *testing.T) {
+	report := validOMPContextPromotionReportV1()
+	report.Observations = report.Observations[:39]
+	if _, _, err := BuildOMPContextPromotionReportV1(report); err == nil {
+		t.Fatal("incomplete cohort accepted")
+	}
+}
+
+func TestBuildOMPContextPromotionReportV1_RejectsSessionOrProviderAuthorityDrift(t *testing.T) {
+	for name, mutate := range map[string]func(*OMPContextPromotionReportV1){
+		"session": func(report *OMPContextPromotionReportV1) {
+			report.Observations[2].SessionReceiptDigest = promotionSHA256([]byte("different-session"))
+		},
+		"provider": func(report *OMPContextPromotionReportV1) {
+			report.Observations[2].ProviderAuthorityDigest = promotionSHA256([]byte("different-provider-authority"))
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			report := validOMPContextPromotionReportV1()
+			mutate(&report)
+			if _, _, err := BuildOMPContextPromotionReportV1(report); err == nil {
+				t.Fatal("authority drift accepted")
+			}
+		})
+	}
+}

--- a/pkg/promptlayer/omp_context_promotion_report_cohort.go
+++ b/pkg/promptlayer/omp_context_promotion_report_cohort.go
@@ -16,14 +16,16 @@ func validateOMPContextPromotionCohortV1(report OMPContextPromotionReportV1) err
 	if err != nil {
 		return err
 	}
+	compactionCount := ompContextPromotionCompactionCountV1(report)
 	aggregate, err := ReduceOMPContextCanaryPairsV1(rows)
 	if err != nil || aggregate.PairCount != 20 || aggregate.ABCount != 10 || aggregate.BACount != 10 ||
-		abCount != 10 || baCount != 10 || aggregate.IntegrityFailures != 0 || aggregate.SecurityFailures != 0 ||
+		abCount != 10 || baCount != 10 || compactionCount < 2 ||
+		aggregate.IntegrityFailures != 0 || aggregate.SecurityFailures != 0 ||
 		aggregate.QualityRegressions != 0 || !aggregate.FallbackVerified || !aggregate.RollbackVerified ||
 		aggregate.MedianReductionBasisPoints < report.Policy.MinReductionBasisPoints {
 		return fmt.Errorf("OMP context promotion cohort gates failed")
 	}
-	expectedGates := expectedOMPContextPromotionGatesV1(aggregate.MedianReductionBasisPoints)
+	expectedGates := expectedOMPContextPromotionGatesV1(aggregate.MedianReductionBasisPoints, compactionCount)
 	if !reflect.DeepEqual(report.Gates, expectedGates) {
 		return fmt.Errorf("OMP context promotion gate projection mismatch")
 	}
@@ -105,20 +107,23 @@ func validateOMPContextPromotionObservationV1(report OMPContextPromotionReportV1
 	} else if *providerAuthority != observation.ProviderAuthorityDigest {
 		return fmt.Errorf("OMP context promotion provider authority changed")
 	}
+	expectedCompactions := observation.CompactionProviderRequests
 	if observation.InputTokens <= 0 || observation.OutputTokens <= 0 || observation.TotalTokens <= 0 ||
 		observation.InputTokens > 1_000_000_000_000 || observation.OutputTokens > 1_000_000_000_000 ||
 		observation.TotalTokens != observation.InputTokens+observation.OutputTokens || observation.QualityScore != 10000 ||
 		observation.SetupProviderRequests < 0 || observation.SetupProviderRequests > 1_000_000 ||
-		observation.CompactionProviderRequests < 0 || observation.CompactionProviderRequests > 1_000_000 ||
+		expectedCompactions < 0 || expectedCompactions > 1 ||
 		observation.PrimaryProviderRequests != 1 ||
-		(variant == "A" && (observation.CompactionProviderRequests != 0 ||
+		(variant == "A" && (expectedCompactions != 0 ||
 			observation.PreCompactionACKs != 0 || observation.PostCompactionACKs != 0 ||
 			observation.CanonicalReadmissions != 0 || observation.EphemeralReadmissions != 0)) ||
-		(variant == "B" && (observation.CompactionProviderRequests != 1 ||
-			observation.PreCompactionACKs != 1 || observation.PostCompactionACKs != 1 ||
-			observation.CanonicalReadmissions != 1 || observation.EphemeralReadmissions != 1)) ||
+		(variant == "B" && ((sessionSequence == 1 && expectedCompactions != 0) ||
+			observation.PreCompactionACKs != expectedCompactions ||
+			observation.PostCompactionACKs != expectedCompactions ||
+			observation.CanonicalReadmissions != expectedCompactions ||
+			observation.EphemeralReadmissions != expectedCompactions)) ||
 		observation.TotalProviderRequests != observation.SetupProviderRequests+
-			observation.CompactionProviderRequests+observation.PrimaryProviderRequests ||
+			expectedCompactions+observation.PrimaryProviderRequests ||
 		observation.RetryCount != 0 || observation.MaxConcurrency != 1 {
 		return fmt.Errorf("OMP context promotion observation facts are invalid")
 	}
@@ -154,6 +159,16 @@ func ompContextPromotionCanaryRowsV1(report OMPContextPromotionReportV1) []OMPCo
 		}
 	}
 	return rows
+}
+
+func ompContextPromotionCompactionCountV1(report OMPContextPromotionReportV1) int {
+	count := 0
+	for _, observation := range report.Observations {
+		if observation.Variant == "B" {
+			count += observation.CompactionProviderRequests
+		}
+	}
+	return count
 }
 
 func ompContextPromotionProviderAuthorityDigestV1(report OMPContextPromotionReportV1) string {
@@ -205,7 +220,10 @@ func ompContextPromotionSessionAuthorityDigestV1(report OMPContextPromotionRepor
 	return promotionSHA256(body)
 }
 
-func expectedOMPContextPromotionGatesV1(medianBasisPoints int64) []OMPContextPromotionGateResultV1 {
+func expectedOMPContextPromotionGatesV1(
+	medianBasisPoints int64,
+	compactionCount int,
+) []OMPContextPromotionGateResultV1 {
 	pass := func(id, observed, required string) OMPContextPromotionGateResultV1 {
 		return OMPContextPromotionGateResultV1{GateID: id, Status: "passed", ObservedValue: observed, RequiredValue: required, Reason: "gate-passed"}
 	}
@@ -213,7 +231,7 @@ func expectedOMPContextPromotionGatesV1(medianBasisPoints int64) []OMPContextPro
 		pass("integrity", "40/40", "40/40"), pass("security", "40/40", "40/40"), pass("quality", "0", "0"),
 		pass("pair-count", "20", "20"), pass("balanced-order", "10:10", "10:10"),
 		pass("provider-authority", "40/40", "40/40"), pass("reusable-session", "38/38", "38/38"),
-		pass("multi-compaction-admission", "20/20", "20/20"),
+		pass("multi-compaction-admission", strconv.Itoa(compactionCount)+"/20", ">=2/20"),
 		pass("token-reduction", strconv.FormatInt(medianBasisPoints, 10), "2000"),
 		pass("fallback", "40/40", "40/40"), pass("rollback", "40/40", "40/40"), pass("cleanup", "40/40", "40/40"),
 		pass("serial-execution", "40/40", "40/40"), pass("no-retry", "0", "0"),

--- a/pkg/promptlayer/omp_context_promotion_report_cohort.go
+++ b/pkg/promptlayer/omp_context_promotion_report_cohort.go
@@ -1,6 +1,7 @@
 package promptlayer
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -130,6 +131,78 @@ func validateOMPContextPromotionObservationV1(report OMPContextPromotionReportV1
 	observationDigests[observation.ObservationDigest] = true
 	usageDigests[observation.UsageDigest] = true
 	return nil
+}
+
+func ompContextPromotionCanaryRowsV1(report OMPContextPromotionReportV1) []OMPContextCanaryRowV1 {
+	if len(report.Tasks) != 20 || len(report.Observations) != 40 {
+		return nil
+	}
+	rows := make([]OMPContextCanaryRowV1, 0, len(report.Observations))
+	for taskIndex, task := range report.Tasks {
+		for pairIndex := range 2 {
+			observation := report.Observations[taskIndex*2+pairIndex]
+			if observation.TaskIDDigest != task.TaskIDDigest {
+				return nil
+			}
+			rows = append(rows, OMPContextCanaryRowV1{
+				TaskID: observation.TaskIDDigest, Variant: OMPContextCanaryVariantV1(observation.Variant),
+				Order: pairIndex + 1, Tokens: observation.InputTokens,
+				IntegrityPassed: observation.IntegrityPassed, SecurityPassed: observation.SecurityPassed,
+				QualityScore: observation.QualityScore, FallbackVerified: observation.FallbackVerified,
+				RollbackVerified: observation.RollbackVerified,
+			})
+		}
+	}
+	return rows
+}
+
+func ompContextPromotionProviderAuthorityDigestV1(report OMPContextPromotionReportV1) string {
+	if len(report.Observations) != 40 {
+		return ""
+	}
+	digest := report.Observations[0].ProviderAuthorityDigest
+	for _, observation := range report.Observations[1:] {
+		if observation.ProviderAuthorityDigest != digest {
+			return ""
+		}
+	}
+	return digest
+}
+
+func ompContextPromotionSessionAuthorityDigestV1(report OMPContextPromotionReportV1) string {
+	receipts := map[string]string{"A": "", "B": ""}
+	for _, observation := range report.Observations {
+		if _, ok := receipts[observation.Variant]; !ok {
+			return ""
+		}
+		if receipts[observation.Variant] == "" {
+			receipts[observation.Variant] = observation.SessionReceiptDigest
+		} else if receipts[observation.Variant] != observation.SessionReceiptDigest {
+			return ""
+		}
+	}
+	providerAuthority := ompContextPromotionProviderAuthorityDigestV1(report)
+	if receipts["A"] == "" || receipts["B"] == "" || receipts["A"] == receipts["B"] ||
+		!validOMPContextMemoryHashV1(providerAuthority) {
+		return ""
+	}
+	body, err := json.Marshal(struct {
+		Producer          OMPContextPromotionProducerV1     `json:"producer"`
+		SessionFacts      OMPContextPromotionSessionFactsV1 `json:"session_facts"`
+		Provider          string                            `json:"provider"`
+		ModelScopeDigest  string                            `json:"model_scope_digest"`
+		ProviderAuthority string                            `json:"provider_authority_digest"`
+		FullSession       string                            `json:"full_session_receipt_digest"`
+		OptimizedSession  string                            `json:"optimized_session_receipt_digest"`
+		CohortDigest      string                            `json:"cohort_manifest_digest"`
+	}{
+		report.Producer, report.SessionFacts, report.Provider, report.ModelScopeDigest, providerAuthority,
+		receipts["A"], receipts["B"], report.CohortManifestDigest,
+	})
+	if err != nil {
+		return ""
+	}
+	return promotionSHA256(body)
 }
 
 func expectedOMPContextPromotionGatesV1(medianBasisPoints int64) []OMPContextPromotionGateResultV1 {

--- a/pkg/promptlayer/omp_context_promotion_runtime_v3.go
+++ b/pkg/promptlayer/omp_context_promotion_runtime_v3.go
@@ -48,6 +48,7 @@ type OMPContextPromotionCurrentRuntimeV3 struct {
 	OMPVersion                   string
 	OMPExecutableSHA256          string
 	PipelineImplementationDigest string
+	ProviderAuthorityDigest      string
 }
 
 // OMPContextPromotionRuntimeBundleV3 is a local, signed promotion authority.
@@ -174,11 +175,7 @@ func verifyOMPContextPromotionRuntimeV3WithLineageAt(bundle OMPContextPromotionR
 	if lineageExpiresAt.Before(expiresAt) {
 		expiresAt = lineageExpiresAt
 	}
-	return VerifiedOMPContextPromotion{
-		reportDigest: attestation.ReportSHA256, evidenceID: report.EvidenceID, expiresAt: expiresAt,
-		producer: report.Producer, candidate: report.Candidate, policyDigest: report.Policy.PolicyDigest,
-		runtime: report.Runtime, provider: report.Provider, modelScopeDigest: report.ModelScopeDigest,
-	}, nil
+	return verifiedOMPContextPromotionFromReportV2(report, attestation.ReportSHA256, expiresAt), nil
 }
 
 func validOMPContextPromotionStaticPolicyV3(value OMPContextPromotionStaticPolicyV3) bool {
@@ -200,8 +197,10 @@ func validOMPContextPromotionStaticPolicyV3(value OMPContextPromotionStaticPolic
 func matchesOMPContextPromotionCurrentRuntimeV3(expected OMPContextPromotionStaticPolicyV3,
 	current OMPContextPromotionCurrentRuntimeV3,
 ) bool {
-	return validOMPContextMemoryHashV1(current.ExecutableSHA256) && current.SourceCommit == expected.SourceCommit &&
-		current.SourceTree == expected.SourceTree && current.Target == expected.Target && current.AutoVersion == expected.AutoVersion &&
+	return validOMPContextMemoryHashV1(current.ExecutableSHA256) &&
+		validOMPContextMemoryHashV1(current.ProviderAuthorityDigest) &&
+		current.SourceCommit == expected.SourceCommit && current.SourceTree == expected.SourceTree &&
+		current.Target == expected.Target && current.AutoVersion == expected.AutoVersion &&
 		current.OMPVersion == expected.OMPVersion && current.OMPExecutableSHA256 == expected.OMPExecutableSHA256 &&
 		current.PipelineImplementationDigest == expected.PipelineImplementationDigest
 }
@@ -217,11 +216,15 @@ func matchesOMPContextPromotionStaticPolicyV3(report OMPContextPromotionReportV1
 		report.Runtime.AutoVersion == current.AutoVersion && report.Runtime.OMPVersion == current.OMPVersion &&
 		report.Runtime.OMPExecutableSHA256 == current.OMPExecutableSHA256 &&
 		report.Runtime.PipelineImplementationDigest == current.PipelineImplementationDigest &&
+		ompContextPromotionProviderAuthorityDigestV1(report) == current.ProviderAuthorityDigest &&
 		report.Provider == expected.Provider && report.ModelScopeDigest == expected.ModelScopeDigest &&
 		report.CohortManifestDigest == expected.CohortManifestDigest && report.OrderSeed == expected.OrderSeed &&
 		report.OraclePolicyDigest == expected.OraclePolicyDigest
 }
 
 func sameOMPContextPromotionHashV3(left, right string) bool {
-	return len(left) == len(right) && subtle.ConstantTimeCompare([]byte(left), []byte(right)) == 1
+	if len(left) != len(right) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(left), []byte(right)) == 1
 }

--- a/pkg/promptlayer/omp_context_promotion_runtime_v3_test.go
+++ b/pkg/promptlayer/omp_context_promotion_runtime_v3_test.go
@@ -48,6 +48,7 @@ func ompContextPromotionRuntimeV3Fixture(t *testing.T) (
 		AutoVersion: policy.AutoVersion, OMPVersion: policy.OMPVersion,
 		OMPExecutableSHA256:          policy.OMPExecutableSHA256,
 		PipelineImplementationDigest: policy.PipelineImplementationDigest,
+		ProviderAuthorityDigest:      ompContextPromotionProviderAuthorityDigestV1(fixture.report),
 	}
 	return fixture, OMPContextPromotionRuntimeBundleV3{
 		ReportBytes: fixture.reportBytes, AttestationBytes: fixture.attestationBytes,
@@ -128,6 +129,9 @@ func TestVerifyOMPContextPromotionRuntimeV3_StaticAndSignedCoordinatesFailClosed
 		"implementation": func(policy *OMPContextPromotionStaticPolicyV3, current *OMPContextPromotionCurrentRuntimeV3) {
 			policy.PipelineImplementationDigest = promotionSHA256([]byte("other-implementation"))
 			current.PipelineImplementationDigest = policy.PipelineImplementationDigest
+		},
+		"provider authority": func(_ *OMPContextPromotionStaticPolicyV3, current *OMPContextPromotionCurrentRuntimeV3) {
+			current.ProviderAuthorityDigest = promotionSHA256([]byte("other-provider-authority"))
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/promptlayer/omp_context_promotion_trust_v2.go
+++ b/pkg/promptlayer/omp_context_promotion_trust_v2.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 )
 
-const ompContextPromotionPublicKey2026Q3K1Base64 = "t2lWmiRdd03NTG4zpzlpDnRUdp9e/ItDGxoHR05aVQk="
+const ompContextPromotionPublicKey2026Q3K1Base64 = "2ZO4NEHN+2yUw3huo8ZIXp/ITGd6WMN+EyiQVc9a3y8="
 
 func mustOMPContextPromotionPublicKeyV2(encoded string) ed25519.PublicKey {
 	encoding := base64.StdEncoding.Strict()

--- a/scripts/companion-release/ompcontextverify/main.go
+++ b/scripts/companion-release/ompcontextverify/main.go
@@ -39,11 +39,41 @@ func main() {
 	}
 }
 
+type promotionArtifactVerifier func(
+	reportBytes, attestationBytes []byte,
+	expected promptlayer.OMPContextPromotionExpectationV2,
+) (bool, error)
+
 func run(arguments []string) error {
+	return runWithVerifiers(arguments, verifyActivePromotionArtifact, verifyHistoricalPromotionArtifact)
+}
+
+func verifyActivePromotionArtifact(
+	reportBytes, attestationBytes []byte,
+	expected promptlayer.OMPContextPromotionExpectationV2,
+) (bool, error) {
+	verified, err := promptlayer.VerifyOMPContextPromotionArtifactV2(reportBytes, attestationBytes, expected)
+	return verified.Valid(), err
+}
+
+func verifyHistoricalPromotionArtifact(
+	reportBytes, attestationBytes []byte,
+	expected promptlayer.OMPContextPromotionExpectationV2,
+) (bool, error) {
+	verified, err := promptlayer.VerifyOMPContextPromotionHistoricalArtifactV2(
+		reportBytes, attestationBytes, expected)
+	return verified.Valid(), err
+}
+
+func runWithVerifiers(
+	arguments []string,
+	activeVerifier, historicalVerifier promotionArtifactVerifier,
+) error {
 	opts, err := parseOptions(arguments)
 	if err != nil {
 		return err
 	}
+	candidateArtifactSHA := "sha256:" + opts.candidateArtifactSHA
 	reportBytes, err := readArtifact(opts.reportPath, maxReportBytes)
 	if err != nil {
 		return fmt.Errorf("report: %w", err)
@@ -68,24 +98,22 @@ func run(arguments []string) error {
 		report.Candidate.Repository != opts.candidateRepository ||
 		report.Candidate.Revision != opts.candidateRevision ||
 		report.Candidate.TreeSHA != opts.candidateTree ||
-		report.Candidate.ArtifactSHA256 != opts.candidateArtifactSHA {
+		report.Candidate.ArtifactSHA256 != candidateArtifactSHA {
 		return errors.New("candidate coordinates differ from exact release source")
 	}
 	if report.Candidate.ArtifactSHA256 != report.Runtime.AutoBinarySHA256 {
 		return errors.New("candidate artifact digest differs from runtime binary digest")
 	}
-	expected := expectationFromStaticPolicy(policy, opts.candidateArtifactSHA)
+	expected := expectationFromStaticPolicy(policy, candidateArtifactSHA)
 	switch opts.mode {
 	case "active":
-		verified, verifyErr := promptlayer.VerifyOMPContextPromotionArtifactV2(
-			reportBytes, attestationBytes, expected)
-		if verifyErr != nil || !verified.Valid() {
+		valid, verifyErr := activeVerifier(reportBytes, attestationBytes, expected)
+		if verifyErr != nil || !valid {
 			return fmt.Errorf("active evidence verification failed: %w", verifyErr)
 		}
 	case "historical":
-		verified, verifyErr := promptlayer.VerifyOMPContextPromotionHistoricalArtifactV2(
-			reportBytes, attestationBytes, expected)
-		if verifyErr != nil || !verified.Valid() {
+		valid, verifyErr := historicalVerifier(reportBytes, attestationBytes, expected)
+		if verifyErr != nil || !valid {
 			return fmt.Errorf("historical evidence verification failed: %w", verifyErr)
 		}
 	default:

--- a/scripts/companion-release/ompcontextverify/main_test.go
+++ b/scripts/companion-release/ompcontextverify/main_test.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/insajin/autopus-adk/pkg/promptlayer"
 )
@@ -85,5 +89,210 @@ func TestDecodeStaticPolicy_RejectsUnknownAndNonCanonicalInput(t *testing.T) {
 		if _, err := decodeStaticPolicy(encoded); err == nil {
 			t.Fatal("static policy wire drift was accepted")
 		}
+	}
+}
+
+type historicalVerifierFixture struct {
+	reportPath, attestationPath, reportSHA, attestationSHA, staticPolicyB64 string
+}
+
+func (f historicalVerifierFixture) arguments(candidateArtifactSHA string) []string {
+	return []string{
+		"--mode", "historical", "--report", f.reportPath, "--attestation", f.attestationPath,
+		"--report-sha256", f.reportSHA, "--attestation-sha256", f.attestationSHA,
+		"--candidate-repository", "Insajin/autopus-adk",
+		"--candidate-revision", strings.Repeat("c", 40),
+		"--candidate-tree", strings.Repeat("d", 40),
+		"--candidate-artifact-sha256", candidateArtifactSHA,
+		"--static-policy-b64", f.staticPolicyB64,
+	}
+}
+
+func promotionTestHash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func newHistoricalVerifierFixture(t *testing.T) historicalVerifierFixture {
+	t.Helper()
+	candidateArtifactSHA := "sha256:" + strings.Repeat("e", 64)
+	report := promptlayer.OMPContextPromotionReportV1{
+		ChallengeDigest: promotionTestHash("challenge"),
+		Producer: promptlayer.OMPContextPromotionProducerV1{
+			Repository:  "Insajin/autopus-harness-bench",
+			WorkflowRef: "refs/heads/main@0123456789abcdef0123456789abcdef01234567",
+			RunID:       "123456", RunAttempt: 1,
+		},
+		Candidate: promptlayer.OMPContextPromotionCandidateV1{
+			Repository: "Insajin/autopus-adk", Revision: strings.Repeat("c", 40),
+			TreeSHA: strings.Repeat("d", 40), ArtifactSHA256: candidateArtifactSHA,
+		},
+		Policy: promptlayer.OMPContextPromotionPolicyReportV1{
+			PolicyID: "omp-context-active-v1", PolicyDigest: promotionTestHash("policy"),
+			HistoryMode: "active", MemoryMode: "off", MinPairCount: 20, MinReductionBasisPoints: 2000,
+		},
+		Runtime: promptlayer.OMPContextPromotionRuntimeV1{
+			AutoVersion: "v0.50.93", AutoBinarySHA256: candidateArtifactSHA,
+			OMPVersion: "omp/17.2.7", OMPExecutableSHA256: promotionTestHash("omp"),
+			ExecutionClass: "external-live", ProductionPathEquivalent: true,
+			RuntimeKind:                  "omp-pipeline-managed-rpc",
+			PipelineImplementationDigest: promotionTestHash("pipeline-implementation"),
+		},
+		SessionFacts: promptlayer.OMPContextPromotionSessionFactsV1{
+			FullProcessStarts: 1, OptimizedProcessStarts: 1, FullSessionCount: 1,
+			OptimizedSessionCount: 1, MaxConcurrency: 1,
+		},
+		Provider: "openai", ModelScopeDigest: promotionTestHash("models"),
+		OraclePolicyDigest: promotionTestHash("oracle"),
+	}
+	startedAt := time.Date(2026, 8, 4, 1, 0, 0, 0, time.UTC)
+	sessionSequences := map[string]int{"A": 0, "B": 0}
+	for index := range 20 {
+		taskDigest := promotionTestHash(fmt.Sprintf("task-%02d", index))
+		order, variants := "AB", []string{"A", "B"}
+		if index%2 == 1 {
+			order, variants = "BA", []string{"B", "A"}
+		}
+		report.Tasks = append(report.Tasks, promptlayer.OMPContextPromotionTaskV1{
+			TaskIDDigest: taskDigest, Order: order,
+		})
+		for _, variant := range variants {
+			sequence := len(report.Observations) + 1
+			sessionSequences[variant]++
+			inputTokens, compactionRequests := int64(10000), 0
+			if variant == "B" {
+				inputTokens, compactionRequests = 7500, 1
+			}
+			began := startedAt.Add(time.Duration(sequence*2) * time.Second)
+			report.Observations = append(report.Observations, promptlayer.OMPContextPromotionObservationV1{
+				Sequence: sequence, TaskIDDigest: taskDigest, Variant: variant,
+				SessionReceiptDigest: promotionTestHash("session-" + variant),
+				SessionSequence:      sessionSequences[variant], ProcessReused: sessionSequences[variant] > 1,
+				Provider: report.Provider, ModelScopeDigest: report.ModelScopeDigest,
+				EndpointClass: "external-provider", Transport: "provider-api", CredentialMode: "locator-only",
+				ProviderAuthorityDigest: promotionTestHash("provider-authority"), ExecutionMode: "external-live",
+				StartedAt: began.Format(time.RFC3339Nano), CompletedAt: began.Add(time.Second).Format(time.RFC3339Nano),
+				InputTokens: inputTokens, OutputTokens: 100, TotalTokens: inputTokens + 100,
+				CompactionProviderRequests: compactionRequests, PrimaryProviderRequests: 1,
+				PreCompactionACKs: compactionRequests, PostCompactionACKs: compactionRequests,
+				CanonicalReadmissions: compactionRequests, EphemeralReadmissions: compactionRequests,
+				TotalProviderRequests: 1 + compactionRequests,
+				ObservationDigest:     promotionTestHash(fmt.Sprintf("observation-%02d", sequence)),
+				UsageDigest:           promotionTestHash(fmt.Sprintf("usage-%02d", sequence)),
+				IntegrityPassed:       true, SecurityPassed: true, QualityScore: 10000,
+				FallbackVerified: true, RollbackVerified: true, CleanupVerified: true, MaxConcurrency: 1,
+			})
+		}
+	}
+	builtReport, reportBytes, err := promptlayer.BuildOMPContextPromotionReportV1(report)
+	if err != nil {
+		t.Fatalf("build report: %v", err)
+	}
+	attestationBytes := []byte("{}")
+	policy := promptlayer.OMPContextPromotionStaticPolicyV3{
+		SchemaVersion:       promptlayer.OMPContextPromotionRuntimeSchemaV3,
+		ProducerRepository:  builtReport.Producer.Repository,
+		ProducerWorkflowRef: builtReport.Producer.WorkflowRef,
+		CandidateRepository: builtReport.Candidate.Repository,
+		SourceCommit:        builtReport.Candidate.Revision, SourceTree: builtReport.Candidate.TreeSHA,
+		Target: "darwin-arm64", AutoVersion: builtReport.Runtime.AutoVersion,
+		PolicyID: builtReport.Policy.PolicyID, PolicyDigest: builtReport.Policy.PolicyDigest,
+		OMPVersion:                   builtReport.Runtime.OMPVersion,
+		OMPExecutableSHA256:          builtReport.Runtime.OMPExecutableSHA256,
+		PipelineImplementationDigest: builtReport.Runtime.PipelineImplementationDigest,
+		Provider:                     builtReport.Provider, ModelScopeDigest: builtReport.ModelScopeDigest,
+		CohortManifestDigest: builtReport.CohortManifestDigest, OrderSeed: builtReport.OrderSeed,
+		OraclePolicyDigest:  builtReport.OraclePolicyDigest,
+		ReleaseLineageKeyID: "release-key", ReleaseLineageHandoff: "v1", MinimumRollbackFloor: 5093,
+	}
+	policyBytes, err := json.Marshal(policy)
+	if err != nil {
+		t.Fatalf("marshal static policy: %v", err)
+	}
+	dir := t.TempDir()
+	reportPath, attestationPath := filepath.Join(dir, "report.json"), filepath.Join(dir, "attestation.json")
+	if err := os.WriteFile(reportPath, reportBytes, 0o600); err != nil {
+		t.Fatalf("write report: %v", err)
+	}
+	if err := os.WriteFile(attestationPath, attestationBytes, 0o600); err != nil {
+		t.Fatalf("write attestation: %v", err)
+	}
+	return historicalVerifierFixture{
+		reportPath: reportPath, attestationPath: attestationPath,
+		reportSHA: digest(reportBytes), attestationSHA: digest(attestationBytes),
+		staticPolicyB64: base64.RawURLEncoding.EncodeToString(policyBytes),
+	}
+}
+
+func TestRun_HistoricalAcceptsRawCandidateDigestAgainstCanonicalReport(t *testing.T) {
+	fixture := newHistoricalVerifierFixture(t)
+	canonicalDigest := "sha256:" + strings.Repeat("e", 64)
+	historicalVerifier := func(
+		reportBytes, _ []byte,
+		expected promptlayer.OMPContextPromotionExpectationV2,
+	) (bool, error) {
+		var report promptlayer.OMPContextPromotionReportV1
+		if err := json.Unmarshal(reportBytes, &report); err != nil {
+			t.Fatalf("decode report in verifier: %v", err)
+		}
+		if report.Candidate.ArtifactSHA256 != canonicalDigest ||
+			expected.Candidate.ArtifactSHA256 != canonicalDigest ||
+			expected.AutoBinarySHA256 != canonicalDigest {
+			t.Fatalf("candidate digest boundary = report %q, candidate %q, runtime %q",
+				report.Candidate.ArtifactSHA256, expected.Candidate.ArtifactSHA256,
+				expected.AutoBinarySHA256)
+		}
+		return true, nil
+	}
+	if err := runWithVerifiers(fixture.arguments(strings.Repeat("e", 64)),
+		verifyActivePromotionArtifact, historicalVerifier); err != nil {
+		t.Fatalf("historical verification failed: %v", err)
+	}
+}
+
+func TestRun_HistoricalRejectsMismatchedCandidateDigest(t *testing.T) {
+	fixture := newHistoricalVerifierFixture(t)
+	verifierCalled := false
+	err := runWithVerifiers(
+		fixture.arguments(strings.Repeat("f", 64)),
+		verifyActivePromotionArtifact,
+		func([]byte, []byte, promptlayer.OMPContextPromotionExpectationV2) (bool, error) {
+			verifierCalled = true
+			return true, nil
+		},
+	)
+	if verifierCalled {
+		t.Fatal("historical verifier called for mismatched candidate digest")
+	}
+	if err == nil || err.Error() != "candidate coordinates differ from exact release source" {
+		t.Fatalf("mismatched candidate digest result = %v", err)
+	}
+}
+
+func TestParseOptions_RejectsNonCanonicalCandidateArtifactDigest(t *testing.T) {
+	for _, test := range []struct {
+		name, value string
+	}{
+		{"prefixed", "sha256:" + strings.Repeat("e", 64)},
+		{"uppercase", strings.Repeat("E", 64)},
+		{"wrong length", strings.Repeat("e", 63)},
+		{"non-hex", strings.Repeat("e", 63) + "g"},
+		{"whitespace", " " + strings.Repeat("e", 63)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := parseOptions([]string{
+				"--mode", "historical", "--report", "report", "--attestation", "attestation",
+				"--report-sha256", strings.Repeat("a", 64),
+				"--attestation-sha256", strings.Repeat("b", 64),
+				"--candidate-repository", "Insajin/autopus-adk",
+				"--candidate-revision", strings.Repeat("c", 40),
+				"--candidate-tree", strings.Repeat("d", 40),
+				"--candidate-artifact-sha256", test.value,
+				"--static-policy-b64", testStaticPolicyB64(t),
+			})
+			if err == nil || err.Error() != "candidate artifact digest is malformed" {
+				t.Fatalf("non-canonical candidate digest result = %v", err)
+			}
+		})
 	}
 }

--- a/scripts/companion-release/ompcontextverify/main_test.go
+++ b/scripts/companion-release/ompcontextverify/main_test.go
@@ -161,7 +161,10 @@ func newHistoricalVerifierFixture(t *testing.T) historicalVerifierFixture {
 			sessionSequences[variant]++
 			inputTokens, compactionRequests := int64(10000), 0
 			if variant == "B" {
-				inputTokens, compactionRequests = 7500, 1
+				inputTokens = 7500
+				if sessionSequences[variant] > 1 {
+					compactionRequests = 1
+				}
 			}
 			began := startedAt.Add(time.Duration(sequence*2) * time.Second)
 			report.Observations = append(report.Observations, promptlayer.OMPContextPromotionObservationV1{

--- a/templates/shared/omp-agent-pipeline.md.tmpl
+++ b/templates/shared/omp-agent-pipeline.md.tmpl
@@ -1,33 +1,54 @@
 # OMP Native Agent Pipeline
 
-This is the default multi-agent execution contract for `/auto go SPEC-ID` on OMP.
-Autopus owns the phase and quality policy; OMP owns subagent lifecycle through its native
-`task`, `hub`, and `todo` tools.
+This is the default multi-agent execution contract for
+`/auto go SPEC-ID [--execution-owner omp|orca]` on OMP.
+Autopus owns phase and quality policy; exactly one selected owner owns the task DAG.
 
 ## Activation
 
 | Flag | Execution |
 |---|---|
-| default | OMP-local task DAG |
-| `--solo` | current session performs the work directly |
-| `--team` | OMP-local task batch with explicit Lead/Builder/Guardian responsibilities |
-| `--multi` | normal gates plus risk-tiered provider dissent review |
+| omitted `--execution-owner` | owner `omp`, receipt source `default` |
+| `--execution-owner omp` | owner `omp`, receipt source `explicit` |
+| `--execution-owner orca` | owner `orca`, receipt source `explicit` |
+| `--solo` | owner `omp` current session performs the work directly |
+| `--team` | owner `omp` task batch with explicit Lead/Builder/Guardian responsibilities |
+| `--multi` | selected owner's normal gates plus risk-tiered provider dissent review |
 
-Choose one DAG owner before dispatch. OMP-local is the default. Orca-supervised execution
-is allowed only when the user explicitly asks for a supervised or durable cross-worktree run;
-in that case run and read `orca skills get orchestration --full` first and do not start a
-competing OMP DAG.
+Parse the owner exactly once before any `task`, DAG-owning `todo`, OMP subprocess, or Orca
+Run effect. Reject repeated, mixed, case-shifted, whitespace-padded, and aliased values; never
+fuzzy-correct or silently fall back. Omission alone selects `omp`. `--solo` and `--team` are
+OMP-only topology flags and conflict with owner `orca`.
+
+Persist `.autopus/pipeline-state/<SPEC-ID>.execution-owner.json` as a body-free
+`pipeline_execution_owner_receipt.v1`: owner, `default|explicit` source, reason, SPEC/run
+identity, `checked_at`, and `verification_status` only.
+
+- Owner `omp` uses native OMP `task`, `hub`, and `todo` and must not create an Orca Run.
+- Owner `orca` must not create an OMP task/todo DAG. Run and read
+  `orca skills get orchestration --full`, then use that current contract to create and supervise
+  one durable cross-worktree Run. A plain full handoff does not satisfy this topology.
+- `auto pipeline run SPEC-ID --platform omp --execution-owner orca` must return structured
+  `pipeline_execution_owner_result.v1` with `status=handoff_required` before any OMP
+  process/task creation. Act on that result; never retry it as owner `omp`.
 
 ## Native Tool Preflight
 
-Before Phase 1:
+Only owner `omp` executes this section. Owner `orca` skips it completely and follows the loaded
+Orca orchestration contract without initializing an OMP checklist or task DAG.
+
+Before Phase 1 for owner `omp`:
 
 1. Confirm that `task`, `hub`, and `todo` are available.
 2. Confirm whether batch mode and per-item isolation are present in the current `task` schema.
 3. Initialize the phase checklist with one top-level `todo` operation.
 4. Set `task_dispatch_count = 0`, `task_roles_dispatched = []`, and `degraded_mode = none`.
 5. If the selected topology cannot create and observe a native task, stop before implementation;
-   never silently fall back to a fake or prompt-only multi-agent run.
+   never silently fall back to a fake, prompt-only, or Orca-owned run.
+
+Every remaining native `task`/`hub`/`todo` instruction through the Completion Gate applies only
+to owner `omp`. Owner `orca` carries the same policy gates inside its one loaded-contract Run
+without creating this OMP DAG.
 
 Use one `task` call for each independent fan-out wave. Put shared goals, constraints, frozen
 context references, owned-path rules, and cross-task interfaces in top-level `context` once.
@@ -207,9 +228,18 @@ security findings, or failed tests. Preserve dissent and report degraded provide
 
 ## Progress and Ownership
 
-Only the main session owns `todo`. Workers report receipts and use `hub`; they do not mutate the
-parent checklist. Advance phases only after the prior phase receipt and gate are verified.
-Record `task_dispatch_count`, `task_roles_dispatched`, `degraded_mode`, and every blocker.
+For owner `omp`, only the main session owns `todo`. Workers report receipts and use `hub`; they
+do not mutate the parent checklist. Advance phases only after the prior phase receipt and gate are
+verified. Record `task_dispatch_count`, `task_roles_dispatched`, `degraded_mode`, and every
+blocker. For owner `orca`, the loaded orchestration Run is the only progress/DAG authority and
+the OMP session creates no parallel `todo` or `task` graph.
+
+## Status Evidence
+
+Generated `/auto status` first uses external `auto status` for project/SPEC lifecycle, then reads
+the current workspace execution-owner receipt and current-session OMP-native `hub` jobs state.
+Combine those sources to detect a competing DAG. The external CLI cannot inspect OMP user-session
+roots and must never pretend to replace native `hub` evidence.
 
 ## Completion Gate
 


### PR DESCRIPTION
## Summary
- make OMP the canonical task/hub execution owner with strict receipts, LSP edit ownership, and generated workflow parity
- add operator model/status/profile UX, including safe display-only fallback for the native OMP 17.2.7 catalog
- complete production-bound active-context evidence, signing, promotion, release verification, and fail-closed authority
- add auth-free native OMP CI smoke and user-facing OMP documentation

## Verification
- `go test -count=1 ./...` (all packages exercised; process-timeout failures under package-wide concurrency passed on sequential rerun)
- `go test -count=1 -p=1` for every timeout-affected package
- `go test -race -count=1 -p=1` for changed packages
- `golangci-lint v2.12.2`: 0 issues
- `go vet ./...`
- `govulncheck v1.6.0 ./...`: 0 reachable vulnerabilities
- `gitleaks v8.30.1 git`: no leaks
- `actionlint v1.7.7`
- live OMP 17.2.7 catalog and OpenAI Codex gateway smokes

## Release
Prepares the frozen v0.50.93 release path. The immutable active-context promotion evidence is produced after merge so it can bind the exact main commit, source tree, candidate digest, and compiled static policy.