### PR TITLE
feat(execplane): Claude 자격 등급 검증과 증거 강도 표기, 재프로브 경로

### DIFF
--- a/.autopus/specs/SPEC-EXECPLANE-001/acceptance.md
+++ b/.autopus/specs/SPEC-EXECPLANE-001/acceptance.md
@@ -4,7 +4,7 @@
 
 ## Test Scenarios
 
-spec.md `## Traceability Matrix`에서 파생한 커버리지(권위 있는 매핑은 spec.md 쪽이다): S1=REQ-001, S2=REQ-002, S3=REQ-003·REQ-004, S4=REQ-005, S5=REQ-006, S6=REQ-007, S7=REQ-008, S8=REQ-009, S9=REQ-003·REQ-009, S10=REQ-004. 9개 요구가 10개 시나리오로 빠짐없이 덮인다. REQ-003은 S3(실행 계정과 프로브 계정의 자격 등급을 비교하는 경우)과 S9(실행 계정을 특정할 수 없는 경우) 둘로, REQ-004는 S3(등급 비교로 판정 경로가 갈리는 경우)과 S10(카탈로그가 자격에 종속된다는 전제 자체)으로, REQ-009는 S8(검증 수단 부재)과 S9 둘로 나뉜다.
+spec.md `## Traceability Matrix`에서 파생한 커버리지(권위 있는 매핑은 spec.md 쪽이다): S1=REQ-001, S2=REQ-002, S3=REQ-003·REQ-004, S4=REQ-005, S5=REQ-006, S6=REQ-007, S7=REQ-008, S8=REQ-009, S9=REQ-003·REQ-009, S10=REQ-004, S11=REQ-005, S12=REQ-004. 9개 요구가 12개 시나리오로 빠짐없이 덮인다. REQ-003은 S3(실행 계정과 프로브 계정의 자격 등급을 비교하는 경우)과 S9(실행 계정을 특정할 수 없는 경우) 둘로, REQ-004는 S3(등급 비교로 판정 경로가 갈리는 경우)·S10(카탈로그가 자격에 종속된다는 전제 자체)·S12(등급 동일 시 재프로브 0회와 등급 상이 시 실행 계정 기준 재프로브) 셋으로, REQ-005는 S4(영수증 7개 필드의 완전성)와 S11(`evidence_kind`가 같은 `verified` 아래에서 근거 강도를 구분하는 것) 둘로, REQ-009는 S8(검증 수단 부재)과 S9 둘로 나뉜다.
 
 ### S1: 세 평면의 소유 표면이 배타적으로 열거된다
 
@@ -39,15 +39,16 @@ And 두 등급을 비교할 수 없거나 등급이 달라 재프로브가 필�
 And 영수증의 카탈로그 출처에 프로브 계정과 그 자격 등급이 함께 남아, 독자가 세 분기 중 어디로 판정됐는지 복원할 수 있다
 And 등급이 다른데 재프로브 없이 통과 판정을 만들면 INV-003 위반이다
 
-### S4: 정합 영수증이 6개 필드를 모두 담는다
+### S4: 정합 영수증이 7개 필드를 모두 담는다
 
 Priority: Must
 Given 정합 점검을 마친 워크로드 하나
 When 정합 영수증을 방출한다
-Then 영수증은 요청 티어, 해석된 provider 모델, 실행 계정 식별자, 카탈로그 출처, resolution reason, verification status 6개 필드를 모두 담는다
-And 카탈로그 출처 필드는 프로브 계정 식별자와 그 계정의 자격 등급(Codex는 `chatgpt_plan_type` 값)을 함께 담는다. 계정만 있고 등급이 없는 영수증은 나머지 5개 필드가 채워져 있어도 불완전으로 판정되고 점검은 실패한다
+Then 영수증은 요청 티어, 해석된 provider 모델, 실행 계정 식별자, 카탈로그 출처, resolution reason, verification status, `evidence_kind` 7개 필드를 모두 담는다
+And 카탈로그 출처 필드는 프로브 계정 식별자와 그 계정의 자격 등급(Codex는 `chatgpt_plan_type`, Claude는 `organizationType` 값)을 함께 담는다. 계정만 있고 등급이 없는 영수증은 다른 여섯 필드가 채워져 있어도 불완전으로 판정되고 점검은 실패한다
+And `evidence_kind` 필드는 `probed_catalog`·`entitlement_parity`·`none` 셋 중 하나를 담는다. 이 값이 비어 있으면 다른 여섯 필드가 모두 채워져 있어도 `Complete()`가 false이고 점검은 실패한다 — 증거 종류가 없는 영수증은 독자가 판정의 근거 강도를 복원할 수 없기 때문이다
 And 영수증은 `pipeline_execution_owner_receipt.v1`과 같은 형태의 스키마 버전 태그를 갖는다
-And 6개 필드 중 하나라도 부재하거나 빈 문자열이면 영수증은 불완전으로 판정되고 점검은 실패한다
+And 7개 필드 중 하나라도 부재하거나 빈 문자열이면 영수증은 불완전으로 판정되고 점검은 실패한다
 
 ### S5: 티어 불일치는 요청값과 실제값을 모두 남기고 fail-loud 한다
 
@@ -83,16 +84,17 @@ And 이 경로는 OMP task DAG를 만들지 않으므로 DAG 소유자는 하나
 ### S8: 검증 수단이 없는 항목은 unverified로 표기된다
 
 Priority: Must
-Given REQ-009가 흡수하는 인스턴스는 셋이다. (1) Claude 모델 가용성 — `claude` CLI 명령 집합(`agents`/`auth`/`auto-mode`/`doctor`/`gateway`/`import`/`install`/`mcp`/`plugin`/`project`/`setup-token`/`ultrareview`)에 모델 열거 명령이 없고 `omp models --json`은 정적 레지스트리라 계정 스코프가 아니므로, 계정별 카탈로그 프로브가 존재하지 않는다(research.md F8)
-And (2) 원격 orca 환경 — `orca account list`가 `--environment`를 "rejected rather than ignored"로 거부하므로 원격 호스트의 계정을 조회할 수단이 없다. `orca environment list --json`이 `{"environments": []}`라 현재 영향 범위는 0건이지만 규칙은 같다(research.md F8)
-And (3) 실행 계정 미특정 — 활성 계정이 없고 등록 계정이 1개가 아닌 경우다. 이 인스턴스의 판정은 S9가 담당하고 S8은 같은 `unverified` 규칙을 공유한다는 사실만 참조한다
-And Codex와 달리 Claude는 신원 대조까지는 가능하다. `claude auth status --json`의 `orgId`가 orca `claude.accounts[].organizationUuid`와 같은 값 `0e61c3e2-35c8-4bf8-91bc-40848f4dc147`이다(research.md F1)
+Given REQ-009가 흡수하는 인스턴스는 넷이다. (1) 원격 orca 환경 — `orca account list`가 `--environment`를 "rejected rather than ignored"로 거부하므로 원격 호스트의 계정을 조회할 수단이 없다. `orca environment list --json`이 `{"environments": []}`라 현재 영향 범위는 0건이지만 규칙은 같다(research.md F8)
+And (2) 실행 계정 미특정 — 활성 계정이 없고 등록 계정이 1개가 아닌 경우다. 이 인스턴스의 판정은 S9가 담당하고 S8은 같은 `unverified` 규칙을 공유한다는 사실만 참조한다
+And (3) 등급 비교 불가 — 자격증명 자체가 없거나 등급 클레임(Codex `chatgpt_plan_type`, Claude `organizationType`)을 담지 않아 P_exec와 P_probe의 비교가 성립하지 않는 경우다. 등급을 읽지 못한 것을 등급이 같은 것으로 낙관 처리하면 실패다
+And (4) 보유 증거 부재 — `evidence_kind`가 `none`인 provider다. 등급이 **완전히 동일**해도 parity는 증거를 옮길 뿐 만들지 않으므로 `verified`가 될 수 없다(research.md F10). `Evaluate`가 `verified`에 요구하는 세 조건(실행 계정 determined + 등급 동일 + 증거 보유) 중 셋째가 빠진 상태다
+And Claude 모델 가용성은 더 이상 이 목록에 속하지 않는다. 관리 계정(`<support>/orca/claude-accounts/<accountId>/auth/oauth-account.json`)과 호스트 CLI(`~/.claude.json`의 `oauthAccount`)가 동일 필드명 `organizationType`으로 등급을 노출하므로, Claude는 `entitlement_parity` 증거로 `verified`가 될 수 있다(research.md F10). 이 워크스테이션 실측은 양쪽 다 `claude_max`이고 판정은 `verified`다
 When 그 항목의 요청 티어에 대해 정합 점검을 수행한다
 Then 영수증의 verification status 값이 `unverified`다
 And 같은 항목이 `verified`로 표기되지 않는다
-And Claude에서 신원 대조가 성공해도 모델 가용성 항목은 여전히 `unverified`다. 신원 검증 성공과 카탈로그 미검증은 동시에 성립하는 정상 상태이며, 신원이 맞았다는 이유로 티어를 `verified`로 승격하면 실패다
-And `subscriptionType`(`max`/`pro`/`free`)에서 플랜 -> 모델 표를 유도해 `verified`를 만들어내지 않는다. 그것은 PR #154가 제거한 하드코딩 티어 테이블의 재도입이다
-And 사유 필드에 검증 수단 부재가 기록되어 미검증과 검증 실패가 구분되고, 세 인스턴스 중 어느 것인지 복원 가능하다
+And 네 번째 인스턴스의 사유는 등급 불일치 사유와 문자열로 구별된다. "등급은 같음을 확인했으나 옮길 증거가 없다"와 "등급이 다르다"는 서로 다른 관측이며, 둘을 한 사유로 뭉뚱그리면 독자가 재프로브가 필요한 상황인지 아닌지를 복원할 수 없어 실패다
+And `subscriptionType`(`max`/`pro`/`free`)이나 `organizationType`에서 플랜 -> 모델 표를 유도해 `verified`를 만들어내지 않는다. 그것은 PR #154가 제거한 하드코딩 티어 테이블의 재도입이다. 등급은 동일성 비교에만 쓰인다
+And 사유 필드에 검증 수단 부재가 기록되어 미검증과 검증 실패가 구분되고, 네 인스턴스 중 어느 것인지 복원 가능하다
 
 ### S9: 실행 계정을 특정할 수 없으면 추측하지 않고 unverified로 분기한다
 
@@ -104,7 +106,7 @@ Then 등록 계정이 정확히 1개면 그 계정을 실행 계정으로 채택
 And 등록 계정이 0개면 실행 계정을 특정하지 않고 REQ-009의 `unverified` 경로로 분기하며, 사유 필드에 계정 부재가 기록된다
 And 등록 계정이 2개 이상이면 어느 것도 고르지 않고 REQ-009의 `unverified` 경로로 분기한다. 활성 계정이 없다는 이유로 첫 번째 계정이나 최근 사용 계정을 고르면 실패다
 And 세 분기 어디에서도 로컬 CLI 로그인 계정을 실행 계정의 대체값으로 쓰지 않는다. 그 값은 S3의 프로브 계정이지 실행 계정이 아니며, 두 계정의 자격 등급이 같더라도 영수증의 실행 계정 필드를 그 값으로 채우면 실패다
-And 1개 채택 분기로 실행 계정이 특정되더라도 그 계정의 카탈로그 프로브가 없으면 모델 가용성은 S8의 `unverified`로 남는다
+And 1개 채택 분기로 실행 계정이 특정되면 그다음 판정은 등급 동일성과 증거 종류가 가른다. Claude는 계정 스코프 카탈로그가 없어도 `organizationType` 등급이 같으면 `entitlement_parity` 증거로 `verified`가 되고, 등급을 읽을 수 없거나 옮길 증거가 없으면 S8의 `unverified`로 남는다
 
 ### S10: 카탈로그는 자격에 종속되므로 자격과 무관한 재사용은 위반이다
 
@@ -116,32 +118,58 @@ Then 두 집합은 같지 않다. 서버가 호출자의 자격을 보고 목록
 And 따라서 카탈로그를 자격과 무관한 것으로 취급하는 구현은 REQ-004 위반이다. 자격 등급을 키에 넣지 않은 카탈로그 캐시, 자격이 바뀐 뒤에도 이전 결과를 그대로 재사용하는 경로, 자격이 확인되지 않은 상태에서 얻은 목록을 티어 근거로 채택하는 판정 셋 다 해당한다
 And 이 시나리오는 REQ-004의 전제를 고정할 뿐 자격에서 모델을 유추하지 않는다. 자격 등급은 S3에서 동일성 비교에만 쓰이며 등급 -> 모델 매핑 표를 만들지 않는다
 
+### S11: 같은 verified 안에서도 증거 종류가 구분되어 기록된다
+
+Priority: Must
+Given 이 워크스테이션에서 게이트를 종단 실행한 결과 집계 판정은 `verification_status: verified`이고 사유는 `claude: execution and probe accounts share entitlement claude_max; codex: execution and probe accounts share entitlement pro`다
+And 그 영수증에서 claude 항목의 실행 계정은 `jroad1049@gmail.com`, 카탈로그 출처는 `jroad1049@gmail.com` @ `claude_max`, `evidence_kind`는 `entitlement_parity`이고, codex 항목의 실행 계정은 `bitgapnam@gmail.com`, 카탈로그 출처는 `gnkong@alipeople.kr` @ `pro`, `evidence_kind`는 `probed_catalog`다. 두 provider가 **둘 다** `verified`인 상태에서 관측된 값이다
+And 두 판정의 근거 강도는 같지 않다. codex는 provider가 내려준 카탈로그를 보유하므로 등급 동일성이 그 카탈로그를 실행 계정으로 옮기지만, claude는 카탈로그가 없어 등급 동일성이 기준 세션의 작업 가정만 옮긴다(research.md F10)
+When 독자가 그 영수증을 읽고 각 provider 판정이 무엇에 기대고 있는지 복원한다
+Then 두 항목의 `evidence_kind`가 `probed_catalog`(codex)와 `entitlement_parity`(claude)로 서로 다른 값으로 기록되어, 같은 `verified` 아래에서도 근거 강도가 구분된다
+And 두 값을 하나로 뭉뚱그리면 위반이다. 둘 다 `verified`라는 이유로 같은 증거 종류를 부여하거나, `evidence_kind`를 영수증에서 빼면 이 SPEC이 막으려던 증거 강도의 조용한 뭉갬이 그대로 재발한다
+And `evidence_kind`는 verification status를 대체하지 않는다. 두 필드는 함께 존재하며 `verified` + `probed_catalog`와 `verified` + `entitlement_parity`는 서로 다른 관측값이다
+And 실측 계정 문자열과 등급 값은 두 증거 종류가 한 영수증에 공존함을 보이는 근거로만 쓰고, 오라클이 그 문자열을 하드코딩해 비교하지 않는다
+
+### S12: 등급이 같으면 재프로브하지 않고, 다르면 실행 계정 기준으로 다시 프로브한다
+
+Priority: Must
+Given Codex 카탈로그 프로브는 `CODEX_HOME`이 가리키는 자격으로 `codex debug models`를 실행하므로, 어느 계정의 카탈로그를 받을지는 그 환경 변수가 결정한다(`pkg/codexruntime/probe.go:39`, research.md F9)
+And 실행 계정의 자격 등급 P_exec와 프로브 계정의 자격 등급 P_probe는 각 `auth.json` id_token의 `https://api.openai.com/auth.chatgpt_plan_type` 클레임에서 네트워크 호출 없이 읽힌다
+When 정합 점검이 두 등급을 비교하고 그 결과로 재프로브 여부를 결정한다
+Then `P_exec == P_probe`이면 재프로브 횟수가 **0회**이고 그 분기에서 발생한 네트워크 호출도 0회다. 등급이 같을 때 카탈로그를 다시 받지 않는 것이 이 설계의 핵심이므로, 이 분기에서 재프로브가 한 번이라도 일어나면 실패다. 현재 이 워크스테이션의 codex(실행 `bitgapnam@gmail.com`, 프로브 `gnkong@alipeople.kr`, 둘 다 `pro`)가 이 분기이며 재프로브 0회로 `verified`가 됐다
+And `P_exec != P_probe`이면 실행 계정의 `CODEX_HOME`을 기준으로 재프로브를 1회 수행한다. 성공하면 영수증의 `catalog_source`가 프로브 계정이 아니라 실행 계정을 가리키고, 그 카탈로그만 티어 근거가 되며 판정은 `verified`가 될 수 있다. `evidence_kind`는 `probed_catalog`로 남는다
+And 재프로브가 실패하면 판정은 `unverified`이고, 사유에 재프로브 실패가 등급 불일치와 **함께** 등장한다. 둘 중 하나만 남기면 독자가 "등급이 달랐다"와 "다시 확인하려 했으나 실패했다"를 구분할 수 없다
+And 등급이 다른데 재프로브 없이 이전 프로브 계정의 카탈로그가 근거로 남아 통과 판정이 나오면 INV-003 위반이다
+And Claude는 계정 스코프 카탈로그가 없으므로 등급이 달라도 재프로브하지 않는다. 옮길 카탈로그가 없어 재시도할 대상 자체가 없으므로 REQ-009의 `unverified` 경로(S8)로 떨어지며, 그 사유는 재프로브 실패가 아니라 증거 부재로 기록된다
+
 ## Oracle Acceptance Notes
 
-이 SPEC은 설계 고정 문서이므로 위 시나리오는 지금 자동화된 테스트로 실행되지 않는다. S1·S2는 문서 검토로 즉시 판정 가능하고, S10의 관측값은 research.md F9의 실측 프로브로 이미 고정되어 있으며, S3~S9는 정합 게이트를 구현하는 후속 SPEC의 수용 오라클로 그대로 이월된다. 이월 시 아래 예상 값을 완화하는 것은 범위 축소로 취급한다.
+이 SPEC은 설계 고정 문서이므로 위 시나리오는 지금 자동화된 테스트로 실행되지 않는다. S1·S2는 문서 검토로 즉시 판정 가능하고, S10의 관측값은 research.md F9의 실측 프로브로, S11·S12의 등급 동일 분기 관측값은 이 워크스테이션의 종단 실행으로 이미 한 번 고정되어 있으며, S3~S9와 S11·S12는 정합 게이트를 구현하는 후속 SPEC의 수용 오라클로 그대로 이월된다. 이월 시 아래 예상 값을 완화하는 것은 범위 축소로 취급한다.
 
 각 시나리오의 판정 기준은 다음 구체 값으로 고정한다. `정상 동작한다` 같은 서술은 통과 근거가 아니다.
 
 - **S1** — 예상 값: Feature Coverage Map 7개 행 각각의 소유 평면 수 = 1. 소유자 미지정 행 0건, 복수 소유 행 0건. 신설 표면 `티어와 실행 계정의 정합 검증`의 소유자 문자열은 정책 평면 하나여야 하며, 같은 표면 이름이 모델·프로세스 평면 목록에 재등장하면 실패.
 - **S2** — 예상 값: 경계 인자 집합에서 `quality`=0, `tier`=0, `balanced`=0, `ultra`=0, `opus`=0, `sonnet`=0, `haiku`=0. 하나라도 1 이상이면 실패. `--model`, `--effort` 두 인자 외의 티어 파생 인자가 추가되어도 실패.
 - **S3** — 예상 값: `receipt.catalog_source`가 프로브 계정과 그 자격 등급을 함께 담고, 그 등급이 실행 계정의 등급과 같다. 등급이 같은 분기에서는 **카탈로그 프로브 호출 수 = 0**이 기대값이다. 재프로브가 한 번이라도 일어나면 설계 단순화의 핵심이 무너진 것이므로 실패로 본다. 등급이 다른 분기에서는 실행 계정 기준 재프로브 결과만 근거여야 하고, 이전 카탈로그가 근거로 남아 있으면 실패. 등급 비교도 재프로브도 불가능하면 통과가 아니라 S8의 `unverified`다. **계정 식별자가 다르다는 것만으로 실패를 판정하는 오라클은 부적합하다** — 조직만 다르고 등급이 같은 실측 쌍(`bitgapnam@gmail.com` vs `gnkong@alipeople.kr`, 둘 다 `chatgpt_plan_type: "pro"`)을 오탐하기 때문이다. 같은 이유로 계정 문자열을 하드코딩해 비교하는 오라클도 F1 시점의 계정 구성이 바뀌면 무의미해지므로 부적합이다. 실측 쌍은 등급 동일 분기가 현재 상태임을 보이는 근거로만 쓴다. 두 계정 값은 `orca account list --json` 한 응답의 `result.codex.activeAccountId`와 `result.codex.systemDefault`에서, 두 등급은 각 계정 `auth.json` id_token의 `chatgpt_plan_type`에서 네트워크 호출 없이 나오므로, 프로브 계정이나 등급을 별도 명령으로 다시 읽는 구현은 중복 조회로 본다.
-- **S4** — 예상 값: 영수증 필드 6개가 모두 존재. 요청 티어 / 해석된 provider 모델 / 실행 계정 식별자 / 카탈로그 출처 / resolution reason / verification status. 이 중 하나라도 누락되거나 빈 문자열이면 실패로 판정한다. 카탈로그 출처는 프로브 계정 식별자와 그 자격 등급 두 값을 모두 담아야 하며, 계정만 담고 등급이 없는 영수증은 필드 개수가 6이어도 불완전으로 실패. 스키마 버전 태그 부재도 실패.
+- **S4** — 예상 값: 영수증 필드 7개가 모두 존재. 요청 티어 / 해석된 provider 모델 / 실행 계정 식별자 / 카탈로그 출처 / resolution reason / verification status / `evidence_kind`. 이 중 하나라도 누락되거나 빈 문자열이면 실패로 판정한다. 특히 `evidence_kind`가 비어 있으면 다른 여섯 필드가 모두 채워져 있어도 `Complete()`는 false여야 하며, true를 반환하면 실패. 카탈로그 출처는 프로브 계정 식별자와 그 자격 등급 두 값을 모두 담아야 하며, 계정만 담고 등급이 없는 영수증은 필드 개수가 7이어도 불완전으로 실패. 스키마 버전 태그 부재도 실패.
 - **S5** — 예상 값: `resolution.reason != ""`. 빈 문자열이면 위반. 요청 티어 값과 실제 제공 모델 값이 둘 다 non-empty여야 하고, 둘 중 하나만 있는 영수증은 실패. 영수증 없이 낮은 모델로 실행된 경우는 조용한 강등이므로 즉시 실패.
 - **S6** — 예상 값: 점검 실패 후 신규 워크트리 수 = 0, Run 수 = 0, 워커 수 = 0, provider 세션 수 = 0. 어느 하나라도 1 이상이면 INV-005 위반. 실패 후 정리(cleanup)로 0에 도달한 경우도 생성이 발생했으므로 실패로 본다.
 - **S7** — 예상 값: 통과 경로의 handoff 결과에 영수증 참조 필드가 1개 이상 존재. 실패 경로에서는 `status: handoff_required`가 반환되지 않고 정합 실패가 반환되어야 하며, 두 결과가 동시에 나오면 실패. 이 경로에서 생성된 OMP task DAG 수 = 0.
-- **S8** — 예상 값: `verification_status == "unverified"`이고 사유 필드 non-empty. 같은 항목에 `verified`가 오면 실패. 프로브가 없다는 이유로 티어를 검증됨으로 낙관 처리하거나, 반대로 검증 실패(카탈로그에 모델 없음)와 같은 상태값으로 뭉뚱그리면 실패. Claude는 신원 대조(`orgId` == `organizationUuid`, 실측 `0e61c3e2-35c8-4bf8-91bc-40848f4dc147`)가 성공해도 모델 가용성 항목이 `unverified`여야 하고, `subscriptionType`을 근거로 `verified`를 만들면 실패. 원격 환경 대상은 `--environment` 거부로 계정 조회 자체가 불가능하므로 같은 `unverified`이며, 사유 문자열이 세 인스턴스(Claude 카탈로그 부재 / 원격 환경 / 계정 미특정) 중 어느 것인지 지목해야 한다.
+- **S8** — 예상 값: `verification_status == "unverified"`이고 사유 필드 non-empty. 같은 항목에 `verified`가 오면 실패. 프로브가 없다는 이유로 티어를 검증됨으로 낙관 처리하거나, 반대로 검증 실패(카탈로그에 모델 없음)와 같은 상태값으로 뭉뚱그리면 실패. 사유 문자열은 네 인스턴스(원격 환경 / 계정 미특정 / 등급 비교 불가 / 증거 부재) 중 어느 것인지 지목해야 한다. 원격 환경 대상은 `--environment` 거부로 계정 조회 자체가 불가능하므로 `unverified`. 증거 부재 인스턴스는 `evidence_kind == "none"`이고 등급이 동일하게 관측되더라도 `verified`가 되면 실패이며, 그 사유가 등급 불일치 사유와 같은 문자열로 축약되면 실패. **Claude 모델 가용성을 이 목록에 남겨 둔 오라클은 부적합하다** — `organizationType` 등급 소스가 있어 Claude는 `entitlement_parity`로 `verified`가 될 수 있고(실측 `claude_max`), 이를 `unverified`로 강제하면 과소 판정이다. 플랜 -> 모델 매핑을 유도해 `verified`를 만드는 반대 방향도 여전히 실패.
 - **S9** — 예상 값: `activeAccountId == null`일 때 등록 계정 수 n으로 분기가 갈린다. n == 1이면 `receipt.execution_account`가 그 계정으로 non-empty, n == 0 또는 n >= 2이면 `receipt.execution_account`가 특정되지 않고 `verification_status == "unverified"` + 사유 non-empty. n >= 2에서 임의의 한 계정을 골라 실행 계정 필드를 채운 영수증은 값이 있어도 실패로 본다. 현재 머신의 Claude는 n == 1(`jroad1049@gmail.com`)이므로 채택 분기가 도달 가능함을 보이는 근거로만 쓰고, 계정 문자열을 하드코딩해 비교하지 않는다.
 - **S10** — 예상 값: 인증 프로브와 미인증 프로브의 슬러그 집합이 다르고, 차이가 정확히 인증 전용 `gpt-5.6-sol-wm`·`gpt-5.3-codex-spark` 대 미인증 전용 `gpt-5.2`다. 두 집합이 같게 관측되면 REQ-004의 전제가 흔들린 것이므로 재측정 전까지 계약을 그대로 두는 판단은 실패로 본다. 구현 판정으로는 자격 등급이 키에 포함되지 않은 카탈로그 캐시 경로 수 = 0, 자격이 확인되지 않은 상태에서 얻은 목록을 티어 근거로 채택한 사례 수 = 0.
