### PR TITLE
fix(config): Codex 최상위 모델 부재 시 같은 세대로 폴백

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Codex 최상위 모델 부재 시 세대를 건너뛰던 폴백** (2026-08-09): 요청한 Codex 모델이 런타임 카탈로그에 없으면 해결기가 카탈로그의 나머지를 무시하고 하드코딩된 `gpt-5.5`로 직행했다. 프론티어 모델 권한이 없는 ChatGPT 계정도 같은 세대의 균형 모델(`gpt-5.6-terra`)은 광고하므로, 최상위 티어 요청이 오히려 한 세대 낮은 모델로 떨어졌다 — 티어를 올리지 않았을 때보다 나쁜 결과다. 이제 프론티어 요청은 같은 세대 균형 모델을 먼저 시도한 뒤에만 legacy로 내려간다. 균형·소형 티어의 폴백은 바뀌지 않는다: 소형 티어는 명시적으로 싼 모델이므로 더 큰 모델의 대체재로 승격하지 않는다. 카탈로그에 아는 모델이 하나도 없으면 종전대로 런타임 기본값에 위임한다. 폴백은 이미 `Codex model fallback: requested=... selected=... reason=model_unavailable`로 stderr에 보고되고 있었고 그 형식도 그대로다.
+
 ### Added
 
 - **`balanced` 프리셋에서 executor를 최상위 티어로 승격** (2026-08-09): 기본 품질 프리셋이 `planner`·`architect`·`spec-writer`·`security-auditor`에만 주던 최상위 티어를 `executor`에도 준다. 근거: 여유가 남아 있던 유일한 Go 시맨틱 과제군에서 프론티어 티어가 42/45, 중간 티어가 36/45였고 어떤 멀티에이전트 구성도 그 격차를 메우지 못했다(최선의 논증 장치는 5콜에 40/45). 그 문항들은 "코드가 정확히 무엇을 하는지 예측"하는 executor형 과제이며, executor의 산출물은 이후 모든 역할이 검토하는 대상이다. 측정된 적 없는 열린 판단 역할(planner·architect·spec-writer)의 티어는 근거 부재를 강등 사유로 삼지 않고 그대로 둔다. Codex 매핑에서 최상위 티어는 모델과 reasoning effort를 함께 올리므로 executor는 `gpt-5.6-terra`/`medium`에서 `gpt-5.6-sol`/`xhigh`로 바뀌며, 카탈로그가 해당 모델을 광고하지 않는 환경에서는 기존 opus 역할과 동일하게 `gpt-5.5`로 폴백한다. `tester`·`reviewer`·`debugger`·`devops`·`validator`·`explorer`는 중간 티어로 남고 `ultra` 프리셋은 바뀌지 않는다.

--- a/pkg/config/codex_profile.go
+++ b/pkg/config/codex_profile.go
@@ -185,6 +185,22 @@ func (c CodexModelCatalog) Supports(model, effort string) bool {
 	return ok && entry.supportsEffort(effort)
 }
 
