### PR TITLE
docs(spec): SPEC-EXECPLANE-001 미결 3건 해소 및 계정 실측 정정

### DIFF
--- a/.autopus/specs/SPEC-EXECPLANE-001/acceptance.md
+++ b/.autopus/specs/SPEC-EXECPLANE-001/acceptance.md
@@ -4,7 +4,7 @@
 
 ## Test Scenarios
 
-spec.md `## Traceability Matrix`에서 파생한 커버리지(권위 있는 매핑은 spec.md 쪽이다): S1=REQ-001, S2=REQ-002, S3=REQ-003·REQ-004, S4=REQ-005, S5=REQ-006, S6=REQ-007, S7=REQ-008, S8=REQ-009. 9개 요구가 8개 시나리오로 빠짐없이 덮인다.
+spec.md `## Traceability Matrix`에서 파생한 커버리지(권위 있는 매핑은 spec.md 쪽이다): S1=REQ-001, S2=REQ-002, S3=REQ-003·REQ-004, S4=REQ-005, S5=REQ-006, S6=REQ-007, S7=REQ-008, S8=REQ-009, S9=REQ-003·REQ-009. 9개 요구가 9개 시나리오로 빠짐없이 덮인다. REQ-003은 S3(실행 계정과 프로브 계정이 갈라진 경우)과 S9(실행 계정을 특정할 수 없는 경우) 둘로, REQ-009는 S8(검증 수단 부재)과 S9 둘로 나뉜다.
 
 ### S1: 세 평면의 소유 표면이 배타적으로 열거된다
 
@@ -27,7 +27,8 @@ And 티어 사다리의 단일 출처는 정책 평면에 남는다
 ### S3: 실행 계정과 로컬 로그인 계정이 다를 때 실행 계정 기준으로 검증한다
 
 Priority: Must
-Given 프로세스 평면이 보고하는 활성 Codex 실행 계정은 `bitgapnam@gmail.com`이고, 이 워크스테이션의 로컬 `codex` CLI 로그인 계정은 `~/.codex/auth.json` 기준 `jroad1049@gmail.com`이다(research.md F1)
+Given 프로세스 평면이 보고하는 활성 Codex 실행 계정은 `orca account list --json`의 `result.codex.activeAccountId` 기준 `bitgapnam@gmail.com`이고, 같은 응답의 `result.codex.systemDefault`가 가리키는 로컬 `codex` CLI 계정은 `gnkong@alipeople.kr`이다(research.md F1)
+And 두 값은 한 번의 `orca account list --json` 호출로 함께 얻는다. 실행 계정은 `activeAccountId`, 비교 대상인 프로브 계정은 `systemDefault`(codex) 또는 provider CLI 신원이므로, 비교에 추가 조회가 필요하지 않다
 And 일반화하면 실행 계정 A와 로컬 로그인 계정 B가 존재하고 A != B이며, 이 시나리오의 판정은 두 계정의 구체 문자열이 아니라 A != B라는 조건과 검증에 사용된 계정이 A인지 여부에만 의존한다
 And 카탈로그 프로브는 PATH 바이너리를 실행하므로 기본값은 B의 카탈로그다(`pkg/codexruntime/probe.go:39`)
 When 정합 점검이 요청 티어를 provider 모델로 해석한다
@@ -73,38 +74,57 @@ Then 점검이 통과하면 handoff 결과에 S4 영수증에 대한 참조가 �
 And 점검이 실패하면 `handoff_required` 결과 대신 정합 실패가 반환되고 handoff 결과는 방출되지 않는다
 And 이 경로는 OMP task DAG를 만들지 않으므로 DAG 소유자는 하나로 유지된다(`pkg/adapter/omp/omp_workflow_render.go:99`)
 
-### S8: 검증 수단이 없는 provider는 unverified로 표기된다
+### S8: 검증 수단이 없는 항목은 unverified로 표기된다
 
 Priority: Must
-Given provider가 계정 범위 카탈로그 프로브를 제공하지 않는다. Codex는 `codex debug models`가 있으나 Claude 등가물은 확인되지 않았다(research.md Completion Debt)
-When 그 provider의 요청 티어에 대해 정합 점검을 수행한다
+Given REQ-009가 흡수하는 인스턴스는 셋이다. (1) Claude 모델 가용성 — `claude` CLI 명령 집합(`agents`/`auth`/`auto-mode`/`doctor`/`gateway`/`import`/`install`/`mcp`/`plugin`/`project`/`setup-token`/`ultrareview`)에 모델 열거 명령이 없고 `omp models --json`은 정적 레지스트리라 계정 스코프가 아니므로, 계정별 카탈로그 프로브가 존재하지 않는다(research.md F8)
+And (2) 원격 orca 환경 — `orca account list`가 `--environment`를 "rejected rather than ignored"로 거부하므로 원격 호스트의 계정을 조회할 수단이 없다. `orca environment list --json`이 `{"environments": []}`라 현재 영향 범위는 0건이지만 규칙은 같다(research.md F8)
+And (3) 실행 계정 미특정 — 활성 계정이 없고 등록 계정이 1개가 아닌 경우다. 이 인스턴스의 판정은 S9가 담당하고 S8은 같은 `unverified` 규칙을 공유한다는 사실만 참조한다
+And Codex와 달리 Claude는 신원 대조까지는 가능하다. `claude auth status --json`의 `orgId`가 orca `claude.accounts[].organizationUuid`와 같은 값 `0e61c3e2-35c8-4bf8-91bc-40848f4dc147`이다(research.md F1)
+When 그 항목의 요청 티어에 대해 정합 점검을 수행한다
 Then 영수증의 verification status 값이 `unverified`다
 And 같은 항목이 `verified`로 표기되지 않는다
-And 사유 필드에 검증 수단 부재가 기록되어, 미검증과 검증 실패가 구분된다
+And Claude에서 신원 대조가 성공해도 모델 가용성 항목은 여전히 `unverified`다. 신원 검증 성공과 카탈로그 미검증은 동시에 성립하는 정상 상태이며, 신원이 맞았다는 이유로 티어를 `verified`로 승격하면 실패다
+And `subscriptionType`(`max`/`pro`/`free`)에서 플랜 -> 모델 표를 유도해 `verified`를 만들어내지 않는다. 그것은 PR #154가 제거한 하드코딩 티어 테이블의 재도입이다
+And 사유 필드에 검증 수단 부재가 기록되어 미검증과 검증 실패가 구분되고, 세 인스턴스 중 어느 것인지 복원 가능하다
+
+### S9: 실행 계정을 특정할 수 없으면 추측하지 않고 unverified로 분기한다
+
+Priority: Must
+Given 프로세스 평면이 보고하는 어떤 provider의 `activeAccountId`가 `null`이다
+And 이 워크스테이션의 Claude가 정확히 그 상태다. `result.claude.activeAccountId`는 `null`이고 `result.claude.accounts[]`에는 `jroad1049@gmail.com`(organizationUuid `0e61c3e2-35c8-4bf8-91bc-40848f4dc147`) 하나만 등록되어 있으며, Claude 블록에는 codex와 달리 `systemDefault` 필드가 없다(research.md F1)
+When 정합 점검이 그 provider의 실행 계정을 확정한다
+Then 등록 계정이 정확히 1개면 그 계정을 실행 계정으로 채택하고, 영수증의 실행 계정 식별자가 그 값으로 채워진다. 현재 머신의 Claude가 이 분기이며 `jroad1049@gmail.com`이 채택된다
+And 등록 계정이 0개면 실행 계정을 특정하지 않고 REQ-009의 `unverified` 경로로 분기하며, 사유 필드에 계정 부재가 기록된다
+And 등록 계정이 2개 이상이면 어느 것도 고르지 않고 REQ-009의 `unverified` 경로로 분기한다. 활성 계정이 없다는 이유로 첫 번째 계정이나 최근 사용 계정을 고르면 실패다
+And 세 분기 어디에서도 로컬 CLI 로그인 계정을 실행 계정의 대체값으로 쓰지 않는다. 그 값은 S3의 프로브 계정 B이지 실행 계정 A가 아니다
+And 1개 채택 분기로 실행 계정이 특정되더라도 그 계정의 카탈로그 프로브가 없으면 모델 가용성은 S8의 `unverified`로 남는다
 
 ## Oracle Acceptance Notes
 
