### PR TITLE
fix(release): reject unusable provider locators early

### DIFF
--- a/scripts/companion-release/prepare-release.sh
+++ b/scripts/companion-release/prepare-release.sh
@@ -41,7 +41,7 @@ done
 
 [[ "$(uname -s)" == 'Darwin' && "$(uname -m)" == 'arm64' ]] || fail 'release prep requires Darwin arm64'
 [[ "$endpoint" =~ ^http://127\.0\.0\.1:[1-9][0-9]{0,4}$ ]] || fail 'endpoint is not exact loopback HTTP'
-[[ "$credential_locator" =~ ^[A-Z][A-Z0-9_]{2,127}$ ]] || fail 'credential locator is malformed'
+[[ "$credential_locator" =~ ^AUTOPUS_OMP_CONTEXT_PROVIDER_[A-Z0-9_]{1,96}$ ]] || fail 'credential locator is malformed'
 [[ -n "${!credential_locator-}" && "${!credential_locator}" != *$'\n'* ]] ||
   fail 'provider credential is unavailable or not single-line'
 [[ "$provider" =~ ^[A-Za-z0-9_.-]+$ && "$model" =~ ^[A-Za-z0-9_.:/-]+$ ]] || fail 'provider or model is malformed'

--- a/scripts/companion-release/tests/release-prep-hardening-test.sh
+++ b/scripts/companion-release/tests/release-prep-hardening-test.sh
@@ -39,7 +39,7 @@ contains "$prep_lib" '/usr/bin/install -m 0555 -o root -g wheel "$candidate"'
 contains "$prep" 'assert_source_identity'
 contains "$prep" 'expected_tag_signer_fingerprint'
 contains "$prep" 'sudo_keepalive_pid=$!'; contains "$prep_lib" '/usr/bin/sudo -k'
-contains "$prep" 'omp-context-promotion-key-id'; contains "$prep" 'staged_promotion_signing_key='; contains "$prep" 'evidence_verification_mode=active'; contains "$prep" '/usr/bin/install -m 0600 "$tag_signing_key"'; trap_line=$(grep -nF 'trap bootstrap_cleanup EXIT' "$prep" | cut -d: -f1); key_stage_line=$(grep -nF 'staged_tag_signing_key=' "$prep" | cut -d: -f1); [[ "$trap_line" -lt "$key_stage_line" ]] || fail 'release prep stages keys before installing cleanup trap'
+contains "$prep" 'omp-context-promotion-key-id'; contains "$prep" 'staged_promotion_signing_key='; contains "$prep" 'evidence_verification_mode=active'; contains "$prep" '/usr/bin/install -m 0600 "$tag_signing_key"'; contains "$prep" '^AUTOPUS_OMP_CONTEXT_PROVIDER_[A-Z0-9_]{1,96}$'; trap_line=$(grep -nF 'trap bootstrap_cleanup EXIT' "$prep" | cut -d: -f1); key_stage_line=$(grep -nF 'staged_tag_signing_key=' "$prep" | cut -d: -f1); [[ "$trap_line" -lt "$key_stage_line" ]] || fail 'release prep stages keys before installing cleanup trap'
 contains "$prep_local_lib" 'ensure_prep_lock "$report"'; not_contains "$prep_local_lib" "--no-tags --depth=1 'https://github.com/Insajin/autopus-adk.git'"
 contains "$prep_lib" 'publish-release-coordinates.sh'
 contains "$publisher" 'gh variable set "${names[$index]}" --repo "$repository"'


### PR DESCRIPTION
## Problem
The second release invocation supplied a generic environment name accepted by `prepare-release.sh` but rejected by the actual observe-session contract, which requires `AUTOPUS_OMP_CONTEXT_PROVIDER_*`. It stopped before setup/provider call 1 with no transcript.

## Fix
Make release-prep validate the exact downstream locator namespace before sudo, builds, or canary startup.

## Evidence
- invalid locator rejected immediately with `credential locator is malformed`
- valid `AUTOPUS_OMP_CONTEXT_PROVIDER_GATEWAY` reaches observe-session setup in a no-call diagnostic
- `bash scripts/companion-release/tests/release-prep-hardening-test.sh`