+// codexModelFallbackCandidates lists substitutes to try, best first, when the
+// requested model is absent from the runtime catalog.
+//
+// Only the frontier tier gains a same-generation step. An account that is not
+// entitled to the frontier model still has the current-generation balanced
+// model, which is a closer substitute than skipping a whole generation down to
+// the legacy slug. The balanced and small tiers keep legacy-only behaviour: the
+// small tier is explicitly the cheap model and is not a defensible stand-in for
+// a larger one.
+func codexModelFallbackCandidates(requested string) []string {
+	if requested == CodexSolModel {
+		return []string{CodexTerraModel, CodexLegacyModel}
+	}
+	return []string{CodexLegacyModel}
+}
+
 // ResolveCodexProfile resolves a requested profile against a runtime catalog.
 func ResolveCodexProfile(requested CodexProfile, catalogJSON []byte) CodexProfileResolution {
 	catalog, err := ParseCodexModelCatalog(catalogJSON)
@@ -203,27 +219,30 @@ func ResolveCodexProfile(requested CodexProfile, catalogJSON []byte) CodexProfil
 
 	model, ok := catalog.findModel(requested.Model)
 	if !ok {
-		legacy, legacyOK := catalog.findModel(CodexLegacyModel)
-		if !legacyOK {
-			return CodexProfileResolution{
-				Requested: requested,
-				Fallback:  true,
-				Reason:    CodexResolutionRuntimeDefault,
+		for _, candidate := range codexModelFallbackCandidates(requested.Model) {
+			entry, entryOK := catalog.findModel(candidate)
+			if !entryOK {
+				continue
 			}
-		}
-		legacyEffort, effortOK := legacy.highestCompatibleEffort(capLegacyCodexEffort(requested.Effort))
-		if !effortOK {
+			wanted := requested.Effort
+			if candidate == CodexLegacyModel {
+				wanted = capLegacyCodexEffort(wanted)
+			}
+			effort, effortOK := entry.highestCompatibleEffort(wanted)
+			if !effortOK {
+				continue
+			}
 			return CodexProfileResolution{
 				Requested: requested,
+				Effective: CodexProfile{Model: candidate, Effort: effort},
 				Fallback:  true,
-				Reason:    CodexResolutionRuntimeDefault,
+				Reason:    CodexResolutionModelUnavailable,
 			}
 		}
 		return CodexProfileResolution{
 			Requested: requested,
-			Effective: CodexProfile{Model: CodexLegacyModel, Effort: legacyEffort},
 			Fallback:  true,
-			Reason:    CodexResolutionModelUnavailable,
+			Reason:    CodexResolutionRuntimeDefault,
 		}
 	}
 	if model.supportsEffort(requested.Effort) {

--- a/pkg/config/codex_profile_fallback_test.go
+++ b/pkg/config/codex_profile_fallback_test.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A ChatGPT account that is not entitled to the frontier model still lists the
+// current-generation balanced model. Resolving to the legacy slug there turns a
+// top-tier request into a generation downgrade, which is worse than the mid
+// tier the caller would have gotten without asking for the top tier at all.
+func TestResolveCodexProfile_FrontierMissingPrefersSameGeneration(t *testing.T) {
+	t.Parallel()
+	// Shape of a real `codex debug models` payload without gpt-5.6-sol.
+	catalog := []byte(`{"models":[
+		{"slug":"gpt-5.6-terra","supported_reasoning_levels":[{"effort":"medium"},{"effort":"high"},{"effort":"xhigh"},{"effort":"max"}]},
+		{"slug":"gpt-5.6-luna","supported_reasoning_levels":[{"effort":"medium"},{"effort":"xhigh"}]},
+		{"slug":"gpt-5.5","supported_reasoning_levels":[{"effort":"xhigh"}]}
+	]}`)
+
+	got := ResolveCodexProfile(CodexProfile{Model: CodexSolModel, Effort: CodexEffortXHigh}, catalog)
+
+	assert.Equal(t, CodexResolutionModelUnavailable, got.Reason)
+	assert.True(t, got.Fallback)
+	assert.Equal(t, CodexProfile{Model: CodexTerraModel, Effort: CodexEffortXHigh}, got.Effective)
+}
+
+// With no same-generation substitute present, the legacy slug is still the
+// answer — the new step must not strand callers on older catalogs.
+func TestResolveCodexProfile_FrontierMissingFallsBackToLegacyWithoutMidTier(t *testing.T) {
+	t.Parallel()
+	catalog := []byte(`{"models":[{"slug":"gpt-5.5","supported_reasoning_levels":[{"effort":"xhigh"}]}]}`)
+
+	got := ResolveCodexProfile(CodexProfile{Model: CodexSolModel, Effort: CodexEffortUltra}, catalog)
+
+	assert.Equal(t, CodexResolutionModelUnavailable, got.Reason)
+	assert.Equal(t, CodexProfile{Model: CodexLegacyModel, Effort: CodexEffortXHigh}, got.Effective)
+}
+
+// The small tier is the explicitly cheap model, so it is never promoted into a
+// substitute for a larger one: a missing balanced tier still lands on legacy
+// even when the small tier is available.
+func TestResolveCodexProfile_MidTierMissingSkipsSmallTier(t *testing.T) {
+	t.Parallel()
+	catalog := []byte(`{"models":[
+		{"slug":"gpt-5.6-luna","supported_reasoning_levels":[{"effort":"medium"},{"effort":"xhigh"},{"effort":"max"}]},
+		{"slug":"gpt-5.5","supported_reasoning_levels":[{"effort":"xhigh"}]}
+	]}`)
+
+	got := ResolveCodexProfile(CodexProfile{Model: CodexTerraModel, Effort: CodexEffortMax}, catalog)
+
+	assert.Equal(t, CodexResolutionModelUnavailable, got.Reason)
+	assert.Equal(t, CodexProfile{Model: CodexLegacyModel, Effort: CodexEffortXHigh}, got.Effective)
+}
+
+// Nothing recognisable in the catalog must still defer to the runtime default
+// rather than inventing a model the account cannot call.
+func TestResolveCodexProfile_NoKnownSubstituteDefersToRuntime(t *testing.T) {
+	t.Parallel()
+	catalog := []byte(`{"models":[{"slug":"other-model","supported_reasoning_levels":[{"effort":"medium"}]}]}`)
+
+	got := ResolveCodexProfile(CodexProfile{Model: CodexSolModel, Effort: CodexEffortXHigh}, catalog)
+
+	assert.Equal(t, CodexResolutionRuntimeDefault, got.Reason)
+	assert.True(t, got.Fallback)
+	assert.Empty(t, got.Effective.Model)
+}


### PR DESCRIPTION
## Problem

When a requested Codex model is absent from the runtime catalog, `ResolveCodexProfile` ignores the rest of the catalog and jumps straight to a hardcoded `CodexLegacyModel = "gpt-5.5"`.

That is a generation skip, not a degradation. A real `codex debug models` payload on a ChatGPT account without frontier entitlement:

```
gpt-5.6-terra  gpt-5.6-luna  gpt-5.5  gpt-5.4-mini  codex-auto-review
```

`gpt-5.6-terra` is right there. So asking for the top tier produced a *worse* model than not asking:

| role | requested | before |
|---|---|---|
| planner (top tier) | `gpt-5.6-sol`/xhigh | `gpt-5.5`/xhigh |
| tester (mid tier) | `gpt-5.6-terra`/medium | `gpt-5.6-terra`/medium |

The top-tier role ended up a generation behind the mid-tier role. This surfaced while verifying #151, which moved `executor` to the top tier: on such a catalog the promotion silently became `gpt-5.6-terra`/medium -> `gpt-5.5`/xhigh.

## Change

A missing frontier model now tries the same-generation balanced model before the legacy slug.

Only the frontier tier gains that step. Balanced and small tiers keep legacy-only behaviour on purpose: the small tier is explicitly the cheap model and is not a defensible stand-in for a larger one, so `terra -> luna` is deliberately *not* introduced. A catalog with no known model still defers to the runtime default.

The existing stderr report is unchanged in shape.

## Verification

Same machine, real `auto init --quality balanced --platforms codex`:

```
            before                    after
planner     gpt-5.5       xhigh       gpt-5.6-terra  xhigh
executor    gpt-5.5       xhigh       gpt-5.6-terra  xhigh
tester      gpt-5.6-terra medium      gpt-5.6-terra  medium

Codex model fallback: requested=gpt-5.6-sol/xhigh selected=gpt-5.6-terra/xhigh reason=model_unavailable
```

The #151 promotion now means "same current-generation model, more reasoning effort" instead of "one generation older".

- `go test ./...` passes
- every `scripts/companion-release/tests/*.sh` hardening script passes
- `gofmt -l`, `go vet ./...`, `git diff --check` clean

No existing catalog fixture contained the balanced model without the frontier model, so the old behaviour was untested in exactly the case that matters. New tests pin: frontier missing prefers the same generation, frontier missing still reaches legacy when no same-generation model exists, a missing balanced tier skips the small tier and lands on legacy, and an unrecognisable catalog defers to the runtime default. Mutation-checked — reverting the ladder to legacy-only fails the first test.