-이 SPEC은 설계 고정 문서이므로 위 시나리오는 지금 자동화된 테스트로 실행되지 않는다. S1·S2는 문서 검토로 즉시 판정 가능하고, S3~S8은 정합 게이트를 구현하는 후속 SPEC의 수용 오라클로 그대로 이월된다. 이월 시 아래 예상 값을 완화하는 것은 범위 축소로 취급한다.
+이 SPEC은 설계 고정 문서이므로 위 시나리오는 지금 자동화된 테스트로 실행되지 않는다. S1·S2는 문서 검토로 즉시 판정 가능하고, S3~S9는 정합 게이트를 구현하는 후속 SPEC의 수용 오라클로 그대로 이월된다. 이월 시 아래 예상 값을 완화하는 것은 범위 축소로 취급한다.
 
 각 시나리오의 판정 기준은 다음 구체 값으로 고정한다. `정상 동작한다` 같은 서술은 통과 근거가 아니다.
 
 - **S1** — 예상 값: Feature Coverage Map 7개 행 각각의 소유 평면 수 = 1. 소유자 미지정 행 0건, 복수 소유 행 0건. 신설 표면 `티어와 실행 계정의 정합 검증`의 소유자 문자열은 정책 평면 하나여야 하며, 같은 표면 이름이 모델·프로세스 평면 목록에 재등장하면 실패.
 - **S2** — 예상 값: 경계 인자 집합에서 `quality`=0, `tier`=0, `balanced`=0, `ultra`=0, `opus`=0, `sonnet`=0, `haiku`=0. 하나라도 1 이상이면 실패. `--model`, `--effort` 두 인자 외의 티어 파생 인자가 추가되어도 실패.
-- **S3** — 예상 값: `receipt.execution_account == receipt.catalog_source_account == A`. 검증에 B의 카탈로그가 쓰였으면 실패. 판정은 A != B 조건에만 의존해야 하며, `bitgapnam@gmail.com`·`jroad1049@gmail.com` 문자열을 하드코딩해 비교하는 오라클은 F1 시점의 계정 구성이 바뀌면 무의미해지므로 부적합으로 본다. 실측 계정 쌍은 A != B가 가설이 아니라 현재 상태임을 보이는 근거로만 쓴다.
+- **S3** — 예상 값: `receipt.execution_account == receipt.catalog_source_account == A`. 검증에 B의 카탈로그가 쓰였으면 실패. 판정은 A != B 조건에만 의존해야 하며, `bitgapnam@gmail.com`·`gnkong@alipeople.kr` 문자열을 하드코딩해 비교하는 오라클은 F1 시점의 계정 구성이 바뀌면 무의미해지므로 부적합으로 본다. 실측 계정 쌍은 A != B가 가설이 아니라 현재 상태임을 보이는 근거로만 쓴다. 두 값은 `orca account list --json` 한 응답의 `result.codex.activeAccountId`와 `result.codex.systemDefault`에서 나오므로, 프로브 계정을 별도 명령이나 로컬 파일에서 다시 읽는 구현은 같은 응답으로 대체 가능한 중복 조회로 본다.
 - **S4** — 예상 값: 영수증 필드 6개가 모두 존재. 요청 티어 / 해석된 provider 모델 / 실행 계정 식별자 / 카탈로그 출처 / resolution reason / verification status. 이 중 하나라도 누락되거나 빈 문자열이면 실패로 판정한다. 스키마 버전 태그 부재도 실패.
 - **S5** — 예상 값: `resolution.reason != ""`. 빈 문자열이면 위반. 요청 티어 값과 실제 제공 모델 값이 둘 다 non-empty여야 하고, 둘 중 하나만 있는 영수증은 실패. 영수증 없이 낮은 모델로 실행된 경우는 조용한 강등이므로 즉시 실패.
 - **S6** — 예상 값: 점검 실패 후 신규 워크트리 수 = 0, Run 수 = 0, 워커 수 = 0, provider 세션 수 = 0. 어느 하나라도 1 이상이면 INV-005 위반. 실패 후 정리(cleanup)로 0에 도달한 경우도 생성이 발생했으므로 실패로 본다.
 - **S7** — 예상 값: 통과 경로의 handoff 결과에 영수증 참조 필드가 1개 이상 존재. 실패 경로에서는 `status: handoff_required`가 반환되지 않고 정합 실패가 반환되어야 하며, 두 결과가 동시에 나오면 실패. 이 경로에서 생성된 OMP task DAG 수 = 0.
-- **S8** — 예상 값: `verification_status == "unverified"`이고 사유 필드 non-empty. 같은 항목에 `verified`가 오면 실패. 프로브가 없다는 이유로 티어를 검증됨으로 낙관 처리하거나, 반대로 검증 실패(카탈로그에 모델 없음)와 같은 상태값으로 뭉뚱그리면 실패.
+- **S8** — 예상 값: `verification_status == "unverified"`이고 사유 필드 non-empty. 같은 항목에 `verified`가 오면 실패. 프로브가 없다는 이유로 티어를 검증됨으로 낙관 처리하거나, 반대로 검증 실패(카탈로그에 모델 없음)와 같은 상태값으로 뭉뚱그리면 실패. Claude는 신원 대조(`orgId` == `organizationUuid`, 실측 `0e61c3e2-35c8-4bf8-91bc-40848f4dc147`)가 성공해도 모델 가용성 항목이 `unverified`여야 하고, `subscriptionType`을 근거로 `verified`를 만들면 실패. 원격 환경 대상은 `--environment` 거부로 계정 조회 자체가 불가능하므로 같은 `unverified`이며, 사유 문자열이 세 인스턴스(Claude 카탈로그 부재 / 원격 환경 / 계정 미특정) 중 어느 것인지 지목해야 한다.
+- **S9** — 예상 값: `activeAccountId == null`일 때 등록 계정 수 n으로 분기가 갈린다. n == 1이면 `receipt.execution_account`가 그 계정으로 non-empty, n == 0 또는 n >= 2이면 `receipt.execution_account`가 특정되지 않고 `verification_status == "unverified"` + 사유 non-empty. n >= 2에서 임의의 한 계정을 골라 실행 계정 필드를 채운 영수증은 값이 있어도 실패로 본다. 현재 머신의 Claude는 n == 1(`jroad1049@gmail.com`)이므로 채택 분기가 도달 가능함을 보이는 근거로만 쓰고, 계정 문자열을 하드코딩해 비교하지 않는다.
 
-판정 시 주의할 점 두 가지.
+판정 시 주의할 점 세 가지.
 
 - S3와 S8은 경계가 인접하다. 실행 계정 A를 특정했으나 A의 카탈로그를 조회할 수단이 없는 경우는 S3의 통과가 아니라 S8의 `unverified`다. 이 분기를 통과로 세면 INV-003이 무력화된다.
-- S5와 S8은 상태값이 달라야 한다. 카탈로그를 조회했고 모델이 없어 강등한 경우는 사유가 붙은 명시적 강등이고, 조회 수단 자체가 없는 경우는 `unverified`다. 둘을 한 값으로 합치면 영수증 독자가 근거의 강도를 복원할 수 없다.
+- S5·S8·S9는 상태값이 서로 달라야 한다. 카탈로그를 조회했고 모델이 없어 강등한 경우(S5)는 사유가 붙은 명시적 강등, 계정은 특정했으나 조회 수단 자체가 없는 경우(S8)는 실행 계정 필드가 채워진 `unverified`, 실행 계정조차 특정하지 못한 경우(S9)는 실행 계정 필드가 비어 있는 `unverified`다. 셋을 한 값으로 합치거나 뒤의 둘을 사유 없이 같은 항목으로 묶으면 영수증 독자가 근거의 강도를 복원할 수 없다.
+- 신원 검증 성공과 모델 가용성 `unverified`가 한 영수증에 함께 있는 것은 모순이 아니라 정상 상태다. Claude에서 `orgId`와 `organizationUuid`가 일치하면 "실행 계정이 검증 대상 계정과 같다"까지는 확정되지만, 그 계정이 어떤 모델을 쓸 수 있는지는 조회할 수단이 없다. 실행 계정 식별자는 확정값이고 verification status는 `unverified`인 조합을 읽고 결함으로 판정하면 안 된다. 두 축은 별개이며, 신원이 맞았다는 이유로 티어를 `verified`로 올리는 쪽이 실제 결함이다.
 
 ## Definition of Done
 
-- [ ] S1~S8이 REQ-001~REQ-009를 빠짐없이 덮는다(REQ-003·REQ-004는 함께 S3)
+- [ ] S1~S9가 REQ-001~REQ-009를 빠짐없이 덮는다(REQ-003은 S3·S9, REQ-004는 S3, REQ-009는 S8·S9)
 - [ ] 각 시나리오의 Then이 관측 가능한 값을 지명한다
-- [ ] S3~S8의 예상 값이 후속 구현 SPEC의 수용 오라클로 이관된다
+- [ ] S3~S9의 예상 값이 후속 구현 SPEC의 수용 오라클로 이관된다
 - [ ] 세 평면 경계에 대한 리뷰 합의가 기록된다

--- a/.autopus/specs/SPEC-EXECPLANE-001/plan.md
+++ b/.autopus/specs/SPEC-EXECPLANE-001/plan.md
@@ -27,6 +27,19 @@ orca가 게이트를 소유하면 orca가 "요청 티어"를 이해해야 한다
 
 omp가 게이트를 소유하면 omp가 "이 워크로드를 실제로 실행할 provider 계정"을 알아야 한다. 계정 소유와 활성 계정 선택은 프로세스 평면의 독점 표면(`orca account list`, research.md Feature Coverage Map)이다. omp의 어휘는 role -> `provider/model:thinking` 10종(`default/plan/slow/smol/designer/vision/commit/tiny/task/advisor`, F5)이며 계정 축이 아예 없다. 계정 축을 omp에 도입하는 것은 프로세스 평면 표면의 **평면 침범**이고, 동시에 정책 평면이 이미 소유한 티어 판정 책임을 모델 평면으로 옮기는 이중 이관이 된다. 기각한다.
 
