### PR TITLE
fix(release): keep prep contracts portable

### DIFF
--- a/.github/workflows/omp-context-promote.yml
+++ b/.github/workflows/omp-context-promote.yml
@@ -407,14 +407,14 @@ jobs:
           GIT_INDEX_FILE="$evidence_index" git update-index --add \
             --cacheinfo "100644,$attestation_blob,omp-context-promotion-attestation.v2.json"
           evidence_tree=$(GIT_INDEX_FILE="$evidence_index" git write-tree)
-          evidence_commit=$(printf '%s\n' 'OMP context promotion evidence v0.50.96' |
+          published_commit=$(printf '%s\n' 'OMP context promotion evidence v0.50.96' |
             git -c user.name='github-actions[bot]' \
               -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
               commit-tree "$evidence_tree")
-          [[ "$(git rev-list --parents -n 1 "$evidence_commit")" == "$evidence_commit" ]] || fail 'published evidence is not an orphan'
+          [[ "$(git rev-list --parents -n 1 "$published_commit")" == "$published_commit" ]] || fail 'published evidence is not an orphan'
           git -c user.name='github-actions[bot]' \
             -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
-            -c tag.gpgSign=false tag -a omp-context-evidence-v0.50.96 "$evidence_commit" \
+            -c tag.gpgSign=false tag -a omp-context-evidence-v0.50.96 "$published_commit" \
               -m 'OMP context promotion evidence v0.50.96'
           tag_object=$(git rev-parse --verify "$tag_ref")
 
@@ -426,7 +426,7 @@ jobs:
           GIT_CONFIG_KEY_0='http.https://github.com/.extraheader' \
           GIT_CONFIG_VALUE_0="AUTHORIZATION: basic ${auth_header}" \
             git push --atomic --force-with-lease="${lock_ref}:${EVIDENCE_COMMIT}" origin \
-              "$tag_ref:$tag_ref" "$EVIDENCE_COMMIT:$lock_ref"
+              "$tag_ref:$tag_ref" "$published_commit:$lock_ref"
           unset auth_header
           remote_state=$(git ls-remote --refs origin "$tag_ref" "$lock_ref")
           [[ "$(awk -v ref="$tag_ref" '$2 == ref { print $0 }' <<<"$remote_state")" == "$tag_object"$'\t'"$tag_ref" ]] || fail 'published evidence tag differs'

--- a/.github/workflows/omp-context-promote.yml
+++ b/.github/workflows/omp-context-promote.yml
@@ -426,7 +426,7 @@ jobs:
           GIT_CONFIG_KEY_0='http.https://github.com/.extraheader' \
           GIT_CONFIG_VALUE_0="AUTHORIZATION: basic ${auth_header}" \
             git push --atomic --force-with-lease="${lock_ref}:${EVIDENCE_COMMIT}" origin \
-              "$tag_ref:$tag_ref" "$published_commit:$lock_ref"
+              "$tag_ref:$tag_ref" "$EVIDENCE_COMMIT:$lock_ref"
           unset auth_header
           remote_state=$(git ls-remote --refs origin "$tag_ref" "$lock_ref")
           [[ "$(awk -v ref="$tag_ref" '$2 == ref { print $0 }' <<<"$remote_state")" == "$tag_object"$'\t'"$tag_ref" ]] || fail 'published evidence tag differs'

--- a/internal/cli/companion_omp_context_promotion_attestation_workflow_test.go
+++ b/internal/cli/companion_omp_context_promotion_attestation_workflow_test.go
@@ -161,7 +161,7 @@ func TestOMPContextPromoteWorkflow_SeparatesSigningVerificationAndWriteAuthority
 		`--cacheinfo "100644,$report_blob,omp-context-promotion-report.v1.json"`,
 		`--cacheinfo "100644,$attestation_blob,omp-context-promotion-attestation.v2.json"`,
 		`commit-tree "$evidence_tree"`,
-		`git rev-list --parents -n 1 "$evidence_commit"`,
+		`git rev-list --parents -n 1 "$published_commit"`,
 		`tag -a omp-context-evidence-v0.50.96`,
 		`git push --atomic --force-with-lease="${lock_ref}:${EVIDENCE_COMMIT}"`,
 		`"$tag_ref:$tag_ref" "$EVIDENCE_COMMIT:$lock_ref"`,

--- a/scripts/companion-release/publish-release-coordinates.sh
+++ b/scripts/companion-release/publish-release-coordinates.sh
@@ -41,8 +41,15 @@ IFS= read -r static_policy_b64 <"$static_policy_file" || fail 'read static polic
 [[ "$static_policy_b64" =~ ^[A-Za-z0-9_-]+$ && ${#static_policy_b64} -le 21846 ]] || fail 'static policy is malformed'
 [[ "$(wc -l <"$static_policy_file" | tr -d ' ')" == '1' ]] || fail 'static policy file is not canonical'
 [[ -f "$tag_signing_key" && ! -L "$tag_signing_key" ]] || fail 'release tag signing key is unsafe'
-[[ "$(/usr/bin/stat -f '%u:%Lp' "$tag_signing_key")" == "$(id -u):600" ]] || fail 'release tag signing key ownership or mode is unsafe'
-for tool in awk gh git jq mktemp shasum ssh-keygen; do command -v "$tool" >/dev/null || fail "$tool is unavailable"; done
+for tool in awk gh git jq mktemp shasum ssh-keygen stat uname; do command -v "$tool" >/dev/null || fail "$tool is unavailable"; done
+tag_signing_key_owner_mode=''
+case "$(uname -s)" in
+  Darwin) tag_signing_key_owner_mode=$(/usr/bin/stat -f '%u:%Lp' "$tag_signing_key") ;;
+  Linux) tag_signing_key_owner_mode=$(stat -c '%u:%a' "$tag_signing_key") ;;
+  *) fail 'release tag signing key platform is unsupported' ;;
+esac
+readonly tag_signing_key_owner_mode
+[[ "$tag_signing_key_owner_mode" == "$(id -u):600" ]] || fail 'release tag signing key ownership or mode is unsafe'
 
 repo_root=$(git rev-parse --show-toplevel)
 [[ "$(pwd -P)" == "$repo_root" ]] || fail 'publisher must run at the repository root'


### PR DESCRIPTION
## Summary
- Avoid ShellCheck's case-collision false positive by naming the generated promotion commit independently from the operator-supplied prep-lock commit.
- Verify the local release signing key with BSD `stat` on Darwin and GNU `stat` on Linux so the production macOS path and Linux hardening fixture enforce the same owner/mode invariant.

## Verification
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7`
- `go test -race -count=1 -timeout=5m -run '^TestReleaseHardeningBashContract$' ./internal/companionmanifest`