+- **S11** — 예상 값: 두 provider 모두 `verification_status == "verified"`인 영수증에서 `evidence_kind`가 codex는 `"probed_catalog"`, claude는 `"entitlement_parity"`로 서로 다른 값이다. 두 항목의 `evidence_kind`가 같은 값이면, 또는 필드가 없으면 실패. 실측 대응은 claude(실행 `jroad1049@gmail.com`, 출처 `jroad1049@gmail.com` @ `claude_max`)와 codex(실행 `bitgapnam@gmail.com`, 출처 `gnkong@alipeople.kr` @ `pro`)이며, 이 값들은 두 증거 종류의 공존을 보이는 근거로만 쓰고 하드코딩 비교 대상으로 삼지 않는다. `evidence_kind`를 verification status로 대체하거나 둘을 한 필드로 합친 영수증은 실패.
+- **S12** — 예상 값: 등급 동일 분기의 **재프로브 호출 수 = 0, 네트워크 호출 수 = 0**. 1 이상이면 실패이며, 이것이 S12에서 가장 먼저 확인할 값이다. 등급 상이 분기에서는 실행 계정 `CODEX_HOME` 기준 재프로브 호출 수 = 1이고, 성공 시 `receipt.catalog_source`의 계정이 실행 계정과 같아야 한다. 이전 프로브 계정이 `catalog_source`에 남아 있으면 실패. 재프로브 실패 시 `verification_status == "unverified"`이고 사유 문자열에 등급 불일치와 재프로브 실패가 **둘 다** 등장해야 하며, 하나만 있으면 실패. Claude 경로에서 재프로브 호출이 관측되면 실패다(카탈로그가 없어 재시도 대상이 없다). 다른 자격 등급의 계정 쌍은 이 워크스테이션에 없으므로 등급 상이 분기는 픽스처로 검증하고, 등급 동일 분기만 실측으로 고정한다.
 
 판정 시 주의할 점 세 가지.
 
 - S3와 S8은 경계가 인접하다. 실행 계정을 특정했으나 그 자격 등급을 읽을 수 없거나, 등급이 달라 재프로브가 필요한데 조회 수단이 없는 경우는 S3의 통과가 아니라 S8의 `unverified`다. 이 분기를 통과로 세면 INV-003이 무력화된다. 반대 방향도 오판이다. 등급이 같음을 확인한 경우는 재프로브 없이도 정상 통과이며, 계정이 다르다는 이유로 이를 `unverified`나 실패로 내리면 과잉 판정이다.
 - S5·S8·S9는 상태값이 서로 달라야 한다. 카탈로그를 조회했고 모델이 없어 강등한 경우(S5)는 사유가 붙은 명시적 강등, 계정은 특정했으나 조회 수단 자체가 없는 경우(S8)는 실행 계정 필드가 채워진 `unverified`, 실행 계정조차 특정하지 못한 경우(S9)는 실행 계정 필드가 비어 있는 `unverified`다. 셋을 한 값으로 합치거나 뒤의 둘을 사유 없이 같은 항목으로 묶으면 영수증 독자가 근거의 강도를 복원할 수 없다.
-- 신원 검증 성공과 모델 가용성 `unverified`가 한 영수증에 함께 있는 것은 모순이 아니라 정상 상태다. Claude에서 `orgId`와 `organizationUuid`가 일치하면 "실행 계정이 검증 대상 계정과 같다"까지는 확정되지만, 그 계정이 어떤 모델을 쓸 수 있는지는 조회할 수단이 없다. 실행 계정 식별자는 확정값이고 verification status는 `unverified`인 조합을 읽고 결함으로 판정하면 안 된다. 두 축은 별개이며, 신원이 맞았다는 이유로 티어를 `verified`로 올리는 쪽이 실제 결함이다.
+- 같은 `verified`라도 `evidence_kind`가 다르면 근거 강도가 다르다. codex의 `verified` + `probed_catalog`는 provider가 실제로 내려준 카탈로그가 등급 동일성을 타고 실행 계정으로 옮겨진 상태이고, claude의 `verified` + `entitlement_parity`는 옮겨진 것이 기준 세션의 작업 가정뿐인 상태다. 두 영수증을 같은 강도로 읽거나, 반대로 `entitlement_parity`라는 이유로 claude 판정을 결함으로 내리는 쪽 모두 오판이다. 실제 결함은 셋 중 하나다. 두 증거 종류를 한 값으로 합치는 것, `evidence_kind`를 영수증에서 빼는 것, 그리고 `evidence_kind`가 `none`인데 등급이 같다는 이유만으로 `verified`를 부여하는 것 — 마지막은 parity가 증거를 옮길 뿐 만들지 않는다는 규칙을 정면으로 어긴다.
 
 ## Definition of Done
 
-- [ ] S1~S10이 REQ-001~REQ-009를 빠짐없이 덮는다(REQ-003은 S3·S9, REQ-004는 S3·S10, REQ-009는 S8·S9)
+- [ ] S1~S12가 REQ-001~REQ-009를 빠짐없이 덮는다(REQ-003은 S3·S9, REQ-004는 S3·S10·S12, REQ-005는 S4·S11, REQ-009는 S8·S9)
 - [ ] 각 시나리오의 Then이 관측 가능한 값을 지명한다
-- [ ] S3~S10의 예상 값이 후속 구현 SPEC의 수용 오라클로 이관된다
+- [ ] S3~S12의 예상 값이 후속 구현 SPEC의 수용 오라클로 이관된다
 - [ ] 세 평면 경계에 대한 리뷰 합의가 기록된다

--- a/.autopus/specs/SPEC-EXECPLANE-001/plan.md
+++ b/.autopus/specs/SPEC-EXECPLANE-001/plan.md
@@ -23,7 +23,30 @@
 
 이것이 기각한 대안 (c)와 충돌하지 않는 이유는 하는 일이 매핑이 아니라 비교이기 때문이다. 두 등급이 같은지만 보고 등급에서 모델을 유추하지 않으므로 하드코딩 매핑 표가 생기지 않는다. (c)를 기각한 근거 — 플랜 -> 모델 표는 증거가 아니라 우리 쪽 추정이다 — 는 그대로 유효하다.
 
-남은 미검증은 하나다. 자격 등급이 **다른** 계정 쌍이 이 워크스테이션에 없어, 등급이 갈릴 때 판정 필드가 실제로 어떻게 달라지는지는 확인하지 못했다. 미인증 프로브가 자격 종속성 자체를 증명하므로 계약은 성립하지만, 등급 불일치의 구체적 형태는 관측이 아니라 추론이다.
+남은 미검증은 하나다. 자격 등급이 **다른** 계정 쌍이 이 워크스테이션에 없어, 등급이 갈릴 때 판정 필드가 실제로 어떻게 달라지는지는 확인하지 못했다. 미인증 프로브가 자격 종속성 자체를 증명하므로 계약은 성립하지만, 등급 불일치의 구체적 형태는 관측이 아니라 추론이다. 따라서 아래에서 규정하는 재프로브 경로도 실기기에서 한 번도 구동된 적이 없고, 그 자리는 stub 기반 계약 테스트가 메운다.
+
+### 두 provider 모두 등급을 로컬에서 읽는다 — 갈리는 것은 등급 동일성이 무엇을 옮기느냐다
+
+F8은 "Claude에 계정별 카탈로그 프로브가 없다"에서 멈춰 Claude를 신원 검증까지로 묶고 모델 가용성을 영구 `unverified`로 결론지었다. **그 결론은 틀렸다.** 카탈로그가 없다는 사실을 등급이 없다는 사실로 오인한 것이다. 게이트가 요구하는 입력은 카탈로그가 아니라 **등급**이고, 등급은 이미 자격증명 파일 안에 있다(F10).
+
+| provider | 등급 필드 | 읽는 위치 |
+| --- | --- | --- |
+| codex | `chatgpt_plan_type` | `auth.json` id_token의 `https://api.openai.com/auth` 클레임 |
+| claude | `organizationType` | orca 관리 계정은 `<support>/orca/claude-accounts/<accountId>/auth/oauth-account.json` 최상위, 호스트 CLI는 `~/.claude.json`의 `oauthAccount` 아래 |
+
+Claude 쪽 두 위치는 **필드명이 같다**. 어휘 매핑 없이 파서 하나가 양쪽을 읽고, 이 워크스테이션 실측은 양쪽 다 `claude_max`다(F10). 등급은 조직 플랜(`organizationType`)으로 잡고 rate-limit 티어(`organizationRateLimitTier`의 `default_claude_max_20x` 대 `..._5x`)는 뺀다 — 후자는 같은 모델 집합을 throttle할 뿐이라, 등급에 섞으면 실제로 동등한 계정 사이에 불필요한 재프로브가 생긴다.
+
+그러므로 provider별 검증 깊이의 차이는 "누가 등급을 갖고 있느냐"가 아니다. 둘 다 갖고 있고, 둘 다 파일 읽기로 얻으므로 네트워크 호출이 0회다. 갈리는 것은 **등급 동일성이 무엇을 옮기느냐**다. Codex에는 provider가 내려준 카탈로그가 있어 등급 동일성이 그 카탈로그를 실행 계정으로 옮긴다. Claude에는 카탈로그가 없어 옮길 것이 기준 세션의 작업 가정뿐이다. 두 판정이 영수증에서 똑같이 `verified`로 읽히면 증거 강도가 조용히 뭉개진다 — 이 SPEC이 막으려던 실패가 게이트 자신 안에서 재발한다. 그래서 영수증에 `evidence_kind`를 둔다(REQ-005).
+
+| 값 | 뜻 | 이 워크스테이션 |
+| --- | --- | --- |
+| `probed_catalog` | provider가 내려준 카탈로그를 보유하고, 등급 동일성이 그것을 실행 계정으로 옮긴다 | codex |
+| `entitlement_parity` | 카탈로그가 없고, 등급 동일성이 기준 세션의 작업 가정만 옮긴다 | claude |
+| `none` | 옮길 증거가 없다. 등급이 아무리 맞아도 `verified`가 될 수 없다 | 해당 계정 없음 |
+
+**parity는 증거를 옮길 뿐 만들지 않는다.** 이것이 판정이 `verified`에 세 조건을 동시에 요구하는 이유다 — 실행 계정 determined + 등급 동일 + 증거 보유. 셋 중 하나라도 빠지면 REQ-009의 `unverified`이며, 특히 등급이 깨끗하게 일치해도 `evidence_kind`가 `none`이면 `verified`가 될 수 없다.
+
+등급이 갈리는 예외 경로에서 provider가 다시 갈린다. Codex는 실행 계정의 `CODEX_HOME`을 기준으로 `codex debug models`를 다시 프로브한다 — 성공하면 카탈로그 출처가 실행 계정을 가리키므로 `verified`가 가능하고, 실패하면 `unverified`이며 사유에 재프로브 실패를 명시한다. Claude는 프로브할 카탈로그가 아예 없으므로 재프로브하지 않고 곧바로 `unverified`다. 등급이 같은 기본 경로에서는 **재프로브가 0회**이고, 따라서 네트워크 호출도 0회로 유지된다(REQ-004).
 
 ### 기각한 대안 (a) — orca(프로세스 평면)에 둔다
 
@@ -51,7 +74,7 @@ Claude에는 `codex debug models` 등가물이 없다. F8의 확인 결과 `clau
 
 여기서 `subscriptionType`(`max`/`pro`/`free`)을 게이트 입력으로 삼아 "이 플랜이면 이 티어까지 허용"으로 판정하자는 안이 있었다. 기각한다. 판정이 성립하려면 플랜 -> 모델 매핑 표를 정책 평면에 하드코딩해야 하는데, 그 표는 계정이 실제로 무엇을 제공받는지에 대한 증거가 아니라 **우리 쪽의 추정**이다. provider가 플랜 정책을 바꾸면 표는 조용히 틀리고, 게이트는 틀린 표를 근거로 `verified`를 찍는다 — REQ-009가 금지하는 상태이자 INV-004가 막으려는 조용한 어긋남이다.
 
-형태로 보면 이 안은 PR #154가 제거한 하드코딩 티어 테이블을 provider 축에 되살리는 일이다. 같은 것을 다른 이름으로 되돌리지 않는다. Claude는 `orgId` 신원 대조까지만 검증하고 모델 가용성은 REQ-009의 `unverified`로 남긴다. 모르는 것을 모른다고 적는 편이 짐작해서 맞히는 것보다 싸다.
+형태로 보면 이 안은 PR #154가 제거한 하드코딩 티어 테이블을 provider 축에 되살리는 일이다. 같은 것을 다른 이름으로 되돌리지 않는다. 기각한 것은 어디까지나 **플랜 -> 모델 매핑**이지 플랜 값을 읽는 행위 자체가 아니다. 채택한 것은 위 절의 **등급 동일성 비교** — `organizationType` 두 값이 같은지만 보고 등급에서 모델을 유추하지 않으므로 하드코딩 표가 생기지 않는다. 둘은 다른 것이다. 매핑은 우리 쪽 추정을 증거로 승격시키고, 동일성 비교는 이미 가진 증거를 다른 계정으로 옮길 자격이 있는지만 확인한다. 그래서 Claude도 등급 축에서는 검증되고, 다만 옮긴 증거가 카탈로그가 아니라는 사실이 `evidence_kind: entitlement_parity`로 영수증에 남는다.
 
 ### 배치 지점 — handoff 직전, 부작용 이전
 
@@ -71,12 +94,13 @@ result := pipelineExecutionOwnerResult{
 
 ### 왜 이 SPEC은 설계만 고정하고 구현을 분리하는가
 
-착수 시점의 이유는 "미결 3건이 열려 있어 구현 선택이 정해지지 않는다"였다. 그 이유는 더 이상 유효하지 않다. research.md F8이 3건을 모두 실측으로 닫았고, 결정은 `### 결정` 표에, 계약은 spec.md REQ-003·REQ-004·REQ-009 본문에 들어갔다. `## Completion Debt`는 `none remaining`이다.
+착수 시점의 이유는 "미결 3건이 열려 있어 구현 선택이 정해지지 않는다"였다. 그 이유는 더 이상 유효하지 않다. research.md F8이 3건을 모두 실측으로 닫았고, F10이 그중 Claude 항목의 결론을 정정했으며, 결정은 `### 결정` 표에, 계약은 spec.md REQ-003·REQ-004·REQ-005·REQ-009 본문에 들어갔다. `## Completion Debt`는 `none remaining`이다.
 
 | 닫힌 질문 | 확정된 결정 | 계약이 앉는 자리 |
 | --- | --- | --- |
 | 계정 조회 소스 | `orca account list --json` 한 호출. 실행 계정은 `result.<provider>.activeAccountId`, 비교 대상 프로브 계정은 `result.codex.systemDefault`(codex) 또는 provider CLI 신원 | REQ-003 / T2 |
-| Claude 카탈로그 부재 | 신원만 검증. `claude auth status --json`의 `orgId`를 orca `claude.accounts[].organizationUuid`와 대조하고, 모델 가용성은 `unverified`로 남긴다 | REQ-004 / T2, REQ-009 / T3 |
+| Claude 카탈로그 부재 | Codex와 같은 **등급 동일성 비교**. orca 관리 계정과 호스트 CLI의 `organizationType`을 대조하고(`claude auth status --json`의 `orgId` 신원 대조는 계정 조인 수단으로만 쓴다), 옮긴 증거가 카탈로그가 아니므로 `evidence_kind: entitlement_parity`로 기록한다. 카탈로그가 없어 재프로브 경로는 두지 않는다 | REQ-004 / T2, REQ-005 / T3 |
+| 증거 강도 표기 | 영수증에 `evidence_kind`(`probed_catalog` \| `entitlement_parity` \| `none`). `verified`는 실행 계정 determined + 등급 동일 + 증거 보유 셋을 모두 요구하고, `none`이면 등급이 같아도 `unverified`다 | REQ-005 / T3, REQ-009 / T3 |
 | 원격 orca 환경 계정 조회 | 새 요구를 만들지 않고 REQ-009에 흡수. `orca account list`가 `--environment`를 구조적으로 거부하므로 "계정 조회 수단 없음"의 인스턴스다 | REQ-009 / T3 |
 
 그렇다면 왜 여전히 구현을 분리하는가. 이유가 바뀌었기 때문이다 — "질문이 열려 있어서"가 아니라 **계약이 먼저 합의되어야 구현이 바로잡힐 수 있어서**다.
@@ -87,7 +111,7 @@ F3이 주는 것은 사례가 아니라 **비용의 크기**다. #151은 측정 
 
 계약을 먼저 고정하는 이유는 따로 있다. 암묵 가정은 코드가 공백을 만나는 자리마다 새로 생기고, 이 접합면에서는 후보가 이미 셋 나왔다 — "로컬 CLI 로그인이 곧 실행 계정"(F1·F2가 반증), "플랜을 알면 모델을 안다"(기각한 대안 (c)), 그리고 새로 좁혀진 축에서 "계정이 다르면 무조건 재프로브해야 한다"(F9가 반증). 셋 다 실제로 검토됐고, 실측이 없었다면 셋 다 그럴듯했다. 계약 없이 구현부터 손대면 같은 종류의 가정이 다른 자리에 다시 자리잡는다.
 
-분리가 남기는 부채도 작아졌다. 요구 9건·불변식 5건·영수증 6필드는 이제 열린 질문에 기대지 않고 단독으로 판정 가능하므로, 후속 구현 SPEC이 발명할 것은 없고 이 문서를 참조 구현하면 된다. 이 분리는 spec.md `## Out of Scope` 첫 항목("정합 게이트의 구현 코드")과 일치한다.
+분리가 남기는 부채도 작아졌다. 요구 9건·불변식 5건·영수증 7필드는 이제 열린 질문에 기대지 않고 단독으로 판정 가능하므로, 후속 구현 SPEC이 발명할 것은 없고 이 문서를 참조 구현하면 된다. 이 분리는 spec.md `## Out of Scope` 첫 항목("정합 게이트의 구현 코드")과 일치한다.
 
 ## File Impact Analysis
 
@@ -96,9 +120,9 @@ F3이 주는 것은 사례가 아니라 **비용의 크기**다. #151은 측정 
 | 파일 | 작업 | 설명 |
 |------|------|------|
 | `.autopus/specs/SPEC-EXECPLANE-001/spec.md` | 생성 | 요구 9건, Outcome Boundary, Traceability Matrix, Out of Scope |
-| `.autopus/specs/SPEC-EXECPLANE-001/research.md` | 생성 | 실측 근거 F1~F9, 불변식 5건, 해소된 결정 표(Completion Debt `none remaining`), Reference Discipline |
+| `.autopus/specs/SPEC-EXECPLANE-001/research.md` | 생성 | 실측 근거 F1~F10, 불변식 5건, 해소된 결정 표(Completion Debt `none remaining`), Reference Discipline |
 | `.autopus/specs/SPEC-EXECPLANE-001/plan.md` | 생성 | 이 문서. 게이트 배치 논증과 T1~T4 설계 태스크 |
-| `.autopus/specs/SPEC-EXECPLANE-001/acceptance.md` | 생성 | S1~S10 시나리오와 Oracle Acceptance Notes |
+| `.autopus/specs/SPEC-EXECPLANE-001/acceptance.md` | 생성 | S1~S12 시나리오와 Oracle Acceptance Notes |
 
 아래 코드는 **참조 대상**이며 이 SPEC에서 수정하지 않는다: `pkg/codexruntime/probe.go`, `internal/cli/codex_catalog_runtime.go`, `internal/cli/pipeline_run_owner.go`, `pkg/adapter/omp/omp_workflow_render.go`, `pkg/config/role_model_policy_matrix.go`.
 
@@ -106,7 +130,7 @@ F3이 주는 것은 사례가 아니라 **비용의 크기**다. #151은 측정 
 
 - **의존 방향**: 정책 -> 모델, 정책 -> 프로세스 단방향만 허용한다. 모델 -> 프로세스, 프로세스 -> 정책 방향의 참조를 만들면 INV-001이 깨진다.
 - **경계 통과 값의 형태**: 정책 -> 프로세스 경계를 넘는 것은 opaque provider model id와 effort뿐이다(F4의 `worker-start` 계약과 동일한 형태). 티어 문자열은 경계에서 소멸한다.
-- **게이트가 읽어 오는 값의 형태**: 정책 평면이 프로세스 평면에서 가져오는 것은 계정 식별자와 그 계정의 자격 등급 둘뿐이고, 둘 다 로컬 상태 조회(`orca account list --json`, `auth.json` id_token 클레임)로 얻어진다. 기본 경로에 provider 네트워크 호출이 없고, 카탈로그 프로브는 두 등급이 갈릴 때만 발생하는 예외 비용이다(REQ-004).
+- **게이트가 읽어 오는 값의 형태**: 정책 평면이 프로세스 평면에서 가져오는 것은 계정 식별자와 그 계정의 자격 등급 둘뿐이고, 둘 다 로컬 상태 조회로 얻어진다 — `orca account list --json`, codex는 `auth.json` id_token의 `chatgpt_plan_type`, claude는 자격증명의 `organizationType`. 두 provider 모두 기본 경로에 네트워크 호출이 없고, 카탈로그 재프로브는 두 등급이 갈릴 때만 발생하는 codex 한정 예외 비용이다(REQ-004).
 - **J1 불변**: PR #154가 닫은 `quality.default` -> 내장 role-model 프로파일 -> omp `modelRoles` 경로는 이 SPEC에서 손대지 않는다. J2는 J1 결과를 입력으로 받는 후단 검증이다.
 - **기존 패턴 재사용**: 영수증은 이미 존재하는 `pipeline_execution_owner_receipt.v1`(INV-002 관측 지점)과 같은 스키마-버전 방식을 따른다. 새 관측 메커니즘을 발명하지 않는다.
 
@@ -139,27 +163,53 @@ J2 접합면의 런타임 흐름. research.md의 세 평면 정적 다이어그�
         v
   +-------------------------------------------------+
   | (2) 자격 등급 비교            REQ-004 / INV-003 |
