### PR TITLE
fix(orchestra): 임시 디렉토리 GC가 소유하지 않은 경로를 지우지 않도록

### DIFF
--- a/pkg/adapter/omp/omp_context_bridge_live_test.go
+++ b/pkg/adapter/omp/omp_context_bridge_live_test.go
@@ -132,7 +132,9 @@ func runOMPContextBridgeStartup(
 	expectedBridgeEvents int,
 ) ([][]byte, string) {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+	// Backstop only. omp enforces its own --max-time below; a Go-side deadline
+	// close to it preempts the tool under load and reports a false rpc_timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, executable,
 		"--mode", "rpc",

--- a/pkg/adapter/omp/omp_model_probe_process_test.go
+++ b/pkg/adapter/omp/omp_model_probe_process_test.go
@@ -34,9 +34,7 @@ printf 'cwd=%s\n' "$PWD"
 	process, err := NewOMPModelProbeProcess(executable, 4096)
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	output, err := process.Run(ctx, "models", "--json")
+	output, err := process.Run(t.Context(), "models", "--json")
 	require.NoError(t, err)
 	text := string(output)
 	assert.Contains(t, text, "args=models --json\n")
@@ -116,12 +114,14 @@ func TestOMPModelProbeProcess_RunEnforcesOutputLimit(t *testing.T) {
 	process, err := NewOMPModelProbeProcess(executable, 64)
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	// The ceiling only bounds a broken limiter. The contract is that the overflow,
+	// not the deadline, ends the run — so ctx must still be live on return. An
+	// absolute wall-clock bound here instead measures machine load.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	started := time.Now()
 	output, err := process.Run(ctx, "models", "--json")
 	assert.ErrorIs(t, err, processprobe.ErrOutputLimit)
-	assert.Less(t, time.Since(started), 2*time.Second)
+	assert.NoError(t, ctx.Err(), "overflow must terminate the run before the deadline")
 	assert.LessOrEqual(t, len(output), 64)
 }
 

--- a/pkg/adapter/omp/omp_readiness_runner_test.go
+++ b/pkg/adapter/omp/omp_readiness_runner_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,9 +26,7 @@ printf 'args=%s\n' "$*"
 	t.Setenv("PATH", binDir)
 
 	runner := commandOMPProbeRunner{maxOutput: 4096}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	output, err := runner.Run(ctx, filepath.Base(executable),
+	output, err := runner.Run(t.Context(), filepath.Base(executable),
 		"--config", filepath.Join(profile, "config.yml"), "models", "--json")
 	require.NoError(t, err)
 	assert.Equal(t,

--- a/pkg/content/hook_round_cursor_contract_test.go
+++ b/pkg/content/hook_round_cursor_contract_test.go
@@ -178,7 +178,10 @@ func runCursorHookAtRound(
 			t.Skip("bun is required for the OpenCode hook contract test")
 		}
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	// Backstop only. Each hook run forks python3 several times, so a tight bound
+	// measures machine load; a hook that wrongly enters its ready/abort wait loop
+	// blocks for MAX_WAIT (120s) and still trips this deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, command, script)
 	payload, err := json.Marshal(map[string]string{hook.payloadKey: output})

--- a/pkg/orchestra/job.go
+++ b/pkg/orchestra/job.go
@@ -125,9 +125,11 @@ func (j *Job) Cleanup() error {
 	return os.RemoveAll(j.Dir)
 }
 
-// CleanupStaleJobs scans baseDir for job subdirectories containing JSON files
-// and removes those whose CreatedAt + ttl is in the past. Returns the count removed.
+// CleanupStaleJobs scans baseDir for orchestra job records and removes the ones
+// whose CreatedAt + ttl is in the past. Returns the count removed.
 // @AX:NOTE [AUTO] REQ-11 opportunistic GC — called at start of every orchestra command; scans both flat and nested job dirs
+// SEC: baseDir is the shared system temp dir, so a removal target is only ever a
+// directory that an owned job record claims — never a path named by foreign JSON.
 func CleanupStaleJobs(baseDir string, ttl time.Duration) (int, error) {
 	entries, err := os.ReadDir(baseDir)
 	if err != nil {
@@ -138,51 +140,68 @@ func CleanupStaleJobs(baseDir string, ttl time.Duration) (int, error) {
 	for _, e := range entries {
 		if e.IsDir() {
 			// Scan subdirectory for job JSON files
-			subDir := filepath.Join(baseDir, e.Name())
-			n, _ := cleanupJobsInDir(subDir, cutoff)
+			n, _ := cleanupJobsInDir(filepath.Join(baseDir, e.Name()), cutoff)
 			removed += n
 			continue
 		}
-		if !strings.HasSuffix(e.Name(), ".json") {
+		job, ok := staleJobRecord(baseDir, e.Name(), cutoff)
+		if !ok {
 			continue
 		}
-		id := strings.TrimSuffix(e.Name(), ".json")
-		job, err := LoadJob(baseDir, id)
-		if err != nil {
-			continue
+		if ownedJobDir(baseDir, job.Dir) {
+			_ = os.RemoveAll(job.Dir)
 		}
-		if job.CreatedAt.Before(cutoff) {
-			if job.Dir != "" {
-				_ = os.RemoveAll(job.Dir)
-			}
-			_ = os.Remove(filepath.Join(baseDir, e.Name()))
-			removed++
-		}
+		_ = os.Remove(filepath.Join(baseDir, e.Name()))
+		removed++
 	}
 	return removed, nil
 }
 
-// cleanupJobsInDir removes stale jobs found as JSON files in dir.
+// cleanupJobsInDir removes dir when it holds a stale job record that claims it.
 func cleanupJobsInDir(dir string, cutoff time.Time) (int, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return 0, err
 	}
-	removed := 0
 	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+		if e.IsDir() {
 			continue
 		}
-		id := strings.TrimSuffix(e.Name(), ".json")
-		job, err := LoadJob(dir, id)
-		if err != nil {
+		job, ok := staleJobRecord(dir, e.Name(), cutoff)
+		if !ok || filepath.Clean(job.Dir) != dir {
 			continue
 		}
-		if job.CreatedAt.Before(cutoff) {
-			_ = os.RemoveAll(dir)
-			removed++
-			break // directory removed, no more files to check
+		if err := os.RemoveAll(dir); err != nil {
+			return 0, err
 		}
+		return 1, nil
 	}
-	return removed, nil
+	return 0, nil
+}
+
+// staleJobRecord loads dir/name as a job record and reports whether it is an
+// orchestra-owned record that has outlived cutoff. Ownership needs the round
+// trip Save() guarantees: the file stem is the job ID and CreatedAt is set.
+// Without that check any foreign JSON object sharing the temp dir decodes into
+// a zero Job whose zero CreatedAt reads as infinitely stale.
+func staleJobRecord(dir, name string, cutoff time.Time) (*Job, bool) {
+	id, isJSON := strings.CutSuffix(name, ".json")
+	if !isJSON {
+		return nil, false
+	}
+	job, err := LoadJob(dir, id)
+	if err != nil || job.ID != id || job.CreatedAt.IsZero() || !job.CreatedAt.Before(cutoff) {
+		return nil, false
+	}
+	return job, true
+}
+
+// ownedJobDir reports whether target is a path strictly inside baseDir, which
+// keeps a removal from escaping the scanned root or wiping the root itself.
+func ownedJobDir(baseDir, target string) bool {
+	if target == "" {
+		return false
+	}
+	rel, err := filepath.Rel(baseDir, filepath.Clean(target))
+	return err == nil && rel != "." && filepath.IsLocal(rel)
 }

--- a/pkg/orchestra/job_cleanup_cov_test.go
+++ b/pkg/orchestra/job_cleanup_cov_test.go
@@ -90,3 +90,97 @@ func TestCleanupStaleJobs_FreshFlatRetained(t *testing.T) {
 	assert.Equal(t, 0, removed)
 	assert.FileExists(t, filepath.Join(baseDir, "recent.json"))
 }
+
+// TestCleanupStaleJobs_KeepsForeignJSONDirectory pins the shared-temp-dir
+// invariant: the GC scans os.TempDir(), where unrelated tools keep working
+// directories full of JSON. A foreign JSON object decodes into a zero Job whose
+// zero CreatedAt otherwise reads as infinitely stale, so the GC used to delete
+// the whole directory out from under a live process.
+func TestCleanupStaleJobs_KeepsForeignJSONDirectory(t *testing.T) {
+	t.Parallel()
+	baseDir := t.TempDir()
+	foreign := filepath.Join(baseDir, "release-coordinate-publish.WgKtut")
+	require.NoError(t, os.MkdirAll(foreign, 0o700))
+	policies := filepath.Join(foreign, "deployment-policies.json")
+	require.NoError(t, os.WriteFile(policies, []byte(`{"branch_policies":[]}`), 0o600))
+	variables := filepath.Join(foreign, "repository-variables.json")
+	require.NoError(t, os.WriteFile(variables, []byte(`[{"name":"UNRELATED"}]`), 0o600))
+
+	removed, err := CleanupStaleJobs(baseDir, 1*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 0, removed, "foreign JSON is not an orchestra job record")
+	assert.FileExists(t, policies)
+	assert.FileExists(t, variables)
+}
+
+// TestCleanupStaleJobs_KeepsRecordWithoutCreatedAt verifies that a job record
+// missing CreatedAt is never treated as stale, even when its ID matches.
+func TestCleanupStaleJobs_KeepsRecordWithoutCreatedAt(t *testing.T) {
+	t.Parallel()
+	baseDir := t.TempDir()
+	subDir := filepath.Join(baseDir, "autopus-orch-undated")
+	require.NoError(t, os.MkdirAll(subDir, 0o700))
+	require.NoError(t, (&Job{ID: "undated", Dir: subDir}).Save())
+
+	removed, err := CleanupStaleJobs(baseDir, 1*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 0, removed)
+	assert.DirExists(t, subDir)
+}
+
+// TestCleanupStaleJobs_KeepsDirectoryNotClaimedByRecord verifies a nested stale
+// record only authorizes removal of the directory it actually lives in.
+func TestCleanupStaleJobs_KeepsDirectoryNotClaimedByRecord(t *testing.T) {
+	t.Parallel()
+	baseDir := t.TempDir()
+	host := filepath.Join(baseDir, "unrelated-workdir")
+	victim := filepath.Join(baseDir, "victim")
+	require.NoError(t, os.MkdirAll(host, 0o700))
+	require.NoError(t, os.MkdirAll(victim, 0o700))
+	stale := &Job{ID: "misplaced", Dir: victim, CreatedAt: time.Now().Add(-2 * time.Hour)}
+	require.NoError(t, writeFlatJobManifest(host, stale))
+
+	removed, err := CleanupStaleJobs(baseDir, 1*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 0, removed)
+	assert.DirExists(t, host)
+	assert.DirExists(t, victim)
+}
+
+// TestCleanupStaleJobs_KeepsFlatTargetOutsideBaseDir verifies a flat manifest
+// cannot direct the GC at a path outside the scanned root; the manifest itself
+// is still reclaimed.
+func TestCleanupStaleJobs_KeepsFlatTargetOutsideBaseDir(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	baseDir := filepath.Join(root, "base")
+	outside := filepath.Join(root, "outside")
+	require.NoError(t, os.MkdirAll(baseDir, 0o700))
+	require.NoError(t, os.MkdirAll(outside, 0o700))
+	stale := &Job{ID: "escaping", Dir: outside, CreatedAt: time.Now().Add(-2 * time.Hour)}
+	require.NoError(t, writeFlatJobManifest(baseDir, stale))
+
+	removed, err := CleanupStaleJobs(baseDir, 1*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 1, removed)
+	assert.DirExists(t, outside, "removal must not escape the scanned root")
+	assert.NoFileExists(t, filepath.Join(baseDir, "escaping.json"))
+}
+
+// TestCleanupStaleJobs_NeverRemovesBaseDir verifies a stale flat record whose
+// Dir is the scanned root reclaims only its own manifest.
+func TestCleanupStaleJobs_NeverRemovesBaseDir(t *testing.T) {
+	t.Parallel()
+	baseDir := t.TempDir()
+	stale := &Job{ID: "rooted", Dir: baseDir, CreatedAt: time.Now().Add(-2 * time.Hour)}
+	require.NoError(t, stale.Save())
+	keeper := filepath.Join(baseDir, "keeper.txt")
+	require.NoError(t, os.WriteFile(keeper, []byte("keep"), 0o600))
+
+	removed, err := CleanupStaleJobs(baseDir, 1*time.Hour)
+	require.NoError(t, err)
+	assert.Equal(t, 1, removed)
+	assert.DirExists(t, baseDir)
+	assert.FileExists(t, keeper)
+	assert.NoFileExists(t, filepath.Join(baseDir, "rooted.json"))
+}

--- a/scripts/companion-release/execsmoke/cli_test.go
+++ b/scripts/companion-release/execsmoke/cli_test.go
@@ -216,6 +216,9 @@ func validCLIArgs(artifact, architecture string) []string {
 		"--artifact", artifact,
 		"--expected-version", expectedFixtureVersion,
 		"--architecture", architecture,
-		"--timeout", "10s",
+		// maximumTimeout, not a measured budget: the fixture exits immediately, so
+		// any smaller value only measures how busy the machine is. The deadline
+		// boundary itself is covered by the zero/excessive timeout cases.
+		"--timeout", "60s",
 	}
 }


### PR DESCRIPTION
## 문제

`internal/cli/orchestra.go`는 모든 orchestra 명령 시작 시 `CleanupStaleJobs(os.TempDir(), 1h)`를 호출한다. `cleanupJobsInDir`가 임의 JSON을 `Job`으로 언마샬하는 데 성공하면(미지 필드는 무시됨) `CreatedAt`이 zero time이 되고, `zero.Before(cutoff)`는 항상 참이라 **그 디렉토리를 통째로 `os.RemoveAll`** 한다.

즉 `$TMPDIR` 직속 하위 디렉토리에 이름이 `^[a-zA-Z0-9_-]+$`인 JSON 오브젝트 파일이 하나라도 있으면 남의 작업 디렉토리가 사라진다.

실제로 관측된 피해: 진행 중인 릴리스 트랜잭션의 `release-coordinate-publish.XXXXXX/`가 삭제됐다. `gh api .../deployment-branch-policies`가 `{branch_policies:[...]}` 오브젝트를 `deployment-policies.json`으로 쓰기 때문이다. 결과는 `jq` ENOENT → `set -e` → 롤백 → exit 75.

flat 경로는 더 나쁘다. `os.RemoveAll(job.Dir)`의 `Dir`이 검증 없이 파일에서 읽은 경로라, 공유 `$TMPDIR`에 JSON 하나만 심으면 임의 경로가 지워진다.

## 수정

소유권 게이트 3종:

- 파일 stem == `job.ID` 이고 `CreatedAt`이 비어있지 않아야 job 레코드로 인정 (`Save()`의 왕복 보장)
- nested 레이아웃은 레코드가 자신이 있는 디렉토리를 `Dir`로 주장할 때만 그 디렉토리 제거
- flat 레이아웃의 제거 대상은 스캔 루트 **내부**여야 하며 루트 자신은 제외

## 검증

- 신규 테스트 5개. 게이트를 되돌리는 뮤테이션에서 5개 전부 실패하며, `release-coordinate-publish.WgKtut/deployment-policies.json` 삭제가 그대로 재현된다.
- `go test ./...`와 셸 하드닝 스위트 동시 실행이 이제 양쪽 다 통과 (수정 전에는 `internal/companionmanifest` 또는 셸 스위트가 실패).

## 부수 커밋: 부하 민감 데드라인

수정 과정에서 드러난, 머신 부하만 측정하던 벽시계 값들을 백스톱으로 교체했다. 프로덕션 상수(`ompVersionTimeout`, `maxDesktopObservationDuration`)는 제품 계약이므로 건드리지 않았다.

| 위치 | 전 | 후 |
| --- | --- | --- |
| `omp_readiness_runner_test.go` | ctx 1s (`signal: killed`) | `t.Context()` |
| `omp_model_probe_process_test.go` (sandbox) | ctx 2s | `t.Context()` |
| `omp_model_probe_process_test.go` (output limit) | `elapsed < 2s` | ctx 30s + `ctx.Err() == nil` |
| `hook_round_cursor_contract_test.go` | ctx 2s | 30s (오작동 시 MAX_WAIT 120s라 여전히 검출) |
| `omp_context_bridge_live_test.go` | ctx 12s | 60s (omp 자체 `--max-time 10s`를 선점하지 않도록) |
| `execsmoke/cli_test.go` | `--timeout 10s` | `60s` = maximumTimeout |

이 중 `hook_round_cursor_contract_test.go`와 `omp_context_bridge_live_test.go`는 동시 실행과 무관하게 `go test ./... -count=1` 단독 실행에서도 실패하던 기존 flake다.
