### PR TITLE
fix(release): 게시된 promotion report의 sha256 접두 digest 수용

### DIFF
--- a/internal/companionmanifest/release_current_evidence_fixture_test.go
+++ b/internal/companionmanifest/release_current_evidence_fixture_test.go
@@ -96,7 +96,7 @@ func newCurrentReleaseFixture(t *testing.T) *currentReleaseFixture {
 	assetBodies["checksums.txt.signatures"] = []byte("AUTOPUS-RELEASE-SIGNATURE-V1\n" +
 		"e1fdfe066484c7eae8ff16fa4b1ee6237b8d06299c2b66ced485f029af77837f\tMAYCAQECAQE=\n")
 	assetBodies["omp-context-promotion-report.v1.json"] = []byte(
-		`{"candidate":{"artifact_sha256":"` + strings.Repeat("a", 64) + `"}}`)
+		`{"candidate":{"artifact_sha256":"sha256:` + strings.Repeat("a", 64) + `"}}`)
 	assetBodies["omp-context-promotion-attestation.v2.json"] = []byte("fixture attestation\n")
 	assetBodies["release-lineage-v1.json"] = lineage
 	assetBodies["release-lineage-v1.sig"] = lineageSignature

--- a/scripts/companion-release/verify-current-release.sh
+++ b/scripts/companion-release/verify-current-release.sh
@@ -262,7 +262,7 @@ env -i PATH="$PATH" HOME="${HOME:-/}" TMPDIR="${TMPDIR:-/tmp}" \
   || fail 'A22 release signature evidence is invalid'
 
 candidate_artifact_sha=$(jq -er '.candidate.artifact_sha256 |
-  select(type == "string" and test("^[0-9a-f]{64}$"))' "$downloaded_report") \
+  select(type == "string" and test("^sha256:[0-9a-f]{64}$")) | ltrimstr("sha256:")' "$downloaded_report") \
   || fail 'released OMP candidate artifact digest is malformed'
 distributed_artifact_sha=$(jq -er '.artifact_digest |
   select(type == "string" and test("^sha256:[0-9a-f]{64}$"))' "$archive_manifest") \


### PR DESCRIPTION
## Problem

v0.50.102 published every asset and then failed its own post-publish check:

```
current release evidence: released OMP candidate artifact digest is malformed
```

`verify-current-release.sh` required a bare digest from the published report:

```sh
candidate_artifact_sha=$(jq -er '.candidate.artifact_sha256 |
  select(type == "string" and test("^[0-9a-f]{64}$"))' "$downloaded_report")
```

But the canary always writes the prefixed form, and `validate_canary` asserts exactly that (`.candidate.artifact_sha256 == "sha256:${candidate_sha}"`). Both the v0.50.100 evidence and the freshly published v0.50.102 asset carry `sha256:<hex>`, so this check could never pass against a real release. It went unnoticed because earlier coordinates failed before reaching this step.

## Change

Extract the digest in the shape the report actually uses and strip the prefix, keeping both downstream consumers correct: the lineage verifier still receives `sha256:<hex>` and `ompcontextverify` still receives bare hex.

```sh
candidate_artifact_sha=$(jq -er '.candidate.artifact_sha256 |
  select(type == "string" and test("^sha256:[0-9a-f]{64}$")) | ltrimstr("sha256:")' "$downloaded_report")
```

The current-release fixture encoded the same wrong shape (bare hex), so it now emits the prefixed digest a real release produces.

## Verification

- `go test -count=1 ./internal/companionmanifest ./pkg/companionmanifest`
- every `scripts/companion-release/tests/*.sh` hardening script passes
- the corrected jq extracts `aaf7855dd8ff760d5e34d31bbe1129342cb7834ad431156d59e65da0b3745deb` from the published v0.50.102 `omp-context-promotion-report.v1.json`
