### PR TITLE
docs(spec): SPEC-EXECPLANE-001 실행 평면 분리와 티어·계정·카탈로그 정합

### DIFF
--- a/.autopus/specs/SPEC-EXECPLANE-001/acceptance.md
+++ b/.autopus/specs/SPEC-EXECPLANE-001/acceptance.md
@@ -1,0 +1,110 @@
+# SPEC-EXECPLANE-001 Acceptance: 실행 평면 분리와 티어·계정·카탈로그 정합
+
+이 문서는 설계 고정 SPEC의 수용 오라클이다. 시나리오는 구현 코드를 요구하지 않고, 각 요구가 무엇을 관측했을 때 충족으로 판정되는지를 확정한다.
+
+## Test Scenarios
+
+spec.md `## Traceability Matrix`에서 파생한 커버리지(권위 있는 매핑은 spec.md 쪽이다): S1=REQ-001, S2=REQ-002, S3=REQ-003·REQ-004, S4=REQ-005, S5=REQ-006, S6=REQ-007, S7=REQ-008, S8=REQ-009. 9개 요구가 8개 시나리오로 빠짐없이 덮인다.
+
+### S1: 세 평면의 소유 표면이 배타적으로 열거된다
+
+Priority: Must
+Given research.md `## Feature Coverage Map`이 7개 실행 표면을 열거하고 각 행에 소유자를 지정한다
+When 각 표면의 소유자를 정책(autopus-adk)·모델(omp)·프로세스(orca) 세 평면 중 하나로 분류한다
+Then 소유 평면이 0개이거나 2개 이상인 표면 행이 0건이다
+And 신설 표면 `티어와 실행 계정의 정합 검증`의 소유자는 정책 평면 하나이며, omp `modelRoles`와 orca `account list` 표면 목록에 같은 이름이 나타나지 않는다
+And 이 배타 분류가 INV-001의 관측 근거로 기록된다
+
+### S2: 프로세스 평면 경계를 넘는 값에 티어 어휘가 없다
+
+Priority: Must
+Given 정책 평면이 프로세스 평면에 실행을 위임하는 유일한 경계는 모델·effort를 받는 `orchestration worker-start`이고, 이 명령은 `--model`에 opaque provider model id를, `--effort`에 effort 레벨을 받는다
+When 정책 평면이 결정한 quality tier를 그 경계 인자로 직렬화한다
+Then `--model` 값은 provider 고유 model id 문자열이고 `--effort` 값은 effort 레벨 문자열이다
+And 경계를 넘는 인자 전체에서 `quality`, `tier`, `balanced`, `ultra`, `opus`, `sonnet`, `haiku` 토큰의 출현 횟수가 각각 0이며, 이는 research.md F4가 `orca agent-context --json` 223개 명령 전수 검색에서 얻은 0건과 일치한다
+And 티어 사다리의 단일 출처는 정책 평면에 남는다
+
+### S3: 실행 계정과 로컬 로그인 계정이 다를 때 실행 계정 기준으로 검증한다
+
+Priority: Must
+Given 프로세스 평면이 보고하는 활성 Codex 실행 계정은 `bitgapnam@gmail.com`이고, 이 워크스테이션의 로컬 `codex` CLI 로그인 계정은 `~/.codex/auth.json` 기준 `jroad1049@gmail.com`이다(research.md F1)
+And 일반화하면 실행 계정 A와 로컬 로그인 계정 B가 존재하고 A != B이며, 이 시나리오의 판정은 두 계정의 구체 문자열이 아니라 A != B라는 조건과 검증에 사용된 계정이 A인지 여부에만 의존한다
+And 카탈로그 프로브는 PATH 바이너리를 실행하므로 기본값은 B의 카탈로그다(`pkg/codexruntime/probe.go:39`)
+When 정합 점검이 요청 티어를 provider 모델로 해석한다
+Then 검증에 사용된 카탈로그의 출처 계정은 A이고, B의 `codex debug models` 결과는 A의 티어 근거로 채택되지 않는다
+And 영수증의 실행 계정 식별자와 카탈로그 출처 계정이 같은 값 A다
+And 두 값이 다르면 검증은 성립하지 않은 것으로 처리되어 통과 판정을 만들지 않는다
+And A 기준 카탈로그를 조회할 수단이 없으면 통과가 아니라 S8의 unverified 경로로 분기한다
+
+### S4: 정합 영수증이 6개 필드를 모두 담는다
+
+Priority: Must
+Given 정합 점검을 마친 워크로드 하나
+When 정합 영수증을 방출한다
+Then 영수증은 요청 티어, 해석된 provider 모델, 실행 계정 식별자, 카탈로그 출처, resolution reason, verification status 6개 필드를 모두 담는다
+And 영수증은 `pipeline_execution_owner_receipt.v1`과 같은 형태의 스키마 버전 태그를 갖는다
+And 6개 필드 중 하나라도 부재하거나 빈 문자열이면 영수증은 불완전으로 판정되고 점검은 실패한다
+
+### S5: 티어 불일치는 요청값과 실제값을 모두 남기고 fail-loud 한다
+
+Priority: Must
+Given 실행 계정 A의 카탈로그에 요청 티어가 해석한 모델이 존재하지 않는다
+When 정합 점검이 그 티어를 해석한다
+Then 점검은 fail closed 하거나 명시적 강등을 기록하며, 기록 없이 더 낮은 모델로 대체하지 않는다
+And 영수증의 `resolution.reason`이 빈 문자열이 아니다
+And 영수증에 요청 티어 값과 실제 제공 모델 값이 둘 다 존재한다. research.md F3의 실측 강등 쌍 `gpt-5.6-terra/medium` -> `gpt-5.5/xhigh`처럼 두 값이 지목 가능해야 한다
+And 두 값 중 하나라도 없거나 `reason`이 비어 있으면 INV-004 위반으로 판정한다
+
+### S6: 점검 실패는 생성된 리소스를 남기지 않는다
+
+Priority: Must
+Given 실행 계정 카탈로그가 요청 티어를 제공하지 않아 반드시 실패하도록 구성된 정합 점검
+When 워크로드 준비 단계를 실행한다
+Then 점검은 워크트리·Run·워커·provider 세션 중 어느 것도 생성하기 전에 종료한다
+And 실행 후 새로 생성된 워크트리 0건, Run 0건, 워커 0건, provider 세션 0건이다
+And 호출자에게 정합 실패가 반환된다
+
+### S7: handoff 결과가 영수증을 참조하고 실패 시 handoff를 대체한다
+
+Priority: Must
+Given `--execution-owner orca` 경로가 `status: handoff_required`와 `required_action`을 담은 handoff 결과를 반환하는 스텁이다(`internal/cli/pipeline_run_owner.go:160-164`)
+When 정합 점검이 handoff 결과 방출 직전에 실행된다
+Then 점검이 통과하면 handoff 결과에 S4 영수증에 대한 참조가 포함되어, 받는 쪽이 이미 검증된 티어 계약에서 출발한다
+And 점검이 실패하면 `handoff_required` 결과 대신 정합 실패가 반환되고 handoff 결과는 방출되지 않는다
+And 이 경로는 OMP task DAG를 만들지 않으므로 DAG 소유자는 하나로 유지된다(`pkg/adapter/omp/omp_workflow_render.go:99`)
+
+### S8: 검증 수단이 없는 provider는 unverified로 표기된다
+
+Priority: Must
+Given provider가 계정 범위 카탈로그 프로브를 제공하지 않는다. Codex는 `codex debug models`가 있으나 Claude 등가물은 확인되지 않았다(research.md Completion Debt)
+When 그 provider의 요청 티어에 대해 정합 점검을 수행한다
+Then 영수증의 verification status 값이 `unverified`다
+And 같은 항목이 `verified`로 표기되지 않는다
+And 사유 필드에 검증 수단 부재가 기록되어, 미검증과 검증 실패가 구분된다
+
+## Oracle Acceptance Notes
+
+이 SPEC은 설계 고정 문서이므로 위 시나리오는 지금 자동화된 테스트로 실행되지 않는다. S1·S2는 문서 검토로 즉시 판정 가능하고, S3~S8은 정합 게이트를 구현하는 후속 SPEC의 수용 오라클로 그대로 이월된다. 이월 시 아래 예상 값을 완화하는 것은 범위 축소로 취급한다.
+
+각 시나리오의 판정 기준은 다음 구체 값으로 고정한다. `정상 동작한다` 같은 서술은 통과 근거가 아니다.
+
+- **S1** — 예상 값: Feature Coverage Map 7개 행 각각의 소유 평면 수 = 1. 소유자 미지정 행 0건, 복수 소유 행 0건. 신설 표면 `티어와 실행 계정의 정합 검증`의 소유자 문자열은 정책 평면 하나여야 하며, 같은 표면 이름이 모델·프로세스 평면 목록에 재등장하면 실패.
+- **S2** — 예상 값: 경계 인자 집합에서 `quality`=0, `tier`=0, `balanced`=0, `ultra`=0, `opus`=0, `sonnet`=0, `haiku`=0. 하나라도 1 이상이면 실패. `--model`, `--effort` 두 인자 외의 티어 파생 인자가 추가되어도 실패.
+- **S3** — 예상 값: `receipt.execution_account == receipt.catalog_source_account == A`. 검증에 B의 카탈로그가 쓰였으면 실패. 판정은 A != B 조건에만 의존해야 하며, `bitgapnam@gmail.com`·`jroad1049@gmail.com` 문자열을 하드코딩해 비교하는 오라클은 F1 시점의 계정 구성이 바뀌면 무의미해지므로 부적합으로 본다. 실측 계정 쌍은 A != B가 가설이 아니라 현재 상태임을 보이는 근거로만 쓴다.
+- **S4** — 예상 값: 영수증 필드 6개가 모두 존재. 요청 티어 / 해석된 provider 모델 / 실행 계정 식별자 / 카탈로그 출처 / resolution reason / verification status. 이 중 하나라도 누락되거나 빈 문자열이면 실패로 판정한다. 스키마 버전 태그 부재도 실패.
+- **S5** — 예상 값: `resolution.reason != ""`. 빈 문자열이면 위반. 요청 티어 값과 실제 제공 모델 값이 둘 다 non-empty여야 하고, 둘 중 하나만 있는 영수증은 실패. 영수증 없이 낮은 모델로 실행된 경우는 조용한 강등이므로 즉시 실패.
+- **S6** — 예상 값: 점검 실패 후 신규 워크트리 수 = 0, Run 수 = 0, 워커 수 = 0, provider 세션 수 = 0. 어느 하나라도 1 이상이면 INV-005 위반. 실패 후 정리(cleanup)로 0에 도달한 경우도 생성이 발생했으므로 실패로 본다.
+- **S7** — 예상 값: 통과 경로의 handoff 결과에 영수증 참조 필드가 1개 이상 존재. 실패 경로에서는 `status: handoff_required`가 반환되지 않고 정합 실패가 반환되어야 하며, 두 결과가 동시에 나오면 실패. 이 경로에서 생성된 OMP task DAG 수 = 0.
+- **S8** — 예상 값: `verification_status == "unverified"`이고 사유 필드 non-empty. 같은 항목에 `verified`가 오면 실패. 프로브가 없다는 이유로 티어를 검증됨으로 낙관 처리하거나, 반대로 검증 실패(카탈로그에 모델 없음)와 같은 상태값으로 뭉뚱그리면 실패.
+
+판정 시 주의할 점 두 가지.
+
+- S3와 S8은 경계가 인접하다. 실행 계정 A를 특정했으나 A의 카탈로그를 조회할 수단이 없는 경우는 S3의 통과가 아니라 S8의 `unverified`다. 이 분기를 통과로 세면 INV-003이 무력화된다.
+- S5와 S8은 상태값이 달라야 한다. 카탈로그를 조회했고 모델이 없어 강등한 경우는 사유가 붙은 명시적 강등이고, 조회 수단 자체가 없는 경우는 `unverified`다. 둘을 한 값으로 합치면 영수증 독자가 근거의 강도를 복원할 수 없다.
+
+## Definition of Done
+
+- [ ] S1~S8이 REQ-001~REQ-009를 빠짐없이 덮는다(REQ-003·REQ-004는 함께 S3)
+- [ ] 각 시나리오의 Then이 관측 가능한 값을 지명한다
+- [ ] S3~S8의 예상 값이 후속 구현 SPEC의 수용 오라클로 이관된다
+- [ ] 세 평면 경계에 대한 리뷰 합의가 기록된다

