### PR TITLE
fix(omp): native snapcompact 모델 capability를 보존

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **v0.50.98 native snapcompact 모델 capability 보존** (2026-08-04): production OMP catalog가 모든 provider 모델을 `input: [text]`로 덮어써 image-capable `openai-codex/gpt-5.6-sol`까지 LLM summary fallback으로 밀어내던 경계를 수정했다. 격리 catalog는 pinned OMP 17.2.7의 exact provider/model capability를 상속하고 unknown 모델은 OMP의 text-only 기본값을 유지한다. managed active startup은 선택된 모델 identity와 `text,image` input capability를 실제 `get_state`에서 확인하므로 native snapcompact를 수행할 수 없는 모델은 첫 provider call 전에 차단된다.
+
 - **v0.50.98 A22 결정적 재빌드·예약 수렴·canary 진단 강화** (2026-08-06): `v0.50.97` release job에서 pinned GoReleaser v2.17.0이 재생성한 unsigned binary와 preflight signed candidate의 서명 전 byte가 달랐으므로 실패 좌표를 재사용하지 않고 active A22 좌표를 `v0.50.98`로 전환했다. canonical candidate builder는 GoReleaser가 주입하는 8자리 short commit과 UTC `YYYY-MM-DDTHH:MM:SSZ` commit timestamp를 정확히 재현하며, operator-owned draft 생성 직후 GitHub Release 목록의 eventual consistency를 bounded retry로 흡수한다. bootstrap/final 40-call production canary는 시작·완료 진행률을 기록하고 실패 시 label, transcript record 수, exit status와 구조화된 `error_code`를 보존해 장시간 무출력과 원인 불명 실패를 구분한다.
 
 - **v0.50.97 A22 릴리스 좌표 재수렴** (2026-08-06): immutable `omp-context-evidence-v0.50.96`이 이미 v0.50.96 source에 바인딩된 뒤 publisher의 지원되지 않는 `gh variable list --limit` 옵션이 coordinate transaction을 차단했으므로, 증거 태그를 이동하거나 exact-source 실행 경계를 우회하지 않고 current A22 좌표를 `v0.50.97`로 전환했다. publisher는 공식 GitHub CLI list 계약으로 repository·protected environment snapshot을 읽고, workflow·preflight·promotion·lineage·Homebrew·current-release verifier와 회귀 fixture를 모두 새 tag/version에 원자적으로 맞춘다.

--- a/internal/cli/pipeline_backend_omp_protocol.go
+++ b/internal/cli/pipeline_backend_omp_protocol.go
@@ -52,13 +52,33 @@ type pipelineOMPRPCProtocol struct {
 	safeCompactionImages map[string]struct{}
 }
 