+### 기각한 대안 (c) — Claude 검증을 `subscriptionType` 플랜 게이트로 한다
+
+Claude에는 `codex debug models` 등가물이 없다. F8의 확인 결과 `claude` CLI 명령 집합은 `agents`/`auth`/`auto-mode`/`doctor`/`gateway`/`import`/`install`/`mcp`/`plugin`/`project`/`setup-token`/`ultrareview`이고 모델 열거 명령이 없으며, `omp models --json`은 계정 스코프가 아닌 **정적 레지스트리**라 특정 계정의 자격을 증명하지 못한다. 대신 `claude auth status --json`이 신원과 플랜을 준다.
+
+```json
+{"loggedIn":true,"authMethod":"claude.ai","apiProvider":"firstParty",
+ "email":"jroad1049@gmail.com","orgId":"0e61c3e2-...","subscriptionType":"max"}
+```
+
+여기서 `subscriptionType`(`max`/`pro`/`free`)을 게이트 입력으로 삼아 "이 플랜이면 이 티어까지 허용"으로 판정하자는 안이 있었다. 기각한다. 판정이 성립하려면 플랜 -> 모델 매핑 표를 정책 평면에 하드코딩해야 하는데, 그 표는 계정이 실제로 무엇을 제공받는지에 대한 증거가 아니라 **우리 쪽의 추정**이다. provider가 플랜 정책을 바꾸면 표는 조용히 틀리고, 게이트는 틀린 표를 근거로 `verified`를 찍는다 — REQ-009가 금지하는 상태이자 INV-004가 막으려는 조용한 어긋남이다.
+
+형태로 보면 이 안은 PR #154가 제거한 하드코딩 티어 테이블을 provider 축에 되살리는 일이다. 같은 것을 다른 이름으로 되돌리지 않는다. Claude는 `orgId` 신원 대조까지만 검증하고 모델 가용성은 REQ-009의 `unverified`로 남긴다. 모르는 것을 모른다고 적는 편이 짐작해서 맞히는 것보다 싸다.
+
 ### 배치 지점 — handoff 직전, 부작용 이전
 
 `--execution-owner orca` 경로는 현재 실행이 없다. `internal/cli/pipeline_run_owner.go:160-164`은 소유자를 기록하고 반환하며 끝난다.