--- a/.autopus/specs/SPEC-EXECPLANE-001/plan.md
+++ b/.autopus/specs/SPEC-EXECPLANE-001/plan.md
@@ -1,0 +1,233 @@
+# SPEC-EXECPLANE-001 Plan: 실행 평면 분리와 티어·계정·카탈로그 정합
+
+**Created**: 2026-08-10
+**Domain**: EXECPLANE
+**Kind**: 설계 고정(design-only). 구현 코드는 이 SPEC의 산출물이 아니다.
+
+## Implementation Strategy
+
+### 게이트는 정책 평면(autopus-adk)에 둔다
+
+정합 게이트가 알아야 하는 값은 셋이다 — **요청 티어**(정책 평면 소유), **실행 계정**(프로세스 평면 소유), **그 계정의 카탈로그**(모델 평면 어휘). 세 값이 한자리에 모여야 판정이 성립하므로, 게이트를 어디에 두느냐는 "어느 평면이 남의 어휘를 읽어도 되는가"의 문제로 환원된다.
+
+정책 평면만 이 조건을 위반 없이 만족한다. 티어 어휘의 단일 출처가 이미 정책 평면(`pkg/config/quality_tier.go`, research.md Feature Coverage Map)이고, J1(티어 -> omp `modelRoles`)의 투영 지점도 정책 평면(`pkg/adapter/omp/omp_model_projection.go:59-107`)이다. 정책 평면이 프로세스 평면에서 계정 식별자를, 모델 평면에서 카탈로그를 **읽어 오는** 방향은 이미 존재하는 의존 방향(정책 -> 모델, 정책 -> 프로세스)과 같다. 새 역방향 의존이 생기지 않는다.
+
+### 기각한 대안 (a) — orca(프로세스 평면)에 둔다
+
+orca가 게이트를 소유하면 orca가 "요청 티어"를 이해해야 한다. 그런데 F4의 전수 검색 결과 `orca agent-context --json`(223 command, schema v1)에 `quality` 0건, `tier` 0건, `opus`/`sonnet`/`gpt-5`/`balanced`/`ultra` 0건이고, 모델·effort를 받는 명령은 `orchestration worker-start` 하나뿐이며 그 계약은 다음과 같다.
+
+```
+--model supports Claude, Codex, and Cursor opaque provider model ids;
+--effort requires --model. Neither can combine with --terminal.
+```
+
+즉 orca는 설계상 opaque provider model id 소비자다. 여기에 티어 사다리를 심으면 티어 어휘가 두 평면에 동시에 존재하게 되어 **INV-001(어휘 무증식)을 직접 위반**하고, REQ-002가 금지하는 바로 그 상태가 된다. 게이트를 orca에 두는 선택은 이 SPEC의 요구 두 건과 정면으로 충돌하므로 기각한다.
+
+### 기각한 대안 (b) — omp(모델 평면)에 둔다
+
+omp가 게이트를 소유하면 omp가 "이 워크로드를 실제로 실행할 provider 계정"을 알아야 한다. 계정 소유와 활성 계정 선택은 프로세스 평면의 독점 표면(`orca account list`, research.md Feature Coverage Map)이다. omp의 어휘는 role -> `provider/model:thinking` 10종(`default/plan/slow/smol/designer/vision/commit/tiny/task/advisor`, F5)이며 계정 축이 아예 없다. 계정 축을 omp에 도입하는 것은 프로세스 평면 표면의 **평면 침범**이고, 동시에 정책 평면이 이미 소유한 티어 판정 책임을 모델 평면으로 옮기는 이중 이관이 된다. 기각한다.
+
+### 배치 지점 — handoff 직전, 부작용 이전
+
+`--execution-owner orca` 경로는 현재 실행이 없다. `internal/cli/pipeline_run_owner.go:160-164`은 소유자를 기록하고 반환하며 끝난다.
+
+```go
+result := pipelineExecutionOwnerResult{
+    Schema: pipelineExecutionOwnerResultSchema, Status: "handoff_required",
+    ...
+    RequiredAction: "orca skills get orchestration --full",
+}
+```
+
+이 지점은 워크트리·Run·워커·provider 세션이 아직 하나도 만들어지지 않은 상태다. 따라서 게이트를 이 반환 직전에 두면 REQ-007(부작용 이전)과 REQ-008(handoff 직전)이 같은 한 지점에서 동시에 충족되며, INV-005(부작용 없음)는 배치의 부산물로 보장된다. 별도의 롤백 경로를 설계할 필요가 없다.
+
+세 평면 합성이 기존 불변식과 충돌하지 않는다는 점도 확인됐다. `pkg/adapter/omp/omp_workflow_render.go:99`의 금지 대상은 OMP **task DAG**이지 omp 실행 자체가 아니다(F7). orca Run이 소유한 워커 안에서 omp가 모델 평면 역할만 수행하고 자기 DAG를 만들지 않으면 INV-002를 준수한다.
+
+### 왜 이 SPEC은 설계만 고정하고 구현을 분리하는가
+
+research.md Completion Debt 3건이 **미해결인 채로는 구현 선택이 정해지지 않는다.** 세 건 모두 계약이 아니라 구현 형태를 바꾸는 질문이다.
+
+| Completion Debt | 미해결이면 바뀌는 구현 선택 |
+| --- | --- |
+| 계정 정보의 정확한 소스 (`orca account list`는 사람이 읽는 텍스트, `--json` 유무 미확인) | 계정 조회를 구조화 출력 파싱으로 할지 `orca agent-context --json` 스키마 경유로 할지 |
+| Claude 쪽 카탈로그 프로브 부재 (Codex는 `codex debug models`, Claude 등가물 미확인) | Claude 티어를 어떤 신호로 검증할지, 아니면 REQ-009의 `unverified` 경로로 보낼지 |
+| 원격 orca 환경(`--on <saved-environment>`)의 계정 조회 | 계정 조회가 로컬 단일 호출인지 원격 host 축을 갖는지 |
+
+계약(요구 9건 · 불변식 5건 · 영수증 6필드)은 세 질문의 답과 무관하게 고정된다. 반대로 구현은 답에 따라 달라진다. 그래서 계약을 먼저 얼리고 구현을 분리했다. 이 분리는 spec.md `## Out of Scope` 첫 항목("정합 게이트의 구현 코드")과 일치한다.
+
+## File Impact Analysis
+
+이 SPEC은 설계 고정 문서이므로 소스 파일을 변경하지 않는다. 산출물은 SPEC 디렉터리의 4개 문서뿐이다.
+
+| 파일 | 작업 | 설명 |
+|------|------|------|
+| `.autopus/specs/SPEC-EXECPLANE-001/spec.md` | 생성 | 요구 9건, Outcome Boundary, Traceability Matrix, Out of Scope |
+| `.autopus/specs/SPEC-EXECPLANE-001/research.md` | 생성 | 실측 근거 F1~F7, 불변식 5건, Completion Debt 3건, Reference Discipline |
+| `.autopus/specs/SPEC-EXECPLANE-001/plan.md` | 생성 | 이 문서. 게이트 배치 논증과 T1~T4 설계 태스크 |
+| `.autopus/specs/SPEC-EXECPLANE-001/acceptance.md` | 생성 | S1~S8 시나리오와 Oracle Acceptance Notes |
+
+아래 코드는 **참조 대상**이며 이 SPEC에서 수정하지 않는다: `pkg/codexruntime/probe.go`, `internal/cli/codex_catalog_runtime.go`, `internal/cli/pipeline_run_owner.go`, `pkg/adapter/omp/omp_workflow_render.go`, `pkg/config/role_model_policy_matrix.go`.
+
+## Architecture Considerations
+
+- **의존 방향**: 정책 -> 모델, 정책 -> 프로세스 단방향만 허용한다. 모델 -> 프로세스, 프로세스 -> 정책 방향의 참조를 만들면 INV-001이 깨진다.
+- **경계 통과 값의 형태**: 정책 -> 프로세스 경계를 넘는 것은 opaque provider model id와 effort뿐이다(F4의 `worker-start` 계약과 동일한 형태). 티어 문자열은 경계에서 소멸한다.
+- **J1 불변**: PR #154가 닫은 `quality.default` -> 내장 role-model 프로파일 -> omp `modelRoles` 경로는 이 SPEC에서 손대지 않는다. J2는 J1 결과를 입력으로 받는 후단 검증이다.
+- **기존 패턴 재사용**: 영수증은 이미 존재하는 `pipeline_execution_owner_receipt.v1`(INV-002 관측 지점)과 같은 스키마-버전 방식을 따른다. 새 관측 메커니즘을 발명하지 않는다.
+
+## Visual Planning Brief
+
+J2 접합면의 런타임 흐름. research.md의 세 평면 정적 다이어그램과 달리 여기서는 **한 워크로드가 준비되는 동안의 시간 순서**를 그린다.
+
+```
+  [정책 평면: autopus-adk]                            부작용 경계 (INV-005)
+                                          =====================================
+  요청 티어 (quality.default)                 이 선 위: 리소스 생성 0건
+        |                                     이 선 아래: 워크트리·Run·워커·세션
+        | J1 (PR #154, 불변)
+        v
+  role -> provider/model:thinking  <----[모델 평면: omp modelRoles]
+        |
+        |  (여기부터 J2 — 이 SPEC의 대상)
+        v
+  +-------------------------------------------------+
+  | (1) 실행 계정 조회            REQ-003 / INV-003 |
+  |     프로세스 평면에 질의                        |
+  |     "이 워크로드를 실제로 실행할 계정은?"       |
+  |     ! 로컬 CLI 로그인 계정으로 가정하지 않는다  |
+  |       F1: orca active = bitgapnam@gmail.com     |
+  |           local codex = jroad1049@gmail.com     |
+  +-------------------------------------------------+
+        | account_id
+        v
+  +-------------------------------------------------+
+  | (2) 그 계정의 카탈로그 확보    REQ-004 / INV-003|
+  |     catalog_source := account_id 기준           |
+  |     ! F2: PATH 바이너리 프로브는 로컬 로그인    |
+  |       계정 기준 -> 실행 계정과 다르면 증거 아님 |
+  +--------------------+----------------------------+
+                       |
+          +------------+------------+
+          | 프로브 있음            | 프로브 없음
+          v                        v
+  (3a) 해석 / 검증          (3b) unverified 표기
+       요청 티어 in 카탈로그?      REQ-009 / INV-004
+       INV-003                     사유 기록, verified 금지
+          |                        |
+          +------------+-----------+
+                       v
+  +-------------------------------------------------+
+  | (4) 정합 영수증 방출          REQ-005 / INV-004 |
+  |   요청 티어 | 해석된 provider 모델              |
+  |   실행 계정 식별자 | 카탈로그 출처              |
+  |   resolution reason | verification status       |
+  |   (+ schema version)                            |
+  +--------------------+----------------------------+
+                       |
+        +--------------+---------------+
+        | 통과 / 명시적 강등            | 불일치·검증 실패
+        v                              v
+  (5) 실행 위임                  (6) fail-loud
+      REQ-008: handoff 직전          REQ-006 / INV-004
+      pipeline_run_owner.go:160-164  요청 티어 + 실제 제공 모델
+      handoff 결과가 영수증 참조     두 값 + 사유를 모두 지목
+        |                              |
+        | REQ-007: 여기까지 부작용 0건  | handoff 결과 대신
+  ======v=============================v==== 부작용 경계 ====
+        |                             (X) 종료. 리소스 0건
+        v                                  INV-005 충족
+  [프로세스 평면: orca]
+   worktree 생성 -> Run -> 워커 -> provider 세션
+   받는 값: opaque model id + effort 만 (REQ-002 / INV-001)
+   티어 어휘는 경계에서 소멸
+```
+
+읽는 법 세 가지.
+
+1. **부작용 경계**는 (5)와 프로세스 평면 사이에 정확히 한 번 그어진다. (1)~(4)와 (6)은 전부 경계 위에 있으므로 실패 경로에 롤백이 필요 없다 — REQ-007이 배치로 충족된다.
+2. **handoff 지점**은 (5)다. `internal/cli/pipeline_run_owner.go:160-164`이 `handoff_required`를 반환하기 직전이며, 게이트가 그 앞에 있으므로 handoff를 받는 쪽은 이미 검증된 티어 계약을 들고 출발한다(REQ-008).
+3. **(1)과 (2)의 계정이 반드시 같아야 한다.** 두 값이 갈라지면 (3a)의 판정은 성립하지 않은 것으로 처리된다(REQ-004). F1·F2가 이 갈라짐이 이 워크스테이션에 이미 존재함을 보여준다.
+
+## Feature Completion Scope
+
+이 SPEC은 **설계 고정 문서**다. 완료 판정에 실행 가능한 코드나 통과하는 테스트를 요구하지 않는다. Outcome Lock을 닫는 것은 "정합 게이트가 동작한다"가 아니라 "정합 게이트의 계약과 배치가 더 이상 해석의 여지 없이 고정됐다"다.
+
+완료 조건은 spec.md `## Outcome Boundary`의 Completion evidence와 동일하게 셋이다.
+
+1. 4개 SPEC 문서(`spec.md`·`plan.md`·`acceptance.md`·`research.md`)가 `auto spec validate`를 통과한다.
+2. research.md Completion Debt 3건이 해소되거나 후속 SPEC으로 이관된다. 3건 중 2건(계정 조회 소스, Claude 카탈로그 부재)은 T2가 해소 대상으로 안고 간다.
+3. 세 평면 경계에 대한 리뷰 합의가 기록된다 — research.md `## Reviewer Brief`의 4개 질문에 대한 판단이 남아야 한다.
+
+| 구분 | 항목 |
+| --- | --- |
+| **범위 안** | 세 평면 소유 표면의 배타 선언 (REQ-001) |
+| | 정책 -> 프로세스 경계의 티어 어휘 금지 목록 (REQ-002) |
+| | 실행 계정 조회의 인터페이스 계약 (REQ-003) |
+| | 실행 계정 기준 카탈로그 검증의 인터페이스 계약 (REQ-004) |
+| | 정합 영수증 6필드 스키마와 스키마 버전 (REQ-005) |
+| | fail-loud 판정 규칙과 강등 기록 규칙 (REQ-006) |
+| | 게이트 배치 지점과 부작용 경계의 확정 (REQ-007, REQ-008) |
+| | 검증 불가 provider의 `unverified` 표기 규칙 (REQ-009) |
+| | S1~S8 시나리오와 그 관측 지점 |
+| **범위 밖** | 정합 게이트의 구현 코드. 이 SPEC은 계약만 고정한다 |
+| | `--execution-owner orca`의 handoff 스텁을 실제 orca Run 생성으로 대체하는 작업 |
+| | 요청 티어를 제공 가능한 계정을 자동 선택하는 다계정 라우팅 |
+| | 티어 강등이 불가피할 때 다른 provider로 넘기는 폴백 정책 |
+| | autopus·omp·orca 관측 데이터를 한 영수증으로 합치는 실행 원장 |
+| | J1(티어 -> omp `modelRoles`) 재설계. PR #154 결과를 불변으로 둔다 |
+| | orca CLI 표면 변경. orca는 소비자로만 취급한다 |
+
+범위 밖 목록은 spec.md `## Out of Scope`와 항목 대응이 1:1이다. 새 항목을 추가하지 않았다.
+
+## Tasks
+
+T1~T4는 모두 **설계·문서·합의 산출물**이다. 코드 작성 태스크는 없다 — 구현은 위 Feature Completion Scope의 범위 밖이다.
+
+- [ ] **T1 — 세 평면 소유 표면 배타 선언과 경계 어휘 금지 목록 확정** (REQ-001, REQ-002 / INV-001 / S1, S2)
+  - 산출물: research.md Feature Coverage Map의 각 표면에 소유 평면을 정확히 하나 지정한 확정판, 그리고 정책 -> 프로세스 경계에서 금지되는 티어 토큰 목록(`balanced`/`ultra`/`opus`/`sonnet`/`haiku`)과 허용되는 통과 값(opaque provider model id, effort)의 명시.
+  - 완료 판정: 같은 어휘가 둘 이상의 평면에 나타나지 않고(S1), 경계 통과 값 정의에 금지 토큰이 하나도 포함되지 않음이 문서로 확인된다(S2). F4의 orca 티어 어휘 0건 실측이 기준선이다.
+
+- [ ] **T2 — 실행 계정 조회와 계정 기준 카탈로그 검증의 인터페이스 계약 확정** (REQ-003, REQ-004 / INV-003 / S3)
+  - 산출물: (i) 실행 계정 식별자를 프로세스 평면에서 얻는 조회의 입력·출력·실패 모드 계약, (ii) 그 계정 식별자를 기준으로 카탈로그를 확보하는 계약과 "카탈로그 출처 계정 ≠ 실행 계정이면 검증 미성립"이라는 판정 규칙.
+  - **이 태스크가 research.md Completion Debt 2건을 해소해야 한다**: ① orca account 조회 소스 — `orca account list`는 사람이 읽는 텍스트이므로 `--json` 유무를 확인하고, 없으면 `orca agent-context --json` 스키마로 대체 가능한지 확정한다. ② Claude 카탈로그 부재 — Codex는 `codex debug models`가 있으나 Claude 등가물이 확인되지 않았으므로, Claude 티어를 어떤 신호로 검증할지 또는 REQ-009의 `unverified` 경로로 보낼지 결정한다. 남은 1건(원격 `--on <saved-environment>` 계정 조회)은 해소하거나 후속 SPEC으로 이관 기록한다.
+  - 완료 판정: 두 계약이 파라미터 수준으로 적혀 있고, S3의 분기 계정 픽스처(orca 활성 `bitgapnam@gmail.com` vs 로컬 codex `jroad1049@gmail.com`, F1)에 대해 판정 결과가 유일하게 결정된다. Completion Debt 2건이 체크 해제 상태로 남아 있지 않다.
+
+- [ ] **T3 — 정합 영수증 스키마 확정** (REQ-005, REQ-006, REQ-009 / INV-004 / S4, S5, S8)
+  - 산출물: 6필드(요청 티어 / 해석된 provider 모델 / 실행 계정 식별자 / 카탈로그 출처 / resolution reason / verification status) 각각의 타입·필수 여부·허용값을 담은 스키마 정의와 스키마 버전 이름. `verification status`의 허용값에 `unverified`가 포함되고 그 경우 사유 필드가 필수임을 규정한다. 명시적 강등 시 요청 값과 실제 값이 **둘 다** 남아야 한다는 제약도 스키마에 표현한다.
+  - 완료 판정: S4에서 6필드와 스키마 버전이 모두 존재하고, S5에서 강등 경로의 `reason`이 비어 있을 수 없으며 요청·실제 두 값이 모두 요구되고, S8에서 프로브 없는 provider가 `verified`로 표기될 수 없음이 스키마만 보고 판정된다. 기존 `pipeline_execution_owner_receipt.v1`과 같은 스키마-버전 방식을 따른다.
+
+- [ ] **T4 — 게이트 배치 지점과 부작용 경계 확정** (REQ-007, REQ-008 / INV-002, INV-005 / S6, S7)
+  - 산출물: 게이트가 실행되는 지점을 `internal/cli/pipeline_run_owner.go:160-164`의 `handoff_required` 반환 직전으로 확정한 배치 결정문, 그 지점 이전에 생성되지 않아야 하는 리소스 목록(워크트리·Run·워커·provider 세션), 그리고 점검 실패 시 handoff 결과 대신 정합 실패를 반환한다는 반환값 규칙. INV-002와의 양립 근거(F7 — 금지 대상은 OMP task DAG이지 omp 실행 자체가 아님, `pkg/adapter/omp/omp_workflow_render.go:99`)를 함께 기록한다.
+  - 완료 판정: S6에서 점검 실패 시 생성된 워크트리·Run·세션이 0건이라는 관측이 배치만으로 도출되고, S7에서 handoff 결과가 영수증을 참조하며 실패 시 정합 실패로 대체됨이 확정된다. 롤백 경로를 추가로 설계할 필요가 없음이 논증돼 있다.
+
+REQ 커버리지: REQ-001·002(T1), REQ-003·004(T2), REQ-005·006·009(T3), REQ-007·008(T4) — 9건 전부 덮이며 spec.md `## Traceability Matrix`와 일치한다.
+
+## Risks & Mitigations
+
+| 리스크 | 영향도 | 대응 |
+|--------|--------|------|
+| Completion Debt ①(계정 조회 소스)이 T2에서 해소되지 않으면 REQ-003의 계약이 추상 수준에 머문다 | 높음 | T2의 완료 판정에 명시적으로 묶었다. 해소 불가로 판단되면 후속 SPEC 이관을 기록하고 REQ-003 계약을 "조회 결과의 형태"까지만 고정한다 |
+| Claude 카탈로그 등가물이 없어 Claude 티어가 전부 `unverified`로 떨어진다 | 중간 | 이는 결함이 아니라 REQ-009가 설계한 정직한 상태다. 은폐 대신 표기하는 것이 INV-004의 요지다. 대안 신호 탐색은 T2의 판단 사항 |
+| 원격 orca 환경(`--on <saved-environment>`)에서 계정 축이 하나 더 늘어난다 | 중간 | Completion Debt ③으로 분리되어 있다. 계약을 계정 식별자 기준으로 쓰면 조회 경로가 로컬이든 원격이든 판정 규칙은 불변이다 |
+| 설계만 고정하고 구현을 분리한 결과, 후속 SPEC이 나오지 않으면 J2가 계속 끊긴 채 남는다 | 중간 | 구현 분리는 spec.md `## Out of Scope`에 명시된 결정이다. 완료 판정 2번(Completion Debt 해소 또는 후속 SPEC 이관)이 이관 기록을 강제한다 |
+| 게이트를 정책 평면에 두면 정책 평면이 프로세스 평면 상태를 읽는 결합이 생긴다 | 낮음 | 방향이 기존 의존 방향(정책 -> 프로세스)과 같고, 읽는 값은 계정 식별자 하나다. 역방향 참조는 만들지 않는다 |
+
+## Dependencies
+
+- **PR #154** — J1(`quality.default` -> 내장 role-model 프로파일 -> omp `modelRoles`)이 닫혀 있음. 이 SPEC은 J1 결과를 입력으로 받는다. 불변으로 취급한다.
+- **PR #152** — 같은 세대 폴백 추가로 F3의 조용한 세대 강등이 해소됨. INV-004의 출처 사례.
+- **orca CLI** — 계정 조회의 사실상 유일한 소스(`account list`). 표면 변경은 요구하지 않고 소비자로만 취급한다(spec.md `## Out of Scope`).
+- **`codex debug models`** — Codex 계정별 카탈로그의 유일한 확인된 프로브(`pkg/codexruntime/probe.go:39`).
+- **`auto spec validate`** — 완료 판정 1번의 검증 수단.
+
+새 외부 라이브러리 의존은 없다. 설계 문서이므로 코드 의존도 추가하지 않는다.
+
+## Exit Criteria
+
+- [ ] `auto spec validate .autopus/specs/SPEC-EXECPLANE-001`이 4개 문서에 대해 통과한다
+- [ ] T1~T4의 산출물이 모두 존재하고 REQ 9건을 빠짐없이 덮는다
+- [ ] research.md Completion Debt 3건이 각각 해소 또는 후속 SPEC 이관으로 처리됐다
+- [ ] research.md `## Reviewer Brief`의 4개 질문에 대한 리뷰 판단이 기록됐다
+- [ ] 범위 밖 항목 목록이 spec.md `## Out of Scope`와 모순되지 않는다
+
+구현 증거·테스트 통과·커버리지 수치는 이 SPEC의 종료 조건이 아니다. 설계 고정 문서이며, 구현은 별도 SPEC의 대상이다.

