### PR TITLE
fix(release): launch local canary on Bash 3

### DIFF
--- a/scripts/companion-release/prepare-release-runtime-lib.sh
+++ b/scripts/companion-release/prepare-release-runtime-lib.sh
@@ -149,7 +149,8 @@ run_canary() {
   [[ "$candidate_sha" == "$isolated_candidate_sha" &&
      "$(shasum -a 256 "$isolated_omp" | awk '{print $1}')" == "$expected_omp_sha256" ]] ||
     fail 'root-owned canary executable bytes differ'
-  if [[ "$inherit_parent_sandbox" -eq 1 ]]; then sandbox_args=(--inherit-parent-sandbox); fi
+  sandbox_args=(--omp "$isolated_omp")
+  if [[ "$inherit_parent_sandbox" -eq 1 ]]; then sandbox_args+=(--inherit-parent-sandbox); fi
   kill -0 "$sudo_keepalive_pid" >/dev/null 2>&1 || fail 'sudo keepalive stopped before production canary'
   printf 'companion release prep: %s production canary started (40 sequential provider calls)\n' \
     "$label" >&2
@@ -172,7 +173,7 @@ run_canary() {
     --credential-locator "$credential_locator" --producer-repository "$repository" --producer-workflow-ref "$producer_workflow_ref" \
     --producer-run-id "$producer_run_id" --producer-run-attempt 1 --candidate-repository "$repository" \
     --policy-id omp-context-active-v1 --oracle-policy-digest "$oracle_policy_digest" --target-git-commit "$source_commit" \
-    --omp "$isolated_omp" "${sandbox_args[@]}" <"$input_jsonl" |
+    "${sandbox_args[@]}" <"$input_jsonl" |
     capture_canary_progress "$output" "$label"; then
     :
   else

--- a/scripts/companion-release/tests/release-runtime-hardening-test.sh
+++ b/scripts/companion-release/tests/release-runtime-hardening-test.sh
@@ -16,6 +16,8 @@ temp=$(mktemp -d "${TMPDIR:-/tmp}/release-hardening-test.XXXXXX")
 trap 'rm -rf -- "$temp"' EXIT
 runtime_lib="$script_dir/prepare-release-runtime-lib.sh"
 source "$runtime_lib"
+contains "$runtime_lib" 'sandbox_args=(--omp "$isolated_omp")'
+contains "$runtime_lib" '"${sandbox_args[@]}" <"$input_jsonl"'
 printf '%s\n' \
   '{"schema_version":"autopus.omp_context_observe_session_response.v1","type":"handshake"}' \
   '{"schema_version":"autopus.omp_context_observe_session_response.v1","type":"error","error_code":"network_transport","error_stage":"call","failed_sequence":17}' \


### PR DESCRIPTION
## Problem
The first post-merge release attempt stopped before provider call 1 because macOS Bash 3.2 treats `"${empty_array[@]}"` as an unbound variable under `set -u`.

## Fix
Seed the argument array with the mandatory `--omp` pair, then append the optional inherited-sandbox flag. The array is therefore always bound and non-empty.

## Evidence
- production attempt reached the start gate, failed before transcript record 1/provider call 1
- `bash -n scripts/companion-release/prepare-release-runtime-lib.sh`
- `bash scripts/companion-release/tests/release-runtime-hardening-test.sh`
- `bash scripts/companion-release/tests/release-prep-hardening-test.sh`