### PR TITLE
fix(release): preserve canary validation failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ All notable changes to this project will be documented in this file.
 
 - **v0.50.96 live canary 결정성 복구** (2026-08-06): 20-pair release-prep cohort가 모호한 평가 문구로 모델의 tool 호출을 허용해 단일-turn lifecycle gate를 깨뜨리던 문제를 수정했다. 각 pair는 이제 tool·command 실행과 부가 텍스트를 명시적으로 금지하고 task index에 바인딩된 정확한 한 줄 출력을 요구해, AB/BA variant가 동일한 observable oracle을 결정적으로 비교한다.
 
+- **v0.50.96 canary 검증·cleanup의 Bash 3.2 상태 보존 수정** (2026-08-06): production canary 완료 후 `validate_canary`가 하나의 `local` 명령에서 `project`를 바인딩하면서 동시에 `$project` 기반 report 경로를 확장해 `set -u`에서 중단되던 문제와, `EXIT` trap 함수 진입 후 `$?`를 읽어 그 실패 상태를 `0`으로 덮던 문제를 수정했다. positional 인자를 먼저 바인딩한 뒤 report 경로를 별도 선언에서 파생하고, trap이 원래 status를 명시적 인자로 전달한다. 누락 report가 의도한 fail-closed 오류에 도달하고 cleanup이 실패 상태와 임시 디렉터리 삭제를 함께 보존하는 회귀 테스트를 추가했다.
+
 - **v0.50.95 실패·미게시 릴리스 시도 보존** (2026-08-05): production evidence, 전체 CI·보안·`83.2%` coverage는 통과했고 protected environment의 exact tag allowlist와 environment-level source pin도 수렴했지만, `macos-15` release job이 존재하지 않는 `/usr/bin/test`를 호출해 root-owned OMP canary materialization 단계에서 중단되었다. `v0.50.95` source tag와 zero-parent annotated `omp-context-evidence-v0.50.95` tag는 immutable 실패 기록으로 보존하며 삭제·이동·재사용하지 않는다. GitHub Release는 생성되지 않았고 Homebrew Formula/Cask도 변경되지 않았다.
 
 - **v0.50.94 실패·미게시 릴리스 시도 보존** (2026-08-04): A22 재시도는 변경하지 않은 전체 커버리지 기준 `83.0%`에 대해 `82.9%`가 두 차례 관측되어 게시 전에 중단되었다. `v0.50.94` source tag와 `omp-context-evidence-v0.50.94` tag/ref는 이 실패 시도의 immutable 기록이며 current release 좌표가 아니고 삭제·이동·재사용하지 않는다. 이 시도에서는 GitHub Release가 생성·게시되지 않았고 Homebrew Formula/Cask도 변경되지 않았다.