--- a/.autopus/specs/SPEC-EXECPLANE-001/research.md
+++ b/.autopus/specs/SPEC-EXECPLANE-001/research.md
@@ -1,0 +1,183 @@
+# SPEC-EXECPLANE-001 Research: 실행 평면 분리와 티어·계정·카탈로그 정합
+
+**Created**: 2026-08-10
+**Domain**: EXECPLANE
+
+## Outcome Lock
+
+autopus-adk가 결정한 모델 티어가 **실제로 그 워크로드를 실행할 계정의 카탈로그로 검증된 뒤에만** 실행이 시작된다. 검증에 실패하면 조용히 강등되지 않고, 실행 전에 정확히 무엇이 어긋났는지(원한 티어 / 실행 계정 / 그 계정이 제공하는 모델)를 지목하며 멈추거나 명시적 강등 영수증을 남긴다.
+
+그리고 orca·omp·autopus-adk가 겹치지 않는 세 평면으로 고정되어, 어느 한 평면에 기능을 추가할 때 나머지 두 곳에 같은 어휘가 복제되지 않는다.
+
+## Visual Planning Brief
+
+```
+                       autopus-adk (정책 평면)
+                SPEC · 16 canonical agent · quality tier
+                     · 게이트 · 합의 전략 · 비용
+                                 |
+             "무엇을, 어느 티어로, 어떤 게이트를 통과해야"
+                                 |
+                 +---------------+---------------+
+                 |                               |
+       orca (프로세스 평면)                omp (모델 평면)
+   worktree 격리 · 계정 · 감독            role -> provider/model:thinking
+   · durability · 스케줄                  · provider 횡단 카탈로그 · RPC
+                 |                               |
+                 +------- 워커 안에서 실행 -------+
+                           (DAG 소유자는 하나)
+```
+
+접합면은 정확히 두 개다.
+
+| 접합면 | 방향 | 현재 상태 |
+| --- | --- | --- |
+| J1 티어 -> 모델 | autopus -> omp | **연결됨** (SPEC 없음, PR #154에서 `role_model_policy` 내장 프로파일로 구현) |
+| J2 티어 -> 실행 계정 | autopus -> orca | **끊김** (이 SPEC의 대상) |
+
+## Semantic Invariant Inventory
+
+| ID | 불변식 | 유형 | 관측 지점 |
+| --- | --- | --- | --- |
+| INV-001 | 한 평면의 어휘는 다른 평면에 복제되지 않는다. orca는 티어 어휘를 갖지 않고 opaque model id만 받는다 | 구조 | `orca agent-context --json`에 tier/quality 토큰 0건 |
+| INV-002 | DAG 소유자는 정확히 하나다. 소유자 `orca`는 OMP task DAG를 만들지 않고, 소유자 `omp`는 orca Run을 만들지 않는다 | 배타 | `pipeline_execution_owner_receipt.v1` |
+| INV-003 | 티어 약속은 그것을 실행할 계정의 카탈로그로 검증된 뒤에만 유효하다 | 정합 | 정합 영수증의 `verified_against` 계정 식별자 |
+| INV-004 | 강등은 조용할 수 없다. 요청 티어와 실제 제공 모델이 다르면 영수증에 사유와 두 값이 모두 남는다 | fail-loud | 영수증의 `resolution.reason` |
+| INV-005 | 정합 점검은 실행 부작용을 만들지 않는다. 워크트리·Run·세션을 생성하기 전에 끝난다 | 순서 | 점검 실패 시 생성된 리소스 0건 |
+
+## Feature Coverage Map
+
+| 표면 | 현재 소유자 | 이 SPEC 이후 |
+| --- | --- | --- |
+| SPEC·16역할·게이트·합의 | autopus | 불변 |
+| quality tier -> provider 모델 투영 | autopus (`pkg/config/quality_tier.go`) | 불변 |
+| role -> `provider/model:thinking` | omp `modelRoles` | 불변 |
+| provider 계정 소유·활성 선택 | orca `account list` | 불변 |
+| worktree 격리·감독·durability | orca | 불변 |
+| **티어와 실행 계정의 정합 검증** | **없음** | **autopus (신규)** |
+| `--execution-owner orca` 실행 | handoff 스텁 | 불변 (별도 SPEC) |
+
+## 측정된 근거
+
+모두 2026-08-10 이 워크스테이션에서 직접 실행해 확인했다.
+
+### F1 — orca 활성 계정과 로컬 CLI 로그인이 이미 갈라져 있다
+
+```
+$ orca account list
+Managed Claude accounts (1):
+  jroad1049@gmail.com
+Managed Codex accounts (1):
+  bitgapnam@gmail.com (active)
+```
+
+반면 로컬 `~/.codex/auth.json`의 `id_token`은 `jroad1049@gmail.com`(Google OAuth, `auth_mode: chatgpt`)이다. 즉 **orca가 워커를 띄울 Codex 계정과 이 머신의 codex CLI 로그인 계정이 다르다**.
+
+### F2 — autopus의 카탈로그 프로브는 PATH 바이너리, 즉 로컬 로그인 계정 기준이다
+
+`pkg/codexruntime/probe.go:39`
+```go
+cmd := exec.CommandContext(probeCtx, binary, "debug", "models")
+```
+
+`internal/cli/codex_catalog_runtime.go:48-58`가 이 결과를 `config.ResolveCodexProviderProfile(entry, catalogJSON)`에 넘긴다. `codex debug models`는 **계정별로 서버가 내려주는 카탈로그**이므로, 프로브 결과는 로컬 로그인 계정의 것이다. F1과 합치면 검증 대상과 실행 대상이 서로 다른 계정이다.
+
+### F3 — 이 실패 양식은 이미 잘못된 결론을 만들었다
+
+`ResolveCodexProfile`이 요청 모델을 카탈로그에서 못 찾으면 하드코딩 레거시 슬러그로 직행했다(PR #152 이전). 이 머신에서 PR #151의 실제 효과는 `gpt-5.6-terra/medium` -> `gpt-5.5/xhigh`, 즉 **세대 강등**이었다. 측정 근거(sol 42 vs sonnet-5 36)는 5.5 대 5.6-terra에 대해 아무 말도 하지 않으므로 그 상태의 #151은 근거가 없었다. PR #152가 같은 세대 폴백을 추가해 해소했다.
+
+교훈: 강등이 조용하면 근거와 결과가 어긋난 채로 티어 결정이 누적된다. INV-004의 출처다.
+
+### F4 — orca에는 티어 어휘가 없다
+
+`orca agent-context --json`(223 command, schema v1) 전수 검색:
+
+| 토큰 | 출현 |
+| --- | --- |
+| `quality` | 0 |
+| `tier` | 0 |
+| `opus` / `sonnet` / `gpt-5` / `balanced` / `ultra` | 0 |
+| `model` | 5 |
+| `effort` | 3 |
+
+모델·effort를 받는 명령은 `orchestration worker-start` 하나뿐이다.
+```
+--model supports Claude, Codex, and Cursor opaque provider model ids;
+--effort requires --model. Neither can combine with --terminal.
+```
+`worktree create --agent <id>`는 모델을 받지 않는다. 즉 orca는 설계상 **opaque id 소비자**이며, 여기에 티어 어휘를 심으면 INV-001을 깬다.
+
+### F5 — omp의 역할 어휘는 상수로 고정되어 있고 autopus가 이미 투영한다
+
+omp `modelRoles`는 `default/plan/slow/smol/designer/vision/commit/tiny/task/advisor` 10종이며 각각 `provider/model:thinking`이다. autopus는 `pkg/config/role_model_policy_matrix.go:16-25`에 같은 10종을 상수로 갖고, capability 6종(`role_model_policy_matrix.go:8-14`)과 16 소스 에이전트(64-81행)로 매핑한다. 투영 지점은 `pkg/adapter/omp/omp_model_projection.go:59-107`, 실제로 쓰는 omp 설정 키는 `modelRoles`, `retry.fallbackChains`, `retry.modelFallback`이다(`omp_model_integration_activation.go:88-128`).
+
+J1은 이미 닫혀 있다. PR #154가 `quality.default` -> 내장 role-model 프로파일 -> `modelRoles` 경로를 추가했다.
+
+### F6 — `--execution-owner orca`는 계약만 있고 실행이 없다
+
+`internal/cli/pipeline_run_owner.go:160-164`
+```go
+result := pipelineExecutionOwnerResult{
+    Schema: pipelineExecutionOwnerResultSchema, Status: "handoff_required",
+    ...
+    RequiredAction: "orca skills get orchestration --full",
+}
+```
+
+소유자를 기록하고 "orca 스킬을 읽어라"를 반환한 뒤 끝난다. 실제 Run 생성·워커 배치는 사람 또는 상위 에이전트가 수행한다. 따라서 이 SPEC의 정합 게이트는 **handoff 직전**에 놓여야 한다. 그래야 handoff를 받은 쪽이 이미 검증된 티어 계약을 들고 출발한다.
+
+### F7 — 단일 DAG 소유자 불변식은 세 평면 합성을 금지하지 않는다
+
+`pkg/adapter/omp/omp_workflow_render.go:99`
+```
+Owner `orca`: do not initialize an OMP task/todo DAG or call `task`.
+```
+
+금지 대상은 **OMP task DAG**이지 omp 실행 자체가 아니다. orca Run이 소유하는 워커 안에서 omp가 모델 평면 역할만 수행하고 자기 DAG를 만들지 않으면 INV-002를 준수한다. 세 평면 합성은 기존 불변식과 양립한다.
+
+## Completion Debt
+
+- [ ] 정합 점검이 조회할 계정 정보의 정확한 소스. `orca account list`는 사람이 읽는 텍스트다. `--json`이 있는지, 없으면 `orca agent-context --json`의 스키마로 대체 가능한지 구현 전에 확정해야 한다.
+- [ ] Claude 쪽 카탈로그 프로브의 부재. Codex는 `codex debug models`가 있지만 Claude는 등가물이 확인되지 않았다. Claude 티어 검증을 어떤 신호로 할지(또는 검증 불가로 명시할지) 결정이 필요하다.
+- [ ] 원격 orca 환경(`--on <saved-environment>`)에서의 계정 조회. 로컬 host와 원격 worker server의 계정이 또 다를 수 있다.
+
+## Evolution Ideas
+
+- 정합 점검 결과를 캐시해 매 실행마다 카탈로그를 프로브하지 않게 만들 수 있다. 계정 전환 감지와 TTL이 필요하다.
+- 여러 계정을 풀로 두고 요청 티어를 제공할 수 있는 계정을 자동 선택하는 라우팅. 지금은 활성 계정 하나를 검증만 한다.
+- 티어 강등이 불가피할 때 대안 provider로 넘기는 정책. capability 라우팅이 provider-neutral이므로 구조적으로는 가능하다.
+- 실행 원장 통합. 정책·모델·프로세스 세 평면의 관측 데이터를 한 영수증으로 조인.
+
+## Reference Discipline
+
+| 참조 | 유형 | 확인 방법 |
+| --- | --- | --- |
+| `orca account list` 출력 | 실측 | 이 워크스테이션에서 직접 실행 |
+| `orca agent-context --json` | 실측 | 223 command 스키마 전수 검색 |
+| `omp config list`의 `modelRoles` | 실측 | 직접 실행 |
+| `pkg/codexruntime/probe.go:39` | 코드 | 직접 읽음 |
+| `internal/cli/codex_catalog_runtime.go:48-58` | 코드 | 직접 읽음 |
+| `internal/cli/pipeline_run_owner.go:160-164` | 코드 | 직접 읽음 |
+| `pkg/adapter/omp/omp_workflow_render.go:99` | 코드 | 직접 읽음 |
+| `pkg/config/role_model_policy_matrix.go:8-81` | 코드 | 직접 읽음 |
+| PR #151 / #152 / #154 | 이력 | 이 저장소 머지 커밋 |
+
+추측은 없다. 위 표에 없는 주장은 이 문서에 담지 않았다.
+
+## Reviewer Brief
+
+이 SPEC은 **설계 고정**이 목적이고 구현을 포함하지 않는다. 리뷰어가 우선 검증할 것:
+
+1. 세 평면 경계가 실제로 배타적인가. 어느 한 평면에 이 SPEC의 요구를 넣었을 때 다른 평면에 같은 어휘가 생기지 않는가.
+2. 정합 게이트를 autopus에 두는 선택이 맞는가. orca에 두면 orca가 티어를 알아야 하고(INV-001 위반), omp에 두면 omp가 실행 계정을 알아야 한다(평면 침범).
+3. F6의 handoff 직전 배치가 INV-005(부작용 없음)를 실제로 보장하는가.
+4. Completion Debt 3건이 구현 착수 전에 해소 가능한 질문인가, 아니면 SPEC 자체를 막는가.
+
+블로킹 대상은 Completion Debt뿐이다. Evolution Ideas는 자문이다.
+
+## Self-Verify Summary
+
+- **Q-CORR-04** (근거 정확성) | status: PASS — 모든 사실 주장이 Reference Discipline 표의 실측 또는 코드 인용에 대응한다. F1·F4·F5는 이 워크스테이션에서 명령을 실행해 얻은 출력이고, F2·F6·F7은 파일:라인 인용이다.
+- **Q-COMP-05** (범위 완결성) | status: PASS — 접합면 J1·J2를 모두 식별했고, J1은 이미 닫혀 있음을 근거와 함께 기록했으며 J2만 이 SPEC의 대상으로 남겼다. 세 평면의 소유 표면을 Feature Coverage Map에 전수 열거했다.
+- **Q-COMP-06** (미해결 항목 분리) | status: PASS — 확정되지 않은 3건을 Completion Debt로 분리했다. Evolution Ideas에는 `SPEC-`·`AC-`·체크박스를 넣지 않아 블로킹 항목과 자문 항목이 섞이지 않는다.
+- **Q-COMP-07** (완료 판정 가능성) | status: PASS — 이 SPEC은 설계 문서이므로 완료 증거는 4개 문서의 `auto spec validate` 통과와 세 평면 경계의 리뷰 합의다. 구현 증거는 요구하지 않으며 그 사실을 Outcome Boundary에 명시했다.

--- a/.autopus/specs/SPEC-EXECPLANE-001/spec.md
+++ b/.autopus/specs/SPEC-EXECPLANE-001/spec.md
@@ -1,0 +1,156 @@
+# SPEC-EXECPLANE-001: 실행 평면 분리와 티어·계정·카탈로그 정합
+
+**Status**: draft
+**Created**: 2026-08-10
+**Domain**: EXECPLANE
+
+---
+id: SPEC-EXECPLANE-001
+title: 실행 평면 분리와 티어·계정·카탈로그 정합
+version: 0.1.0
+status: draft
+priority: HIGH
+---
+
+## Purpose
+
+autopus-adk·omp·orca 셋을 동시에 쓰되 서로의 어휘를 복제하지 않도록 **세 평면 경계를 고정**하고, 그 경계에서 끊겨 있는 접합면 하나 — 티어 약속과 실제 실행 계정 — 를 잇는 계약을 정의한다.
+
+이 SPEC은 설계 고정 문서다. 구현은 포함하지 않는다.
+
+## Background
+
+세 시스템은 각자 독점적인 강점을 갖는다.
+
+| 평면 | 시스템 | 독점 표면 |
+| --- | --- | --- |
+| 정책 | autopus-adk | SPEC, 16 canonical agent, quality tier, 게이트, 합의 전략, 비용 |
+| 모델 | omp | role -> `provider/model:thinking`, provider 횡단 카탈로그, RPC 제어 |
+| 프로세스 | orca | worktree 격리, provider 계정 소유, 감독 워커, durability, 스케줄 |
+
+접합면은 둘이다. **J1(티어 -> 모델)은 PR #154로 닫혔다** — `quality.default`가 내장 role-model 프로파일을 거쳐 omp `modelRoles`에 도달한다. **J2(티어 -> 실행 계정)는 끊겨 있다.**
+
+끊김의 형태는 research.md F1·F2에 실측으로 기록되어 있다. 이 워크스테이션에서 orca의 활성 Codex 계정은 `bitgapnam@gmail.com`인데 로컬 `codex` CLI 로그인은 `jroad1049@gmail.com`이다. autopus의 카탈로그 프로브는 PATH 바이너리를 실행하므로(`pkg/codexruntime/probe.go:39`) **로컬 로그인 계정의 카탈로그로 검증하고, orca는 다른 계정으로 실행한다**. `codex debug models`는 계정별 카탈로그이므로 두 집합은 다를 수 있다.
+
+이 실패 양식은 가설이 아니다. PR #151에서 실제로 발생해 티어 승격이 세대 강등으로 뒤집혔고, 조용했기 때문에 근거와 결과가 어긋난 채 결론까지 갔다(research.md F3).
+
+## Outcome Boundary
+
+- **Outcome Lock**: 세 평면의 소유 표면이 문서로 배타적으로 고정되고, autopus가 결정한 모델 티어는 그 워크로드를 실제로 실행할 계정의 카탈로그로 검증된 뒤에만 실행 단계로 넘어간다. 검증에 실패하면 조용히 강등되지 않고 원한 티어·실행 계정·실제 제공 모델 셋을 모두 지목하는 영수증을 남긴 뒤 멈추거나 명시적으로 강등한다.
+- **Mandatory requirements**: 평면 배타성 선언(REQ-001), orca 티어 어휘 무증식(REQ-002), 실행 계정 확인(REQ-003), 실행 계정 기준 카탈로그 검증(REQ-004), 정합 영수증 방출(REQ-005), 불일치 시 fail-loud(REQ-006), 부작용 이전 배치(REQ-007), handoff 경계 배치(REQ-008), 검증 불가 provider의 명시적 표기(REQ-009).
+- **Explicit non-goals**: 정합 게이트의 구현(별도 SPEC), `--execution-owner orca` handoff 스텁을 실제 Run으로 대체하는 일(별도 SPEC), 여러 계정 사이의 자동 라우팅, 티어 강등 시 대안 provider 폴백, 실행 원장 통합, J1 재설계(PR #154 결과 불변), omp `modelRoles` 어휘 변경, orca CLI 표면 변경.
+- **Completion evidence**: 4개 SPEC 문서가 `auto spec validate`를 통과하고, research.md의 Completion Debt 3건이 해소 또는 후속 SPEC으로 이관되며, 세 평면 경계에 대한 리뷰 합의가 기록된다. 구현 증거는 요구하지 않는다.
+
+## Requirements
+
+### REQ-001 — 세 평면의 소유 표면은 배타적으로 선언된다
+THE SYSTEM SHALL declare exactly one owning plane for each execution surface — policy for SPEC, canonical agent roles, quality tiers, gates, consensus, and cost; model for role-to-model routing, thinking levels, and cross-provider catalogs; process for worktree isolation, provider accounts, supervision, durability, and scheduling — so that adding a capability to one plane never duplicates its vocabulary in another.
+- EARS type: Ubiquitous
+- Priority: Must
+- Trigger/Condition: 세 시스템 중 하나에 모델 선택·실행 배치 관련 표면을 추가할 때.
+- Observability: research.md Feature Coverage Map의 각 표면에 소유자가 정확히 하나 지정되어 있고, 같은 어휘가 둘 이상의 평면에 나타나지 않음을 S1로 확인한다.
+
+### REQ-002 — 프로세스 평면에 티어 어휘를 도입하지 않는다
+THE SYSTEM SHALL keep the process plane free of tier vocabulary, passing only opaque provider model identifiers and effort levels across the policy-to-process boundary, so the tier ladder stays single-sourced in the policy plane.
+- EARS type: Ubiquitous
+- Priority: Must
+- Trigger/Condition: 정책 평면이 프로세스 평면에 실행을 위임할 때.
+- Observability: 경계를 넘는 값에 `balanced`/`ultra`/`opus`/`sonnet`/`haiku` 토큰이 없고 provider 고유 model id와 effort만 있음을 S2로 확인한다.
+
+### REQ-003 — 실행 전에 실제 실행 계정을 확인한다
+WHEN the policy plane prepares a workload for execution, THEN THE SYSTEM SHALL determine the provider account that will actually run it from the process plane rather than assuming the account the local CLI is logged in as.
+- EARS type: Event-driven
+- Priority: Must
+- Trigger/Condition: 파이프라인·워크플로가 provider 프로파일을 확정하는 시점.
+- Observability: 정합 영수증에 실행 계정 식별자가 기록되고, 그 값이 로컬 CLI 로그인 계정과 다를 수 있음을 S3의 분기 계정 픽스처로 확인한다.
+
+### REQ-004 — 카탈로그 검증은 실행 계정 기준으로 수행한다
+THE SYSTEM SHALL validate a requested model tier against the model catalog of the execution account identified in REQ-003, and SHALL NOT treat a catalog probed under a different account as evidence for that tier.
+- EARS type: Ubiquitous
+- Priority: Must
+- Trigger/Condition: 요청 티어를 provider 모델로 해석할 때.
+- Observability: 검증에 사용한 카탈로그의 출처 계정이 영수증의 실행 계정과 일치함을 S3로 확인한다. 두 값이 다르면 검증은 성립하지 않은 것으로 처리된다.
+
+### REQ-005 — 정합 결과를 영수증으로 방출한다
+THE SYSTEM SHALL emit an integrity receipt carrying the requested tier, the resolved provider model, the execution account identifier, the catalog source, the resolution reason, and the verification status, so a later reader can reconstruct why a workload ran at the tier it ran at.
+- EARS type: Ubiquitous
+- Priority: Must
+- Trigger/Condition: 정합 점검이 끝난 시점.
+- Observability: 영수증이 위 6개 필드를 모두 담고 스키마 버전을 갖는지 S4로 확인한다.
+
+### REQ-006 — 티어 불일치는 조용히 강등되지 않는다
+IF the execution account cannot serve the requested tier, THEN THE SYSTEM SHALL fail closed or record an explicit downgrade that names both the requested tier and the model actually available, and SHALL NOT substitute a lower model with no record.
+- EARS type: Unwanted
+- Priority: Must
+- Trigger/Condition: 실행 계정 카탈로그에 요청 모델이 없을 때.
+- Observability: 강등 경로에서 영수증의 `reason`이 비어 있지 않고 요청 값과 실제 값이 모두 존재함을 S5로 확인한다. 두 값 중 하나라도 없으면 위반이다.
+
+### REQ-007 — 정합 점검은 실행 부작용 이전에 끝난다
+WHEN the integrity check runs, THEN THE SYSTEM SHALL complete it before creating any worktree, Run, worker, or provider session, so a failed check leaves no resource behind.
+- EARS type: Event-driven
+- Priority: Must
+- Trigger/Condition: 워크로드 준비 단계.
+- Observability: 점검 실패 시나리오에서 생성된 워크트리·Run·세션이 0건임을 S6로 확인한다.
+
+### REQ-008 — 소유자 handoff 직전에 배치한다
+WHERE the execution owner is the process plane, THE SYSTEM SHALL run the integrity check before emitting the handoff result, so the receiving side starts from an already-verified tier contract instead of rediscovering the mismatch mid-run.
+- EARS type: State-driven
+- Priority: Must
+- Trigger/Condition: `--execution-owner orca` 경로가 handoff 결과를 반환하기 직전.
+- Observability: handoff 결과에 정합 영수증 참조가 포함되고, 점검 실패 시 handoff 결과 대신 정합 실패가 반환됨을 S7로 확인한다.
+
+### REQ-009 — 검증 수단이 없는 provider는 검증됨으로 표기하지 않는다
+IF a provider exposes no account-scoped catalog probe, THEN THE SYSTEM SHALL mark that provider's tier as unverified in the receipt rather than reporting it as verified.
+- EARS type: Unwanted
+- Priority: Must
+- Trigger/Condition: provider가 카탈로그 조회 수단을 제공하지 않을 때.
+- Observability: 해당 provider의 영수증 항목이 `unverified` 상태와 사유를 갖고, `verified`로 표기되지 않음을 S8로 확인한다.
+
+## Acceptance Criteria
+
+- [ ] 세 평면의 소유 표면이 배타적으로 열거되고 중복 어휘가 없다
+- [ ] 프로세스 평면 경계를 넘는 값에 티어 어휘가 없다
+- [ ] 정합 점검이 로컬 로그인 계정이 아니라 실행 계정을 사용한다
+- [ ] 정합 영수증이 6개 필드를 모두 담는다
+- [ ] 티어 불일치가 조용히 강등되지 않는다
+- [ ] 점검 실패가 리소스를 남기지 않는다
+- [ ] handoff 결과가 정합 영수증을 참조한다
+- [ ] 검증 불가 provider가 `unverified`로 표기된다
+
+## Traceability Matrix
+
+| Requirement | Plan Task | Acceptance Scenario | Semantic Invariant |
+|-------------|-----------|---------------------|--------------------|
+| REQ-001 | T1 | S1 | INV-001 |
+| REQ-002 | T1 | S2 | INV-001 |
+| REQ-003 | T2 | S3 | INV-003 |
+| REQ-004 | T2 | S3 | INV-003 |
+| REQ-005 | T3 | S4 | INV-004 |
+| REQ-006 | T3 | S5 | INV-004 |
+| REQ-007 | T4 | S6 | INV-005 |
+| REQ-008 | T4 | S7 | INV-002, INV-005 |
+| REQ-009 | T3 | S8 | INV-004 |
+
+## Out of Scope
+
+- 정합 게이트의 구현 코드. 이 SPEC은 계약만 고정한다.
+- `--execution-owner orca`의 handoff 스텁을 실제 orca Run 생성으로 대체하는 작업.
+- 요청 티어를 제공 가능한 계정을 자동 선택하는 다계정 라우팅.
+- 티어 강등이 불가피할 때 다른 provider로 넘기는 폴백 정책.
+- autopus·omp·orca 관측 데이터를 한 영수증으로 합치는 실행 원장.
+- J1(티어 -> omp `modelRoles`) 재설계. PR #154 결과를 불변으로 둔다.
+- orca CLI 표면 변경. orca는 소비자로만 취급한다.
+
+## Traceability
+
+| Requirement | Test | Status |
+|-------------|------|--------|
+| REQ-001 | S1 | pending |
+| REQ-002 | S2 | pending |
+| REQ-003 | S3 | pending |
+| REQ-004 | S3 | pending |
+| REQ-005 | S4 | pending |
+| REQ-006 | S5 | pending |
+| REQ-007 | S6 | pending |
+| REQ-008 | S7 | pending |
+| REQ-009 | S8 | pending |


### PR DESCRIPTION
설계 고정 SPEC. 구현 코드 변경 0건 — `.autopus/specs/SPEC-EXECPLANE-001/` 4개 문서만 추가한다.

## 왜

autopus-adk·omp·orca를 동시에 쓰려면 먼저 경계가 있어야 한다. 없으면 방금 #154에서 정리한 티어 어휘가 다시 세 곳으로 복제된다.

| 평면 | 시스템 | 독점 표면 |
| --- | --- | --- |
| 정책 | autopus-adk | SPEC, 16 canonical agent, quality tier, 게이트, 합의, 비용 |
| 모델 | omp | role → `provider/model:thinking`, provider 횡단 카탈로그, RPC |
| 프로세스 | orca | worktree 격리, provider 계정, 감독 워커, durability, 스케줄 |

접합면은 둘이고, 하나는 이미 닫혀 있다.

- **J1 티어 → 모델**: PR #154로 닫힘. `quality.default` → 내장 role-model 프로파일 → omp `modelRoles`.
- **J2 티어 → 실행 계정**: 끊김. 이 SPEC의 대상.

## 무엇이 끊겨 있나 (실측)

```
orca 활성 Codex 계정   bitgapnam@gmail.com
로컬 codex 로그인       jroad1049@gmail.com
autopus 카탈로그 프로브  PATH 바이너리 → 즉 로컬 로그인 계정 기준
```

`codexruntime.ProbeModelCatalog`은 `exec.CommandContext(binary, "debug", "models")`로 PATH 바이너리를 실행한다(`probe.go:39`). `codex debug models`는 **계정별** 카탈로그다. 즉 **검증 대상 계정과 실행 대상 계정이 다르다.**

이 실패 양식은 가설이 아니다. PR #151에서 실제로 발생해 티어 승격이 `gpt-5.6-terra/medium` → `gpt-5.5/xhigh` 세대 강등으로 뒤집혔고, 조용했기 때문에 근거와 결과가 어긋난 채 결론까지 갔다. PR #152가 사후 수습했다.

## 고정한 것

요구 9개(REQ-001~009), 불변식 5개(INV-001~005), 시나리오 8개(S1~S8).

- **INV-001 어휘 무증식** — orca는 opaque model id + effort만 받는다. `orca agent-context --json` 223개 명령 전수 검색에서 `quality`/`tier`/`opus`/`sonnet`/`balanced`/`ultra` 0건이며, 이 상태를 유지한다.
- **INV-002 단일 DAG 소유자** — 기존 불변식과 양립함을 근거와 함께 기록했다. `--execution-owner orca`가 금지하는 건 *OMP task DAG*이지 omp 실행 자체가 아니므로(`omp_workflow_render.go:99`), orca Run이 소유하는 워커 안에서 omp가 모델 평면 역할만 하는 구성은 준수다.
- **INV-003 실행 계정 기준 검증** — 로컬 로그인 계정의 카탈로그는 다른 계정의 티어 근거가 될 수 없다.
- **INV-004 fail-loud** — 강등은 조용할 수 없다. 요청 티어와 실제 제공 모델을 둘 다 남긴다. 검증 수단이 없는 provider는 `verified`가 아니라 `unverified`로 표기한다.
- **INV-005 부작용 없음** — 점검은 워크트리·Run·워커·세션 생성 이전에 끝난다. 실패 경로에 롤백이 필요 없도록 배치로 보장한다.

게이트는 정책 평면에 둔다. orca에 두면 orca가 티어를 알아야 하고(INV-001 위반), omp에 두면 omp가 실행 계정을 알아야 한다(평면 침범). plan.md에서 두 대안을 명시적으로 기각했다.

## 범위 밖

정합 게이트 구현, `--execution-owner orca` handoff 스텁(`pipeline_run_owner.go:160-164`)을 실제 Run으로 대체하는 작업, 다계정 자동 라우팅, 티어 강등 시 provider 폴백, 실행 원장 통합, J1 재설계, orca CLI 표면 변경.

## 미해결 (Completion Debt 3건)

구현 착수 전에 답해야 하고, 답에 따라 구현 선택이 갈린다. 계약 자체는 답과 무관하게 고정된다.

1. `orca account list`는 사람이 읽는 텍스트다. `--json`이 있는지, 없으면 무엇으로 대체하는지.
2. Claude 쪽에 `codex debug models` 등가물이 확인되지 않았다. 검증 신호를 정하거나 검증 불가로 명시해야 한다.
3. 원격 orca 환경(`--on <saved-environment>`)의 계정은 또 다를 수 있다.

## 검증

`auto spec validate` 통과. `auto check --hygiene --arch --staged` exit 0. 코드 변경 0건이라 스위트는 무관하다.

research.md의 모든 사실 주장은 Reference Discipline 표에 실측 명령 출력 또는 파일:라인 인용으로 대응한다. 추측은 담지 않았다.