@@ -45,15 +58,19 @@ result := pipelineExecutionOwnerResult{
 
 ### 왜 이 SPEC은 설계만 고정하고 구현을 분리하는가
 
-research.md Completion Debt 3건이 **미해결인 채로는 구현 선택이 정해지지 않는다.** 세 건 모두 계약이 아니라 구현 형태를 바꾸는 질문이다.
+착수 시점의 이유는 "미결 3건이 열려 있어 구현 선택이 정해지지 않는다"였다. 그 이유는 더 이상 유효하지 않다. research.md F8이 3건을 모두 실측으로 닫았고, 결정은 `### 결정` 표에, 계약은 spec.md REQ-003·REQ-004·REQ-009 본문에 들어갔다. `## Completion Debt`는 `none remaining`이다.
 
-| Completion Debt | 미해결이면 바뀌는 구현 선택 |
-| --- | --- |
-| 계정 정보의 정확한 소스 (`orca account list`는 사람이 읽는 텍스트, `--json` 유무 미확인) | 계정 조회를 구조화 출력 파싱으로 할지 `orca agent-context --json` 스키마 경유로 할지 |
-| Claude 쪽 카탈로그 프로브 부재 (Codex는 `codex debug models`, Claude 등가물 미확인) | Claude 티어를 어떤 신호로 검증할지, 아니면 REQ-009의 `unverified` 경로로 보낼지 |
-| 원격 orca 환경(`--on <saved-environment>`)의 계정 조회 | 계정 조회가 로컬 단일 호출인지 원격 host 축을 갖는지 |
+| 닫힌 질문 | 확정된 결정 | 계약이 앉는 자리 |
+| --- | --- | --- |
+| 계정 조회 소스 | `orca account list --json` 한 호출. 실행 계정은 `result.<provider>.activeAccountId`, 비교 대상 프로브 계정은 `result.codex.systemDefault`(codex) 또는 provider CLI 신원 | REQ-003 / T2 |
+| Claude 카탈로그 부재 | 신원만 검증. `claude auth status --json`의 `orgId`를 orca `claude.accounts[].organizationUuid`와 대조하고, 모델 가용성은 `unverified`로 남긴다 | REQ-004 / T2, REQ-009 / T3 |
+| 원격 orca 환경 계정 조회 | 새 요구를 만들지 않고 REQ-009에 흡수. `orca account list`가 `--environment`를 구조적으로 거부하므로 "계정 조회 수단 없음"의 인스턴스다 | REQ-009 / T3 |
 
-계약(요구 9건 · 불변식 5건 · 영수증 6필드)은 세 질문의 답과 무관하게 고정된다. 반대로 구현은 답에 따라 달라진다. 그래서 계약을 먼저 얼리고 구현을 분리했다. 이 분리는 spec.md `## Out of Scope` 첫 항목("정합 게이트의 구현 코드")과 일치한다.
+그렇다면 왜 여전히 구현을 분리하는가. 이유가 바뀌었기 때문이다 — "질문이 열려 있어서"가 아니라 **계약이 먼저 합의되어야 구현이 바로잡힐 수 있어서**다.
+
+F3의 실패는 구현이 없어서 생긴 것이 아니다. `ResolveCodexProfile`은 있었고 동작했다. 없었던 것은 "어느 계정의 카탈로그가 증거로 인정되는가"에 대한 합의였고, 그 공백을 코드가 하드코딩 레거시 폴백으로 메우면서 세대 강등이 조용히 통과했다. 계약 없이 구현부터 손대면 같은 종류의 암묵 가정 — 이번에는 "로컬 CLI 로그인이 곧 실행 계정", "플랜을 알면 모델을 안다" — 이 다른 자리에 다시 자리잡는다. 위의 기각한 대안 (c)가 실제로 검토되고 기각됐다는 사실이 그 위험이 가설이 아님을 보여준다.
+
+분리가 남기는 부채도 작아졌다. 요구 9건·불변식 5건·영수증 6필드는 이제 열린 질문에 기대지 않고 단독으로 판정 가능하므로, 후속 구현 SPEC이 발명할 것은 없고 이 문서를 참조 구현하면 된다. 이 분리는 spec.md `## Out of Scope` 첫 항목("정합 게이트의 구현 코드")과 일치한다.
 
 ## File Impact Analysis
 
@@ -62,9 +79,9 @@ research.md Completion Debt 3건이 **미해결인 채로는 구현 선택이 �
 | 파일 | 작업 | 설명 |
 |------|------|------|
 | `.autopus/specs/SPEC-EXECPLANE-001/spec.md` | 생성 | 요구 9건, Outcome Boundary, Traceability Matrix, Out of Scope |
-| `.autopus/specs/SPEC-EXECPLANE-001/research.md` | 생성 | 실측 근거 F1~F7, 불변식 5건, Completion Debt 3건, Reference Discipline |
+| `.autopus/specs/SPEC-EXECPLANE-001/research.md` | 생성 | 실측 근거 F1~F8, 불변식 5건, 해소된 결정 표(Completion Debt `none remaining`), Reference Discipline |
 | `.autopus/specs/SPEC-EXECPLANE-001/plan.md` | 생성 | 이 문서. 게이트 배치 논증과 T1~T4 설계 태스크 |
-| `.autopus/specs/SPEC-EXECPLANE-001/acceptance.md` | 생성 | S1~S8 시나리오와 Oracle Acceptance Notes |
+| `.autopus/specs/SPEC-EXECPLANE-001/acceptance.md` | 생성 | S1~S9 시나리오와 Oracle Acceptance Notes |
 
 아래 코드는 **참조 대상**이며 이 SPEC에서 수정하지 않는다: `pkg/codexruntime/probe.go`, `internal/cli/codex_catalog_runtime.go`, `internal/cli/pipeline_run_owner.go`, `pkg/adapter/omp/omp_workflow_render.go`, `pkg/config/role_model_policy_matrix.go`.
 
@@ -94,25 +111,31 @@ J2 접합면의 런타임 흐름. research.md의 세 평면 정적 다이어그�
   | (1) 실행 계정 조회            REQ-003 / INV-003 |
   |     프로세스 평면에 질의                        |
   |     "이 워크로드를 실제로 실행할 계정은?"       |
+  |     해석: active -> 단일 등록 -> unverified     |
   |     ! 로컬 CLI 로그인 계정으로 가정하지 않는다  |
-  |       F1: orca active = bitgapnam@gmail.com     |
-  |           local codex = jroad1049@gmail.com     |
+  |       F1: orca active  = bitgapnam@gmail.com    |
+  |           local codex  = gnkong@alipeople.kr    |
+  |           local claude = jroad1049@gmail.com    |
   +-------------------------------------------------+
-        | account_id
+        | account_id (또는 미특정)
         v
   +-------------------------------------------------+
   | (2) 그 계정의 카탈로그 확보    REQ-004 / INV-003|
   |     catalog_source := account_id 기준           |
+  |     Codex : codex debug models = 계정별 카탈로그|
+  |     Claude: 등가물 없음 -> orgId 신원 대조까지만|
   |     ! F2: PATH 바이너리 프로브는 로컬 로그인    |
   |       계정 기준 -> 실행 계정과 다르면 증거 아님 |
   +--------------------+----------------------------+
                        |
           +------------+------------+
-          | 프로브 있음            | 프로브 없음
+          | 계정별 카탈로그 있음   | 카탈로그 없음 · 계정 미특정
+          |   (Codex 축)           |   (Claude 가용성 · 원격 환경)
           v                        v
   (3a) 해석 / 검증          (3b) unverified 표기
        요청 티어 in 카탈로그?      REQ-009 / INV-004
-       INV-003                     사유 기록, verified 금지
+       출처 계정 == 실행 계정      사유 기록, verified 금지
+       INV-003                     신원만 대조, 가용성 미검증
           |                        |
           +------------+-----------+
                        v
@@ -142,11 +165,12 @@ J2 접합면의 런타임 흐름. research.md의 세 평면 정적 다이어그�
    티어 어휘는 경계에서 소멸
 ```
 
-읽는 법 세 가지.
+읽는 법 네 가지.
 
 1. **부작용 경계**는 (5)와 프로세스 평면 사이에 정확히 한 번 그어진다. (1)~(4)와 (6)은 전부 경계 위에 있으므로 실패 경로에 롤백이 필요 없다 — REQ-007이 배치로 충족된다.
 2. **handoff 지점**은 (5)다. `internal/cli/pipeline_run_owner.go:160-164`이 `handoff_required`를 반환하기 직전이며, 게이트가 그 앞에 있으므로 handoff를 받는 쪽은 이미 검증된 티어 계약을 들고 출발한다(REQ-008).
-3. **(1)과 (2)의 계정이 반드시 같아야 한다.** 두 값이 갈라지면 (3a)의 판정은 성립하지 않은 것으로 처리된다(REQ-004). F1·F2가 이 갈라짐이 이 워크스테이션에 이미 존재함을 보여준다.
+3. **(1)과 (2)의 계정이 반드시 같아야 한다.** 두 값이 갈라지면 (3a)의 판정은 성립하지 않은 것으로 처리된다(REQ-004). F1·F2가 이 갈라짐이 이 워크스테이션에 이미 존재함을 보여준다 — Codex 축에서 orca 활성 계정은 `bitgapnam@gmail.com`이고 PATH의 `codex`가 쓰는 계정은 `gnkong@alipeople.kr`이다.
+4. **(2)의 분기는 provider 속성이지 실행 시점의 운이 아니다.** Codex는 계정별 카탈로그 프로브가 있으므로 (3a)로 가고, Claude는 등가물이 없으므로 `orgId` 신원 대조를 통과하더라도 가용성 축에서는 항상 (3b)로 간다. (3b)에 모이는 세 인스턴스 — Claude 가용성, 원격 환경, 실행 계정 미특정 — 는 REQ-009 하나가 같은 규칙으로 다룬다.
 
 ## Feature Completion Scope
 
@@ -155,7 +179,7 @@ J2 접합면의 런타임 흐름. research.md의 세 평면 정적 다이어그�
 완료 조건은 spec.md `## Outcome Boundary`의 Completion evidence와 동일하게 셋이다.
 
 1. 4개 SPEC 문서(`spec.md`·`plan.md`·`acceptance.md`·`research.md`)가 `auto spec validate`를 통과한다.
-2. research.md Completion Debt 3건이 해소되거나 후속 SPEC으로 이관된다. 3건 중 2건(계정 조회 소스, Claude 카탈로그 부재)은 T2가 해소 대상으로 안고 간다.
+2. research.md Completion Debt 3건이 해소되거나 후속 SPEC으로 이관된다. **이미 충족됐다** — 3건 모두 F8에서 실측으로 해소되어 `### 결정` 표에 남았고 `## Completion Debt`는 `none remaining`이다. 후속 SPEC 이관은 한 건도 발생하지 않았다. 남은 일은 이관 기록이 아니라 그 결정을 인터페이스 계약으로 고정하는 것이며, T2와 T3가 그 자리다.
 3. 세 평면 경계에 대한 리뷰 합의가 기록된다 — research.md `## Reviewer Brief`의 4개 질문에 대한 판단이 남아야 한다.
 
 | 구분 | 항목 |
@@ -168,7 +192,7 @@ J2 접합면의 런타임 흐름. research.md의 세 평면 정적 다이어그�
 | | fail-loud 판정 규칙과 강등 기록 규칙 (REQ-006) |
 | | 게이트 배치 지점과 부작용 경계의 확정 (REQ-007, REQ-008) |
 | | 검증 불가 provider의 `unverified` 표기 규칙 (REQ-009) |
-| | S1~S8 시나리오와 그 관측 지점 |
+| | S1~S9 시나리오와 그 관측 지점 |
 | **범위 밖** | 정합 게이트의 구현 코드. 이 SPEC은 계약만 고정한다 |
 | | `--execution-owner orca`의 handoff 스텁을 실제 orca Run 생성으로 대체하는 작업 |
 | | 요청 티어를 제공 가능한 계정을 자동 선택하는 다계정 라우팅 |
@@ -187,14 +211,18 @@ T1~T4는 모두 **설계·문서·합의 산출물**이다. 코드 작성 태스
   - 산출물: research.md Feature Coverage Map의 각 표면에 소유 평면을 정확히 하나 지정한 확정판, 그리고 정책 -> 프로세스 경계에서 금지되는 티어 토큰 목록(`balanced`/`ultra`/`opus`/`sonnet`/`haiku`)과 허용되는 통과 값(opaque provider model id, effort)의 명시.
   - 완료 판정: 같은 어휘가 둘 이상의 평면에 나타나지 않고(S1), 경계 통과 값 정의에 금지 토큰이 하나도 포함되지 않음이 문서로 확인된다(S2). F4의 orca 티어 어휘 0건 실측이 기준선이다.
 
-- [ ] **T2 — 실행 계정 조회와 계정 기준 카탈로그 검증의 인터페이스 계약 확정** (REQ-003, REQ-004 / INV-003 / S3)
+- [ ] **T2 — 실행 계정 조회와 계정 기준 카탈로그 검증의 인터페이스 계약 확정** (REQ-003, REQ-004 / INV-003 / S3, S9)
   - 산출물: (i) 실행 계정 식별자를 프로세스 평면에서 얻는 조회의 입력·출력·실패 모드 계약, (ii) 그 계정 식별자를 기준으로 카탈로그를 확보하는 계약과 "카탈로그 출처 계정 ≠ 실행 계정이면 검증 미성립"이라는 판정 규칙.
-  - **이 태스크가 research.md Completion Debt 2건을 해소해야 한다**: ① orca account 조회 소스 — `orca account list`는 사람이 읽는 텍스트이므로 `--json` 유무를 확인하고, 없으면 `orca agent-context --json` 스키마로 대체 가능한지 확정한다. ② Claude 카탈로그 부재 — Codex는 `codex debug models`가 있으나 Claude 등가물이 확인되지 않았으므로, Claude 티어를 어떤 신호로 검증할지 또는 REQ-009의 `unverified` 경로로 보낼지 결정한다. 남은 1건(원격 `--on <saved-environment>` 계정 조회)은 해소하거나 후속 SPEC으로 이관 기록한다.
-  - 완료 판정: 두 계약이 파라미터 수준으로 적혀 있고, S3의 분기 계정 픽스처(orca 활성 `bitgapnam@gmail.com` vs 로컬 codex `jroad1049@gmail.com`, F1)에 대해 판정 결과가 유일하게 결정된다. Completion Debt 2건이 체크 해제 상태로 남아 있지 않다.
+  - **이 태스크는 미결을 해소하는 것이 아니라 이미 해소된 결정을 계약으로 고정한다**(research.md F8 `### 결정`). 계약에 반드시 들어갈 세 가지:
+    - **조회 소스** — `orca account list --json` 단일 호출. 실행 계정은 `result.<provider>.activeAccountId`, 비교 대상 프로브 계정은 `result.codex.systemDefault`(codex) 또는 provider CLI 신원(`claude auth status --json`의 `orgId`를 `claude.accounts[].organizationUuid`에 조인). 한 호출로 두 값을 모두 얻으므로 비교에 추가 조회가 필요 없다. `--environment`는 구조적으로 거부되므로 이 계약은 로컬 호스트 축만 갖는다.
+    - **실행 계정 해석 규칙** — `activeAccountId`가 있으면 그 값, 없고 등록 계정이 **정확히 1개**면 그 계정, 그 외(0개 또는 2개 이상)는 특정하지 않고 REQ-009의 `unverified`로 분기. 세 단계가 이 우선순위 그대로 계약에 적혀야 하고, 마지막 단계에서 추측으로 하나를 고르는 경로는 금지된다.
+    - **provider별 검증 깊이** — Codex는 `codex debug models`가 계정별 카탈로그를 주므로 카탈로그 완전 검증. Claude는 등가물이 없으므로 신원 대조까지만 하고 모델 가용성은 `unverified`. 검증 깊이가 provider의 고정 속성이지 실행 시점의 재량이 아님을 계약이 못 박는다.
+  - 완료 판정: 세 요소가 모두 파라미터 수준으로 적혀 있고, S3의 분기 계정 픽스처(orca 활성 Codex `bitgapnam@gmail.com` vs 로컬 codex CLI `gnkong@alipeople.kr`, F1)와 S9의 계정 미특정 픽스처 각각에 대해 판정 결과가 유일하게 결정된다. research.md `## Completion Debt`가 `none remaining` 상태로 유지된다.
 
-- [ ] **T3 — 정합 영수증 스키마 확정** (REQ-005, REQ-006, REQ-009 / INV-004 / S4, S5, S8)
-  - 산출물: 6필드(요청 티어 / 해석된 provider 모델 / 실행 계정 식별자 / 카탈로그 출처 / resolution reason / verification status) 각각의 타입·필수 여부·허용값을 담은 스키마 정의와 스키마 버전 이름. `verification status`의 허용값에 `unverified`가 포함되고 그 경우 사유 필드가 필수임을 규정한다. 명시적 강등 시 요청 값과 실제 값이 **둘 다** 남아야 한다는 제약도 스키마에 표현한다.
-  - 완료 판정: S4에서 6필드와 스키마 버전이 모두 존재하고, S5에서 강등 경로의 `reason`이 비어 있을 수 없으며 요청·실제 두 값이 모두 요구되고, S8에서 프로브 없는 provider가 `verified`로 표기될 수 없음이 스키마만 보고 판정된다. 기존 `pipeline_execution_owner_receipt.v1`과 같은 스키마-버전 방식을 따른다.
+- [ ] **T3 — 정합 영수증 스키마 확정** (REQ-005, REQ-006, REQ-009 / INV-004 / S4, S5, S8, S9)
+  - 산출물: 6필드(요청 티어 / 해석된 provider 모델 / 실행 계정 식별자 / 카탈로그 출처 / resolution reason / verification status) 각각의 타입·필수 여부·허용값을 담은 스키마 정의와 스키마 버전 이름. `verification status`의 허용값에 `unverified`가 포함되고 그 경우 사유 필드가 필수임을 규정한다. 명시적 강등 시 요청 값과 실제 값이 **둘 다** 남아야 한다는 제약도 스키마에 표현한다. 실행 계정 식별자는 미특정일 수 있으므로 그 표현(빈 값이 아니라 명시적 미특정 상태)도 스키마가 정의한다.
+  - **REQ-009가 흡수하는 세 인스턴스를 같은 fail-loud 규칙으로 다뤄야 한다**: ① Claude 모델 가용성 — 계정별 카탈로그 프로브가 없다, ② 원격 orca 환경 — `orca account list`가 `--environment`를 거부해 원격 호스트의 계정을 조회할 수 없다, ③ 실행 계정 미특정 — 활성 계정이 없고 등록 계정이 0개이거나 2개 이상이다(REQ-003). 셋은 사유 문자열만 다르고 상태값(`unverified`)·사유 필수·`verified` 금지는 동일하다. 셋을 구분하는 별도 상태값이나 예외 경로를 만들지 않는다.
+  - 완료 판정: S4에서 6필드와 스키마 버전이 모두 존재하고, S5에서 강등 경로의 `reason`이 비어 있을 수 없으며 요청·실제 두 값이 모두 요구되고, S8에서 프로브 없는 provider가, S9에서 실행 계정이 미특정인 워크로드가 각각 `verified`로 표기될 수 없음이 스키마만 보고 판정된다. 기존 `pipeline_execution_owner_receipt.v1`과 같은 스키마-버전 방식을 따른다.
 
 - [ ] **T4 — 게이트 배치 지점과 부작용 경계 확정** (REQ-007, REQ-008 / INV-002, INV-005 / S6, S7)
   - 산출물: 게이트가 실행되는 지점을 `internal/cli/pipeline_run_owner.go:160-164`의 `handoff_required` 반환 직전으로 확정한 배치 결정문, 그 지점 이전에 생성되지 않아야 하는 리소스 목록(워크트리·Run·워커·provider 세션), 그리고 점검 실패 시 handoff 결과 대신 정합 실패를 반환한다는 반환값 규칙. INV-002와의 양립 근거(F7 — 금지 대상은 OMP task DAG이지 omp 실행 자체가 아님, `pkg/adapter/omp/omp_workflow_render.go:99`)를 함께 기록한다.
@@ -206,10 +234,10 @@ REQ 커버리지: REQ-001·002(T1), REQ-003·004(T2), REQ-005·006·009(T3), REQ
 
 | 리스크 | 영향도 | 대응 |
 |--------|--------|------|
-| Completion Debt ①(계정 조회 소스)이 T2에서 해소되지 않으면 REQ-003의 계약이 추상 수준에 머문다 | 높음 | T2의 완료 판정에 명시적으로 묶었다. 해소 불가로 판단되면 후속 SPEC 이관을 기록하고 REQ-003 계약을 "조회 결과의 형태"까지만 고정한다 |
-| Claude 카탈로그 등가물이 없어 Claude 티어가 전부 `unverified`로 떨어진다 | 중간 | 이는 결함이 아니라 REQ-009가 설계한 정직한 상태다. 은폐 대신 표기하는 것이 INV-004의 요지다. 대안 신호 탐색은 T2의 판단 사항 |
-| 원격 orca 환경(`--on <saved-environment>`)에서 계정 축이 하나 더 늘어난다 | 중간 | Completion Debt ③으로 분리되어 있다. 계약을 계정 식별자 기준으로 쓰면 조회 경로가 로컬이든 원격이든 판정 규칙은 불변이다 |
-| 설계만 고정하고 구현을 분리한 결과, 후속 SPEC이 나오지 않으면 J2가 계속 끊긴 채 남는다 | 중간 | 구현 분리는 spec.md `## Out of Scope`에 명시된 결정이다. 완료 판정 2번(Completion Debt 해소 또는 후속 SPEC 이관)이 이관 기록을 강제한다 |
+| 해소된 결정 3건이 T2·T3의 계약 문장으로 옮겨지지 않고 research.md 결정 표에만 남는다 | 중간 | 리스크가 "미결"에서 "결정이 계약에 미반영"으로 이동했다. T2 완료 판정이 조회 소스·해석 규칙·검증 깊이 세 요소를 파라미터 수준으로 요구하고, T3 완료 판정이 REQ-009의 세 인스턴스를 요구한다 |
+| Claude 카탈로그 등가물이 없어 Claude 티어의 모델 가용성이 전부 `unverified`로 떨어진다 | 중간 | 이는 결함이 아니라 REQ-009가 설계한 정직한 상태다. 은폐 대신 표기하는 것이 INV-004의 요지다. `subscriptionType` 플랜 게이트로 메우는 안은 기각한 대안 (c)로 기록됐다 |
+| 원격 orca 환경(`--on <saved-environment>`)에서 계정 축이 하나 더 늘어난다 | 낮음 | REQ-009에 흡수됐다. `orca account list`가 `--environment`를 거부하므로 원격은 "조회 수단 없음"의 인스턴스이고, `orca environment list --json`이 `{"environments": []}`라 현재 영향도 0건이다 |
+| 설계만 고정하고 구현을 분리한 결과, 후속 SPEC이 나오지 않으면 J2가 계속 끊긴 채 남는다 | 중간 | 구현 분리는 spec.md `## Out of Scope`에 명시된 결정이다. 결정이 모두 닫혔으므로 후속 SPEC은 발명이 아니라 이 문서의 참조 구현이며, 착수 장벽이 그만큼 낮다 |
 | 게이트를 정책 평면에 두면 정책 평면이 프로세스 평면 상태를 읽는 결합이 생긴다 | 낮음 | 방향이 기존 의존 방향(정책 -> 프로세스)과 같고, 읽는 값은 계정 식별자 하나다. 역방향 참조는 만들지 않는다 |
 
 ## Dependencies
@@ -226,7 +254,7 @@ REQ 커버리지: REQ-001·002(T1), REQ-003·004(T2), REQ-005·006·009(T3), REQ
 
 - [ ] `auto spec validate .autopus/specs/SPEC-EXECPLANE-001`이 4개 문서에 대해 통과한다
 - [ ] T1~T4의 산출물이 모두 존재하고 REQ 9건을 빠짐없이 덮는다
-- [ ] research.md Completion Debt 3건이 각각 해소 또는 후속 SPEC 이관으로 처리됐다
+- [ ] research.md Completion Debt 3건이 각각 해소 또는 후속 SPEC 이관으로 처리됐다 — 3건 모두 F8에서 해소됐고 `## Completion Debt`는 `none remaining`이다. 남은 확인은 그 결정이 T2·T3 산출물에 계약으로 들어갔는지다
 - [ ] research.md `## Reviewer Brief`의 4개 질문에 대한 리뷰 판단이 기록됐다
 - [ ] 범위 밖 항목 목록이 spec.md `## Out of Scope`와 모순되지 않는다
 

--- a/.autopus/specs/SPEC-EXECPLANE-001/research.md
+++ b/.autopus/specs/SPEC-EXECPLANE-001/research.md
@@ -61,17 +61,28 @@ autopus-adk가 결정한 모델 티어가 **실제로 그 워크로드를 실행
 
 모두 2026-08-10 이 워크스테이션에서 직접 실행해 확인했다.
 
-### F1 — orca 활성 계정과 로컬 CLI 로그인이 이미 갈라져 있다
+### F1 — 실행 계정과 프로브 계정이 이미 갈라져 있다
+
+`orca account list --json`이 구조화된 페이로드를 준다.
 
 ```
-$ orca account list
-Managed Claude accounts (1):
-  jroad1049@gmail.com
-Managed Codex accounts (1):
-  bitgapnam@gmail.com (active)
+result.<provider>.accounts[]   { id, email, organizationUuid | providerAccountId, ... }
+result.<provider>.activeAccountId
+result.<provider>.activeAccountIdsByRuntime  { host, wsl }
+result.codex.systemDefault     { hasAuth, authKind, email, providerAccountId }   // codex에만 존재
 ```
 
-반면 로컬 `~/.codex/auth.json`의 `id_token`은 `jroad1049@gmail.com`(Google OAuth, `auth_mode: chatgpt`)이다. 즉 **orca가 워커를 띄울 Codex 계정과 이 머신의 codex CLI 로그인 계정이 다르다**.
+이 워크스테이션의 실측값은 계정 **셋**이다.
+
+| 축 | 계정 | 출처 |
+| --- | --- | --- |
+| orca 관리 Codex `activeAccountId` | `bitgapnam@gmail.com` | `orca account list --json` |
+| 로컬 codex CLI = orca `codex.systemDefault` | `gnkong@alipeople.kr` | `~/.codex/auth.json` id_token, `systemDefault.email` |
+| 로컬 claude CLI = orca 관리 Claude | `jroad1049@gmail.com` | `claude auth status --json`, `claude.accounts[0]` |
+
+Codex 축에서 **orca가 워커를 띄울 계정과 PATH의 codex가 쓰는 계정이 다르다**. 한 번의 `orca account list --json` 호출이 두 값을 모두 반환하므로 비교는 추가 조회 없이 가능하다.
+
+Claude 축에서는 `claude auth status --json`의 `orgId`가 orca `claude.accounts[0].organizationUuid`와 같은 값(`0e61c3e2-35c8-4bf8-91bc-40848f4dc147`)이라 두 소스를 신원으로 조인할 수 있다. 다만 `claude.activeAccountId`는 `null`이고 Claude 블록에는 `systemDefault` 필드가 없다 — provider 사이의 비대칭이다.
 
 ### F2 — autopus의 카탈로그 프로브는 PATH 바이너리, 즉 로컬 로그인 계정 기준이다
 
@@ -135,11 +146,38 @@ Owner `orca`: do not initialize an OMP task/todo DAG or call `task`.
 
 금지 대상은 **OMP task DAG**이지 omp 실행 자체가 아니다. orca Run이 소유하는 워커 안에서 omp가 모델 평면 역할만 수행하고 자기 DAG를 만들지 않으면 INV-002를 준수한다. 세 평면 합성은 기존 불변식과 양립한다.
 
+### F8 — 세 미결 질문의 실측 답
+
+**계정 조회 소스.** `orca account list --json`이 존재하고 F1의 스키마를 반환한다. `--environment`/`--pairing-code`는 무시가 아니라 **거부**된다. 헬프 노트: *"Lists the accounts on this machine. `--environment` / `--pairing-code` are rejected rather than ignored; run it on the host whose accounts you want to see."*
+
+**Claude 카탈로그.** `codex debug models` 등가물이 없다. `claude` CLI 명령 집합은 `agents`, `auth`, `auto-mode`, `doctor`, `gateway`, `import`, `install`, `mcp`, `plugin`, `project`, `setup-token`, `ultrareview`이며 모델 열거 명령이 없다. `omp models --json`은 있으나 **정적 레지스트리**다 — 계정 스코프가 아니라 provider별 모델 메타데이터를 반환하므로 특정 계정의 자격을 증명하지 못한다.
+
+```json
+{"provider":"anthropic","id":"claude-opus-5","selector":"anthropic/claude-opus-5",
+ "thinking":["low","medium","high","xhigh","max"],"cost":{"input":5,"output":25}}
+```
+
+대신 `claude auth status --json`이 신원과 플랜을 준다.
+
+```json
+{"loggedIn":true,"authMethod":"claude.ai","apiProvider":"firstParty",
+ "email":"jroad1049@gmail.com","orgId":"0e61c3e2-...","subscriptionType":"max"}
+```
+
+**원격 환경.** `orca environment list --json`은 이 머신에서 `{"environments": []}`를 반환한다. 저장된 원격 환경이 0건이므로 원격 경로는 현재 미사용이다. `orchestration worker-list`는 터미널 리소스 회계만 보고하고 계정을 노출하지 않아 사후 검증 경로도 없다.
+
+### 결정
+
+| 질문 | 결정 | 근거 |
+| --- | --- | --- |
+| 계정 조회 소스 | `orca account list --json`. 실행 계정은 `activeAccountId`, 프로브 계정은 `systemDefault`(codex) 또는 provider CLI 신원 | 한 호출로 두 값을 모두 얻어 비교 가능 |
+| Claude 검증 깊이 | **신원만 검증**. `claude auth status --json`의 `orgId`를 orca `organizationUuid`와 대조하고, 모델 가용성은 unverified로 표기 | `subscriptionType`으로 플랜→모델을 매핑하면 하드코딩 티어 테이블이 되살아난다. PR #154가 제거한 것과 같은 종류다 |
+| Claude `activeAccountId`가 null | 등록 계정이 **정확히 1개**면 그것을 실행 계정으로 보고, 0개이거나 2개 이상이면 unverified | 추측하지 않는다. 현재 상태(1개 등록)에서 동작하고, 모호해지면 모호하다고 보고한다 |
+| 원격 환경 | 별도 요구를 만들지 않고 **REQ-009에 흡수**. 원격 대상이면 "계정 조회 수단 없음"의 인스턴스이므로 unverified | `account list`가 원격을 구조적으로 거부하고, 저장된 환경이 0건이라 당장 영향도 없다 |
+
 ## Completion Debt
 
-- [ ] 정합 점검이 조회할 계정 정보의 정확한 소스. `orca account list`는 사람이 읽는 텍스트다. `--json`이 있는지, 없으면 `orca agent-context --json`의 스키마로 대체 가능한지 구현 전에 확정해야 한다.
-- [ ] Claude 쪽 카탈로그 프로브의 부재. Codex는 `codex debug models`가 있지만 Claude는 등가물이 확인되지 않았다. Claude 티어 검증을 어떤 신호로 할지(또는 검증 불가로 명시할지) 결정이 필요하다.
-- [ ] 원격 orca 환경(`--on <saved-environment>`)에서의 계정 조회. 로컬 host와 원격 worker server의 계정이 또 다를 수 있다.
+none remaining. 착수 시점의 미결 3건은 F8에서 실측으로 해소되어 결정 표에 반영됐고, 그 결정은 spec.md REQ-003·REQ-004·REQ-009 본문에 계약으로 들어갔다.
 
 ## Evolution Ideas
 
@@ -152,7 +190,12 @@ Owner `orca`: do not initialize an OMP task/todo DAG or call `task`.
 
 | 참조 | 유형 | 확인 방법 |
 | --- | --- | --- |
-| `orca account list` 출력 | 실측 | 이 워크스테이션에서 직접 실행 |
+| `orca account list --json` 페이로드 | 실측 | 이 워크스테이션에서 직접 실행 |
+| `claude auth status --json` 페이로드 | 실측 | 직접 실행 |
+| `claude --help` 명령 집합 | 실측 | 직접 실행, 모델 열거 명령 부재 확인 |
+| `omp models --json` 엔트리 구조 | 실측 | 직접 실행, 계정 스코프 아님 확인 |
+| `orca environment list --json` | 실측 | 직접 실행, `environments: []` |
+| `~/.codex/auth.json` id_token 클레임 | 실측 | 직접 디코드 |
 | `orca agent-context --json` | 실측 | 223 command 스키마 전수 검색 |
 | `omp config list`의 `modelRoles` | 실측 | 직접 실행 |
 | `pkg/codexruntime/probe.go:39` | 코드 | 직접 읽음 |

--- a/.autopus/specs/SPEC-EXECPLANE-001/spec.md
+++ b/.autopus/specs/SPEC-EXECPLANE-001/spec.md
@@ -30,16 +30,16 @@ autopus-adk·omp·orca 셋을 동시에 쓰되 서로의 어휘를 복제하지 
 
 접합면은 둘이다. **J1(티어 -> 모델)은 PR #154로 닫혔다** — `quality.default`가 내장 role-model 프로파일을 거쳐 omp `modelRoles`에 도달한다. **J2(티어 -> 실행 계정)는 끊겨 있다.**
 
-끊김의 형태는 research.md F1·F2에 실측으로 기록되어 있다. 이 워크스테이션에서 orca의 활성 Codex 계정은 `bitgapnam@gmail.com`인데 로컬 `codex` CLI 로그인은 `jroad1049@gmail.com`이다. autopus의 카탈로그 프로브는 PATH 바이너리를 실행하므로(`pkg/codexruntime/probe.go:39`) **로컬 로그인 계정의 카탈로그로 검증하고, orca는 다른 계정으로 실행한다**. `codex debug models`는 계정별 카탈로그이므로 두 집합은 다를 수 있다.
+끊김의 형태는 research.md F1·F2·F8에 실측으로 기록되어 있다. 이 워크스테이션에는 provider 계정이 셋 있다 — orca 관리 Codex 활성 계정 `bitgapnam@gmail.com`, 로컬 codex CLI 계정 `gnkong@alipeople.kr`(orca가 `codex.systemDefault`로 같은 값을 보고한다), 로컬 claude CLI 계정 `jroad1049@gmail.com`. autopus의 카탈로그 프로브는 PATH 바이너리를 실행하므로(`pkg/codexruntime/probe.go:39`) **`gnkong` 계정의 카탈로그로 검증하고, orca는 `bitgapnam` 계정으로 실행한다**. `codex debug models`는 계정별 카탈로그이므로 두 집합은 다를 수 있다.
 
 이 실패 양식은 가설이 아니다. PR #151에서 실제로 발생해 티어 승격이 세대 강등으로 뒤집혔고, 조용했기 때문에 근거와 결과가 어긋난 채 결론까지 갔다(research.md F3).
 
 ## Outcome Boundary
 
 - **Outcome Lock**: 세 평면의 소유 표면이 문서로 배타적으로 고정되고, autopus가 결정한 모델 티어는 그 워크로드를 실제로 실행할 계정의 카탈로그로 검증된 뒤에만 실행 단계로 넘어간다. 검증에 실패하면 조용히 강등되지 않고 원한 티어·실행 계정·실제 제공 모델 셋을 모두 지목하는 영수증을 남긴 뒤 멈추거나 명시적으로 강등한다.
-- **Mandatory requirements**: 평면 배타성 선언(REQ-001), orca 티어 어휘 무증식(REQ-002), 실행 계정 확인(REQ-003), 실행 계정 기준 카탈로그 검증(REQ-004), 정합 영수증 방출(REQ-005), 불일치 시 fail-loud(REQ-006), 부작용 이전 배치(REQ-007), handoff 경계 배치(REQ-008), 검증 불가 provider의 명시적 표기(REQ-009).
+- **Mandatory requirements**: 평면 배타성 선언(REQ-001), orca 티어 어휘 무증식(REQ-002), 실행 계정 확인과 해석 규칙(REQ-003), 실행 계정 기준 카탈로그 검증(REQ-004), 정합 영수증 방출(REQ-005), 불일치 시 fail-loud(REQ-006), 부작용 이전 배치(REQ-007), handoff 경계 배치(REQ-008), 검증 불가 항목의 명시적 표기(REQ-009).
 - **Explicit non-goals**: 정합 게이트의 구현(별도 SPEC), `--execution-owner orca` handoff 스텁을 실제 Run으로 대체하는 일(별도 SPEC), 여러 계정 사이의 자동 라우팅, 티어 강등 시 대안 provider 폴백, 실행 원장 통합, J1 재설계(PR #154 결과 불변), omp `modelRoles` 어휘 변경, orca CLI 표면 변경.
-- **Completion evidence**: 4개 SPEC 문서가 `auto spec validate`를 통과하고, research.md의 Completion Debt 3건이 해소 또는 후속 SPEC으로 이관되며, 세 평면 경계에 대한 리뷰 합의가 기록된다. 구현 증거는 요구하지 않는다.
+- **Completion evidence**: 4개 SPEC 문서가 `auto spec validate`를 통과하고, 착수 시점의 Completion Debt 3건이 해소되며(research.md F8의 실측과 결정 표 — 현재 `none remaining`, 후속 이관 0건), 세 평면 경계에 대한 리뷰 합의가 기록된다. 구현 증거는 요구하지 않는다.
 
 ## Requirements
 
@@ -58,11 +58,12 @@ THE SYSTEM SHALL keep the process plane free of tier vocabulary, passing only op
 - Observability: 경계를 넘는 값에 `balanced`/`ultra`/`opus`/`sonnet`/`haiku` 토큰이 없고 provider 고유 model id와 effort만 있음을 S2로 확인한다.
 
 ### REQ-003 — 실행 전에 실제 실행 계정을 확인한다
-WHEN the policy plane prepares a workload for execution, THEN THE SYSTEM SHALL determine the provider account that will actually run it from the process plane rather than assuming the account the local CLI is logged in as.
+WHEN the policy plane prepares a workload for execution, THEN THE SYSTEM SHALL determine the provider account that will actually run it from the process plane rather than assuming the account the local CLI is logged in as, resolving it as the process plane's active account for that provider, or — when no active account is selected — the single registered account when exactly one exists, and otherwise marking the account as indeterminate.
 - EARS type: Event-driven
 - Priority: Must
 - Trigger/Condition: 파이프라인·워크플로가 provider 프로파일을 확정하는 시점.
-- Observability: 정합 영수증에 실행 계정 식별자가 기록되고, 그 값이 로컬 CLI 로그인 계정과 다를 수 있음을 S3의 분기 계정 픽스처로 확인한다.
+- Observability: 정합 영수증에 실행 계정 식별자가 기록되고, 그 값이 로컬 CLI 로그인 계정과 다를 수 있음을 S3의 분기 계정 픽스처로 확인한다. 활성 계정이 없고 등록 계정이 0개이거나 2개 이상이면 영수증이 실행 계정을 특정하지 않고 REQ-009의 unverified 경로로 분기함을 S9로 확인한다.
+- 해소된 설계 결정: 조회 소스는 `orca account list --json`이다. 실행 계정은 `activeAccountId`, 비교 대상인 프로브 계정은 `systemDefault`(codex) 또는 provider CLI 신원이며, 한 번의 호출로 두 값을 모두 얻는다(research.md F1, F8). 활성 계정이 없을 때 추측하지 않는 이유는 잘못 특정한 계정이 조용한 강등을 만들기 때문이다.
 
 ### REQ-004 — 카탈로그 검증은 실행 계정 기준으로 수행한다
 THE SYSTEM SHALL validate a requested model tier against the model catalog of the execution account identified in REQ-003, and SHALL NOT treat a catalog probed under a different account as evidence for that tier.
@@ -70,6 +71,7 @@ THE SYSTEM SHALL validate a requested model tier against the model catalog of th
 - Priority: Must
 - Trigger/Condition: 요청 티어를 provider 모델로 해석할 때.
 - Observability: 검증에 사용한 카탈로그의 출처 계정이 영수증의 실행 계정과 일치함을 S3로 확인한다. 두 값이 다르면 검증은 성립하지 않은 것으로 처리된다.
+- 해소된 설계 결정: Codex는 `codex debug models`가 계정별 카탈로그를 주므로 완전 검증이 가능하다. Claude는 등가물이 없어(research.md F8) **신원까지만 검증한다** — `claude auth status --json`의 `orgId`를 프로세스 평면의 `organizationUuid`와 대조해 실행 계정이 검증 대상 계정과 같은지 확인하고, 모델 가용성은 REQ-009의 unverified로 남긴다. `subscriptionType`으로 플랜→모델을 매핑하는 선택은 기각했다: 하드코딩 티어 테이블을 되살리는 일이며 PR #154가 제거한 것과 같은 종류다.
 
 ### REQ-005 — 정합 결과를 영수증으로 방출한다
 THE SYSTEM SHALL emit an integrity receipt carrying the requested tier, the resolved provider model, the execution account identifier, the catalog source, the resolution reason, and the verification status, so a later reader can reconstruct why a workload ran at the tier it ran at.
@@ -99,12 +101,13 @@ WHERE the execution owner is the process plane, THE SYSTEM SHALL run the integri
 - Trigger/Condition: `--execution-owner orca` 경로가 handoff 결과를 반환하기 직전.
 - Observability: handoff 결과에 정합 영수증 참조가 포함되고, 점검 실패 시 handoff 결과 대신 정합 실패가 반환됨을 S7로 확인한다.
 
-### REQ-009 — 검증 수단이 없는 provider는 검증됨으로 표기하지 않는다
-IF a provider exposes no account-scoped catalog probe, THEN THE SYSTEM SHALL mark that provider's tier as unverified in the receipt rather than reporting it as verified.
+### REQ-009 — 검증할 수 없는 것은 검증됨으로 표기하지 않는다
+IF the execution account cannot be determined, or the account that will run the workload exposes no account-scoped catalog probe, THEN THE SYSTEM SHALL mark that provider's tier as unverified in the receipt with a reason rather than reporting it as verified.
 - EARS type: Unwanted
 - Priority: Must
-- Trigger/Condition: provider가 카탈로그 조회 수단을 제공하지 않을 때.
-- Observability: 해당 provider의 영수증 항목이 `unverified` 상태와 사유를 갖고, `verified`로 표기되지 않음을 S8로 확인한다.
+- Trigger/Condition: 계정을 특정할 수 없거나 그 계정의 카탈로그를 조회할 수단이 없을 때.
+- Observability: 해당 provider의 영수증 항목이 `unverified` 상태와 비어 있지 않은 사유를 갖고, `verified`로 표기되지 않음을 S8로 확인한다. 실행 계정을 특정할 수 없는 경우는 S9로 확인한다.
+- 이 요구가 흡수하는 세 인스턴스: (1) Claude 모델 가용성 — 계정별 카탈로그 프로브가 없다, (2) 원격 orca 환경 — `orca account list`가 `--environment`를 구조적으로 거부하므로 원격 호스트의 계정을 조회할 수 없다, (3) 활성 계정 부재 + 등록 계정이 1개가 아닌 경우(REQ-003). 셋 다 별도 요구를 만들지 않고 같은 fail-loud 규칙으로 다룬다.
 
 ## Acceptance Criteria
 
@@ -115,7 +118,8 @@ IF a provider exposes no account-scoped catalog probe, THEN THE SYSTEM SHALL mar
 - [ ] 티어 불일치가 조용히 강등되지 않는다
 - [ ] 점검 실패가 리소스를 남기지 않는다
 - [ ] handoff 결과가 정합 영수증을 참조한다
-- [ ] 검증 불가 provider가 `unverified`로 표기된다
+- [ ] 검증할 수 없는 항목이 `unverified`로 표기된다
+- [ ] 실행 계정을 특정할 수 없으면 추측하지 않고 unverified로 분기한다
 
 ## Traceability Matrix
 
@@ -123,13 +127,13 @@ IF a provider exposes no account-scoped catalog probe, THEN THE SYSTEM SHALL mar
 |-------------|-----------|---------------------|--------------------|
 | REQ-001 | T1 | S1 | INV-001 |
 | REQ-002 | T1 | S2 | INV-001 |
-| REQ-003 | T2 | S3 | INV-003 |
+| REQ-003 | T2 | S3, S9 | INV-003 |
 | REQ-004 | T2 | S3 | INV-003 |
 | REQ-005 | T3 | S4 | INV-004 |
 | REQ-006 | T3 | S5 | INV-004 |
 | REQ-007 | T4 | S6 | INV-005 |
 | REQ-008 | T4 | S7 | INV-002, INV-005 |
-| REQ-009 | T3 | S8 | INV-004 |
+| REQ-009 | T3 | S8, S9 | INV-004 |
 
 ## Out of Scope
 
@@ -147,10 +151,10 @@ IF a provider exposes no account-scoped catalog probe, THEN THE SYSTEM SHALL mar
 |-------------|------|--------|
 | REQ-001 | S1 | pending |
 | REQ-002 | S2 | pending |
-| REQ-003 | S3 | pending |
+| REQ-003 | S3, S9 | pending |
 | REQ-004 | S3 | pending |
 | REQ-005 | S4 | pending |
 | REQ-006 | S5 | pending |
 | REQ-007 | S6 | pending |
 | REQ-008 | S7 | pending |
-| REQ-009 | S8 | pending |
+| REQ-009 | S8, S9 | pending |


### PR DESCRIPTION
SPEC-EXECPLANE-001 착수 시점의 Completion Debt 3건을 실측으로 해소하고, 초안의 사실 오류 하나를 정정한다. 코드 변경 0건.

## 사실 정정 — 계정이 둘이 아니라 셋이다

초안 research.md F1에 "로컬 codex 로그인 = `jroad1049@gmail.com`"이라고 적었다. 세션 대화에서 인용한 값이었고 내가 직접 확인하지 않았다. 실측하니 **`jroad1049`는 Claude 계정**이었다.

| 축 | 계정 | 출처 |
| --- | --- | --- |
| orca 관리 Codex `activeAccountId` | `bitgapnam@gmail.com` | `orca account list --json` |
| 로컬 codex CLI = orca `codex.systemDefault` | `gnkong@alipeople.kr` | `~/.codex/auth.json` id_token |
| 로컬 claude CLI = orca 관리 Claude | `jroad1049@gmail.com` | `claude auth status --json` |

Codex 축의 분기(실행 `bitgapnam` vs 프로브 `gnkong`)는 그대로 성립하며 SPEC의 논지는 오히려 강해진다. `spec.md` Background, `research.md` F1, `plan.md` 다이어그램, `acceptance.md` S3에서 모두 정정했다.

## Debt 1 — 계정 조회 소스 → 해소

`orca account list --json`이 존재하고 필요한 걸 다 준다.

```
result.<provider>.accounts[]   { id, email, organizationUuid | providerAccountId, ... }
result.<provider>.activeAccountId
result.codex.systemDefault     { hasAuth, authKind, email, providerAccountId }
```

`systemDefault`가 로컬 CLI 로그인과 정확히 일치하므로 **한 번의 호출로 실행 계정과 프로브 계정을 모두 얻어 비교**할 수 있다. 추가 조회가 필요 없다.

## Debt 2 — Claude 카탈로그 → 신원만 검증

`codex debug models` 등가물이 없다. `claude` CLI 명령 집합에 모델 열거가 없고, `omp models --json`은 계정 스코프가 아닌 정적 레지스트리다.

대신 `claude auth status --json`의 `orgId`가 orca `claude.accounts[].organizationUuid`와 **같은 값**이라 신원 조인이 가능하다.

**결정: 신원까지만 검증하고 모델 가용성은 `unverified`.**

`subscriptionType`(max/pro/free)으로 플랜→모델을 매핑하는 안은 기각했다. 그 표는 계정이 실제로 무엇을 제공받는지에 대한 증거가 아니라 우리 쪽 추정이고, PR #154가 막 제거한 하드코딩 티어 테이블을 provider 축에서 되살리는 일이다. 능동 프로브(`claude --model X --print`)는 세션을 만들어 INV-005(부작용 없음)와 충돌한다.

이 결정의 귀결 하나를 오라클에 못 박았다: **신원 대조 성공 + 모델 가용성 unverified는 모순이 아니라 정상 상태**다.

## Debt 3 — 원격 환경 → REQ-009에 흡수

`orca account list`는 `--environment`를 무시가 아니라 **거부**한다("rejected rather than ignored; run it on the host whose accounts you want to see"). `orca environment list --json`은 `{"environments": []}` — 저장된 원격 환경 0건이라 당장 영향도 없다.

새 요구를 만들지 않았다. 원격은 "계정 조회 수단 없음"의 인스턴스이므로 REQ-009가 그대로 적용된다.

## 파생 결정 — Claude `activeAccountId`가 null

실측 중 발견했다. Claude는 등록 계정이 하나 있는데 `activeAccountId`가 `null`이고, Claude 블록에는 codex와 달리 `systemDefault` 필드가 없다.

**결정: 등록 계정이 정확히 1개면 그것, 0개이거나 2개 이상이면 `unverified`.** 추측하지 않는다 — 잘못 특정한 계정이 바로 조용한 강등을 만든다.

## 계약 반영

- **REQ-003** 본문에 실행 계정 해석 규칙 3단계(active → 단일 등록 → 미특정)를 넣었다.
- **REQ-004** 본문에 provider별 검증 깊이(Codex=카탈로그 완전 검증, Claude=신원만)를 넣었다.
- **REQ-009**를 "검증 수단이 없는 provider" → "검증할 수 없는 것"으로 넓히고, 흡수하는 세 인스턴스(Claude 가용성 / 원격 환경 / 계정 미특정)를 명시했다.
- **S9 신규** — 계정 미특정 시나리오. REQ-003 → S3·S9, REQ-009 → S8·S9로 매핑 갱신.
- `research.md` Completion Debt → `none remaining`, 후속 SPEC 이관 0건.

## 검증

`auto spec validate` 통과. `auto check --hygiene --arch --staged` exit 0. S1~S9 파서 인식 확인. 계정 문자열 전수 감사 결과 `jroad1049`가 codex 축으로 적힌 곳 0건.