--- a/scripts/companion-release/prepare-release-runtime-lib.sh
+++ b/scripts/companion-release/prepare-release-runtime-lib.sh
@@ -14,7 +14,7 @@ remove_isolation_root() {
   [[ ! -e "$root" && ! -L "$root" ]]
 }
 cleanup() {
-  local status=$? remote_status=0 remote_source='' record cleanup_failed=0
+  local status=$1 remote_status=0 remote_source='' record cleanup_failed=0
   if [[ -n "$evidence_source_commit" && "$retain_prep_lock" -eq 0 ]]; then
     remote_source=$(git ls-remote --exit-code --refs origin "$evidence_source_ref" 2>/dev/null) || remote_status=$?
     if [[ "$remote_status" -eq 0 && "$remote_source" == "$evidence_source_commit"$'\t'"$evidence_source_ref" ]]; then
@@ -126,7 +126,8 @@ run_canary() {
   assert_source_identity
 }
 validate_canary() {
-  local project=$1 output=$2 candidate=$3 report="$project/.autopus/runtime/omp-context/promotion-report-v1.json" candidate_sha
+  local project=$1 output=$2 candidate=$3 candidate_sha
+  local report="$project/.autopus/runtime/omp-context/promotion-report-v1.json"
   [[ -f "$report" && ! -L "$report" ]] || fail 'production report is absent'
   candidate_sha=$(shasum -a 256 "$candidate" | awk '{print $1}')
   jq -s -e '([.[] | select(.type == "handshake")] | length) == 1 and ([.[] | select(.type == "call")] | length) == 40 and ([.[] | select(.type == "call") | .task_id_digest] | unique | length) == 20 and ([.[] | select(.type == "shutdown")] | length) == 1 and .[-1].cleanup_verified == true and .[-1].calls_completed == 40' "$output" >/dev/null || fail 'production canary transcript is invalid'

--- a/scripts/companion-release/prepare-release.sh
+++ b/scripts/companion-release/prepare-release.sh
@@ -110,7 +110,7 @@ rm -f -- "$runtime_lib"
 # shellcheck source=/dev/null
 source /dev/fd/9
 exec 9<&-
-trap cleanup EXIT
+trap 'cleanup $?' EXIT
 
 readonly staged_omp="$temp_dir/omp-v17.2.7"
 cp "$omp_executable" "$staged_omp"

--- a/scripts/companion-release/tests/release-prep-environment-inheritance-test.sh
+++ b/scripts/companion-release/tests/release-prep-environment-inheritance-test.sh
@@ -5,6 +5,7 @@ umask 077
 tests_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 script_dir=$(cd -- "$tests_dir/.." && pwd)
 runtime_lib="$script_dir/prepare-release-runtime-lib.sh"
+prep="$script_dir/prepare-release.sh"
 mock_gh="$tests_dir/testdata/mock-release-prep-gh.sh"
 temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/release-prep-environment.XXXXXX")
 trap 'rm -rf -- "$temp_dir"' EXIT
@@ -22,6 +23,17 @@ repository='Insajin/autopus-adk'
 environment_name='adk-companion-release'
 # shellcheck source=../prepare-release-runtime-lib.sh
 source "$runtime_lib"
+grep -Fq "trap 'cleanup \$?' EXIT" "$prep" ||
+  fail 'release prep does not pass the original exit status into cleanup'
+
+validation_error="$temp_dir/validation-error"
+if (validate_canary "$temp_dir/missing-project" "$temp_dir/missing-output" "$temp_dir/missing-candidate") 2>"$validation_error"; then
+  fail 'missing production report validation succeeded'
+fi
+grep -Fq 'production report is absent' "$validation_error" ||
+  fail 'canary validation failed before deriving its report path'
+! grep -Fq 'unbound variable' "$validation_error" ||
+  fail 'canary validation derived its report path before binding project'
 
 printf '%s\n' '[]' >"$state/environment-variables.json"
 environment_variables=$(gh variable list --repo "$repository" --env "$environment_name" --json name,value)
@@ -45,8 +57,22 @@ mkdir -p "$empty_cleanup_dir"
   retain_prep_lock=0
   isolation_roots=()
   temp_dir="$empty_cleanup_dir"
-  cleanup
+  cleanup 0
 ) || fail 'empty isolation cleanup failed'
 [[ ! -e "$empty_cleanup_dir" ]] || fail 'empty isolation cleanup left temporary state'
+
+failure_cleanup_dir="$temp_dir/failure-cleanup"
+mkdir -p "$failure_cleanup_dir"
+if (
+  evidence_source_commit=''
+  retain_prep_lock=0
+  isolation_roots=()
+  temp_dir="$failure_cleanup_dir"
+  trap 'cleanup $?' EXIT
+  false
+); then
+  fail 'cleanup erased a failing release-prep status'
+fi
+[[ ! -e "$failure_cleanup_dir" ]] || fail 'failing cleanup left temporary state'
 [[ "$(<"$state/write-count")" == '0' ]] || fail 'read-only checks mutated release state'
 printf 'release prep environment test: PASS\n'


### PR DESCRIPTION
## Summary
- bind `validate_canary` positional arguments before deriving the project-relative report path
- pass the original status into the release-prep `EXIT` trap instead of reading `$?` after function entry
- preserve fail-closed validation and cleanup behavior under macOS Bash 3.2 `set -u`

## Production reproduction
The first merged-source v0.50.96 bootstrap cohort completed all 40 calls, then `validate_canary` stopped at `/dev/fd/9: line 129: project: unbound variable`. The `EXIT` trap subsequently replaced that failure with status 0. No evidence/tag/release/prep-lock ref was created, and the root-owned isolation directory was removed.

## Verification
- `/bin/bash scripts/companion-release/tests/release-prep-environment-inheritance-test.sh`
- `go test -count=1 ./internal/companionmanifest -run "^(TestReleaseHardeningBashContract|TestReleaseScripts_SourceFilesStayBelowLimit)$"`