+type pipelineOMPModelState struct {
+	Provider string   `json:"provider"`
+	ID       string   `json:"id"`
+	Input    []string `json:"input"`
+}
+
 type pipelineOMPState struct {
-	SessionID             string `json:"sessionId"`
-	IsStreaming           *bool  `json:"isStreaming"`
-	IsCompacting          *bool  `json:"isCompacting"`
-	MessageCount          *int   `json:"messageCount"`
-	QueuedMessageCount    *int   `json:"queuedMessageCount"`
-	AutoCompactionEnabled *bool  `json:"autoCompactionEnabled"`
+	SessionID             string                 `json:"sessionId"`
+	IsStreaming           *bool                  `json:"isStreaming"`
+	IsCompacting          *bool                  `json:"isCompacting"`
+	MessageCount          *int                   `json:"messageCount"`
+	QueuedMessageCount    *int                   `json:"queuedMessageCount"`
+	AutoCompactionEnabled *bool                  `json:"autoCompactionEnabled"`
+	Model                 *pipelineOMPModelState `json:"model"`
+}
+
+func (state pipelineOMPState) supportsNativeImageCompaction(selector string) bool {
+	provider, modelID, ok := strings.Cut(selector, "/")
+	if !ok || state.Model == nil || state.Model.Provider != provider || state.Model.ID != modelID {
+		return false
+	}
+	text, image := false, false
+	for _, input := range state.Model.Input {
+		text = text || input == "text"
+		image = image || input == "image"
+	}
+	return text && image
 }
 
 func newPipelineOMPRPCProtocol(process *pipelineOMPProcess) *pipelineOMPRPCProtocol {

--- a/internal/cli/pipeline_omp_context_active_evaluator.go
+++ b/internal/cli/pipeline_omp_context_active_evaluator.go
@@ -47,7 +47,7 @@ func startPipelineOMPActiveEvaluatorSession(
 		return nil, err
 	}
 	protocol := newPipelineOMPRPCProtocol(process)
-	sessionID, err := protocol.initializeManaged(ctx)
+	sessionID, err := protocol.initializeManaged(ctx, candidate.Provider+"/"+candidate.Model)
 	if err != nil {
 		_ = process.Close()
 		return nil, err

--- a/internal/cli/pipeline_omp_context_active_process.go
+++ b/internal/cli/pipeline_omp_context_active_process.go
@@ -21,7 +21,7 @@ const (
 	pipelineOMPActiveEndpointKey    = "AUTOPUS_OMP_CONTEXT_PROVIDER_ENDPOINT"
 	pipelineOMPActiveCredentialKey  = "AUTOPUS_OMP_CONTEXT_PROVIDER_TOKEN"
 	pipelineOMPActiveRPCIdentity    = "autopus.omp-pipeline-managed-rpc.v3"
-	pipelineOMPActivePolicyIdentity = "manual-compact-completed-history-before-reused-call;canonical-ephemeral-readmission;correlated-ack;provider-bound-endpoint;auto-compaction=off;retry-off;ambient-off;sandbox=candidate-managed|producer-inherited-external-live-image-darwin-v3;tools=read,bash,edit,write,grep,glob,todo"
+	pipelineOMPActivePolicyIdentity = "manual-compact-completed-history-before-reused-call;canonical-ephemeral-readmission;correlated-ack;provider-bound-endpoint;model-image-capability=required;auto-compaction=off;retry-off;ambient-off;sandbox=candidate-managed|producer-inherited-external-live-image-darwin-v3;tools=read,bash,edit,write,grep,glob,todo"
 )
 
 const pipelineOMPActiveDefaultContextWindow = 262144
@@ -265,7 +265,9 @@ func writePipelineOMPActiveModels(runtimeRoot string, active pipelineOMPActivePr
 		}
 		sort.Strings(ids)
 		for _, id := range ids {
-			fmt.Fprintf(&body, "      - id: %s\n        name: Managed Active\n        reasoning: true\n        input: [text]\n        contextWindow: %d\n        maxTokens: 32768\n",
+			// Preserve capabilities from the pinned OMP catalog for known models; OMP defaults
+			// unknown custom models to text-only, which the managed startup gate rejects.
+			fmt.Fprintf(&body, "      - id: %s\n        name: Managed Active\n        reasoning: true\n        contextWindow: %d\n        maxTokens: 32768\n",
 				id, active.backend.ModelContextWindow)
 		}
 	}

--- a/internal/cli/pipeline_omp_context_active_rpc.go
+++ b/internal/cli/pipeline_omp_context_active_rpc.go
@@ -70,7 +70,7 @@ func newPipelineOMPActiveSessionStart(
 		protocol := newPipelineOMPRPCProtocol(process)
 		initializeCtx, cancel := context.WithTimeout(ctx, backend.MaxTime)
 		defer cancel()
-		sessionID, err := protocol.initializeManaged(initializeCtx)
+		sessionID, err := protocol.initializeManaged(initializeCtx, candidate.Provider+"/"+candidate.Model)
 		if err != nil {
 			_ = process.Close()
 			return nil, err
@@ -177,7 +177,7 @@ func (session *pipelineOMPActiveRPCSession) closeLocked() error {
 	return errors.Join(evidenceErr, session.process.Close())
 }
 
-func (protocol *pipelineOMPRPCProtocol) initializeManaged(ctx context.Context) (string, error) {
+func (protocol *pipelineOMPRPCProtocol) initializeManaged(ctx context.Context, selector string) (string, error) {
 	data, err := protocol.call(ctx, pipelineOMPRPCCommand{
 		Type: "negotiate_protocol", ProtocolVersion: pipelineOMPRPCProtocolVersion,
 	}, false)
@@ -201,6 +201,9 @@ func (protocol *pipelineOMPRPCProtocol) initializeManaged(ctx context.Context) (
 	state, err := protocol.readIdleState(ctx, "managed-start")
 	if err != nil || state.AutoCompactionEnabled == nil || *state.AutoCompactionEnabled {
 		return "", errors.New("managed active OMP compaction setting is unavailable")
+	}
+	if !state.supportsNativeImageCompaction(selector) {
+		return "", errors.New("managed active OMP native image compaction capability is unavailable")
 	}
 	return state.SessionID, nil
 }

--- a/internal/cli/pipeline_omp_context_active_rpc_execute.go
+++ b/internal/cli/pipeline_omp_context_active_rpc_execute.go
@@ -26,6 +26,9 @@ func (protocol *pipelineOMPRPCProtocol) executeManaged(
 	if err != nil || beforeState.SessionID != expectedSession {
 		return "", pipelineOMPActiveCallReceipt{}, errors.New("managed active OMP pre-prompt session changed")
 	}
+	if !beforeState.supportsNativeImageCompaction(model) {
+		return "", pipelineOMPActiveCallReceipt{}, errors.New("managed active OMP native image compaction capability is unavailable")
+	}
 	var preparedPrompt string
 	promptReady := false
 	rehydrationCalls := 0

--- a/internal/cli/pipeline_omp_context_active_rpc_integration_test.go
+++ b/internal/cli/pipeline_omp_context_active_rpc_integration_test.go
@@ -154,6 +154,30 @@ func TestPipelineOMPActiveProcessConfig_BindsProviderEndpointWithoutCredentialMa
 	assert.NotContains(t, string(serialized), "127.0.0.1")
 }
 
+func TestPipelineOMPActiveRPC_RejectsTextOnlyPhaseModelBeforeProviderCall(t *testing.T) {
+	session, _, logPath := pipelineOMPActiveRPCSessionFixture(t, false)
+	session.selector = "provider-a/model-text-only"
+
+	_, _, err := session.Execute(context.Background(), "safe plan phase")
+
+	require.ErrorContains(t, err, "native image compaction capability is unavailable")
+	_, commands := pipelineOMPRPCRecordsByKind(readPipelineOMPRPCRecords(t, logPath))
+	assert.Zero(t, countPipelineOMPRPCCommand(commands, "prompt"))
+	assert.Zero(t, countPipelineOMPRPCCommand(commands, "compact"))
+}
+
+func TestPipelineOMPActiveRPC_RejectsTextOnlyModelBeforeProviderCall(t *testing.T) {
+	session, _, logPath, err := pipelineOMPActiveRPCSessionFixtureWithModel(
+		t, "model-text-only", pipelineOMPActiveSandboxManaged,
+	)
+
+	require.ErrorContains(t, err, "native image compaction capability is unavailable")
+	assert.Nil(t, session)
+	_, commands := pipelineOMPRPCRecordsByKind(readPipelineOMPRPCRecords(t, logPath))
+	assert.Zero(t, countPipelineOMPRPCCommand(commands, "prompt"))
+	assert.Zero(t, countPipelineOMPRPCCommand(commands, "compact"))
+}
+
 func TestPipelineOMPActiveRPC_InheritedParentSandboxUsesDirectVerifiedImage(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("inherited parent sandbox is Darwin-only")
@@ -183,13 +207,24 @@ func pipelineOMPActiveRPCSessionFixtureWithSandbox(
 	sandboxMode pipelineOMPActiveSandboxMode,
 ) (*pipelineOMPActiveEvaluatorSession, pipelineOMPBackendConfig, string) {
 	t.Helper()
-	requireDarwinManagedOMPSandboxForTest(t)
-	config, _ := pipelineOMPBackendTestConfig(t)
-	config.Executable = os.Args[0]
 	model := "model-a"
 	if unsafe {
 		model = "model-unsafe"
 	}
+	session, config, logPath, err := pipelineOMPActiveRPCSessionFixtureWithModel(t, model, sandboxMode)
+	require.NoError(t, err)
+	return session, config, logPath
+}
+
+func pipelineOMPActiveRPCSessionFixtureWithModel(
+	t *testing.T,
+	model string,
+	sandboxMode pipelineOMPActiveSandboxMode,
+) (*pipelineOMPActiveEvaluatorSession, pipelineOMPBackendConfig, string, error) {
+	t.Helper()
+	requireDarwinManagedOMPSandboxForTest(t)
+	config, _ := pipelineOMPBackendTestConfig(t)
+	config.Executable = os.Args[0]
 	logPath := filepath.Join(config.ProjectDir, "active-native-rpc.jsonl")
 	config.PhaseModels = map[pipeline.PhaseID]string{pipeline.PhasePlan: "provider-a/" + model}
 	config.Environment = append(config.Environment,
@@ -216,8 +251,7 @@ func pipelineOMPActiveRPCSessionFixtureWithSandbox(
 	session, err := startPipelineOMPActiveEvaluatorSession(
 		context.Background(), config, candidate, prepared, true, sandboxMode,
 	)
-	require.NoError(t, err)
-	return session, config, logPath
+	return session, config, logPath, err
 }
 
 func pipelineOMPActiveNativeFixture(args []string) (string, string, bool) {
@@ -277,6 +311,21 @@ func runPipelineOMPActiveRPCFixture() int {
 	messageCount, promptCount, compactionCount := 0, 0, 0
 	inputTokens, outputTokens, cacheReadTokens := int64(0), int64(0), int64(0)
 	transcript := []json.RawMessage{json.RawMessage(`{"role":"system","content":"safe system context"}`)}
+	provider, modelID := "", ""
+	for index := 0; index+1 < len(os.Args); index++ {
+		if os.Args[index] != "--model" {
+			continue
+		}
+		provider, modelID, _ = strings.Cut(os.Args[index+1], "/")
+		break
+	}
+	if provider == "" || modelID == "" {
+		return 80
+	}
+	modelInput := []string{"text", "image"}
+	if modelID == "model-text-only" {
+		modelInput = []string{"text"}
+	}
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
 		var command pipelineOMPRPCCommand
@@ -291,10 +340,18 @@ func runPipelineOMPActiveRPCFixture() int {
 		switch command.Type {
 		case "negotiate_protocol":
 			writePipelineOMPActiveResponse(output, command, map[string]any{"protocolVersion": 2})
+		case "set_model":
+			provider, modelID = command.Provider, command.ModelID
+			modelInput = []string{"text", "image"}
+			if modelID == "model-text-only" {
+				modelInput = []string{"text"}
+			}
+			writePipelineOMPActiveResponse(output, command, nil)
 		case "get_state":
 			writePipelineOMPActiveResponse(output, command, map[string]any{
 				"sessionId": "active-session", "isStreaming": false, "isCompacting": false,
 				"messageCount": messageCount, "queuedMessageCount": 0, "autoCompactionEnabled": false,
+				"model": map[string]any{"provider": provider, "id": modelID, "input": modelInput},
 			})
 		case "get_session_stats":
 			writePipelineOMPActiveResponse(output, command, map[string]any{

--- a/internal/cli/pipeline_omp_context_active_test.go
+++ b/internal/cli/pipeline_omp_context_active_test.go
@@ -172,6 +172,7 @@ func TestWritePipelineOMPActiveModels_BindsConfiguredContextWindow(t *testing.T)
 	require.NoError(t, err)
 	assert.Contains(t, string(body), "contextWindow: 1000000")
 	assert.NotContains(t, string(body), "contextWindow: 262144")
+	assert.NotContains(t, string(body), "input:")
 }
 
 func TestConfigurePipelineOMPActiveSandbox_InheritedParentSkipsInnerWrapperOnDarwin(t *testing.T) {

--- a/internal/cli/workflow_context_runtime_implementation_identity_test.go
+++ b/internal/cli/workflow_context_runtime_implementation_identity_test.go
@@ -18,7 +18,7 @@ func TestWorkflowContextImplementationIdentityCommand(t *testing.T) {
 	var identity workflowContextImplementationIdentityV1
 	require.NoError(t, json.Unmarshal(output.Bytes(), &identity))
 	require.Equal(t, workflowContextImplementationIdentitySchemaV1, identity.SchemaVersion)
-	require.Equal(t, "sha256:dd7be49d3342e54abffde9c8c3256cec68db5340d003267230f856774ad7ee0a",
+	require.Equal(t, "sha256:9d858448649f91b5476d2b60e7b3d8b40be52806f647dc5723e8500ecc57f96a",
 		identity.PipelineImplementationDigest)
 	require.Equal(t, "autopus.omp-pipeline-managed-rpc.v3", identity.RPCIdentity)
 	require.Equal(t, pipelineOMPActivePolicyIdentity, identity.PolicyIdentity)


### PR DESCRIPTION
## 문제
- v0.50.98 40-call production canary가 provider call 17에서 `runtime_failed`로 중단됐습니다.
- OMP 17.2.7의 native `compact`는 모델 입력 modality가 생략되면 `text` 기본값으로 해석해 `snapcompact needs a vision-capable model`로 실패했습니다.

## 수정
- 생성하는 `models.yml`에 pinned OMP catalog의 `input` capability와 정확한 `contextWindow`를 상속합니다.
- managed startup 및 매 phase `set_model` 뒤 `get_state`에서 image compaction capability를 fail-close 검증합니다.
- 구현 identity digest와 릴리스 변경 로그를 갱신했습니다.

## 검증
- `go test ./internal/cli -count=1`
- `go test ./pkg/promptlayer ./pkg/adapter/omp ./pkg/config -count=1`
- `go vet ./...`
- `bash scripts/companion-release/tests/release-prep-hardening-test.sh`
- `go run ./cmd/auto spec validate .autopus/specs/SPEC-OMP-004 --strict`
- installed OMP 17.2.7 direct RPC smoke: inherited `input=[text,image]`, native snapcompact 성공, `preserveData` 확인, provider call 0

전체 `go test ./... -count=1`은 병렬 부하에서 기존 2초 경계 테스트 4건이 초과해 실패했고, 실패한 `pkg/content` 및 `pkg/worker/setup` 테스트는 패키지별 재실행에서 통과했습니다.