-  |     P_exec == P_probe ?                         |
-  |     (chatgpt_plan_type, 네트워크 0회)           |
-  |       같음 -> 기존 카탈로그 판정 신뢰           |
-  |       다름 -> 실행 계정 기준 재프로브           |
-  |       불가 -> (3b) unverified                   |
-  |     P := auth.json id_token 클레임              |
-  |          https://api.openai.com/auth            |
-  |     Claude: 물려받을 카탈로그 없음              |
-  |             -> orgId 신원 대조까지만            |
+  |     G_exec == G_probe ?  — 두 provider 모두     |
+  |     로컬 파일 읽기, 네트워크 0회                |
+  |     codex : chatgpt_plan_type                   |
+  |             auth.json id_token 클레임           |
+  |             (https://api.openai.com/auth)       |
+  |     claude: organizationType                    |
+  |             orca: oauth-account.json 최상위     |
+  |             호스트: ~/.claude.json 의           |
+  |                     oauthAccount 아래           |
+  |     ! 두 위치가 같은 필드명 -> 파서 하나        |
+  |     ! rate-limit 티어는 등급이 아니다           |
+  |       (20x/5x는 같은 모델 집합을 throttle)      |
   |     ! F9: 조직만 다른 두 pro 계정은 판정 필드   |
   |       (슬러그·reasoning levels) 전부 동일       |
   +--------------------+----------------------------+
                        |
+        +--------------+-------------------------------+
+        | 등급 상이 (codex 축)                         | 등급 동일 · 비교 불가 -> 재프로브 없음
+        v                                              |
+  +-------------------------------------------------+  |
+  | (2b) 실행 계정 기준 재프로브  REQ-004 / INV-003 |  |
+  |      codex 한정. 실행 계정의 CODEX_HOME 으로    |  |
+  |      codex debug models 를 다시 실행한다.       |  |
+  |      *** 이 그림에서 유일한 네트워크 호출 ***   |  |
+  |      성공 -> 카탈로그 출처 = 실행 계정          |  |
+  |              evidence_kind = probed_catalog     |  |
+  |      실패 -> (3b). 사유에 재프로브 실패 명시    |  |
+  |      claude: 카탈로그가 없어 재프로브하지 않고  |  |
+  |              곧바로 (3b)                        |  |
+  +------------------------+------------------------+  |
+                           |                           |
+                       +---+---------------------------+
+                       |
           +------------+------------+
-          | 등급 동일 · 재프로브   | 등급 비교 불가 · 카탈로그 부재
-          |   성공 (Codex 축)      |   (Claude 가용성 · 원격 · 미특정)
+          | 등급 동일 or 재프로브  | 증거 없음(none) — verified 불가
+          | 성공 & 증거 보유       |   · 재프로브 실패
+          |  probed_catalog        |   · 원격 환경 · 실행 계정 미특정
+          |  entitlement_parity    |   · 등급 비교 불가
           v                        v
-  (3a) 해석 / 검증          (3b) unverified 표기
-       요청 티어 in 카탈로그?      REQ-009 / INV-004
-       출처 자격 == 실행 자격      사유 기록, verified 금지
-       INV-003                     신원만 대조, 가용성 미검증
+  (3a) 해석 / 검증              (3b) unverified 표기
+       요청 티어 in 카탈로그?   REQ-009 / INV-004
+       출처 자격 == 실행 자격   사유 기록, verified 금지
+       INV-003                  parity는 증거를 옮길 뿐
+       verified 세 조건:        만들지 않는다 — none이면
+         계정 determined        등급이 같아도 verified 불가
+         + 등급 동일
+         + 증거 보유
           |                        |
           +------------+-----------+
                        v
@@ -168,6 +218,8 @@ J2 접합면의 런타임 흐름. research.md의 세 평면 정적 다이어그�
   |   요청 티어 | 해석된 provider 모델              |
   |   실행 계정 식별자 | 카탈로그 출처(+자격 등급)  |
   |   resolution reason | verification status       |
+  |   evidence_kind: probed_catalog |               |
+  |                  entitlement_parity | none      |
   |   (+ schema version)                            |
   +--------------------+----------------------------+
                        |
@@ -189,13 +241,14 @@ J2 접합면의 런타임 흐름. research.md의 세 평면 정적 다이어그�
    티어 어휘는 경계에서 소멸
 ```
 
-읽는 법 다섯 가지.
+읽는 법 여섯 가지.
 
 1. **부작용 경계**는 (5)와 프로세스 평면 사이에 정확히 한 번 그어진다. (1)~(4)와 (6)은 전부 경계 위에 있으므로 실패 경로에 롤백이 필요 없다 — REQ-007이 배치로 충족된다.
 2. **handoff 지점**은 (5)다. `internal/cli/pipeline_run_owner.go:160-164`이 `handoff_required`를 반환하기 직전이며, 게이트가 그 앞에 있으므로 handoff를 받는 쪽은 이미 검증된 티어 계약을 들고 출발한다(REQ-008).
-3. **(2)의 기본 경로는 자격 등급 비교이고 네트워크 호출이 0회다.** 이 경로는 카탈로그를 다시 받지 않는다. `auth.json` id_token의 `chatgpt_plan_type` 두 값을 읽어 같은지 보는 것이 전부이며, 같으면 기존 카탈로그 판정을 그대로 증거로 인정한다. 카탈로그 재프로브는 등급이 갈릴 때만 발생하는 예외 경로다.
+3. **(2)의 기본 경로는 자격 등급 비교이고 네트워크 호출이 0회다.** 두 provider 모두 카탈로그를 다시 받지 않는다. codex는 `auth.json` id_token의 `chatgpt_plan_type`, claude는 자격증명의 `organizationType` — 각각 두 값을 파일에서 읽어 같은지 보는 것이 전부다. 등급이 같으면 재프로브가 0회이므로 (2b)가 통째로 건너뛰어진다.
 4. **판정을 무효화하는 것은 신원 차이가 아니라 자격 차이다.** (1)의 실행 계정과 (2)의 프로브 계정이 서로 다른 계정이어도 자격 등급이 같으면 (3a)의 판정은 성립한다. 이 워크스테이션이 정확히 그 경우다 — Codex 축에서 orca 활성 계정은 `bitgapnam@gmail.com`, PATH의 `codex`가 쓰는 계정은 `gnkong@alipeople.kr`로 신원은 갈라지지만(F1·F2), 둘 다 `pro`라 판정에 쓰이는 필드가 하나도 다르지 않다(F9). 등급이 다르거나 등급을 비교할 수 없을 때만 판정이 무너진다(REQ-004).
-5. **(2)의 분기는 provider 속성이지 실행 시점의 운이 아니다.** Codex는 자격 클레임과 계정별 카탈로그 프로브를 둘 다 갖고 있으므로 등급 비교 -> (필요 시) 재프로브 -> (3a)로 간다. Claude는 물려받을 카탈로그 자체가 없어 등급이 같은지 따지는 것이 무의미하고, `orgId` 신원 대조를 통과하더라도 가용성 축에서는 항상 (3b)로 간다. (3b)에 모이는 세 인스턴스 — Claude 가용성, 원격 환경, 실행 계정 미특정 — 는 REQ-009 하나가 같은 규칙으로 다룬다.
+5. **(2b)는 이 그림의 유일한 네트워크 경로이고 codex 전용이다.** 등급이 갈릴 때만 진입하며, 실행 계정의 `CODEX_HOME`으로 `codex debug models`를 다시 실행한다. 성공하면 카탈로그 출처가 실행 계정을 가리키므로 (3a)에서 `verified`가 가능하고, 실패하면 (3b)로 떨어지며 사유에 재프로브 실패를 명시한다. Claude는 프로브할 카탈로그가 없어 이 블록에 들어가지 않고 곧바로 (3b)다. 등급 동일 경로에서는 이 화살표가 아예 그려지지 않는다는 점이 REQ-004의 비용 주장(기본 경로 네트워크 0회)의 그림 상 근거다.
+6. **(3a)로 들어가도 증거 종류가 판정을 한 번 더 가른다.** (2)와 (2b)를 통과한 뒤 남는 질문은 "옮길 증거를 실제로 갖고 있는가"다. `probed_catalog`(provider가 내려준 카탈로그 보유 — codex)와 `entitlement_parity`(카탈로그 없이 기준 세션의 작업 가정만 이전 — claude)는 둘 다 증거이므로 `verified`로 갈 수 있지만, 영수증에서 서로 구분돼 남는다. `none`은 등급이 아무리 깨끗이 맞아도 `verified`가 될 수 없다 — parity는 증거를 옮길 뿐 만들지 않기 때문이다. (3b)에 모이는 인스턴스는 넷이다: 원격 환경, 실행 계정 미특정, 등급 비교 불가, 보유 증거 없음. Claude 모델 가용성은 더 이상 여기 속하지 않는다. REQ-009 하나가 넷을 같은 규칙으로 다룬다.
 
 ## Feature Completion Scope
 
@@ -213,11 +266,11 @@ J2 접합면의 런타임 흐름. research.md의 세 평면 정적 다이어그�
 | | 정책 -> 프로세스 경계의 티어 어휘 금지 목록 (REQ-002) |
 | | 실행 계정 조회의 인터페이스 계약 (REQ-003) |
 | | 자격 등급 동일성 검증과 불일치 시 재프로브의 인터페이스 계약 (REQ-004) |
-| | 정합 영수증 6필드 스키마와 스키마 버전 (REQ-005) |
+| | 정합 영수증 7필드 스키마와 스키마 버전, 증거 종류(`evidence_kind`) 표기 규칙 (REQ-005) |
 | | fail-loud 판정 규칙과 강등 기록 규칙 (REQ-006) |
 | | 게이트 배치 지점과 부작용 경계의 확정 (REQ-007, REQ-008) |
 | | 검증 불가 provider의 `unverified` 표기 규칙 (REQ-009) |
-| | S1~S10 시나리오와 그 관측 지점 |
+| | S1~S12 시나리오와 그 관측 지점 |
 | **범위 밖** | 정합 게이트의 구현 코드. 이 SPEC은 계약만 고정한다 |
 | | `--execution-owner orca`의 handoff 스텁을 실제 orca Run 생성으로 대체하는 작업 |
 | | 요청 티어를 제공 가능한 계정을 자동 선택하는 다계정 라우팅 |
@@ -228,7 +281,7 @@ J2 접합면의 런타임 흐름. research.md의 세 평면 정적 다이어그�
 
 범위 밖 목록은 spec.md `## Out of Scope`와 항목 대응이 1:1이다. 새 항목을 추가하지 않았다.
 
-관측 한계 하나를 제약으로 명시해 둔다. 자격 등급이 **다른** Codex 계정 쌍이 이 워크스테이션에 없어, 등급이 갈릴 때 판정 필드가 실제로 어떻게 달라지는지는 실측되지 않았다. 이것은 완료를 막지 않는다 — F9의 미인증 프로브가 자격 종속성 자체를 이미 증명했고, 계약이 요구하는 것은 "등급이 다르면 재프로브하거나 unverified로 표기한다"는 규칙이지 등급별 카탈로그 내용의 목록이 아니기 때문이다. 따라서 Completion Debt로 되돌리지 않고 관측 한계로 기록하며, research.md `## Completion Debt`는 `none remaining`으로 유지된다.
+관측 한계 하나를 제약으로 명시해 둔다. 자격 등급이 **다른** 계정 쌍이 이 워크스테이션에 없다. 두 provider 모두 실행 계정과 프로브 계정의 등급이 같은 상태(codex `pro`/`pro`, claude `claude_max`/`claude_max`)라서, 등급이 갈릴 때 판정 필드가 어떻게 달라지는지, 그리고 codex 재프로브 경로가 실제로 어떤 결과를 내는지는 실측되지 않았다 — **재프로브 경로는 실기기에서 한 번도 구동된 적이 없다.** 이것은 완료를 막지 않는다. F9의 미인증 프로브가 자격 종속성 자체를 이미 증명했고, 계약이 요구하는 것은 "등급이 다르면 재프로브하고, 재프로브도 불가하면 unverified로 표기한다"는 규칙이지 등급별 카탈로그 내용의 목록이 아니기 때문이다. 그 규칙은 실행 계정 등급을 주입한 stub 픽스처로 판정 가능하다. 따라서 Completion Debt로 되돌리지 않고 관측 한계로 기록하며, research.md `## Completion Debt`는 `none remaining`으로 유지된다. Claude 모델 가용성은 더 이상 이 한계 목록에 없다 — F10이 `organizationType` 등급 소스를 실측으로 확인해 `entitlement_parity` 증거로 검증되기 때문이다.
 
 ## Tasks
 
@@ -238,18 +291,18 @@ T1~T4는 모두 **설계·문서·합의 산출물**이다. 코드 작성 태스
   - 산출물: research.md Feature Coverage Map의 각 표면에 소유 평면을 정확히 하나 지정한 확정판, 그리고 정책 -> 프로세스 경계에서 금지되는 티어 토큰 목록(`balanced`/`ultra`/`opus`/`sonnet`/`haiku`)과 허용되는 통과 값(opaque provider model id, effort)의 명시.
   - 완료 판정: 같은 어휘가 둘 이상의 평면에 나타나지 않고(S1), 경계 통과 값 정의에 금지 토큰이 하나도 포함되지 않음이 문서로 확인된다(S2). F4의 orca 티어 어휘 0건 실측이 기준선이다.
 
-- [ ] **T2 — 실행 계정 조회와 자격 등급 기준 카탈로그 검증의 인터페이스 계약 확정** (REQ-003, REQ-004 / INV-003 / S3, S9, S10)
+- [ ] **T2 — 실행 계정 조회와 자격 등급 기준 카탈로그 검증의 인터페이스 계약 확정** (REQ-003, REQ-004 / INV-003 / S3, S9, S10, S12)
   - 산출물: (i) 실행 계정 식별자를 프로세스 평면에서 얻는 조회의 입력·출력·실패 모드 계약, (ii) 그 실행 계정의 자격 등급을 프로브 계정의 자격 등급과 대조하는 계약과 "두 등급이 같음을 확인하지 못하면 그 카탈로그는 증거가 아니다"라는 판정 규칙, 그리고 등급이 다를 때의 재프로브 경로와 재프로브도 불가할 때의 REQ-009 분기.
-  - **이 태스크는 미결을 해소하는 것이 아니라 이미 해소된 결정을 계약으로 고정한다**(research.md F8 `### 결정`). 계약에 반드시 들어갈 세 가지:
+  - **이 태스크는 미결을 해소하는 것이 아니라 이미 해소된 결정을 계약으로 고정한다**(research.md F8·F10 `### 결정`). 계약에 반드시 들어갈 세 가지:
     - **조회 소스** — `orca account list --json` 단일 호출. 실행 계정은 `result.<provider>.activeAccountId`, 비교 대상 프로브 계정은 `result.codex.systemDefault`(codex) 또는 provider CLI 신원(`claude auth status --json`의 `orgId`를 `claude.accounts[].organizationUuid`에 조인). 한 호출로 두 값을 모두 얻으므로 비교에 추가 조회가 필요 없다. `--environment`는 구조적으로 거부되므로 이 계약은 로컬 호스트 축만 갖는다.
     - **실행 계정 해석 규칙** — `activeAccountId`가 있으면 그 값, 없고 등록 계정이 **정확히 1개**면 그 계정, 그 외(0개 또는 2개 이상)는 특정하지 않고 REQ-009의 `unverified`로 분기. 세 단계가 이 우선순위 그대로 계약에 적혀야 하고, 마지막 단계에서 추측으로 하나를 고르는 경로는 금지된다.
-    - **provider별 검증 깊이** — Codex는 **자격 등급 비교가 기본 경로**이고, 카탈로그 재프로브는 등급이 다를 때만 수행하는 예외 경로다. 자격 등급은 `auth.json` id_token의 `https://api.openai.com/auth.chatgpt_plan_type` 클레임에서 읽으며 네트워크 호출을 요구하지 않는다. 세 분기가 계약에 그대로 적혀야 한다 — 등급이 같으면 기존 카탈로그 판정을 증거로 인정하고, 다르면 실행 계정 기준으로 재프로브하며, 둘 다 불가하면 REQ-009의 `unverified`로 떨어진다. 이 비교는 동일성 판정이며 등급에서 모델을 유추하지 않는다는 단서도 함께 박는다(하드코딩 매핑 표 금지). Claude는 계정별 카탈로그 프로브가 없어 물려받을 판정 자체가 없으므로 등급 비교 경로를 두지 않고 `orgId` 신원 대조까지만 하며, 모델 가용성은 `unverified`로 남긴다. 검증 깊이가 provider의 고정 속성이지 실행 시점의 재량이 아님을 계약이 못 박는다.
-  - 완료 판정: 세 요소가 모두 파라미터 수준으로 적혀 있고, 세 픽스처 각각에 대해 판정 결과가 유일하게 결정된다 — S3의 신원 분기·등급 동일 픽스처(orca 활성 Codex `bitgapnam@gmail.com` vs 로컬 codex CLI `gnkong@alipeople.kr`, 둘 다 `chatgpt_plan_type: "pro"`, F1·F9)에서는 재프로브 없이 판정이 성립하고, S10의 자격 종속성 픽스처에서는 자격이 다른 카탈로그의 재사용이 위반으로 판정되며, S9의 계정 미특정 픽스처에서는 unverified로 분기한다. research.md `## Completion Debt`가 `none remaining` 상태로 유지된다.
+    - **provider별 검증 깊이** — 두 provider 모두 **자격 등급 비교가 기본 경로**이고, 갈리는 것은 등급 동일성이 무엇을 옮기느냐다. 등급을 읽는 위치 두 곳을 계약에 그대로 박는다: codex는 `auth.json` id_token의 `https://api.openai.com/auth.chatgpt_plan_type` 클레임, claude는 자격증명의 `organizationType` — orca 관리 계정은 `<support>/orca/claude-accounts/<accountId>/auth/oauth-account.json` 최상위, 호스트 CLI는 `~/.claude.json`의 `oauthAccount` 아래이며 **두 위치가 같은 필드명을 쓰므로 파서 하나가 양쪽을 읽는다**(F10). 어느 쪽도 네트워크 호출을 요구하지 않는다. Claude 등급은 조직 플랜(`organizationType`)이지 rate-limit 티어가 아님을 계약이 명시한다 — `organizationRateLimitTier`의 `default_claude_max_20x`와 `..._5x`는 같은 모델 집합을 throttle할 뿐이라, 등급에 섞으면 실제로 동등한 계정 사이에 불필요한 재프로브가 발생한다. 세 분기가 계약에 그대로 적혀야 한다 — 등급이 같으면 기존 판정을 증거로 인정하고, 다르면 실행 계정 기준으로 재프로브하며, 재프로브도 불가하면 REQ-009의 `unverified`로 떨어진다. 재프로브는 **codex 한정**이다: 실행 계정의 `CODEX_HOME`으로 `codex debug models`를 다시 실행하고, 성공하면 카탈로그 출처가 실행 계정을 가리켜 `verified`가 가능하며, 실패하면 `unverified`이고 사유에 재프로브 실패를 명시한다. Claude는 프로브할 카탈로그가 없으므로 재프로브 경로를 두지 않고 등급 불일치 시 곧바로 `unverified`다. 등급이 같은 기본 경로에서 재프로브 횟수가 0회, 따라서 네트워크 호출도 0회임을 계약이 비용 조항으로 못 박는다. 이 비교는 동일성 판정이며 등급에서 모델을 유추하지 않는다는 단서도 함께 박는다(하드코딩 매핑 표 금지). 옮긴 증거의 종류 차이 — codex는 provider가 내려준 카탈로그, claude는 기준 세션의 작업 가정 — 는 REQ-005의 `evidence_kind`로 영수증에 남기며, 검증 깊이가 provider의 고정 속성이지 실행 시점의 재량이 아님을 계약이 못 박는다.
+  - 완료 판정: 세 요소가 모두 파라미터 수준으로 적혀 있고, 네 픽스처 각각에 대해 판정 결과가 유일하게 결정된다 — S3의 신원 분기·등급 동일 픽스처(orca 활성 Codex `bitgapnam@gmail.com` vs 로컬 codex CLI `gnkong@alipeople.kr`, 둘 다 `chatgpt_plan_type: "pro"`, F1·F9)에서는 재프로브 없이 판정이 성립하고, S12의 등급 상이 픽스처에서는 codex가 실행 계정 `CODEX_HOME` 기준으로 정확히 1회 재프로브하며 실패 시 두 사유가 함께 기록되고 claude는 재프로브 없이 분기하며, S10의 자격 종속성 픽스처에서는 자격이 다른 카탈로그의 재사용이 위반으로 판정되고, S9의 계정 미특정 픽스처에서는 unverified로 분기한다. research.md `## Completion Debt`가 `none remaining` 상태로 유지된다.
 
-- [ ] **T3 — 정합 영수증 스키마 확정** (REQ-005, REQ-006, REQ-009 / INV-004 / S4, S5, S8, S9)
-  - 산출물: 6필드(요청 티어 / 해석된 provider 모델 / 실행 계정 식별자 / 카탈로그 출처 / resolution reason / verification status) 각각의 타입·필수 여부·허용값을 담은 스키마 정의와 스키마 버전 이름. **카탈로그 출처 필드는 프로브 계정 식별자와 그 계정의 자격 등급을 함께 담는다** — 계정 식별자만으로는 INV-003("실행 계정과 같은 자격으로 얻은 카탈로그인가")을 나중에 되짚을 수 없기 때문이며, 따라서 등급 값이 빠진 출처는 스키마 위반이다. `verification status`의 허용값에 `unverified`가 포함되고 그 경우 사유 필드가 필수임을 규정한다. 명시적 강등 시 요청 값과 실제 값이 **둘 다** 남아야 한다는 제약도 스키마에 표현한다. 실행 계정 식별자와 자격 등급은 각각 미특정일 수 있으므로 그 표현(빈 값이 아니라 명시적 미특정 상태)도 스키마가 정의한다.
-  - **REQ-009가 흡수하는 세 인스턴스를 같은 fail-loud 규칙으로 다뤄야 한다**: ① Claude 모델 가용성 — 계정별 카탈로그 프로브가 없다, ② 원격 orca 환경 — `orca account list`가 `--environment`를 거부해 원격 호스트의 계정을 조회할 수 없다, ③ 실행 계정 미특정 — 활성 계정이 없고 등록 계정이 0개이거나 2개 이상이다(REQ-003). 셋은 사유 문자열만 다르고 상태값(`unverified`)·사유 필수·`verified` 금지는 동일하다. 셋을 구분하는 별도 상태값이나 예외 경로를 만들지 않는다.
-  - 완료 판정: S4에서 6필드와 스키마 버전이 모두 존재하고 카탈로그 출처가 프로브 계정과 그 자격 등급을 함께 담으며, S5에서 강등 경로의 `reason`이 비어 있을 수 없고 요청·실제 두 값이 모두 요구되며, S8에서 프로브 없는 provider가, S9에서 실행 계정이 미특정인 워크로드가 각각 `verified`로 표기될 수 없음이 스키마만 보고 판정된다. 기존 `pipeline_execution_owner_receipt.v1`과 같은 스키마-버전 방식을 따른다.
+- [ ] **T3 — 정합 영수증 스키마 확정** (REQ-005, REQ-006, REQ-009 / INV-004 / S4, S5, S8, S9, S11)
+  - 산출물: 7필드(요청 티어 / 해석된 provider 모델 / 실행 계정 식별자 / 카탈로그 출처 / resolution reason / verification status / `evidence_kind`) 각각의 타입·필수 여부·허용값을 담은 스키마 정의와 스키마 버전 이름. **카탈로그 출처 필드는 프로브 계정 식별자와 그 계정의 자격 등급을 함께 담는다** — 계정 식별자만으로는 INV-003("실행 계정과 같은 자격으로 얻은 카탈로그인가")을 나중에 되짚을 수 없기 때문이며, 따라서 등급 값이 빠진 출처는 스키마 위반이다. **`evidence_kind`의 허용값은 `probed_catalog`·`entitlement_parity`·`none` 셋뿐이고**, `verified`는 실행 계정 determined + 등급 동일 + **증거 보유** 세 조건을 모두 요구한다 — `none`이면 등급이 아무리 깨끗이 맞아도 `verified`가 될 수 없다. parity는 증거를 옮길 뿐 만들지 않기 때문이다. `evidence_kind`가 없는 영수증은 불완전한 영수증이며 스키마 위반이다. 두 provider가 똑같이 `verified`로 읽히면서 증거 강도가 뭉개지는 것을 막는 것이 이 필드의 존재 이유다. `verification status`의 허용값에 `unverified`가 포함되고 그 경우 사유 필드가 필수임을 규정한다. 명시적 강등 시 요청 값과 실제 값이 **둘 다** 남아야 한다는 제약도 스키마에 표현한다. 실행 계정 식별자와 자격 등급은 각각 미특정일 수 있으므로 그 표현(빈 값이 아니라 명시적 미특정 상태)도 스키마가 정의한다.
+  - **REQ-009가 흡수하는 네 인스턴스를 같은 fail-loud 규칙으로 다뤄야 한다**: ① 원격 orca 환경 — `orca account list`가 `--environment`를 거부해 원격 호스트의 계정을 조회할 수 없다, ② 실행 계정 미특정 — 활성 계정이 없고 등록 계정이 0개이거나 2개 이상이다(REQ-003), ③ 자격증명이 없거나 등급 클레임을 담지 않아 등급 비교 자체가 성립하지 않는다, ④ 보유 증거가 없는 provider — `evidence_kind`가 `none`이면 등급이 맞아도 `verified`가 될 수 없다. 넷은 사유 문자열만 다르고 상태값(`unverified`)·사유 필수·`verified` 금지는 동일하다. 넷을 구분하는 별도 상태값이나 예외 경로를 만들지 않는다. Claude 모델 가용성은 더 이상 이 목록에 속하지 않는다 — `organizationType` 등급 소스가 있어 `entitlement_parity` 증거로 검증된다(F10).
+  - 완료 판정: S4에서 7필드와 스키마 버전이 모두 존재하고 카탈로그 출처가 프로브 계정과 그 자격 등급을 함께 담으며 `evidence_kind`가 누락된 영수증이 불완전으로 판정되고, S11에서 둘 다 `verified`인 두 provider 항목이 `probed_catalog`와 `entitlement_parity`로 구분돼 기록됨이 스키마로 강제되며, S5에서 강등 경로의 `reason`이 비어 있을 수 없고 요청·실제 두 값이 모두 요구되며, S8에서 증거를 보유하지 못한 provider가, S9에서 실행 계정이 미특정인 워크로드가 각각 `verified`로 표기될 수 없음이 스키마만 보고 판정된다. 기존 `pipeline_execution_owner_receipt.v1`과 같은 스키마-버전 방식을 따른다.
 
 - [ ] **T4 — 게이트 배치 지점과 부작용 경계 확정** (REQ-007, REQ-008 / INV-002, INV-005 / S6, S7)
   - 산출물: 게이트가 실행되는 지점을 `internal/cli/pipeline_run_owner.go:160-164`의 `handoff_required` 반환 직전으로 확정한 배치 결정문, 그 지점 이전에 생성되지 않아야 하는 리소스 목록(워크트리·Run·워커·provider 세션), 그리고 점검 실패 시 handoff 결과 대신 정합 실패를 반환한다는 반환값 규칙. INV-002와의 양립 근거(F7 — 금지 대상은 OMP task DAG이지 omp 실행 자체가 아님, `pkg/adapter/omp/omp_workflow_render.go:99`)를 함께 기록한다.
@@ -261,13 +314,15 @@ REQ 커버리지: REQ-001·002(T1), REQ-003·004(T2), REQ-005·006·009(T3), REQ
 
 | 리스크 | 영향도 | 대응 |
 |--------|--------|------|
-| 해소된 결정 3건이 T2·T3의 계약 문장으로 옮겨지지 않고 research.md 결정 표에만 남는다 | 중간 | 리스크가 "미결"에서 "결정이 계약에 미반영"으로 이동했다. T2 완료 판정이 조회 소스·해석 규칙·검증 깊이 세 요소를 파라미터 수준으로 요구하고, T3 완료 판정이 REQ-009의 세 인스턴스를 요구한다 |
-| Claude 카탈로그 등가물이 없어 Claude 티어의 모델 가용성이 전부 `unverified`로 떨어진다 | 중간 | 이는 결함이 아니라 REQ-009가 설계한 정직한 상태다. 은폐 대신 표기하는 것이 INV-004의 요지다. `subscriptionType` 플랜 게이트로 메우는 안은 기각한 대안 (c)로 기록됐다 |
+| 해소된 결정이 T2·T3의 계약 문장으로 옮겨지지 않고 research.md 결정 표에만 남는다 | 중간 | 리스크가 "미결"에서 "결정이 계약에 미반영"으로 이동했다. T2 완료 판정이 조회 소스·해석 규칙·검증 깊이(등급 추출 위치 두 곳 포함) 세 요소를 파라미터 수준으로 요구하고, T3 완료 판정이 7필드와 `evidence_kind` 3종, REQ-009의 네 인스턴스를 요구한다 |
+| ~~Claude 모델 가용성이 영구 `unverified`로 남는다~~ **해소됨** | — | F10이 `organizationType` 등급 소스를 실측으로 확인해 Claude도 Codex와 같은 등급 동일성 비교를 받는다. F8의 영구 unverified 결론은 카탈로그 부재를 등급 부재로 오인한 것이었다. 남는 것은 증거 강도의 차이뿐이고, 그 차이는 은폐되지 않고 `evidence_kind: entitlement_parity`로 영수증에 명시된다. `subscriptionType` 플랜 게이트로 메우는 안(플랜 -> 모델 매핑)은 여전히 기각한 대안 (c)이며, 채택한 등급 동일성 비교와 다른 것이다 |
+| 두 provider가 똑같이 `verified`로 읽혀 증거 강도가 조용히 뭉개진다 | 중간 | 이 SPEC이 막으려던 실패가 게이트 자신 안에서 재발하는 형태다. `evidence_kind` 3종(`probed_catalog`/`entitlement_parity`/`none`)을 영수증 필수 필드로 두고, `verified`에 실행 계정 determined + 등급 동일 + 증거 보유 세 조건을 모두 요구해 막는다. `none`이면 등급이 맞아도 `verified`가 불가하다(T3, S4·S11) |
+| 등급 불일치 시의 재프로브 경로가 실기기에서 한 번도 구동된 적이 없다 | 중간 | 자격 등급이 다른 계정 쌍이 이 워크스테이션에 없다(codex `pro`/`pro`, claude `claude_max`/`claude_max`). 실행 계정 등급과 재프로브 결과를 주입한 **stub 기반 계약 테스트**로 판정을 고정한다 — 등급 상이 시 codex 재프로브 정확히 1회, 성공 시 출처가 실행 계정, 실패 시 `unverified` + 재프로브 실패 사유, claude는 재프로브 0회(S12). 계약이 요구하는 것은 등급별 카탈로그 내용의 목록이 아니라 이 분기 규칙이므로 stub으로 충분하다 |
 | 원격 orca 환경(`--on <saved-environment>`)에서 계정 축이 하나 더 늘어난다 | 낮음 | REQ-009에 흡수됐다. `orca account list`가 `--environment`를 거부하므로 원격은 "조회 수단 없음"의 인스턴스이고, `orca environment list --json`이 `{"environments": []}`라 현재 영향도 0건이다 |
 | 설계만 고정하고 구현을 분리한 결과, 후속 SPEC이 나오지 않으면 J2가 계속 끊긴 채 남는다 | 중간 | 구현 분리는 spec.md `## Out of Scope`에 명시된 결정이다. 결정이 모두 닫혔으므로 후속 SPEC은 발명이 아니라 이 문서의 참조 구현이며, 착수 장벽이 그만큼 낮다 |
 | 게이트를 정책 평면에 두면 정책 평면이 프로세스 평면 상태를 읽는 결합이 생긴다 | 낮음 | 방향이 기존 의존 방향(정책 -> 프로세스)과 같고, 읽는 값은 계정 식별자와 그 자격 등급 둘뿐이다. 역방향 참조는 만들지 않는다 |
 | 실행 계정과 프로브 계정이 갈라진 채로 티어 판정이 통과한다 | 낮음 (착수 시점 중간에서 하향) | F9가 위험 조건을 신원 차이에서 **자격 등급 차이**로 좁혔다. 이 워크스테이션의 분기 쌍(`bitgapnam@gmail.com` vs `gnkong@alipeople.kr`)은 둘 다 `chatgpt_plan_type: "pro"`라 판정 필드가 하나도 다르지 않다. REQ-004의 기본 경로가 등급 비교이므로 신원 분기 자체는 판정을 무효화하지 않고, 무효화 조건은 등급 불일치 하나로 남는다 |
-| 자격 등급 클레임이 없거나 provider가 다른 형식으로 노출해 비교 자체가 불가능하다 | 중간 | 비교 불가는 "판정 성립"이 아니라 "판정 미성립"이다. REQ-009의 `unverified`로 떨어지고 사유에 비교 불가를 남긴다. Codex는 `auth.json` id_token 클레임이 실측으로 확인됐고(F9), Claude는 물려받을 카탈로그가 없어 이미 unverified 경로다. 새 provider가 붙을 때 클레임이 없으면 기본값은 `verified`가 아니라 `unverified`이며, 이 기본값을 계약이 명시한다 |
+| 자격 등급 클레임이 없거나 provider가 다른 형식으로 노출해 비교 자체가 불가능하다 | 중간 | 비교 불가는 "판정 성립"이 아니라 "판정 미성립"이다. REQ-009의 `unverified`로 떨어지고 사유에 비교 불가를 남긴다. Codex는 `auth.json` id_token 클레임이(F9), Claude는 두 자격증명의 `organizationType`이(F10) 실측으로 확인됐다. 새 provider가 붙을 때 클레임이 없으면 기본값은 `verified`가 아니라 `unverified`이고 `evidence_kind`는 `none`이며, 이 기본값을 계약이 명시한다 |
 
 ## Dependencies
 
@@ -275,6 +330,7 @@ REQ 커버리지: REQ-001·002(T1), REQ-003·004(T2), REQ-005·006·009(T3), REQ
 - **PR #152** — 한 계정 안에서 일어난 F3의 조용한 세대 강등을 같은 세대 폴백 추가로 해소했다. 계정·자격 불일치 사례가 아니라 **조용한 오판정의 비용**을 보여주는 근거이며, 그 비용이 INV-004의 출처다.
 - **orca CLI** — 계정 조회의 사실상 유일한 소스(`account list`). 표면 변경은 요구하지 않고 소비자로만 취급한다(spec.md `## Out of Scope`).
 - **`codex debug models`** — Codex 카탈로그의 유일한 확인된 프로브(`pkg/codexruntime/probe.go:39`). F9에서 이 카탈로그가 계정 신원이 아니라 **호출자의 자격**에 종속됨이 확인됐다.
+- **Claude 자격증명 파일** — Claude 등급의 유일한 소스. orca 관리본 `<support>/orca/claude-accounts/<accountId>/auth/oauth-account.json`과 호스트 `~/.claude.json`이 같은 필드명(`organizationType`)으로 등급을 노출한다(F10). 둘 다 읽기 전용으로 취급하고, provider CLI에 새 표면을 요구하지 않는다.
 - **`auto spec validate`** — 완료 판정 1번의 검증 수단.
 
 새 외부 라이브러리 의존은 없다. 설계 문서이므로 코드 의존도 추가하지 않는다.
@@ -283,7 +339,7 @@ REQ 커버리지: REQ-001·002(T1), REQ-003·004(T2), REQ-005·006·009(T3), REQ
 
 - [ ] `auto spec validate .autopus/specs/SPEC-EXECPLANE-001`이 4개 문서에 대해 통과한다
 - [ ] T1~T4의 산출물이 모두 존재하고 REQ 9건을 빠짐없이 덮는다
-- [ ] research.md Completion Debt 3건이 각각 해소 또는 후속 SPEC 이관으로 처리됐다 — 3건 모두 F8에서 해소됐고 `## Completion Debt`는 `none remaining`이다. 남은 확인은 그 결정이 T2·T3 산출물에 계약으로 들어갔는지다
+- [ ] research.md Completion Debt 3건이 각각 해소 또는 후속 SPEC 이관으로 처리됐다 — 3건 모두 F8에서 해소됐고(그중 Claude 항목의 결론은 F10이 정정했다) `## Completion Debt`는 `none remaining`이다. 남은 확인은 그 결정이 T2·T3 산출물에 계약으로 들어갔는지다
 - [ ] research.md `## Reviewer Brief`의 4개 질문에 대한 리뷰 판단이 기록됐다
 - [ ] 범위 밖 항목 목록이 spec.md `## Out of Scope`와 모순되지 않는다
 

--- a/.autopus/specs/SPEC-EXECPLANE-001/research.md
+++ b/.autopus/specs/SPEC-EXECPLANE-001/research.md
@@ -205,19 +205,43 @@ Owner `orca`: do not initialize an OMP task/todo DAG or call `task`.
 
 이 비교는 플랜에서 모델을 유추하지 않는다. 두 값이 같은지만 본다. 따라서 하드코딩 매핑 표가 필요 없고, F8에서 Claude `subscriptionType` 게이트를 기각한 근거와 충돌하지 않는다 — 기각한 것은 "플랜 -> 모델 매핑"이고 여기서 쓰는 것은 "플랜 동일성 비교"다.
 
+### F10 — Claude에도 자격 등급 소스가 있다
+
+F8은 "Claude에 계정별 카탈로그 프로브가 없다"에서 멈춰 모델 가용성을 영구 unverified로 두었다. 그 결론이 성급했다. 게이트가 필요한 것은 카탈로그가 아니라 **등급**이고, 등급은 자격증명에 있다.
+
+| 위치 | 경로 | 형태 |
+| --- | --- | --- |
+| orca 관리 계정 | `<support>/orca/claude-accounts/<accountId>/auth/oauth-account.json` | `organizationType` 최상위 |
+| 호스트 CLI | `~/.claude.json` | `oauthAccount.organizationType` |
+
+두 곳이 **동일한 필드명**을 쓴다(`organizationType`, `organizationUuid`, `emailAddress`, `organizationRateLimitTier`, `billingType`, `seatTier`). 어휘 매핑 없이 한 파서로 양쪽을 읽는다. 이 워크스테이션 실측은 양쪽 다 `claude_max`이고 `organizationUuid`도 같다.
+
+등급은 조직 플랜(`organizationType`)으로 잡았고 rate-limit 티어는 뺐다. `default_claude_max_20x`와 `..._5x`는 같은 모델 집합을 throttle할 뿐이라, 등급에 섞으면 동등한 계정 사이에 불필요한 재프로브가 생긴다.
+
+**다만 Codex와 같은 강도가 아니다.** Codex는 provider가 내려준 카탈로그를 보유하므로 등급 동일성이 그 카탈로그를 실행 계정으로 옮긴다. Claude는 카탈로그가 없어 옮길 것이 기준 세션의 작업 가정뿐이다. 두 판정이 영수증에서 똑같이 `verified`로 읽히면, 이 SPEC이 막으려던 증거 강도의 조용한 뭉갬이 그대로 재발한다. 그래서 영수증에 `evidence_kind`를 두었다.
+
+| 값 | 뜻 |
+| --- | --- |
+| `probed_catalog` | provider가 내려준 카탈로그를 보유하고, 등급 동일성이 그것을 실행 계정으로 옮긴다 |
+| `entitlement_parity` | 카탈로그가 없고, 등급 동일성이 기준 세션의 작업 가정만 옮긴다 |
+| `none` | 옮길 증거가 없다. 등급이 아무리 맞아도 verified가 될 수 없다 |
+
+parity는 증거를 **옮길** 뿐 만들지 않는다. 이것이 `Evaluate`가 verified에 세 조건(실행 계정 determined + 등급 동일 + 증거 보유)을 모두 요구하는 이유다.
+
 ### 결정
 
 | 질문 | 결정 | 근거 |
 | --- | --- | --- |
 | 계정 조회 소스 | `orca account list --json`. 실행 계정은 `activeAccountId`, 프로브 계정은 `systemDefault`(codex) 또는 provider CLI 신원 | 한 호출로 두 값을 모두 얻어 비교 가능 |
-| Claude 검증 깊이 | **신원만 검증**. `claude auth status --json`의 `orgId`를 orca `organizationUuid`와 대조하고, 모델 가용성은 unverified로 표기 | `subscriptionType`으로 플랜→모델을 매핑하면 하드코딩 티어 테이블이 되살아난다. PR #154가 제거한 것과 같은 종류다 |
+| Claude 검증 깊이 | **Codex와 같은 자격 등급 비교**. 관리 계정과 호스트 계정의 `organizationType`을 대조한다. 다만 카탈로그가 없으므로 증거 종류는 `entitlement_parity`로 기록한다 | F10 — 두 자격증명이 동일 필드명으로 등급을 노출한다. F8의 "신원만 검증" 결론은 카탈로그 부재를 등급 부재로 오인한 것이었다. 기각한 것은 여전히 "플랜 -> 모델 매핑"이고, 여기서 쓰는 것은 "등급 동일성 비교"다 |
+| 증거 강도 표기 | 영수증에 `evidence_kind`(`probed_catalog` \| `entitlement_parity` \| `none`). `verified`는 실행 계정 determined + 등급 동일 + 증거 보유 셋을 모두 요구한다 | 두 provider가 똑같이 `verified`로 읽히면 증거 강도가 조용히 뭉개진다 — 이 SPEC이 막으려던 바로 그 실패다 |
 | Claude `activeAccountId`가 null | 등록 계정이 **정확히 1개**면 그것을 실행 계정으로 보고, 0개이거나 2개 이상이면 unverified | 추측하지 않는다. 현재 상태(1개 등록)에서 동작하고, 모호해지면 모호하다고 보고한다 |
 | 원격 환경 | 별도 요구를 만들지 않고 **REQ-009에 흡수**. 원격 대상이면 "계정 조회 수단 없음"의 인스턴스이므로 unverified | `account list`가 원격을 구조적으로 거부하고, 저장된 환경이 0건이라 당장 영향도 없다 |
 | Codex 검증 방식 | **자격 등급 비교가 기본 경로**. 실행 계정과 프로브 계정의 `chatgpt_plan_type`이 같으면 기존 카탈로그 판정을 신뢰하고, 다르면 실행 계정 기준 재프로브 또는 unverified | F9 — 조직만 다른 두 pro 계정은 판정 필드가 동일했다. 위험은 신원 차이가 아니라 자격 차이이며, 플랜 클레임은 네트워크 없이 읽힌다 |
 
 ## Completion Debt
 
-none remaining. 착수 시점의 미결 3건은 F8에서, 카탈로그의 계정 종속성 전제는 F9에서 실측으로 해소되어 결정 표에 반영됐다. 그 결정은 spec.md REQ-003·REQ-004·REQ-009 본문에 계약으로 들어갔다. 다른 자격 등급의 계정 쌍은 이 워크스테이션에 없어 미검증으로 남지만, F9의 미인증 프로브가 자격 종속성 자체를 증명하므로 계약을 막지 않는다.
+none remaining. 착수 시점의 미결 3건은 F8에서, 카탈로그의 계정 종속성 전제는 F9에서, Claude 자격 등급 소스는 F10에서 실측으로 해소되어 결정 표에 반영됐다. 그 결정은 spec.md REQ-003·REQ-004·REQ-005·REQ-009 본문에 계약으로 들어갔다. 다른 자격 등급의 계정 쌍은 이 워크스테이션에 없어 미검증으로 남지만, F9의 미인증 프로브가 자격 종속성 자체를 증명하므로 계약을 막지 않는다.
 
 ## Evolution Ideas
 

--- a/.autopus/specs/SPEC-EXECPLANE-001/spec.md
+++ b/.autopus/specs/SPEC-EXECPLANE-001/spec.md
@@ -74,17 +74,18 @@ THE SYSTEM SHALL treat a probed catalog as evidence for a requested tier only wh
 - EARS type: Ubiquitous
 - Priority: Must
 - Trigger/Condition: 요청 티어를 provider 모델로 해석할 때.
-- Observability: 영수증의 카탈로그 출처가 프로브 계정과 그 자격 등급을 함께 담고, 그 등급이 실행 계정의 등급과 같음을 S3로 확인한다. 등급이 다른데 재프로브 없이 통과한 판정은 위반이다. 카탈로그가 자격에 종속된다는 전제 자체는 S10으로 고정한다 — 자격과 무관하게 카탈로그를 캐시하거나 재사용하는 구현은 등급 비교를 무의미하게 만든다.
+- Observability: 영수증의 카탈로그 출처가 프로브 계정과 그 자격 등급을 함께 담고, 그 등급이 실행 계정의 등급과 같음을 S3로 확인한다. 등급이 다른데 재프로브 없이 통과한 판정은 위반이다. 재프로브 경로 자체 — 등급 동일 시 호출 0회, 상이 시 실행 계정 기준 1회, 실패 시 unverified — 는 S12로 고정한다. 카탈로그가 자격에 종속된다는 전제는 S10으로 고정한다: 자격과 무관하게 카탈로그를 캐시하거나 재사용하는 구현은 등급 비교를 무의미하게 만든다.
 - 해소된 설계 결정 1 — 기본 경로는 자격 비교다. 조직만 다르고 자격 등급이 같은 두 Codex 계정은 판정 필드(슬러그 집합, `supported_reasoning_levels`)가 완전히 동일했다(research.md F9). 반면 인증 자체를 제거하면 슬러그 집합이 달라진다. 따라서 판정을 무효화하는 것은 신원 차이가 아니라 자격 차이이며, Codex의 자격 등급은 `auth.json` id_token의 `https://api.openai.com/auth.chatgpt_plan_type` 클레임에서 **네트워크 호출 없이** 읽힌다. 등급이 같으면 카탈로그를 다시 받지 않는다.
 - 해소된 설계 결정 2 — 이 비교는 자격에서 모델을 유추하지 않는다. 두 등급이 같은지만 본다. 그래서 하드코딩 매핑 표가 필요 없고, Claude `subscriptionType` 게이트를 기각한 근거(플랜 -> 모델 매핑은 추정이다)와 충돌하지 않는다.
-- 해소된 설계 결정 3 — provider별 깊이는 그대로다. Codex는 자격 비교 후 필요 시 카탈로그 재프로브까지 가능하다. Claude는 계정별 카탈로그 프로브가 없어 `claude auth status --json`의 `orgId`를 프로세스 평면의 `organizationUuid`와 대조하는 신원 검증까지만 하고, 모델 가용성은 REQ-009의 unverified로 남긴다.
+- 해소된 설계 결정 3 — provider별 깊이는 자격 등급을 어디서 읽느냐가 아니라 **등급 동일성이 무엇을 옮기느냐**로 갈린다. 두 provider 모두 관리 계정과 호스트 계정의 등급을 로컬에서 읽는다: Codex는 id_token의 `chatgpt_plan_type`, Claude는 자격증명의 `organizationType`(orca 관리본은 최상위, 호스트 `~/.claude.json`은 `oauthAccount` 아래 — 같은 필드명이다). 차이는 Codex에는 provider가 내려준 카탈로그가 있어 등급 동일성이 **그 카탈로그**를 옮기는 반면, Claude에는 카탈로그가 없어 기준 세션의 작업 가정만 옮긴다는 점이다. 그 차이는 REQ-005의 `evidence_kind`로 영수증에 남는다.
+- 해소된 설계 결정 4 — Claude 등급은 조직 플랜(`organizationType`)이지 rate-limit 티어가 아니다. `default_claude_max_20x`와 `..._5x`는 같은 모델 집합을 throttle할 뿐이라, 이를 등급에 섞으면 실제로 동등한 계정 사이에 불필요한 재프로브가 발생한다.
 
 ### REQ-005 — 정합 결과를 영수증으로 방출한다
-THE SYSTEM SHALL emit an integrity receipt carrying the requested tier, the resolved provider model, the execution account identifier, the catalog source with the entitlement grade it was probed under, the resolution reason, and the verification status, so a later reader can reconstruct why a workload ran at the tier it ran at.
+THE SYSTEM SHALL emit an integrity receipt carrying the requested tier, the resolved provider model, the execution account identifier, the catalog source with the entitlement grade it was probed under, the resolution reason, the verification status, and the kind of evidence the verdict rests on, so a later reader can reconstruct both why a workload ran at the tier it ran at and how strong that basis was.
 - EARS type: Ubiquitous
 - Priority: Must
 - Trigger/Condition: 정합 점검이 끝난 시점.
-- Observability: 영수증이 위 6개 필드를 모두 담고 스키마 버전을 갖는지 S4로 확인한다.
+- Observability: 영수증이 위 7개 필드를 모두 담고 스키마 버전을 갖는지 S4로 확인한다. 같은 `verified` 판정 안에서도 `evidence_kind`가 provider별 근거 강도를 구분해 남기는지는 S11로 확인한다.
 
 ### REQ-006 — 티어 불일치는 조용히 강등되지 않는다
 IF the execution account cannot serve the requested tier, THEN THE SYSTEM SHALL fail closed or record an explicit downgrade that names both the requested tier and the model actually available, and SHALL NOT substitute a lower model with no record.
@@ -113,14 +114,16 @@ IF the execution account cannot be determined, or the account that will run the 
 - Priority: Must
 - Trigger/Condition: 계정을 특정할 수 없거나 그 계정의 카탈로그를 조회할 수단이 없을 때.
 - Observability: 해당 provider의 영수증 항목이 `unverified` 상태와 비어 있지 않은 사유를 갖고, `verified`로 표기되지 않음을 S8로 확인한다. 실행 계정을 특정할 수 없는 경우는 S9로 확인한다.
-- 이 요구가 흡수하는 세 인스턴스: (1) Claude 모델 가용성 — 계정별 카탈로그 프로브가 없다, (2) 원격 orca 환경 — `orca account list`가 `--environment`를 구조적으로 거부하므로 원격 호스트의 계정을 조회할 수 없다, (3) 활성 계정 부재 + 등록 계정이 1개가 아닌 경우(REQ-003). 셋 다 별도 요구를 만들지 않고 같은 fail-loud 규칙으로 다룬다.
+- 이 요구가 흡수하는 인스턴스: (1) 원격 orca 환경 — `orca account list`가 `--environment`를 구조적으로 거부하므로 원격 호스트의 계정을 조회할 수 없다, (2) 활성 계정 부재 + 등록 계정이 1개가 아닌 경우(REQ-003), (3) 자격증명이 없거나 등급 클레임을 담지 않아 등급 비교 자체가 성립하지 않는 경우, (4) 보유 증거가 없는 provider — 등급이 아무리 깨끗이 맞아도 parity는 증거를 옮길 뿐 만들지 않으므로 verified가 될 수 없다. 넷 다 별도 요구를 만들지 않고 같은 fail-loud 규칙으로 다룬다. Claude 모델 가용성은 더 이상 여기 속하지 않는다 — `organizationType`이 등급 소스를 제공하므로 `entitlement_parity` 증거로 검증된다.
 
 ## Acceptance Criteria
 
 - [ ] 세 평면의 소유 표면이 배타적으로 열거되고 중복 어휘가 없다
 - [ ] 프로세스 평면 경계를 넘는 값에 티어 어휘가 없다
 - [ ] 정합 점검이 로컬 로그인 계정이 아니라 실행 계정을 사용한다
-- [ ] 정합 영수증이 6개 필드를 모두 담는다
+- [ ] 정합 영수증이 7개 필드를 모두 담는다
+- [ ] 같은 `verified` 안에서도 `evidence_kind`가 근거 강도를 구분해 남긴다
+- [ ] 자격 등급이 같으면 재프로브하지 않고, 다르면 실행 계정 기준으로 다시 프로브한다
 - [ ] 티어 불일치가 조용히 강등되지 않는다
 - [ ] 점검 실패가 리소스를 남기지 않는다
 - [ ] handoff 결과가 정합 영수증을 참조한다
@@ -134,8 +137,8 @@ IF the execution account cannot be determined, or the account that will run the 
 | REQ-001 | T1 | S1 | INV-001 |
 | REQ-002 | T1 | S2 | INV-001 |
 | REQ-003 | T2 | S3, S9 | INV-003 |
-| REQ-004 | T2 | S3, S10 | INV-003 |
-| REQ-005 | T3 | S4 | INV-004 |
+| REQ-004 | T2 | S3, S10, S12 | INV-003 |
+| REQ-005 | T3 | S4, S11 | INV-004 |
 | REQ-006 | T3 | S5 | INV-004 |
 | REQ-007 | T4 | S6 | INV-005 |
 | REQ-008 | T4 | S7 | INV-002, INV-005 |
@@ -158,8 +161,8 @@ IF the execution account cannot be determined, or the account that will run the 
 | REQ-001 | S1 | pending |
 | REQ-002 | S2 | pending |
 | REQ-003 | S3, S9 | pending |
-| REQ-004 | S3, S10 | pending |
-| REQ-005 | S4 | pending |
+| REQ-004 | S3, S10, S12 | pending |
+| REQ-005 | S4, S11 | pending |
 | REQ-006 | S5 | pending |
 | REQ-007 | S6 | pending |
 | REQ-008 | S7 | pending |

--- a/internal/cli/pipeline_run_integrity.go
+++ b/internal/cli/pipeline_run_integrity.go
@@ -80,10 +80,8 @@ func runPipelineTierIntegrityGate(ctx context.Context, projectDir, specID string
 		// reason lands in the receipt, which is REQ-009's unverified branch and
 		// not a pipeline abort. That covers orca missing from PATH.
 		evidence, _ := runtimeExecplaneTierProbe(ctx, provider)
-		receipts = append(receipts, execplane.Evaluate(
-			tierRequestForProvider(cfg.Quality, provider),
-			evidence.Resolution, evidence.ExecEntitlement, evidence.ProbeEntitlement, checkedAt,
-		))
+		receipts = append(receipts, evaluateProviderTierIntegrity(
+			ctx, cfg, tierRequestForProvider(cfg.Quality, provider), evidence, checkedAt))
 	}
 	status, reason := foldPipelineTierIntegrity(receipts)
 	path, err := persistPipelineTierIntegrityReceipt(specID, pipelineTierIntegrityReceipt{
@@ -99,6 +97,25 @@ func runPipelineTierIntegrityGate(ctx context.Context, projectDir, specID string
 		}
 	}
 	return pipelineTierIntegrityResult{Status: status, Reason: reason, ReceiptPath: path}
+}
+
+// evaluateProviderTierIntegrity turns one provider's evidence into a receipt,
+// taking REQ-004's re-probe branch before the verdict is formed. Matching
+// grades never reach it, so the ordinary path stays free of subprocesses.
+func evaluateProviderTierIntegrity(
+	ctx context.Context,
+	cfg *config.HarnessConfig,
+	request execplane.TierRequest,
+	evidence execplane.Evidence,
+	checkedAt time.Time,
+) execplane.IntegrityReceipt {
+	catalog, note := reprobeCatalogUnderExecutionAccount(ctx, cfg, request.Provider, evidence)
+	receipt := execplane.Evaluate(
+		request, evidence.Resolution, evidence.ExecEntitlement, catalog, checkedAt)
+	if note != "" {
+		receipt.ResolutionReason += "; " + note
+	}
+	return receipt
 }
 
 // pipelineTierIntegritySkipped is the outcome recorded when no gate ran. REQ-008
@@ -175,6 +192,9 @@ func tierRequestForProvider(quality config.QualityConf, provider string) execpla
 	request := execplane.TierRequest{
 		Provider:      provider,
 		RequestedTier: quality.EffectiveMode(provider),
+		// A provider this gate does not own holds nothing, and Evidence says so
+		// rather than leaving a reader to infer it from a missing field.
+		Evidence: execplane.EvidenceNone,
 	}
 	switch provider {
 	case execplane.ProviderCodex:
@@ -185,10 +205,19 @@ func tierRequestForProvider(quality config.QualityConf, provider string) execpla
 		if profile.Effort != "" {
 			request.ResolvedModel += "/" + profile.Effort
 		}
+		// The pipeline holds a codex catalog the provider itself served, and a
+		// mismatched entitlement is answered by re-probing rather than by
+		// weakening the claim.
+		request.Evidence = execplane.EvidenceProbedCatalog
 	case execplane.ProviderClaude:
 		request.ResolvedModel = topClaudeModelForRun(quality)
+		// No account-scoped catalog probe exists for claude, so parity carries
+		// only the weaker claim that the executor runs on the same plan as the
+		// reference session. The receipt names that weakness instead of letting
+		// it read like a probed catalog.
+		request.Evidence = execplane.EvidenceEntitlementParity
 	}
-	// An unknown provider leaves the resolved model empty, which fails the
+	// An unknown provider also leaves the resolved model empty, which fails the
 	// receipt's completeness check instead of guessing a model on its behalf.
 	return request
 }

--- a/internal/cli/pipeline_run_integrity_reprobe.go
+++ b/internal/cli/pipeline_run_integrity_reprobe.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/insajin/autopus-adk/pkg/codexruntime"
+	"github.com/insajin/autopus-adk/pkg/config"
+	"github.com/insajin/autopus-adk/pkg/execplane"
+)
+
+// execplaneCatalogReprobeFunc re-reads a provider's model catalog under an
+// explicit account home. It is the gate's second and last outside-world seam,
+// kept package-level for the same reason the tier probe is: a test drives the
+// re-probe branch without codex installed.
+type execplaneCatalogReprobeFunc func(ctx context.Context, binary, codexHome string) ([]byte, error)
+
+var runtimeExecplaneCatalogReprobe execplaneCatalogReprobeFunc = probeCodexCatalogUnderHome
+
+// probeCodexCatalogUnderHome reads `codex debug models` with CODEX_HOME pinned
+// to one account's managed home. It is a single read-only subprocess: no
+// worktree, Run, or session is created, and nothing is written into that home.
+func probeCodexCatalogUnderHome(ctx context.Context, binary, codexHome string) ([]byte, error) {
+	return codexruntime.ProbeModelCatalogUnderHome(ctx, binary, codexHome, codexRuntimeCatalogTimeout)
+}
+
+// reprobeCatalogUnderExecutionAccount implements REQ-004's mismatch branch. A
+// catalog probed under a different entitlement proves nothing about the account
+// that will run the workload, so it is fetched again with CODEX_HOME pinned to
+// that account. It returns the entitlement the held catalog now belongs to, and
+// the note the receipt's reason must carry.
+//
+// Matching grades return before any I/O: entitlement comparison is worth having
+// only because it spends no subprocess, and re-probing every run would erase
+// that. Claude is not re-probed at all — it exposes no account-scoped catalog
+// probe, so a mismatch there stays REQ-009 unverified rather than growing a
+// second re-probe mechanism that proves nothing.
+func reprobeCatalogUnderExecutionAccount(
+	ctx context.Context, cfg *config.HarnessConfig, provider string, evidence execplane.Evidence,
+) (execplane.Entitlement, string) {
+	held := evidence.ProbeEntitlement
+	verdict, _ := execplane.CompareEntitlement(evidence.ExecEntitlement, held)
+	if verdict != execplane.VerdictReprobe || provider != execplane.ProviderCodex {
+		return held, ""
+	}
+	home, err := execplane.ManagedCodexHome(evidence.Resolution.Account.ID)
+	if err == nil {
+		_, err = runtimeExecplaneCatalogReprobe(ctx, codexProviderBinary(cfg), home)
+	}
+	if err != nil {
+		// The error itself is dropped: it can name a managed home path, and the
+		// receipt only needs to say which step failed.
+		return held, "catalog re-probe under the execution account failed"
+	}
+	// The catalog now comes from the execution account, so that account is its
+	// own catalog source and the grade it was probed under is its own.
+	return evidence.ExecEntitlement, "catalog was re-probed under the execution account"
+}
+
+// codexProviderBinary names the codex CLI this run would launch. A project may
+// point it at a wrapper, and a re-probe that read the catalog through a
+// different binary would not be evidence about this run.
+func codexProviderBinary(cfg *config.HarnessConfig) string {
+	if entry, ok := cfg.Orchestra.Providers[execplane.ProviderCodex]; ok && entry.Binary != "" {
+		return entry.Binary
+	}
+	return config.DefaultCodexProviderEntry().Binary
+}

--- a/internal/cli/pipeline_run_integrity_reprobe_test.go
+++ b/internal/cli/pipeline_run_integrity_reprobe_test.go
@@ -1,0 +1,148 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/insajin/autopus-adk/pkg/execplane"
+)
+
+// execplaneReprobeAccountID is the managed account the mismatch fixture resolves
+// to. It is UUID-shaped because that is the only shape execplane will join into
+// a managed home path, and the receipts are checked for leaking it.
+const execplaneReprobeAccountID = "3f9c1d20-4a7b-4c31-9f2e-8b6d5a1c7e40"
+
+// stubExecplaneCatalogReprobe pins the re-probe seam and returns its call
+// counter. The counter is the point: REQ-004's cheap path is defined by the
+// subprocesses it does not spend, and only a counter can hold that.
+func stubExecplaneCatalogReprobe(t *testing.T, reprobe execplaneCatalogReprobeFunc) *int {
+	t.Helper()
+	original := runtimeExecplaneCatalogReprobe
+	t.Cleanup(func() { runtimeExecplaneCatalogReprobe = original })
+	calls := 0
+	runtimeExecplaneCatalogReprobe = func(ctx context.Context, binary, home string) ([]byte, error) {
+		calls++
+		return reprobe(ctx, binary, home)
+	}
+	return &calls
+}
+
+// noExecplaneCatalogReprobe pins the seam shut. Matching or unrecoverable grades
+// must cost zero subprocesses, so a re-probe is a gate bug and fails here rather
+// than reaching whatever codex happens to be on PATH.
+func noExecplaneCatalogReprobe(t *testing.T) *int {
+	t.Helper()
+	return stubExecplaneCatalogReprobe(t, func(context.Context, string, string) ([]byte, error) {
+		t.Error("the gate re-probed a provider whose entitlements did not differ")
+		return nil, errors.New("re-probe is not permitted here")
+	})
+}
+
+// mismatchedCodexTierEvidence differs from the verified fixture in one place:
+// codex's held catalog was probed under a weaker grade than the account that
+// will run the workload. Claude's grades match, so exactly one provider can
+// spend a subprocess and the counter distinguishes the two paths.
+func mismatchedCodexTierEvidence(_ context.Context, provider string) (execplane.Evidence, error) {
+	evidence := execplane.Evidence{
+		Resolution: execplane.AccountResolution{
+			Provider: provider, Status: execplane.AccountActive,
+			Account: execplane.Account{ID: execplaneReprobeAccountID, Email: "exec@example.test"},
+			Probe:   execplane.Account{Email: "probe@example.test"},
+		},
+		ExecEntitlement:  execplane.Entitlement{Grade: "pro", Source: "exec@example.test"},
+		ProbeEntitlement: execplane.Entitlement{Grade: "pro", Source: "probe@example.test"},
+	}
+	if provider == execplane.ProviderCodex {
+		evidence.ProbeEntitlement.Grade = "plus"
+	}
+	return evidence, nil
+}
+
+// providerTierIntegrityReceipt picks one provider's receipt out of the folded
+// record, failing rather than silently asserting nothing when it is absent.
+func providerTierIntegrityReceipt(
+	t *testing.T, receipt pipelineTierIntegrityReceipt, provider string,
+) execplane.IntegrityReceipt {
+	t.Helper()
+	for _, candidate := range receipt.Providers {
+		if candidate.Provider == provider {
+			return candidate
+		}
+	}
+	require.FailNow(t, "the gate recorded no receipt for provider "+provider)
+	return execplane.IntegrityReceipt{}
+}
+
+func TestPipelineTierIntegrityGate_MismatchedEntitlementReprobesUnderTheExecutionAccount(t *testing.T) {
+	var homes []string
+	calls := stubExecplaneCatalogReprobe(t,
+		func(_ context.Context, binary, home string) ([]byte, error) {
+			assert.Equal(t, "codex", binary,
+				"the re-probe must read the catalog through the CLI this run would launch")
+			homes = append(homes, home)
+			return []byte(`{"models":[{"slug":"gpt-5.6-sol"}]}`), nil
+		})
+
+	_, result, err := runPipelineOrcaHandoffWithProbe(t, mismatchedCodexTierEvidence)
+
+	assert.ErrorIs(t, err, errPipelineExecutionOwnerHandoffRequired)
+	assert.Equal(t, 1, *calls, "only the mismatched provider may spend a subprocess")
+	require.Len(t, homes, 1)
+	assert.Contains(t, homes[0], execplaneReprobeAccountID,
+		"the catalog must be re-read under the execution account's own home")
+	assert.Equal(t, execplane.StatusVerified, result.VerificationStatus,
+		"a successful re-probe restores the evidence the mismatch destroyed")
+
+	receipt := readPipelineTierIntegrityReceipt(t, result.IntegrityReceiptPath)
+	codex := providerTierIntegrityReceipt(t, receipt, execplane.ProviderCodex)
+	assert.Equal(t, execplane.StatusVerified, codex.VerificationStatus)
+	assert.Equal(t, "exec@example.test", codex.CatalogSource.Account,
+		"a re-probed catalog is the execution account's own catalog")
+	assert.Equal(t, "pro", codex.CatalogSource.Entitlement)
+	assert.Equal(t, execplane.EvidenceProbedCatalog, codex.EvidenceKind)
+	assert.Contains(t, codex.ResolutionReason, "re-probed under the execution account",
+		"the receipt must say the catalog was replaced, not that it always matched")
+	assert.True(t, codex.Complete())
+
+	claude := providerTierIntegrityReceipt(t, receipt, execplane.ProviderClaude)
+	assert.Equal(t, execplane.EvidenceEntitlementParity, claude.EvidenceKind,
+		"claude has no account-scoped catalog probe, so parity is all it can claim")
+	assert.NotContains(t, claude.ResolutionReason, "re-probe",
+		"matching grades must not be described as a re-probe")
+}
+
+func TestPipelineTierIntegrityGate_FailedReprobeIsUnverifiedAndNamesTheFailure(t *testing.T) {
+	const probeFailure = "codex debug models under /Users/somebody/managed-home: exit status 1"
+	calls := stubExecplaneCatalogReprobe(t,
+		func(context.Context, string, string) ([]byte, error) {
+			return nil, errors.New(probeFailure)
+		})
+
+	_, result, err := runPipelineOrcaHandoffWithProbe(t, mismatchedCodexTierEvidence)
+
+	// REQ-004's last branch: neither the held catalog nor a fresh one is
+	// evidence, so the run degrades to REQ-009 instead of blocking the handoff.
+	assert.ErrorIs(t, err, errPipelineExecutionOwnerHandoffRequired)
+	assert.Equal(t, 1, *calls)
+	assert.Equal(t, execplane.StatusUnverified, result.VerificationStatus)
+	assert.Contains(t, result.VerificationReason,
+		"catalog re-probe under the execution account failed")
+	assert.NotContains(t, result.VerificationReason, probeFailure,
+		"the probe error can name a managed home, so only the failed step is reported")
+
+	receipt := readPipelineTierIntegrityReceipt(t, result.IntegrityReceiptPath)
+	codex := providerTierIntegrityReceipt(t, receipt, execplane.ProviderCodex)
+	assert.Equal(t, execplane.StatusUnverified, codex.VerificationStatus)
+	assert.Contains(t, codex.ResolutionReason, "entitlement differs",
+		"the reason must still name the mismatch that forced the re-probe")
+	assert.Contains(t, codex.ResolutionReason,
+		"catalog re-probe under the execution account failed")
+	assert.Equal(t, "probe@example.test", codex.CatalogSource.Account,
+		"a failed re-probe must not relabel the mismatched catalog as the executor's")
+	assert.True(t, codex.Complete(),
+		"an unverified receipt is still a complete record of why")
+}

--- a/internal/cli/pipeline_run_integrity_test.go
+++ b/internal/cli/pipeline_run_integrity_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,9 +35,9 @@ func stubExecplaneTierProbe(t *testing.T, probe execplaneTierProbeFunc) {
 // that differs from the probe account but shares its entitlement grade — the
 // S3 shape in which the held catalog stands as evidence with no re-probe.
 //
-// It answers for claude too, which production never does (claude exposes no
-// per-account grade source). That is deliberate: this fixture exercises the
-// handoff wiring for a verified verdict, not a claim about claude.
+// Both providers answer with a grade, which the prober now recovers for claude
+// as well; what differs between them is not the grade but what the grade
+// licenses, and the evidence kind on each receipt is where that shows.
 func verifiedExecplaneTierEvidence(_ context.Context, provider string) (execplane.Evidence, error) {
 	return execplane.Evidence{
 		Resolution: execplane.AccountResolution{
@@ -92,8 +93,10 @@ func readPipelineTierIntegrityReceipt(t *testing.T, path string) pipelineTierInt
 		require.NoError(t, statErr)
 		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
 	}
-	assert.NotContains(t, string(body), execplaneTierProbeAccountID,
-		"a managed account id must never reach a receipt")
+	for _, accountID := range []string{execplaneTierProbeAccountID, execplaneReprobeAccountID} {
+		assert.NotContains(t, string(body), accountID,
+			"a managed account id must never reach a receipt")
+	}
 	var receipt pipelineTierIntegrityReceipt
 	require.NoError(t, json.Unmarshal(body, &receipt))
 	return receipt
@@ -109,7 +112,11 @@ func readPipelineExecutionOwnerReceipt(t *testing.T, path string) pipelineExecut
 }
 
 func TestPipelineTierIntegrityGate_VerifiedHandoffReferencesTheReceipt(t *testing.T) {
+	reprobes := noExecplaneCatalogReprobe(t)
 	specID, result, err := runPipelineOrcaHandoffWithProbe(t, verifiedExecplaneTierEvidence)
+
+	// REQ-004's point: matching grades reuse the held catalog for free.
+	assert.Zero(t, *reprobes)
 
 	assert.ErrorIs(t, err, errPipelineExecutionOwnerHandoffRequired)
 	assert.Equal(t, "handoff_required", result.Status)
@@ -128,6 +135,11 @@ func TestPipelineTierIntegrityGate_VerifiedHandoffReferencesTheReceipt(t *testin
 	assert.Equal(t, result.VerificationReason, receipt.Reason)
 	assert.False(t, receipt.CheckedAt.IsZero())
 	require.Len(t, receipt.Providers, len(pipelineTierIntegrityProviders))
+	// Both verify, but not on the same footing: only codex holds a served catalog.
+	wantEvidence := map[string]execplane.EvidenceKind{
+		execplane.ProviderCodex:  execplane.EvidenceProbedCatalog,
+		execplane.ProviderClaude: execplane.EvidenceEntitlementParity,
+	}
 	for _, provider := range receipt.Providers {
 		where := []any{"provider=%s", provider.Provider}
 		assert.Equal(t, execplane.IntegrityReceiptSchema, provider.Schema, where...)
@@ -137,11 +149,13 @@ func TestPipelineTierIntegrityGate_VerifiedHandoffReferencesTheReceipt(t *testin
 		assert.Equal(t, "probe@example.test", provider.CatalogSource.Account, where...)
 		assert.Equal(t, "pro", provider.CatalogSource.Entitlement, where...)
 		assert.Contains(t, result.VerificationReason, provider.Provider+": ", where...)
+		assert.Equal(t, wantEvidence[provider.Provider], provider.EvidenceKind, where...)
 	}
 }
 
 func TestPipelineTierIntegrityGate_UnverifiedSurfacesStatusAndReason(t *testing.T) {
 	const reason = "two registered accounts and no active selection"
+	noExecplaneCatalogReprobe(t)
 	_, result, err := runPipelineOrcaHandoffWithProbe(t,
 		func(_ context.Context, provider string) (execplane.Evidence, error) {
 			return execplane.Evidence{Resolution: execplane.AccountResolution{
@@ -175,6 +189,7 @@ func TestPipelineTierIntegrityGate_UnverifiedSurfacesStatusAndReason(t *testing.
 
 func TestPipelineTierIntegrityGate_OrcaProbeFailureStillHandsOffUnverified(t *testing.T) {
 	const reason = "process plane account listing is unavailable"
+	noExecplaneCatalogReprobe(t)
 	_, result, err := runPipelineOrcaHandoffWithProbe(t,
 		func(_ context.Context, provider string) (execplane.Evidence, error) {
 			// The prober's documented failure shape: an indeterminate
@@ -205,18 +220,37 @@ func TestTierRequestForProvider_NamesTierAndModelWithoutInferringOne(t *testing.
 	t.Parallel()
 
 	quality := config.DefaultFullConfig("tier-request").Quality
+	// Each owned provider names its evidence kind, so a bare "verified" can
+	// never hide which of two very different verifications produced it.
+	wantEvidence := map[string]execplane.EvidenceKind{
+		execplane.ProviderCodex:  execplane.EvidenceProbedCatalog,
+		execplane.ProviderClaude: execplane.EvidenceEntitlementParity,
+	}
 	for _, provider := range pipelineTierIntegrityProviders {
 		request := tierRequestForProvider(quality, provider)
 		assert.Equal(t, provider, request.Provider)
 		assert.NotEmpty(t, request.RequestedTier, provider)
 		assert.NotEmpty(t, request.ResolvedModel, provider)
+		assert.Equal(t, wantEvidence[provider], request.Evidence, provider)
 	}
 	assert.Equal(t, config.QualityProviderCodex, execplane.ProviderCodex,
 		"the gate and the quality plane must name providers identically")
 
-	// An unowned provider is not guessed at: the empty model fails the
-	// receipt's completeness check rather than inventing a tier contract.
-	assert.Empty(t, tierRequestForProvider(quality, "gemini").ResolvedModel)
+	// An unowned provider is not guessed at: no model and no evidence.
+	unowned := tierRequestForProvider(quality, "gemini")
+	assert.Empty(t, unowned.ResolvedModel)
+	assert.Equal(t, execplane.EvidenceNone, unowned.Evidence)
+
+	// Even a spotless entitlement match cannot verify it: parity transfers
+	// evidence across accounts, it never manufactures any.
+	unownedReceipt := execplane.Evaluate(unowned,
+		execplane.AccountResolution{Provider: "gemini", Status: execplane.AccountActive,
+			Account: execplane.Account{Email: "exec@example.test"}},
+		execplane.Entitlement{Grade: "pro", Source: "exec@example.test"},
+		execplane.Entitlement{Grade: "pro", Source: "probe@example.test"},
+		time.Now().UTC())
+	assert.Equal(t, execplane.EvidenceNone, unownedReceipt.EvidenceKind)
+	assert.Equal(t, execplane.StatusUnverified, unownedReceipt.VerificationStatus)
 }
 
 func TestFoldPipelineTierIntegrity_DemandsEveryProviderAndAlwaysGivesAReason(t *testing.T) {
@@ -231,6 +265,9 @@ func TestFoldPipelineTierIntegrity_DemandsEveryProviderAndAlwaysGivesAReason(t *
 		},
 		ResolutionReason:   "execution and probe accounts share entitlement pro",
 		VerificationStatus: execplane.StatusVerified,
+		// Expectation change: Complete() now demands an evidence kind, so a
+		// fixture that omits it is no longer a verified receipt.
+		EvidenceKind: execplane.EvidenceProbedCatalog,
 	}
 	status, reason := foldPipelineTierIntegrity([]execplane.IntegrityReceipt{verified})
 	assert.Equal(t, execplane.StatusVerified, status)

--- a/pkg/codexruntime/probe.go
+++ b/pkg/codexruntime/probe.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"syscall"
 	"time"
@@ -15,14 +16,29 @@ import (
 const (
 	catalogProbeStartAttempts   = 5
 	catalogProbeStartRetryDelay = 10 * time.Millisecond
+	// codexHomeEnv is the variable the codex CLI resolves its credential home
+	// from. Pinning it is the only way to read the catalog one specific account
+	// is served, because the catalog depends on the credential in that home.
+	codexHomeEnv = "CODEX_HOME"
 )
 
-// ProbeModelCatalog reads and validates a bounded `codex debug models` response.
+// ProbeModelCatalog reads and validates a bounded `codex debug models` response
+// under the process environment's own codex home.
 func ProbeModelCatalog(ctx context.Context, binary string, timeout time.Duration) ([]byte, error) {
+	return ProbeModelCatalogUnderHome(ctx, binary, "", timeout)
+}
+
+// ProbeModelCatalogUnderHome probes the catalog with CODEX_HOME pinned to
+// codexHome, so a caller can read the catalog the account owning that home is
+// actually served. An empty codexHome inherits the process environment, which
+// is exactly what ProbeModelCatalog does.
+func ProbeModelCatalogUnderHome(
+	ctx context.Context, binary, codexHome string, timeout time.Duration,
+) ([]byte, error) {
 	probeCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	for attempt := 0; ; attempt++ {
-		output, err := probeModelCatalogOnce(probeCtx, binary)
+		output, err := probeModelCatalogOnce(probeCtx, binary, codexHome)
 		if err == nil || !errors.Is(err, syscall.ETXTBSY) ||
 			attempt+1 >= catalogProbeStartAttempts {
 			return output, err
@@ -35,8 +51,13 @@ func ProbeModelCatalog(ctx context.Context, binary string, timeout time.Duration
 	}
 }
 
-func probeModelCatalogOnce(probeCtx context.Context, binary string) ([]byte, error) {
+func probeModelCatalogOnce(probeCtx context.Context, binary, codexHome string) ([]byte, error) {
 	cmd := exec.CommandContext(probeCtx, binary, "debug", "models")
+	if codexHome != "" {
+		// exec keeps the last occurrence of a duplicated key, so appending
+		// overrides an inherited home without rebuilding the environment.
+		cmd.Env = append(os.Environ(), codexHomeEnv+"="+codexHome)
+	}
 	cmd.WaitDelay = time.Second
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/pkg/execplane/account_contract_test.go
+++ b/pkg/execplane/account_contract_test.go
@@ -163,11 +163,14 @@ func TestEvaluateLeavesExecutionAccountEmptyWhenIndeterminate(t *testing.T) {
 	}
 	matched := execplane.Entitlement{Grade: "pro", Source: "host-cli@example.test"}
 
+	// A held catalog, so the receipt can only fall to unverified because nobody
+	// was named as the executor.
 	receipt := execplane.Evaluate(
 		execplane.TierRequest{
 			Provider:      execplane.ProviderCodex,
 			RequestedTier: "ultra",
 			ResolvedModel: "gpt-5.6-sol",
+			Evidence:      execplane.EvidenceProbedCatalog,
 		},
 		resolution, matched, matched, time.Now(),
 	)
@@ -176,4 +179,6 @@ func TestEvaluateLeavesExecutionAccountEmptyWhenIndeterminate(t *testing.T) {
 		"an unresolved account must stay unnamed rather than borrow the probe account")
 	assert.Equal(t, execplane.StatusUnverified, receipt.VerificationStatus)
 	assert.Equal(t, resolution.Reason, receipt.ResolutionReason)
+	assert.Equal(t, execplane.EvidenceProbedCatalog, receipt.EvidenceKind,
+		"the held evidence is still recorded; it just covers nobody in particular")
 }

--- a/pkg/execplane/contract_test.go
+++ b/pkg/execplane/contract_test.go
@@ -103,6 +103,58 @@ func fixtureGradedAuth(t *testing.T, grade string) []byte {
 	})
 }
 
+// fixtureOrgUUIDClaim and fixtureAccountUUIDClaim are the account identifiers
+// a real Claude credential carries beside the plan grade. Fixtures include
+// them so tests can prove the parser leaves them behind: an org or account
+// UUID reaching a receipt is a credential leak, not a richer record.
+const (
+	fixtureOrgUUIDClaim     = "fixture-organization-uuid"
+	fixtureAccountUUIDClaim = "fixture-account-uuid"
+)
+
+// fixtureClaudeAccount builds the entitlement block both Claude credential
+// sources expose under identical field names. rateLimitTier is a capacity
+// knob, not a plan, and is present so tests can hold it against the grade.
+func fixtureClaudeAccount(orgType, rateLimitTier string) map[string]any {
+	return map[string]any{
+		"organizationType":          orgType,
+		"organizationUuid":          fixtureOrgUUIDClaim,
+		"accountUuid":               fixtureAccountUUIDClaim,
+		"emailAddress":              "claude-owner@example.test",
+		"organizationRateLimitTier": rateLimitTier,
+		"billingType":               "subscription",
+		"seatTier":                  "standard",
+	}
+}
+
+// claudeCredentialShape selects which of the two on-disk layouts to render.
+type claudeCredentialShape bool
+
+const (
+	// claudeManagedShape is the orca-managed oauth-account.json, which stores
+	// the entitlement fields at the top level.
+	claudeManagedShape claudeCredentialShape = false
+	// claudeHostShape is ~/.claude.json, which nests the same field names one
+	// level down under `oauthAccount`.
+	claudeHostShape claudeCredentialShape = true
+)
+
+// fixtureClaudeCredential renders one account block in the requested layout.
+func fixtureClaudeCredential(t *testing.T, shape claudeCredentialShape, account map[string]any) []byte {
+	t.Helper()
+
+	document := any(account)
+	if shape == claudeHostShape {
+		document = map[string]any{
+			"numStartups":  7,
+			"oauthAccount": account,
+		}
+	}
+	payload, err := json.Marshal(document)
+	require.NoError(t, err)
+	return payload
+}
+
 // mentionsGrade reports whether reason names grade as a whole word. Plain
 // substring matching would accept the word "probe" as evidence that the grade
 // "pro" was recorded, hiding a reason that only ever names one side of the

--- a/pkg/execplane/credential_source.go
+++ b/pkg/execplane/credential_source.go
@@ -1,0 +1,129 @@
+package execplane
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// credentialSource states, for one provider, where the entitlement grade lives
+// and how to recover it. Providers differ in the managed layout, in the local
+// CLI's location, and in whether the grade sits in a token claim or in an
+// account record. Collecting those differences in one table keeps Inspect free
+// of provider branches: a third provider is one entry, not a new fork.
+type credentialSource struct {
+	provider string
+	// parse recovers the grade from a credential payload.
+	parse func(payload []byte, source string) (Entitlement, error)
+	// identity recovers the signed in address from the credential itself, for
+	// providers whose roster entry carries no host identity. It is optional.
+	identity func(payload []byte) string
+	// readManaged reads the credential of one orca-managed account.
+	readManaged func(accountID string) ([]byte, error)
+	// readHost reads the credential the local CLI is logged in as.
+	readHost func() ([]byte, error)
+	// executionScope and probeScope name each location for a human, and stand
+	// in as the entitlement source when no address is known.
+	executionScope string
+	probeScope     string
+}
+
+var credentialSources = []credentialSource{
+	{
+		provider:       ProviderCodex,
+		parse:          ParseCodexEntitlement,
+		readManaged:    readManagedCodexAuth,
+		readHost:       readLocalCodexAuth,
+		executionScope: codexExecutionScope,
+		probeScope:     codexProbeScope,
+	},
+	{
+		// Claude's roster carries no host identity, so the local address is
+		// recovered from the configuration that also carries the grade.
+		provider:       ProviderClaude,
+		parse:          ParseClaudeEntitlement,
+		identity:       claudeCredentialEmail,
+		readManaged:    readManagedClaudeAuth,
+		readHost:       readLocalClaudeConfig,
+		executionScope: claudeExecutionScope,
+		probeScope:     claudeProbeScope,
+	},
+}
+
+// credentialSourceFor returns the entry for one provider. A provider outside
+// the table has no credential to read, which leaves both grades unknown and
+// the run unverified rather than failing it.
+func credentialSourceFor(provider string) (credentialSource, bool) {
+	for _, source := range credentialSources {
+		if source.provider == provider {
+			return source, true
+		}
+	}
+	return credentialSource{}, false
+}
+
+// readManagedCredential reads the credential of one orca-managed account. It
+// is the default Prober.Credential seam.
+func readManagedCredential(provider, accountID string) ([]byte, error) {
+	source, known := credentialSourceFor(provider)
+	if !known {
+		return nil, unknownCredentialSource(provider)
+	}
+	return source.readManaged(accountID)
+}
+
+// readLocalCredential reads the credential the provider's local CLI is logged
+// in as. It is the default Prober.HostCredential seam.
+func readLocalCredential(provider string) ([]byte, error) {
+	source, known := credentialSourceFor(provider)
+	if !known {
+		return nil, unknownCredentialSource(provider)
+	}
+	return source.readHost()
+}
+
+func unknownCredentialSource(provider string) error {
+	return fmt.Errorf("%w: provider %q carries no credential source",
+		ErrCredentialUnavailable, provider)
+}
+
+// credentialLabel names the account an entitlement was read from, without
+// leaking its internal identifier. The address is what a later reader
+// recognizes; the managed account UUID stays out of receipts, logs, and
+// errors, and a location name is used when no address is known.
+func credentialLabel(source credentialSource, account Account, payload []byte, scope string) string {
+	if account.Email != "" {
+		return account.Email
+	}
+	if source.identity != nil {
+		if email := source.identity(payload); email != "" {
+			return email
+		}
+	}
+	return scope
+}
+
+// claudeCredentialEmail recovers the signed in address from a Claude
+// credential. The orca-managed copy records it at the top level and the host
+// CLI nests it under `oauthAccount`, matching where each keeps the grade.
+//
+// Only the address is read. The account and organization identifiers beside it
+// are deliberately left in the payload: they are internal values, and the
+// receipt names people, not identifiers.
+func claudeCredentialEmail(payload []byte) string {
+	var record struct {
+		EmailAddress string `json:"emailAddress"`
+		OAuthAccount *struct {
+			EmailAddress string `json:"emailAddress"`
+		} `json:"oauthAccount"`
+	}
+	if err := json.Unmarshal(payload, &record); err != nil {
+		return ""
+	}
+	if record.EmailAddress != "" {
+		return record.EmailAddress
+	}
+	if record.OAuthAccount != nil {
+		return record.OAuthAccount.EmailAddress
+	}
+	return ""
+}

--- a/pkg/execplane/entitlement.go
+++ b/pkg/execplane/entitlement.go
@@ -69,6 +69,37 @@ func ParseCodexEntitlement(authJSON []byte, source string) (Entitlement, error) 
 	return Entitlement{Grade: grade, Source: source}, nil
 }
 
+// claudeCredential mirrors the entitlement fields Claude records for the signed
+// in account. The orca-managed copy stores the object at the top level while
+// the host CLI nests it under `oauthAccount`; both carry identical field names,
+// so one shape covers both sources.
+type claudeCredential struct {
+	OrganizationType string `json:"organizationType"`
+	OAuthAccount     *struct {
+		OrganizationType string `json:"organizationType"`
+	} `json:"oauthAccount"`
+}
+
+// ParseClaudeEntitlement recovers the plan grade from a Claude credential.
+//
+// The grade is the organization plan, not the rate-limit tier: capacity tiers
+// such as 5x versus 20x throttle the same model set, so comparing them would
+// force a needless re-probe between accounts that are in fact equivalent.
+func ParseClaudeEntitlement(payload []byte, source string) (Entitlement, error) {
+	var credential claudeCredential
+	if err := json.Unmarshal(payload, &credential); err != nil {
+		return Entitlement{}, fmt.Errorf("parse claude credential: %w", err)
+	}
+	grade := credential.OrganizationType
+	if grade == "" && credential.OAuthAccount != nil {
+		grade = credential.OAuthAccount.OrganizationType
+	}
+	if grade == "" {
+		return Entitlement{}, ErrNoEntitlementClaim
+	}
+	return Entitlement{Grade: grade, Source: source}, nil
+}
+
 // decodeJWTClaims decodes the payload segment without verifying the signature.
 // The token already authenticated the local CLI; this only reads a self-report
 // of the grade, and a forged grade would only make the gate re-probe or refuse.

--- a/pkg/execplane/entitlement_claude_contract_test.go
+++ b/pkg/execplane/entitlement_claude_contract_test.go
@@ -1,0 +1,172 @@
+package execplane_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/insajin/autopus-adk/pkg/execplane"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseClaudeEntitlementReadsBothCredentialLayouts covers S3 / REQ-004:
+// the orca-managed credential stores the entitlement fields at the top level
+// and the host CLI nests the same field names under `oauthAccount`. Both are
+// the same account on the same plan, so a parser that understands only one
+// layout would report the other as unknown and force a re-probe that has
+// nothing to re-probe.
+func TestParseClaudeEntitlementReadsBothCredentialLayouts(t *testing.T) {
+	t.Parallel()
+
+	account := fixtureClaudeAccount("claude_max", "default_claude_max_20x")
+
+	managed, err := execplane.ParseClaudeEntitlement(
+		fixtureClaudeCredential(t, claudeManagedShape, account), "managed@example.test")
+	require.NoError(t, err)
+	host, err := execplane.ParseClaudeEntitlement(
+		fixtureClaudeCredential(t, claudeHostShape, account), "host-cli@example.test")
+	require.NoError(t, err)
+
+	assert.Equal(t, "claude_max", managed.Grade)
+	assert.Equal(t, managed.Grade, host.Grade,
+		"the same account read from two layouts must land on one grade")
+	assert.True(t, managed.Known())
+	assert.True(t, host.Known())
+
+	// The source labels stay distinct, so the receipt can still name which
+	// credential each side of the comparison came from.
+	assert.Equal(t, "managed@example.test", managed.Source)
+	assert.Equal(t, "host-cli@example.test", host.Source)
+
+	verdict, reason := execplane.CompareEntitlement(managed, host)
+	assert.Equal(t, execplane.VerdictTrusted, verdict)
+	assert.True(t, mentionsGrade(reason, "claude_max"), "reason must name the grade: %q", reason)
+}
+
+// TestParseClaudeEntitlementIgnoresRateLimitTier covers S3 / REQ-004 and the
+// premise S10 fixes: `organizationRateLimitTier` throttles how much of the
+// same model set an account may consume, so folding it into the grade would
+// declare two equivalent accounts unequal and demand a re-probe that could not
+// change any answer.
+func TestParseClaudeEntitlementIgnoresRateLimitTier(t *testing.T) {
+	t.Parallel()
+
+	twentyX, err := execplane.ParseClaudeEntitlement(
+		fixtureClaudeCredential(t, claudeHostShape,
+			fixtureClaudeAccount("claude_max", "default_claude_max_20x")),
+		"host-cli@example.test")
+	require.NoError(t, err)
+	fiveX, err := execplane.ParseClaudeEntitlement(
+		fixtureClaudeCredential(t, claudeManagedShape,
+			fixtureClaudeAccount("claude_max", "default_claude_max_5x")),
+		"managed@example.test")
+	require.NoError(t, err)
+
+	assert.Equal(t, "claude_max", twentyX.Grade)
+	assert.Equal(t, twentyX.Grade, fiveX.Grade,
+		"a capacity tier is not a plan; 5x and 20x are the same entitlement")
+
+	verdict, _ := execplane.CompareEntitlement(fiveX, twentyX)
+	assert.Equal(t, execplane.VerdictTrusted, verdict,
+		"a rate-limit difference must not cost a re-probe")
+}
+
+// TestParseClaudeEntitlementRejectsUnusableCredentials covers S8 / REQ-009: a
+// credential with no plan claim yields an error and an unknown entitlement
+// rather than an assumed grade. Assuming one here would fabricate exactly the
+// equality REQ-004 exists to check.
+func TestParseClaudeEntitlementRejectsUnusableCredentials(t *testing.T) {
+	t.Parallel()
+
+	missing := fixtureClaudeAccount("claude_max", "default_claude_max_20x")
+	delete(missing, "organizationType")
+
+	cases := map[string]struct {
+		payload      []byte
+		wantSentinel bool
+	}{
+		"managed credential omits the plan field": {
+			payload:      fixtureClaudeCredential(t, claudeManagedShape, missing),
+			wantSentinel: true,
+		},
+		"host credential omits the plan field": {
+			payload:      fixtureClaudeCredential(t, claudeHostShape, missing),
+			wantSentinel: true,
+		},
+		"plan field is empty": {
+			payload: fixtureClaudeCredential(t, claudeHostShape,
+				fixtureClaudeAccount("", "default_claude_max_20x")),
+			wantSentinel: true,
+		},
+		"host credential carries no oauth account": {
+			payload:      []byte(`{"numStartups":7,"oauthAccount":null}`),
+			wantSentinel: true,
+		},
+		"credential is an empty document": {
+			payload:      []byte(`{}`),
+			wantSentinel: true,
+		},
+		"credential is not json": {
+			payload: []byte(`{"oauthAccount":`),
+		},
+	}
+
+	for name, tc := range cases {
+		entitlement, err := execplane.ParseClaudeEntitlement(tc.payload, "host-cli@example.test")
+
+		require.Error(t, err, name)
+		if tc.wantSentinel {
+			assert.True(t, errors.Is(err, execplane.ErrNoEntitlementClaim), name)
+		}
+		assert.False(t, entitlement.Known(), "%s: a failed parse must not report a grade", name)
+	}
+}
+
+// TestParseClaudeEntitlementDropsAccountIdentifiers covers the redaction rule
+// the gate runs under: the plan grade and the caller's own source label are
+// the only things allowed out. The organization and account UUIDs sit in the
+// very object the grade is read from, so copying the struct wholesale — the
+// obvious shortcut — would push them into every receipt and log line.
+func TestParseClaudeEntitlementDropsAccountIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	entitlement, err := execplane.ParseClaudeEntitlement(
+		fixtureClaudeCredential(t, claudeHostShape,
+			fixtureClaudeAccount("claude_max", "default_claude_max_20x")),
+		"host-cli@example.test")
+	require.NoError(t, err)
+
+	encoded, err := json.Marshal(entitlement)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(encoded), fixtureOrgUUIDClaim)
+	assert.NotContains(t, string(encoded), fixtureAccountUUIDClaim)
+	assert.NotContains(t, string(encoded), "claude-owner@example.test",
+		"the credential's own email is not the source label the caller chose")
+}
+
+// TestClaudeAndCodexGradesNeverCompareEqual covers S3 / REQ-004: the two
+// providers name their plans in disjoint vocabularies, so a Codex `pro` and a
+// Claude `claude_max` are different grades and their comparison demands a
+// re-probe. An implementation that normalized grades to a shared ladder would
+// silently declare a Codex catalog evidence for a Claude execution account.
+func TestClaudeAndCodexGradesNeverCompareEqual(t *testing.T) {
+	t.Parallel()
+
+	codex, err := execplane.ParseCodexEntitlement(
+		fixtureGradedAuth(t, "pro"), "codex-host@example.test")
+	require.NoError(t, err)
+	claude, err := execplane.ParseClaudeEntitlement(
+		fixtureClaudeCredential(t, claudeHostShape,
+			fixtureClaudeAccount("claude_max", "default_claude_max_20x")),
+		"claude-host@example.test")
+	require.NoError(t, err)
+
+	require.NotEqual(t, codex.Grade, claude.Grade)
+
+	verdict, reason := execplane.CompareEntitlement(claude, codex)
+	assert.Equal(t, execplane.VerdictReprobe, verdict)
+	assert.True(t, mentionsGrade(reason, "claude_max"), "reason must name both grades: %q", reason)
+	assert.True(t, mentionsGrade(reason, "pro"), "reason must name both grades: %q", reason)
+}

--- a/pkg/execplane/entitlement_contract_test.go
+++ b/pkg/execplane/entitlement_contract_test.go
@@ -33,6 +33,7 @@ func TestCompareEntitlementTrustsEqualGradesAcrossDifferentAccounts(t *testing.T
 			Provider:      execplane.ProviderCodex,
 			RequestedTier: "ultra",
 			ResolvedModel: "gpt-5.6-sol",
+			Evidence:      execplane.EvidenceProbedCatalog,
 		},
 		execplane.AccountResolution{
 			Provider: execplane.ProviderCodex,
@@ -90,11 +91,14 @@ func TestCompareEntitlementDemandsReprobeWhenGradesDiffer(t *testing.T) {
 	assert.True(t, mentionsGrade(reason, "pro"), "reason must name the execution grade: %q", reason)
 	assert.True(t, mentionsGrade(reason, "plus"), "reason must name the probe grade: %q", reason)
 
+	// The catalog is held, so only the grade mismatch can sink this receipt and
+	// the assertions below cannot pass for the wrong reason.
 	receipt := execplane.Evaluate(
 		execplane.TierRequest{
 			Provider:      execplane.ProviderCodex,
 			RequestedTier: "ultra",
 			ResolvedModel: "gpt-5.6-sol",
+			Evidence:      execplane.EvidenceProbedCatalog,
 		},
 		execplane.AccountResolution{
 			Provider: execplane.ProviderCodex,

--- a/pkg/execplane/probe.go
+++ b/pkg/execplane/probe.go
@@ -68,33 +68,35 @@ type Evidence struct {
 type Prober struct {
 	// AccountListing returns a raw `orca account list --json` payload.
 	AccountListing func(ctx context.Context) ([]byte, error)
-	// Credential returns the raw auth.json of one orca-managed account.
-	Credential func(accountID string) ([]byte, error)
-	// HostCredential returns the raw auth.json of the local CLI home.
-	HostCredential func() ([]byte, error)
+	// Credential returns the raw credential of one orca-managed account. It
+	// takes the provider because one Prober serves every provider in a run,
+	// and each keeps its managed credential in its own layout.
+	Credential func(provider, accountID string) ([]byte, error)
+	// HostCredential returns the raw credential of the provider's local CLI.
+	HostCredential func(provider string) ([]byte, error)
 }
 
 // NewProber returns a Prober wired to the real process plane and filesystem.
 func NewProber() Prober {
 	return Prober{
 		AccountListing: ListOrcaAccounts,
-		Credential:     readManagedCodexAuth,
-		HostCredential: readLocalCodexAuth,
+		Credential:     readManagedCredential,
+		HostCredential: readLocalCredential,
 	}
 }
 
 // Inspect resolves the execution account for one provider and recovers both
-// entitlement grades, without a single network call: the grade lives in a claim
-// of a credential already on disk.
+// entitlement grades, without a single network call: both providers already
+// record the grade in a credential on disk.
 //
 // The returned Evidence is always safe to hand to Evaluate, including alongside
 // an error. A probe that fails yields an indeterminate resolution with a
 // non-empty reason, which is the unverified branch rather than a guess.
 //
-// Claude carries no per-account entitlement source, so both entitlements stay
-// zero and CompareEntitlement degrades to unverified on its own. That is the
-// intended path, not an omission — a provider-specific branch here would be a
-// second place where "unverified" is decided.
+// Both providers record the grade on disk, in different places and shapes, so
+// the credential table decides where to read and how to parse it. A provider
+// absent from that table leaves both entitlements zero, which CompareEntitlement
+// degrades to unverified on its own.
 func (p Prober) Inspect(ctx context.Context, provider string) (Evidence, error) {
 	listing, err := p.listAccounts(ctx)
 	if err != nil {
@@ -108,37 +110,40 @@ func (p Prober) Inspect(ctx context.Context, provider string) (Evidence, error) 
 	}
 
 	evidence := Evidence{Resolution: resolution}
-	if provider != ProviderCodex {
+	source, known := credentialSourceFor(provider)
+	if !known {
 		return evidence, nil
 	}
 	// An unreadable credential is a degradation, not a failure: the grade stays
 	// unknown, CompareEntitlement reports why, and the receipt says unverified.
 	// Surfacing it as an error here would turn a reportable state into an abort.
 	if resolution.Determined() {
-		evidence.ExecEntitlement, _ = p.executionEntitlement(resolution.Account)
+		evidence.ExecEntitlement, _ = p.executionEntitlement(source, resolution.Account)
 	}
-	evidence.ProbeEntitlement, _ = p.hostEntitlement(resolution.Probe)
+	evidence.ProbeEntitlement, _ = p.hostEntitlement(source, resolution.Probe)
 	return evidence, nil
 }
 
 // executionEntitlement reads the grade of the account that will run the
 // workload, from the credential orca swaps in for it.
-func (p Prober) executionEntitlement(account Account) (Entitlement, error) {
-	payload, err := p.readCredential(account.ID)
+func (p Prober) executionEntitlement(source credentialSource, account Account) (Entitlement, error) {
+	payload, err := p.readCredential(source, account.ID)
 	if err != nil {
 		return Entitlement{}, err
 	}
-	return ParseCodexEntitlement(payload, accountLabel(account, executionCredentialScope))
+	return source.parse(payload,
+		credentialLabel(source, account, payload, source.executionScope))
 }
 
 // hostEntitlement reads the grade the held catalog was probed under, which is
 // the local CLI login and not necessarily the execution account.
-func (p Prober) hostEntitlement(probe Account) (Entitlement, error) {
-	payload, err := p.readHostCredential()
+func (p Prober) hostEntitlement(source credentialSource, probe Account) (Entitlement, error) {
+	payload, err := p.readHostCredential(source)
 	if err != nil {
 		return Entitlement{}, err
 	}
-	return ParseCodexEntitlement(payload, accountLabel(probe, probeCredentialScope))
+	return source.parse(payload,
+		credentialLabel(source, probe, payload, source.probeScope))
 }
 
 func (p Prober) listAccounts(ctx context.Context) ([]byte, error) {
@@ -148,18 +153,18 @@ func (p Prober) listAccounts(ctx context.Context) ([]byte, error) {
 	return ListOrcaAccounts(ctx)
 }
 
-func (p Prober) readCredential(accountID string) ([]byte, error) {
+func (p Prober) readCredential(source credentialSource, accountID string) ([]byte, error) {
 	if p.Credential != nil {
-		return p.Credential(accountID)
+		return p.Credential(source.provider, accountID)
 	}
-	return readManagedCodexAuth(accountID)
+	return source.readManaged(accountID)
 }
 
-func (p Prober) readHostCredential() ([]byte, error) {
+func (p Prober) readHostCredential(source credentialSource) ([]byte, error) {
 	if p.HostCredential != nil {
-		return p.HostCredential()
+		return p.HostCredential(source.provider)
 	}
-	return readLocalCodexAuth()
+	return source.readHost()
 }
 
 // indeterminate builds the resolution used when the process plane could not be
@@ -170,14 +175,4 @@ func indeterminate(provider, reason string) AccountResolution {
 		Status:   AccountIndeterminate,
 		Reason:   reason,
 	}
-}
-
-// accountLabel names an account for the receipt without leaking its internal
-// identifier. The email is what a later reader recognizes; the managed account
-// UUID stays out of receipts, logs, and errors.
-func accountLabel(account Account, fallback string) string {
-	if account.Email != "" {
-		return account.Email
-	}
-	return fallback
 }

--- a/pkg/execplane/probe_claude_test.go
+++ b/pkg/execplane/probe_claude_test.go
@@ -1,0 +1,227 @@
+package execplane
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	probeClaudeAccountID = "22222222-2222-4222-8222-222222222222"
+	probeClaudeExecEmail = "claude-exec@example.test"
+	probeClaudeHostEmail = "claude-host@example.test"
+	probeClaudeGrade     = "claude_max"
+)
+
+// Claude records the grade in the account record rather than in a token, and
+// the managed copy and the host configuration keep it at different depths.
+// Both must reach the same grade.
+func TestInspectFillsBothClaudeEntitlements(t *testing.T) {
+	t.Parallel()
+
+	supportRoot, configDir := t.TempDir(), t.TempDir()
+	probeWriteManagedClaudeAuth(t, supportRoot, probeClaudeAccountID, probeClaudeGrade)
+	probeWriteHostClaudeConfig(t, configDir, probeClaudeGrade)
+	prober := probeClaudeFilesystemProber(t, supportRoot, configDir)
+
+	evidence, err := prober.Inspect(context.Background(), ProviderClaude)
+	require.NoError(t, err)
+	assert.Equal(t, AccountSoleRegistered, evidence.Resolution.Status)
+	assert.Equal(t, Entitlement{Grade: probeClaudeGrade, Source: probeClaudeExecEmail},
+		evidence.ExecEntitlement)
+	// The claude roster carries no host identity, so the address comes from the
+	// configuration that carried the grade rather than from a scope label.
+	assert.Equal(t, Entitlement{Grade: probeClaudeGrade, Source: probeClaudeHostEmail},
+		evidence.ProbeEntitlement)
+
+	verdict, reason := CompareEntitlement(evidence.ExecEntitlement, evidence.ProbeEntitlement)
+	assert.Equal(t, VerdictTrusted, verdict)
+	assert.NotEmpty(t, reason)
+}
+
+// Two claude accounts on different plans are the case the gate exists for: the
+// held catalog is not evidence for the account that will run.
+func TestInspectReportsClaudeGradeDifference(t *testing.T) {
+	t.Parallel()
+
+	supportRoot, configDir := t.TempDir(), t.TempDir()
+	probeWriteManagedClaudeAuth(t, supportRoot, probeClaudeAccountID, "claude_pro")
+	probeWriteHostClaudeConfig(t, configDir, probeClaudeGrade)
+	prober := probeClaudeFilesystemProber(t, supportRoot, configDir)
+
+	evidence, err := prober.Inspect(context.Background(), ProviderClaude)
+	require.NoError(t, err)
+	assert.Equal(t, "claude_pro", evidence.ExecEntitlement.Grade)
+	assert.Equal(t, probeClaudeGrade, evidence.ProbeEntitlement.Grade)
+
+	verdict, reason := CompareEntitlement(evidence.ExecEntitlement, evidence.ProbeEntitlement)
+	assert.Equal(t, VerdictReprobe, verdict)
+	assert.NotEmpty(t, reason)
+}
+
+// A machine with no claude credential is an ordinary state, not a crash: both
+// grades stay unknown and the comparison says why.
+func TestInspectDegradesWhenClaudeCredentialIsMissing(t *testing.T) {
+	t.Parallel()
+
+	prober := probeClaudeFilesystemProber(t, t.TempDir(), t.TempDir())
+
+	evidence, err := prober.Inspect(context.Background(), ProviderClaude)
+	require.NoError(t, err)
+	assert.False(t, evidence.ExecEntitlement.Known())
+	assert.False(t, evidence.ProbeEntitlement.Known())
+
+	verdict, reason := CompareEntitlement(evidence.ExecEntitlement, evidence.ProbeEntitlement)
+	assert.Equal(t, VerdictUnverified, verdict)
+	assert.NotEmpty(t, reason)
+}
+
+// A credential that is present but malformed degrades exactly like a missing
+// one: Inspect returns zero entitlements instead of failing the run.
+func TestInspectDegradesWhenClaudeCredentialIsMalformed(t *testing.T) {
+	t.Parallel()
+
+	supportRoot, configDir := t.TempDir(), t.TempDir()
+	path, err := managedClaudeAuthPath(supportRoot, probeClaudeAccountID)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("{not json"), 0o600))
+	probeWriteHostClaudeConfig(t, configDir, probeClaudeGrade)
+
+	evidence, err := probeClaudeFilesystemProber(t, supportRoot, configDir).
+		Inspect(context.Background(), ProviderClaude)
+	require.NoError(t, err)
+	assert.False(t, evidence.ExecEntitlement.Known())
+	assert.True(t, evidence.ProbeEntitlement.Known())
+
+	verdict, reason := CompareEntitlement(evidence.ExecEntitlement, evidence.ProbeEntitlement)
+	assert.Equal(t, VerdictUnverified, verdict)
+	assert.NotEmpty(t, reason)
+}
+
+// CLAUDE_CONFIG_DIR relocates the CLI's configuration directory, so it is
+// where the account record is looked for first.
+func TestReadLocalClaudeConfigHonorsConfigDir(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(claudeConfigDirEnv, configDir)
+	probeWriteHostClaudeConfig(t, configDir, probeClaudeGrade)
+
+	payload, err := readLocalClaudeConfig()
+	require.NoError(t, err)
+	entitlement, err := ParseClaudeEntitlement(payload, claudeProbeScope)
+	require.NoError(t, err)
+	assert.Equal(t, probeClaudeGrade, entitlement.Grade)
+	assert.Equal(t, probeClaudeHostEmail, claudeCredentialEmail(payload))
+}
+
+// A relocated configuration directory does not always carry the account
+// record, and the home copy is the same source rather than a second one.
+func TestReadLocalClaudeConfigFallsBackToTheHomeCopy(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(claudeConfigDirEnv, t.TempDir())
+	probeWriteHostClaudeConfig(t, home, probeClaudeGrade)
+
+	payload, err := readLocalClaudeConfig()
+	require.NoError(t, err)
+	entitlement, err := ParseClaudeEntitlement(payload, claudeProbeScope)
+	require.NoError(t, err)
+	assert.Equal(t, probeClaudeGrade, entitlement.Grade)
+}
+
+func TestReadLocalClaudeConfigReportsMissingConfiguration(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(claudeConfigDirEnv, t.TempDir())
+
+	payload, err := readLocalClaudeConfig()
+	require.ErrorIs(t, err, ErrCredentialUnavailable)
+	assert.Nil(t, payload)
+	assert.Contains(t, err.Error(), claudeProbeScope)
+}
+
+// probeClaudeFilesystemProber wires the seams to the real path assembly and
+// reader against injected roots, so the test exercises the production path.
+func probeClaudeFilesystemProber(t *testing.T, supportRoot, configDir string) Prober {
+	t.Helper()
+
+	return Prober{
+		AccountListing: func(context.Context) ([]byte, error) { return probeClaudeListing(), nil },
+		Credential: func(provider, accountID string) ([]byte, error) {
+			assert.Equal(t, ProviderClaude, provider)
+			path, err := managedClaudeAuthPath(supportRoot, accountID)
+			if err != nil {
+				return nil, err
+			}
+			return readCredentialFile(path, claudeExecutionScope, maxCredentialBytes)
+		},
+		HostCredential: func(provider string) ([]byte, error) {
+			assert.Equal(t, ProviderClaude, provider)
+			path, err := localClaudeConfigPath(configDir, "")
+			if err != nil {
+				return nil, err
+			}
+			return readCredentialFile(path, claudeProbeScope, maxHostConfigBytes)
+		},
+	}
+}
+
+// probeClaudeListing mirrors an orca roster for claude, which reports no
+// systemDefault: the host identity is not in the roster for this provider.
+func probeClaudeListing() []byte {
+	return []byte(fmt.Sprintf(`{"ok":true,"result":{"claude":{
+		"accounts":[{"id":%q,"email":%q,"organizationUuid":"org-claude"}],
+		"activeAccountId":null}}}`, probeClaudeAccountID, probeClaudeExecEmail))
+}
+
+// probeWriteManagedClaudeAuth writes the shape orca keeps for a managed
+// account: the account record at the top level of the credential.
+func probeWriteManagedClaudeAuth(t *testing.T, supportRoot, accountID, grade string) {
+	t.Helper()
+
+	path, err := managedClaudeAuthPath(supportRoot, accountID)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path,
+		probeClaudeRecord(t, probeClaudeExecEmail, grade), 0o600))
+}
+
+// probeWriteHostClaudeConfig writes the shape the host CLI keeps: the same
+// record nested under `oauthAccount`, beside unrelated configuration.
+func probeWriteHostClaudeConfig(t *testing.T, configDir, grade string) {
+	t.Helper()
+
+	path, err := localClaudeConfigPath(configDir, "")
+	require.NoError(t, err)
+	record := map[string]any{}
+	require.NoError(t, json.Unmarshal(probeClaudeRecord(t, probeClaudeHostEmail, grade), &record))
+	payload, err := json.Marshal(map[string]any{
+		"numStartups":  3,
+		"oauthAccount": record,
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, payload, 0o600))
+}
+
+// probeClaudeRecord builds a synthetic account record. The identifiers in it
+// are fixtures: the gate reads the plan and the address and nothing else.
+func probeClaudeRecord(t *testing.T, email, grade string) []byte {
+	t.Helper()
+
+	payload, err := json.Marshal(map[string]any{
+		"emailAddress":              email,
+		"organizationType":          grade,
+		"organizationUuid":          "00000000-0000-4000-8000-00000000000f",
+		"accountUuid":               "00000000-0000-4000-8000-00000000000e",
+		"organizationRateLimitTier": "default_claude_max_20x",
+		"billingType":               "subscription",
+	})
+	require.NoError(t, err)
+	return payload
+}

--- a/pkg/execplane/probe_home.go
+++ b/pkg/execplane/probe_home.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// orcaSupportDir is orca's directory under the user's application support
-	// root, where it keeps the per-account Codex homes it swaps CODEX_HOME to.
+	// root, where it keeps the per-account provider state it swaps in.
 	orcaSupportDir = "orca"
 	// orcaCodexAccountsDir holds one managed home per Codex account id.
 	orcaCodexAccountsDir = "codex-accounts"
@@ -23,16 +23,41 @@ const (
 	codexAuthFileName = "auth.json"
 	// codexHomeEnv overrides the local codex home.
 	codexHomeEnv = "CODEX_HOME"
-	// maxCredentialBytes bounds a credential read. An auth.json is a few
-	// kilobytes; a larger file is a malfunction and is refused rather than read.
+)
+
+const (
+	// orcaClaudeAccountsDir holds one managed credential per Claude account id.
+	orcaClaudeAccountsDir = "claude-accounts"
+	// orcaClaudeAuthDir is the credential directory inside a managed account.
+	orcaClaudeAuthDir = "auth"
+	// claudeAuthFileName holds the signed in account's plan fields. Claude
+	// records the grade in the account record rather than inside a token.
+	claudeAuthFileName = "oauth-account.json"
+	// localClaudeConfigFile is the configuration of the PATH claude CLI. It
+	// nests the same account fields under `oauthAccount`.
+	localClaudeConfigFile = ".claude.json"
+	// claudeConfigDirEnv relocates the local claude configuration directory,
+	// the way CODEX_HOME relocates the codex home.
+	claudeConfigDirEnv = "CLAUDE_CONFIG_DIR"
+)
+
+const (
+	// maxCredentialBytes bounds a credential read. A credential file is a few
+	// kilobytes; a larger one is a malfunction and is refused rather than read.
 	maxCredentialBytes = 1 << 20
+	// maxHostConfigBytes bounds the local claude configuration, which is not a
+	// bare credential: it accumulates per-project state beside the account
+	// fields, so a real one outgrows a credential by orders of magnitude.
+	maxHostConfigBytes = 16 << 20
 )
 
 // Credential scopes name a credential location for humans. They are used in
 // place of the path, which embeds the managed account identifier.
 const (
-	executionCredentialScope = "orca-managed codex home"
-	probeCredentialScope     = "local codex home"
+	codexExecutionScope  = "orca-managed codex home"
+	codexProbeScope      = "local codex home"
+	claudeExecutionScope = "orca-managed claude account"
+	claudeProbeScope     = "local claude configuration"
 )
 
 var (
@@ -51,19 +76,55 @@ var (
 var managedAccountIDPattern = regexp.MustCompile(
 	`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 
-// managedCodexAuthPath builds the credential path of one orca-managed account
-// under supportRoot, the user's application support directory. The root is a
-// parameter so a test can point the layout at a temporary tree.
-func managedCodexAuthPath(supportRoot, accountID string) (string, error) {
+// managedAccountPath joins a location inside one orca-managed account under
+// supportRoot, the user's application support directory. The root is a
+// parameter so a test can point the layout at a temporary tree, and every
+// provider reaches its managed state through this one validation.
+func managedAccountPath(supportRoot, accountsDir, accountID, scope string, tail ...string) (string, error) {
 	if !managedAccountIDPattern.MatchString(accountID) {
 		return "", ErrUnsafeAccountID
 	}
 	if supportRoot == "" {
 		return "", fmt.Errorf("%w: no application support directory to locate the %s",
-			ErrCredentialUnavailable, executionCredentialScope)
+			ErrCredentialUnavailable, scope)
 	}
-	return filepath.Join(supportRoot, orcaSupportDir, orcaCodexAccountsDir,
-		accountID, orcaManagedHomeDir, codexAuthFileName), nil
+	elements := make([]string, 0, 4+len(tail))
+	elements = append(elements, supportRoot, orcaSupportDir, accountsDir, accountID)
+	return filepath.Join(append(elements, tail...)...), nil
+}
+
+// managedCodexHomePath builds the CODEX_HOME orca swaps in for one account.
+func managedCodexHomePath(supportRoot, accountID string) (string, error) {
+	return managedAccountPath(supportRoot, orcaCodexAccountsDir, accountID,
+		codexExecutionScope, orcaManagedHomeDir)
+}
+
+// ManagedCodexHome resolves the CODEX_HOME of one orca-managed account against
+// the real application support directory. A re-probe runs the codex CLI under
+// this home so the catalog it returns is the execution account's own. Only the
+// path is assembled here; nothing under it is read or written.
+func ManagedCodexHome(accountID string) (string, error) {
+	supportRoot, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("%w: cannot locate the %s: %w",
+			ErrCredentialUnavailable, codexExecutionScope, err)
+	}
+	return managedCodexHomePath(supportRoot, accountID)
+}
+
+// managedCodexAuthPath builds the credential path of one orca-managed Codex
+// account, which lives inside that account's managed home.
+func managedCodexAuthPath(supportRoot, accountID string) (string, error) {
+	return managedAccountPath(supportRoot, orcaCodexAccountsDir, accountID,
+		codexExecutionScope, orcaManagedHomeDir, codexAuthFileName)
+}
+
+// managedClaudeAuthPath builds the credential path of one orca-managed Claude
+// account. Claude keeps the account record in its own credential directory
+// rather than in a CLI home, so the layout differs below the account id.
+func managedClaudeAuthPath(supportRoot, accountID string) (string, error) {
+	return managedAccountPath(supportRoot, orcaClaudeAccountsDir, accountID,
+		claudeExecutionScope, orcaClaudeAuthDir, claudeAuthFileName)
 }
 
 // localCodexAuthPath builds the credential path of the PATH codex CLI. An
@@ -74,59 +135,114 @@ func localCodexAuthPath(codexHome, userHome string) (string, error) {
 	}
 	if userHome == "" {
 		return "", fmt.Errorf("%w: no home directory to locate the %s",
-			ErrCredentialUnavailable, probeCredentialScope)
+			ErrCredentialUnavailable, codexProbeScope)
 	}
 	return filepath.Join(userHome, localCodexHomeDir, codexAuthFileName), nil
 }
 
-// readManagedCodexAuth reads the credential of the account that will run the
-// workload. It is the default Prober.Credential seam.
+// localClaudeConfigPath builds the configuration path of the PATH claude CLI.
+// CLAUDE_CONFIG_DIR relocates that CLI's configuration directory, so it wins
+// when set.
+func localClaudeConfigPath(configDir, userHome string) (string, error) {
+	if configDir != "" {
+		return filepath.Join(configDir, localClaudeConfigFile), nil
+	}
+	if userHome == "" {
+		return "", fmt.Errorf("%w: no home directory to locate the %s",
+			ErrCredentialUnavailable, claudeProbeScope)
+	}
+	return filepath.Join(userHome, localClaudeConfigFile), nil
+}
+
+// readManagedCodexAuth reads the credential of the Codex account that will run
+// the workload.
 func readManagedCodexAuth(accountID string) ([]byte, error) {
 	supportRoot, err := os.UserConfigDir()
 	if err != nil {
 		return nil, fmt.Errorf("%w: cannot locate the %s: %w",
-			ErrCredentialUnavailable, executionCredentialScope, err)
+			ErrCredentialUnavailable, codexExecutionScope, err)
 	}
 	path, err := managedCodexAuthPath(supportRoot, accountID)
 	if err != nil {
 		return nil, err
 	}
-	return readCredentialFile(path, executionCredentialScope)
+	return readCredentialFile(path, codexExecutionScope, maxCredentialBytes)
 }
 
-// readLocalCodexAuth reads the credential the held catalog was probed under. It
-// is the default Prober.HostCredential seam.
+// readManagedClaudeAuth reads the credential of the Claude account that will
+// run the workload.
+func readManagedClaudeAuth(accountID string) ([]byte, error) {
+	supportRoot, err := os.UserConfigDir()
+	if err != nil {
+		return nil, fmt.Errorf("%w: cannot locate the %s: %w",
+			ErrCredentialUnavailable, claudeExecutionScope, err)
+	}
+	path, err := managedClaudeAuthPath(supportRoot, accountID)
+	if err != nil {
+		return nil, err
+	}
+	return readCredentialFile(path, claudeExecutionScope, maxCredentialBytes)
+}
+
+// readLocalCodexAuth reads the credential the held Codex catalog was probed
+// under, which is the PATH CLI's login rather than the execution account.
 func readLocalCodexAuth() ([]byte, error) {
 	codexHome := os.Getenv(codexHomeEnv)
 	userHome, homeErr := os.UserHomeDir()
 	if codexHome == "" && homeErr != nil {
 		return nil, fmt.Errorf("%w: cannot locate the %s: %w",
-			ErrCredentialUnavailable, probeCredentialScope, homeErr)
+			ErrCredentialUnavailable, codexProbeScope, homeErr)
 	}
 	path, err := localCodexAuthPath(codexHome, userHome)
 	if err != nil {
 		return nil, err
 	}
-	return readCredentialFile(path, probeCredentialScope)
+	return readCredentialFile(path, codexProbeScope, maxCredentialBytes)
+}
+
+// readLocalClaudeConfig reads the configuration the held Claude catalog was
+// probed under. A relocated configuration directory does not always carry the
+// account record — which of the two locations holds it depends on the CLI
+// version — so the home copy is retried as the same source, not a second one.
+func readLocalClaudeConfig() ([]byte, error) {
+	configDir := os.Getenv(claudeConfigDirEnv)
+	userHome, homeErr := os.UserHomeDir()
+	if configDir == "" && homeErr != nil {
+		return nil, fmt.Errorf("%w: cannot locate the %s: %w",
+			ErrCredentialUnavailable, claudeProbeScope, homeErr)
+	}
+	path, err := localClaudeConfigPath(configDir, userHome)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := readCredentialFile(path, claudeProbeScope, maxHostConfigBytes)
+	if err == nil || configDir == "" || userHome == "" {
+		return payload, err
+	}
+	homePath, homePathErr := localClaudeConfigPath("", userHome)
+	if homePathErr != nil {
+		return nil, err
+	}
+	return readCredentialFile(homePath, claudeProbeScope, maxHostConfigBytes)
 }
 
 // readCredentialFile reads a bounded credential. A missing or unreadable file
 // is an ordinary outcome here: it returns an identifiable reason so the caller
 // degrades to an unknown grade instead of failing the run.
-func readCredentialFile(path, scope string) ([]byte, error) {
+func readCredentialFile(path, scope string, maxBytes int64) ([]byte, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, credentialReadError(scope, err)
 	}
 	defer file.Close()
 
-	payload, err := io.ReadAll(io.LimitReader(file, maxCredentialBytes+1))
+	payload, err := io.ReadAll(io.LimitReader(file, maxBytes+1))
 	if err != nil {
 		return nil, credentialReadError(scope, err)
 	}
-	if len(payload) > maxCredentialBytes {
+	if int64(len(payload)) > maxBytes {
 		return nil, fmt.Errorf("%w: credential in the %s exceeds %d bytes",
-			ErrCredentialUnavailable, scope, maxCredentialBytes)
+			ErrCredentialUnavailable, scope, maxBytes)
 	}
 	return payload, nil
 }

--- a/pkg/execplane/probe_home_test.go
+++ b/pkg/execplane/probe_home_test.go
@@ -15,15 +15,7 @@ import (
 func TestManagedCodexAuthPathRejectsUnsafeAccountID(t *testing.T) {
 	t.Parallel()
 
-	unsafe := []string{
-		"..",
-		"../../etc",
-		probeExecAccountID + "/../../..",
-		"11111111-1111-4111-8111-111111111111\x00",
-		"not-a-uuid",
-		"",
-	}
-	for _, accountID := range unsafe {
+	for _, accountID := range unsafeAccountIDs() {
 		path, err := managedCodexAuthPath("/support", accountID)
 		require.ErrorIsf(t, err, ErrUnsafeAccountID, "account id %q", accountID)
 		assert.Empty(t, path)
@@ -74,7 +66,7 @@ func TestReadLocalCodexAuthReadsCodexHomeCredential(t *testing.T) {
 
 	payload, err := readLocalCodexAuth()
 	require.NoError(t, err)
-	entitlement, err := ParseCodexEntitlement(payload, probeCredentialScope)
+	entitlement, err := ParseCodexEntitlement(payload, codexProbeScope)
 	require.NoError(t, err)
 	assert.Equal(t, "pro", entitlement.Grade)
 }
@@ -86,10 +78,10 @@ func TestReadCredentialFileReportsMissingFileWithoutLeakingPath(t *testing.T) {
 
 	path := filepath.Join(t.TempDir(), probeExecAccountID, "home", "auth.json")
 
-	payload, err := readCredentialFile(path, executionCredentialScope)
+	payload, err := readCredentialFile(path, codexExecutionScope, maxCredentialBytes)
 	require.ErrorIs(t, err, ErrCredentialUnavailable)
 	assert.Nil(t, payload)
-	assert.Contains(t, err.Error(), executionCredentialScope)
+	assert.Contains(t, err.Error(), codexExecutionScope)
 	assert.NotContains(t, err.Error(), path)
 	assert.NotContains(t, err.Error(), probeExecAccountID)
 }
@@ -101,10 +93,71 @@ func TestReadCredentialFileRefusesOversizedCredential(t *testing.T) {
 	require.NoError(t, os.WriteFile(path,
 		[]byte(strings.Repeat("x", maxCredentialBytes+1)), 0o600))
 
-	payload, err := readCredentialFile(path, probeCredentialScope)
+	payload, err := readCredentialFile(path, codexProbeScope, maxCredentialBytes)
 	require.ErrorIs(t, err, ErrCredentialUnavailable)
 	assert.Nil(t, payload)
 	assert.Contains(t, err.Error(), "exceeds")
+}
+
+// The managed claude account id reaches a path the same way the codex one
+// does, so it is validated before it becomes a path element.
+func TestManagedClaudeAuthPathBuildsManagedCredentialPath(t *testing.T) {
+	t.Parallel()
+
+	path, err := managedClaudeAuthPath("/support", probeClaudeAccountID)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/support", "orca", "claude-accounts",
+		probeClaudeAccountID, "auth", "oauth-account.json"), path)
+
+	_, err = managedClaudeAuthPath("", probeClaudeAccountID)
+	require.ErrorIs(t, err, ErrCredentialUnavailable)
+}
+
+func TestManagedClaudeAuthPathRejectsUnsafeAccountID(t *testing.T) {
+	t.Parallel()
+
+	for _, accountID := range unsafeAccountIDs() {
+		path, err := managedClaudeAuthPath("/support", accountID)
+		require.ErrorIsf(t, err, ErrUnsafeAccountID, "account id %q", accountID)
+		assert.Empty(t, path)
+	}
+}
+
+func TestReadManagedClaudeAuthRefusesTraversalBeforeTouchingDisk(t *testing.T) {
+	t.Parallel()
+
+	payload, err := readManagedClaudeAuth("../../../etc/passwd")
+	require.ErrorIs(t, err, ErrUnsafeAccountID)
+	assert.Nil(t, payload)
+}
+
+func TestLocalClaudeConfigPathHonorsConfigDir(t *testing.T) {
+	t.Parallel()
+
+	path, err := localClaudeConfigPath("/custom/claude", "/home/user")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/custom/claude", ".claude.json"), path)
+
+	path, err = localClaudeConfigPath("", "/home/user")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/user", ".claude.json"), path)
+
+	_, err = localClaudeConfigPath("", "")
+	require.ErrorIs(t, err, ErrCredentialUnavailable)
+}
+
+// The managed home is what a re-probe runs the codex CLI under, so it is the
+// account home itself rather than the credential inside it.
+func TestManagedCodexHomePathStopsAtTheAccountHome(t *testing.T) {
+	t.Parallel()
+
+	path, err := managedCodexHomePath("/support", probeExecAccountID)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/support", "orca", "codex-accounts",
+		probeExecAccountID, "home"), path)
+
+	_, err = ManagedCodexHome("not-a-uuid")
+	require.ErrorIs(t, err, ErrUnsafeAccountID)
 }
 
 func managedCodexAuthPathError(t *testing.T, accountID string) error {
@@ -113,4 +166,17 @@ func managedCodexAuthPathError(t *testing.T, accountID string) error {
 	_, err := managedCodexAuthPath("/support", accountID)
 	require.Error(t, err)
 	return err
+}
+
+// unsafeAccountIDs lists identifiers a subprocess payload could carry that must
+// never reach a path.
+func unsafeAccountIDs() []string {
+	return []string{
+		"..",
+		"../../etc",
+		probeExecAccountID + "/../../..",
+		"11111111-1111-4111-8111-111111111111\x00",
+		"not-a-uuid",
+		"",
+	}
 }

--- a/pkg/execplane/probe_test.go
+++ b/pkg/execplane/probe_test.go
@@ -36,8 +36,11 @@ func TestInspectWithoutOrcaYieldsReceiptReadyUnverifiedEvidence(t *testing.T) {
 	assert.False(t, evidence.Resolution.Determined())
 	assert.NotEmpty(t, evidence.Resolution.Reason)
 
+	// The pipeline still holds a probed catalog; what is missing is the account
+	// it would be evidence for, so the receipt stays complete and unverified.
 	receipt := Evaluate(
-		TierRequest{Provider: ProviderCodex, RequestedTier: "ultra", ResolvedModel: "gpt-5.6-sol"},
+		TierRequest{Provider: ProviderCodex, RequestedTier: "ultra",
+			ResolvedModel: "gpt-5.6-sol", Evidence: EvidenceProbedCatalog},
 		evidence.Resolution, evidence.ExecEntitlement, evidence.ProbeEntitlement, time.Now())
 	assert.Equal(t, StatusUnverified, receipt.VerificationStatus)
 	assert.NotEmpty(t, receipt.ResolutionReason)
@@ -77,7 +80,8 @@ func TestInspectKeepsManagedAccountIDOutOfTheReceipt(t *testing.T) {
 	evidence, err := prober.Inspect(context.Background(), ProviderCodex)
 	require.NoError(t, err)
 	receipt := Evaluate(
-		TierRequest{Provider: ProviderCodex, RequestedTier: "ultra", ResolvedModel: "gpt-5.6-sol"},
+		TierRequest{Provider: ProviderCodex, RequestedTier: "ultra",
+			ResolvedModel: "gpt-5.6-sol", Evidence: EvidenceProbedCatalog},
 		evidence.Resolution, evidence.ExecEntitlement, evidence.ProbeEntitlement, time.Now())
 	encoded, err := json.Marshal(receipt)
 	require.NoError(t, err)
@@ -103,31 +107,28 @@ func TestInspectDegradesWhenExecutionCredentialIsMissing(t *testing.T) {
 	assert.NotEmpty(t, reason)
 }
 
-// Claude has no per-account entitlement source, so the credential seams must
-// not be consulted and both grades stay unknown without a provider branch.
-func TestInspectLeavesClaudeEntitlementsUnknown(t *testing.T) {
+// A provider the credential table does not name has nothing on disk to read,
+// so the seams stay untouched and both grades stay unknown.
+func TestInspectSkipsCredentialsForUnnamedProvider(t *testing.T) {
 	t.Parallel()
 
 	prober := Prober{
-		AccountListing: func(context.Context) ([]byte, error) { return probeClaudeListing(), nil },
-		Credential: func(string) ([]byte, error) {
-			t.Error("claude must not read a codex credential")
+		AccountListing: func(context.Context) ([]byte, error) { return probeCodexListing(), nil },
+		Credential: func(string, string) ([]byte, error) {
+			t.Error("an unnamed provider must not read a credential")
 			return nil, nil
 		},
-		HostCredential: func() ([]byte, error) {
-			t.Error("claude must not read a codex credential")
+		HostCredential: func(string) ([]byte, error) {
+			t.Error("an unnamed provider must not read a credential")
 			return nil, nil
 		},
 	}
 
-	evidence, err := prober.Inspect(context.Background(), ProviderClaude)
+	evidence, err := prober.Inspect(context.Background(), "gemini")
 	require.NoError(t, err)
-	assert.Equal(t, AccountSoleRegistered, evidence.Resolution.Status)
+	assert.False(t, evidence.Resolution.Determined())
 	assert.False(t, evidence.ExecEntitlement.Known())
 	assert.False(t, evidence.ProbeEntitlement.Known())
-
-	verdict, _ := CompareEntitlement(evidence.ExecEntitlement, evidence.ProbeEntitlement)
-	assert.Equal(t, VerdictUnverified, verdict)
 }
 
 func TestInspectReportsUnparsableListing(t *testing.T) {
@@ -150,19 +151,21 @@ func probeFilesystemProber(t *testing.T, supportRoot, localHome string, listing 
 
 	return Prober{
 		AccountListing: func(context.Context) ([]byte, error) { return listing, nil },
-		Credential: func(accountID string) ([]byte, error) {
+		Credential: func(provider, accountID string) ([]byte, error) {
+			assert.Equal(t, ProviderCodex, provider)
 			path, err := managedCodexAuthPath(supportRoot, accountID)
 			if err != nil {
 				return nil, err
 			}
-			return readCredentialFile(path, executionCredentialScope)
+			return readCredentialFile(path, codexExecutionScope, maxCredentialBytes)
 		},
-		HostCredential: func() ([]byte, error) {
+		HostCredential: func(provider string) ([]byte, error) {
+			assert.Equal(t, ProviderCodex, provider)
 			path, err := localCodexAuthPath(localHome, "")
 			if err != nil {
 				return nil, err
 			}
-			return readCredentialFile(path, probeCredentialScope)
+			return readCredentialFile(path, codexProbeScope, maxCredentialBytes)
 		},
 	}
 }
@@ -173,12 +176,6 @@ func probeCodexListing() []byte {
 		"activeAccountId":%q,
 		"systemDefault":{"hasAuth":true,"email":%q,"providerAccountId":"org-host"}}}}`,
 		probeExecAccountID, probeExecEmail, probeExecAccountID, probeHostEmail))
-}
-
-func probeClaudeListing() []byte {
-	return []byte(fmt.Sprintf(`{"ok":true,"result":{"claude":{
-		"accounts":[{"id":%q,"email":%q,"organizationUuid":"org-claude"}],
-		"activeAccountId":null}}}`, probeExecAccountID, probeExecEmail))
 }
 
 func probeWriteManagedAuth(t *testing.T, supportRoot, accountID, grade string) {

--- a/pkg/execplane/receipt.go
+++ b/pkg/execplane/receipt.go
@@ -21,6 +21,26 @@ type CatalogSource struct {
 	Entitlement string `json:"entitlement"`
 }
 
+// EvidenceKind names what entitlement parity actually licenses for a provider.
+// Recording it keeps two very different verifications from reading alike: a
+// Codex catalog was fetched from the provider, while a Claude judgement only
+// says the executor runs under the same plan as the reference session. Folding
+// both into a bare "verified" would recreate the silent conflation this gate
+// exists to prevent.
+type EvidenceKind string
+
+const (
+	// EvidenceNone means nothing backs the tier claim.
+	EvidenceNone EvidenceKind = "none"
+	// EvidenceProbedCatalog means a provider-served model catalog is held, and
+	// entitlement parity licenses reading it as evidence for the execution
+	// account.
+	EvidenceProbedCatalog EvidenceKind = "probed_catalog"
+	// EvidenceEntitlementParity means no catalog exists for this provider, so
+	// parity only carries the reference session's working assumption across.
+	EvidenceEntitlementParity EvidenceKind = "entitlement_parity"
+)
+
 // IntegrityReceipt reconstructs why a workload ran at the tier it ran at.
 type IntegrityReceipt struct {
 	Schema             string        `json:"schema"`
@@ -31,6 +51,7 @@ type IntegrityReceipt struct {
 	CatalogSource      CatalogSource `json:"catalog_source"`
 	ResolutionReason   string        `json:"resolution_reason"`
 	VerificationStatus string        `json:"verification_status"`
+	EvidenceKind       EvidenceKind  `json:"evidence_kind"`
 	CheckedAt          time.Time     `json:"checked_at"`
 }
 
@@ -39,16 +60,21 @@ type TierRequest struct {
 	Provider      string
 	RequestedTier string
 	ResolvedModel string
+	// Evidence declares what the pipeline holds for this provider. A provider
+	// with no evidence can never reach StatusVerified no matter how cleanly the
+	// entitlements match, because parity transfers evidence rather than
+	// creating it.
+	Evidence EvidenceKind
 }
 
 // Evaluate produces the integrity receipt for one provider. It performs no I/O:
 // callers supply the account resolution and both entitlements, which keeps the
 // decision reproducible and keeps the gate free of execution side effects.
 //
-// A trusted verdict is the only path to StatusVerified. Both reprobe and
-// unverified land on StatusUnverified here, because this function is given a
-// catalog that was already probed — re-probing is the caller's move, and until
-// it happens the held evidence does not cover the execution account.
+// StatusVerified needs three things together: a determined execution account, a
+// trusted entitlement comparison, and evidence to transfer. Parity moves
+// evidence across accounts; it never manufactures it, so a provider that holds
+// nothing stays unverified however cleanly its grades match.
 func Evaluate(
 	request TierRequest,
 	resolution AccountResolution,
@@ -64,7 +90,8 @@ func Evaluate(
 			Account:     probeEntitlement.Source,
 			Entitlement: probeEntitlement.Grade,
 		},
-		CheckedAt: now.UTC(),
+		EvidenceKind: request.Evidence,
+		CheckedAt:    now.UTC(),
 	}
 	if !resolution.Determined() {
 		receipt.VerificationStatus = StatusUnverified
@@ -81,10 +108,14 @@ func Evaluate(
 
 	verdict, reason := CompareEntitlement(execEntitlement, probeEntitlement)
 	receipt.ResolutionReason = reason
-	if verdict == VerdictTrusted {
-		receipt.VerificationStatus = StatusVerified
-	} else {
+	switch {
+	case verdict != VerdictTrusted:
 		receipt.VerificationStatus = StatusUnverified
+	case request.Evidence == "" || request.Evidence == EvidenceNone:
+		receipt.VerificationStatus = StatusUnverified
+		receipt.ResolutionReason = reason + "; no evidence is held for this provider"
+	default:
+		receipt.VerificationStatus = StatusVerified
 	}
 	return receipt
 }
@@ -93,12 +124,12 @@ func Evaluate(
 // that omits one is not a weaker receipt, it is an unusable one.
 func (r IntegrityReceipt) Complete() bool {
 	if r.Schema == "" || r.RequestedTier == "" || r.ResolvedModel == "" ||
-		r.ResolutionReason == "" || r.VerificationStatus == "" {
+		r.ResolutionReason == "" || r.VerificationStatus == "" || r.EvidenceKind == "" {
 		return false
 	}
 	if r.VerificationStatus == StatusVerified {
 		return r.ExecutionAccount != "" && r.CatalogSource.Account != "" &&
-			r.CatalogSource.Entitlement != ""
+			r.CatalogSource.Entitlement != "" && r.EvidenceKind != EvidenceNone
 	}
 	return true
 }

--- a/pkg/execplane/receipt_contract_test.go
+++ b/pkg/execplane/receipt_contract_test.go
@@ -9,9 +9,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// fixtureTierRequest is the policy plane's ask, carried into the gate unchanged.
-func fixtureTierRequest(provider, tier, model string) execplane.TierRequest {
-	return execplane.TierRequest{Provider: provider, RequestedTier: tier, ResolvedModel: model}
+// fixtureTierRequest is the policy plane's ask, carried into the gate
+// unchanged. Evidence is a required argument rather than a defaulted field:
+// what the pipeline actually holds for a provider now decides whether the
+// receipt can reach verified, so no caller may leave it implicit.
+func fixtureTierRequest(
+	provider, tier, model string, evidence execplane.EvidenceKind,
+) execplane.TierRequest {
+	return execplane.TierRequest{
+		Provider:      provider,
+		RequestedTier: tier,
+		ResolvedModel: model,
+		Evidence:      evidence,
+	}
 }
 
 // fixtureDeterminedAccount is a resolution that names exactly one execution account.
@@ -26,12 +36,14 @@ func fixtureDeterminedAccount(provider, email string) execplane.AccountResolutio
 
 // fixtureVerifiedReceipt is the only receipt shape that may carry
 // StatusVerified: a determined account whose grade equals the grade the held
-// catalog was probed under.
+// catalog was probed under, backed by evidence that grade equality can carry
+// across.
 func fixtureVerifiedReceipt(t *testing.T) execplane.IntegrityReceipt {
 	t.Helper()
 
 	receipt := execplane.Evaluate(
-		fixtureTierRequest(execplane.ProviderCodex, "ultra", "gpt-5.6-sol"),
+		fixtureTierRequest(execplane.ProviderCodex, "ultra", "gpt-5.6-sol",
+			execplane.EvidenceProbedCatalog),
 		fixtureDeterminedAccount(execplane.ProviderCodex, "execution@example.test"),
 		execplane.Entitlement{Grade: "pro", Source: "execution@example.test"},
 		execplane.Entitlement{Grade: "pro", Source: "host-cli@example.test"},
@@ -61,6 +73,7 @@ func TestVerifiedReceiptCarriesAllSixFields(t *testing.T) {
 	assert.Equal(t, "host-cli@example.test", receipt.CatalogSource.Account)
 	assert.Equal(t, "pro", receipt.CatalogSource.Entitlement)
 	assert.NotEmpty(t, receipt.ResolutionReason)
+	assert.Equal(t, execplane.EvidenceProbedCatalog, receipt.EvidenceKind)
 	assert.Equal(t, time.UTC, receipt.CheckedAt.Location())
 	assert.True(t, receipt.Complete())
 }
@@ -86,6 +99,10 @@ func TestIncompleteReceiptIsRejectedFieldByField(t *testing.T) {
 		{"catalog grade missing", func(r *execplane.IntegrityReceipt) { r.CatalogSource.Entitlement = "" }},
 		{"resolution reason missing", func(r *execplane.IntegrityReceipt) { r.ResolutionReason = "" }},
 		{"status missing", func(r *execplane.IntegrityReceipt) { r.VerificationStatus = "" }},
+		{"evidence kind missing", func(r *execplane.IntegrityReceipt) { r.EvidenceKind = "" }},
+		{"evidence kind is none", func(r *execplane.IntegrityReceipt) {
+			r.EvidenceKind = execplane.EvidenceNone
+		}},
 	}
 
 	for _, tc := range cases {
@@ -129,7 +146,8 @@ func TestResolutionReasonIsNeverEmpty(t *testing.T) {
 
 			for name, resolution := range resolutions {
 				receipt := execplane.Evaluate(
-					fixtureTierRequest(execplane.ProviderCodex, "ultra", "gpt-5.6-sol"),
+					fixtureTierRequest(execplane.ProviderCodex, "ultra", "gpt-5.6-sol",
+						execplane.EvidenceProbedCatalog),
 					resolution, execution, probe, time.Now(),
 				)
 				assert.NotEmpty(t, receipt.ResolutionReason,
@@ -148,7 +166,8 @@ func TestReceiptNamesRequestedTierAndServedModelSeparately(t *testing.T) {
 	t.Parallel()
 
 	receipt := execplane.Evaluate(
-		fixtureTierRequest(execplane.ProviderCodex, "ultra", "gpt-5.5"),
+		fixtureTierRequest(execplane.ProviderCodex, "ultra", "gpt-5.5",
+			execplane.EvidenceProbedCatalog),
 		fixtureDeterminedAccount(execplane.ProviderCodex, "execution@example.test"),
 		execplane.Entitlement{Grade: "pro", Source: "execution@example.test"},
 		execplane.Entitlement{Grade: "plus", Source: "host-cli@example.test"},
@@ -180,7 +199,8 @@ func TestDeterminedIdentityWithoutCatalogProbeStaysUnverified(t *testing.T) {
 	}
 	require.True(t, resolution.Determined())
 
-	request := fixtureTierRequest(execplane.ProviderClaude, "ultra", "claude-opus-5")
+	request := fixtureTierRequest(
+		execplane.ProviderClaude, "ultra", "claude-opus-5", execplane.EvidenceNone)
 	receipt := execplane.Evaluate(
 		request, resolution, execplane.Entitlement{}, execplane.Entitlement{}, time.Now())
 
@@ -188,6 +208,7 @@ func TestDeterminedIdentityWithoutCatalogProbeStaysUnverified(t *testing.T) {
 		"identity is settled even though availability is not")
 	assert.Equal(t, execplane.StatusUnverified, receipt.VerificationStatus)
 	assert.NotEmpty(t, receipt.ResolutionReason)
+	assert.Equal(t, execplane.EvidenceNone, receipt.EvidenceKind)
 	assert.True(t, receipt.Complete())
 
 	// S8 (no probe available) and S9 (no account resolved) share the status but
@@ -203,19 +224,27 @@ func TestDeterminedIdentityWithoutCatalogProbeStaysUnverified(t *testing.T) {
 	assert.NotEqual(t, receipt.ResolutionReason, unresolved.ResolutionReason)
 }
 
-// TestVerifiedRequiresDeterminedAccountAndEqualKnownGrades covers S8 / REQ-009
-// as a property over the whole input space: verified is reachable only from a
-// determined account whose known grade equals the known grade the catalog was
-// probed under, and it never appears without a reason. This is what blocks the
-// optimistic shortcuts — deriving a grade from a subscription type, treating a
-// missing probe as harmless, or trusting a catalog whose grade is unknown.
-func TestVerifiedRequiresDeterminedAccountAndEqualKnownGrades(t *testing.T) {
+// TestVerifiedRequiresDeterminedAccountEqualGradesAndEvidence covers S8 /
+// REQ-009 as a property over the whole input space: verified is reachable only
+// when all three hold together — a determined account, a known grade equal to
+// the known grade the catalog was probed under, and evidence for parity to
+// carry across — and it never appears without a reason. This is what blocks
+// the optimistic shortcuts: deriving a grade from a subscription type,
+// treating a missing probe as harmless, trusting a catalog whose grade is
+// unknown, or reading clean grade parity as if it were itself evidence.
+func TestVerifiedRequiresDeterminedAccountEqualGradesAndEvidence(t *testing.T) {
 	t.Parallel()
 
 	entitlements := []execplane.Entitlement{
 		{},
 		{Grade: "pro", Source: "host-cli@example.test"},
 		{Grade: "plus", Source: "host-cli@example.test"},
+	}
+	evidences := []execplane.EvidenceKind{
+		"",
+		execplane.EvidenceNone,
+		execplane.EvidenceProbedCatalog,
+		execplane.EvidenceEntitlementParity,
 	}
 	resolutions := []execplane.AccountResolution{
 		fixtureDeterminedAccount(execplane.ProviderCodex, "execution@example.test"),
@@ -235,23 +264,31 @@ func TestVerifiedRequiresDeterminedAccountAndEqualKnownGrades(t *testing.T) {
 	for _, resolution := range resolutions {
 		for _, execution := range entitlements {
 			for _, probe := range entitlements {
-				receipt := execplane.Evaluate(
-					fixtureTierRequest(execplane.ProviderCodex, "ultra", "gpt-5.6-sol"),
-					resolution, execution, probe, time.Now(),
-				)
-				where := []any{"%s / exec %q / probe %q",
-					resolution.Status, execution.Grade, probe.Grade}
+				for _, evidence := range evidences {
+					receipt := execplane.Evaluate(
+						fixtureTierRequest(
+							execplane.ProviderCodex, "ultra", "gpt-5.6-sol", evidence),
+						resolution, execution, probe, time.Now(),
+					)
+					where := []any{"%s / exec %q / probe %q / evidence %q",
+						resolution.Status, execution.Grade, probe.Grade, evidence}
 
-				require.NotEmpty(t, receipt.ResolutionReason, where...)
-				wantVerified := resolution.Determined() &&
-					execution.Known() && probe.Known() && execution.Grade == probe.Grade
-				if !wantVerified {
-					assert.Equal(t, execplane.StatusUnverified, receipt.VerificationStatus, where...)
-					continue
+					require.NotEmpty(t, receipt.ResolutionReason, where...)
+					assert.Equal(t, evidence, receipt.EvidenceKind, where...)
+
+					wantVerified := resolution.Determined() &&
+						execution.Known() && probe.Known() && execution.Grade == probe.Grade &&
+						evidence != "" && evidence != execplane.EvidenceNone
+					if !wantVerified {
+						assert.Equal(t, execplane.StatusUnverified,
+							receipt.VerificationStatus, where...)
+						continue
+					}
+					assert.Equal(t, execplane.StatusVerified,
+						receipt.VerificationStatus, where...)
+					assert.NotEmpty(t, receipt.ExecutionAccount, where...)
+					assert.True(t, receipt.Complete(), where...)
 				}
-				assert.Equal(t, execplane.StatusVerified, receipt.VerificationStatus, where...)
-				assert.NotEmpty(t, receipt.ExecutionAccount, where...)
-				assert.True(t, receipt.Complete(), where...)
 			}
 		}
 	}

--- a/pkg/execplane/receipt_evidence_contract_test.go
+++ b/pkg/execplane/receipt_evidence_contract_test.go
@@ -1,0 +1,120 @@
+package execplane_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/execplane"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEntitlementParityWithoutEvidenceStaysUnverified covers S8 / REQ-009 and
+// is the sharpest edge of REQ-004: entitlement parity transfers evidence
+// between accounts, it does not create any. A provider that holds nothing —
+// no catalog, no reference judgement — has nothing for parity to carry, so the
+// cleanest possible grade match still leaves the tier unverified, and the
+// reason says so rather than reusing the wording of a trusted comparison.
+func TestEntitlementParityWithoutEvidenceStaysUnverified(t *testing.T) {
+	t.Parallel()
+
+	resolution := fixtureDeterminedAccount(execplane.ProviderClaude, "execution@example.test")
+	matched := execplane.Entitlement{Grade: "claude_max", Source: "host-cli@example.test"}
+	verdict, _ := execplane.CompareEntitlement(matched, matched)
+	require.Equal(t, execplane.VerdictTrusted, verdict,
+		"the fixture must be a clean parity or it proves nothing about evidence")
+
+	// The zero value and the explicit "none" are the same claim written two
+	// ways, and a gate that only checked one of them would let an unset field
+	// through as if it were evidence.
+	for _, evidence := range []execplane.EvidenceKind{"", execplane.EvidenceNone} {
+		receipt := execplane.Evaluate(
+			fixtureTierRequest(execplane.ProviderClaude, "ultra", "claude-opus-5", evidence),
+			resolution, matched, matched, time.Now(),
+		)
+
+		assert.Equal(t, execplane.StatusUnverified, receipt.VerificationStatus,
+			"evidence %q: parity alone must not promote a tier to verified", evidence)
+		assert.Equal(t, "execution@example.test", receipt.ExecutionAccount,
+			"evidence %q: the executor is still known; only the evidence is missing", evidence)
+		assert.NotEmpty(t, receipt.ResolutionReason, "evidence %q", evidence)
+		assert.Contains(t, receipt.ResolutionReason, "evidence",
+			"evidence %q: the reason must name the missing evidence, not just the grades",
+			evidence)
+	}
+
+	// Same account, same grades, same everything but a held catalog: the only
+	// input that moved is the evidence, and it is what decides the status.
+	withEvidence := execplane.Evaluate(
+		fixtureTierRequest(execplane.ProviderClaude, "ultra", "claude-opus-5",
+			execplane.EvidenceProbedCatalog),
+		resolution, matched, matched, time.Now(),
+	)
+	assert.Equal(t, execplane.StatusVerified, withEvidence.VerificationStatus)
+}
+
+// TestEvidenceKindDistinguishesEquallyVerifiedProviders covers S4 / REQ-005:
+// two providers can both read `verified` while resting on very different
+// footing — Codex on a catalog the provider actually served, Claude on nothing
+// stronger than "the executor runs the same plan as the reference session".
+// The receipt has to keep those apart, because collapsing them into a bare
+// status is the silent conflation this gate exists to prevent.
+func TestEvidenceKindDistinguishesEquallyVerifiedProviders(t *testing.T) {
+	t.Parallel()
+
+	codexGrade := execplane.Entitlement{Grade: "pro", Source: "codex-host@example.test"}
+	probed := execplane.Evaluate(
+		fixtureTierRequest(execplane.ProviderCodex, "ultra", "gpt-5.6-sol",
+			execplane.EvidenceProbedCatalog),
+		fixtureDeterminedAccount(execplane.ProviderCodex, "codex-exec@example.test"),
+		codexGrade, codexGrade, time.Now(),
+	)
+
+	claudeGrade := execplane.Entitlement{Grade: "claude_max", Source: "claude-host@example.test"}
+	parity := execplane.Evaluate(
+		fixtureTierRequest(execplane.ProviderClaude, "ultra", "claude-opus-5",
+			execplane.EvidenceEntitlementParity),
+		fixtureDeterminedAccount(execplane.ProviderClaude, "claude-exec@example.test"),
+		claudeGrade, claudeGrade, time.Now(),
+	)
+
+	require.Equal(t, execplane.StatusVerified, probed.VerificationStatus)
+	require.Equal(t, parity.VerificationStatus, probed.VerificationStatus,
+		"both providers verify, which is exactly why the status cannot be the whole record")
+
+	assert.Equal(t, execplane.EvidenceProbedCatalog, probed.EvidenceKind)
+	assert.Equal(t, execplane.EvidenceEntitlementParity, parity.EvidenceKind)
+	assert.NotEqual(t, probed.EvidenceKind, parity.EvidenceKind)
+	assert.True(t, probed.Complete())
+	assert.True(t, parity.Complete())
+}
+
+// TestEvidenceKindSurvivesSerialization covers S4 / REQ-005: the receipt is
+// read back later, by someone who was not here. Evidence strength that lives
+// only in memory reconstructs nothing, so it travels as a stable JSON key with
+// the wire spellings the gate publishes.
+func TestEvidenceKindSurvivesSerialization(t *testing.T) {
+	t.Parallel()
+
+	// Spelled out rather than compared to the constants alone: renaming a wire
+	// value has to break a test rather than move both sides together.
+	wire := map[execplane.EvidenceKind]string{
+		execplane.EvidenceNone:              "none",
+		execplane.EvidenceProbedCatalog:     "probed_catalog",
+		execplane.EvidenceEntitlementParity: "entitlement_parity",
+	}
+
+	for kind, spelling := range wire {
+		receipt := fixtureVerifiedReceipt(t)
+		receipt.EvidenceKind = kind
+
+		encoded, err := json.Marshal(receipt)
+		require.NoError(t, err, spelling)
+		assert.Contains(t, string(encoded), `"evidence_kind":"`+spelling+`"`)
+
+		var decoded execplane.IntegrityReceipt
+		require.NoError(t, json.Unmarshal(encoded, &decoded), spelling)
+		assert.Equal(t, kind, decoded.EvidenceKind, spelling)
+	}
+}


### PR DESCRIPTION
게이트의 남은 두 구멍을 메운다. Claude가 더 이상 영구 `unverified`가 아니고, 등급 불일치 시 재프로브가 실제로 동작한다.

## 실제 머신 종단 실행

```
verification_status: verified
reason: claude: execution and probe accounts share entitlement claude_max;
        codex: execution and probe accounts share entitlement pro
```

| provider | 실행 계정 | catalog_source | evidence_kind | 판정 |
| --- | --- | --- | --- | --- |
| claude | `jroad1049@gmail.com` | `jroad1049@gmail.com` @ `claude_max` | `entitlement_parity` | **verified** |
| codex | `bitgapnam@gmail.com` | `gnkong@alipeople.kr` @ `pro` | `probed_catalog` | **verified** |

## ① Claude 가용성 — 앞선 결론이 성급했다

F8은 "Claude에 계정별 카탈로그 프로브가 없다"에서 멈춰 모델 가용성을 영구 `unverified`로 뒀다. **카탈로그 부재를 등급 부재로 오인한 것이었다.** 게이트에 필요한 건 카탈로그가 아니라 등급이고, 등급은 자격증명에 있다.

| 위치 | 경로 | 형태 |
| --- | --- | --- |
| orca 관리 | `<support>/orca/claude-accounts/<id>/auth/oauth-account.json` | `organizationType` 최상위 |
| 호스트 CLI | `~/.claude.json` | `oauthAccount.organizationType` |

**동일 필드명**이라 한 파서로 양쪽을 읽는다. 어휘 매핑 없음.

등급은 조직 플랜(`organizationType`)이고 rate-limit 티어는 **제외**했다. `default_claude_max_20x`와 `_5x`는 같은 모델 집합을 throttle할 뿐이라, 등급에 섞으면 실제로 동등한 계정 사이에 불필요한 재프로브가 생긴다.

기각한 `subscriptionType` 게이트와 혼동하면 안 된다. 기각한 건 **플랜 → 모델 매핑**(추정)이고, 채택한 건 **등급 동일성 비교**(사실)다.

## ② `evidence_kind` — 이 SPEC의 존재 이유

Claude와 Codex가 똑같이 `verified`로 읽히면 증거 강도가 조용히 뭉개진다. 그건 이 SPEC이 막으려던 바로 그 실패다.

| 값 | 뜻 |
| --- | --- |
| `probed_catalog` | provider가 내려준 카탈로그 보유. 등급 동일성이 **그 카탈로그**를 실행 계정으로 옮긴다 |
| `entitlement_parity` | 카탈로그 없음. 등급 동일성이 기준 세션의 **작업 가정**만 옮긴다 |
| `none` | 옮길 증거 없음 |

`Evaluate`는 이제 **세 조건**을 모두 요구한다: 실행 계정 determined + 등급 동일 + 증거 보유. **parity는 증거를 옮길 뿐 만들지 않는다.** 등급이 아무리 깨끗이 맞아도 증거가 없으면 verified가 아니다.

## ③ 재프로브 — 계약의 절반이 미구현이었다

`VerdictReprobe`가 그냥 unverified로 떨어지고 있었다. 이제 codex는 실행 계정의 `CODEX_HOME`으로 `codex debug models`를 다시 프로브한다.

```
등급 동일  →  재프로브 0회, 네트워크 0회        ← 기본 경로
등급 상이  →  실행 계정 기준 1회 → 성공 시 verified
재프로브 실패 →  unverified + 사유에 실패 단계 명시
```

등급 동일 분기의 **호출 0회**를 카운터로 고정했다 — 이게 설계의 핵심이라 회귀하면 즉시 실패한다. Claude는 카탈로그가 없어 재프로브하지 않고 REQ-009로 떨어진다.

`codexruntime.ProbeModelCatalogUnderHome`을 추가하고 기존 `ProbeModelCatalog`은 그 위임으로 축소했다. 기존 호출부 3곳 시그니처 불변.

## 보안

실패한 재프로브의 원본 에러는 폐기한다 — 관리 홈 경로를 담을 수 있다. 영수증에는 실패한 **단계 이름**만 남는다. 자격증명 UUID는 어떤 경로로도 밖에 나가지 않는다.

## SPEC 갱신

REQ-004(결정 3·4), REQ-005(7필드), REQ-009(인스턴스 4종, Claude 가용성 제외). research.md에 F10 추가. S11(증거 강도 구분)·S12(재프로브 3분기) 신설.

## 검증

- `go test ./... -count=1` ‖ 셸 하드닝 스위트 동시 실행 양쪽 exit 0.
- 게이트 테스트 5종 전부 통과 — verified 참조, unverified 노출, orca 부재, 재프로브 성공, 재프로브 실패.
- 계약 테스트에 mutation 6종 추가 탐지: 증거 없는데 verified / rate limit을 등급에 섞음 / evidence_kind 누락 / 한쪽 레이아웃만 파싱 / 등급을 provider 횡단 정규화 / 자격증명 UUID를 Entitlement에 복사.
- `auto spec validate` 통과, `auto check --hygiene --arch --staged` exit 0.
