### PR TITLE
test: 프로덕션 예산 테스트에 상한 seam 적용

### DIFF
--- a/pkg/adapter/omp/omp.go
+++ b/pkg/adapter/omp/omp.go
@@ -29,6 +29,12 @@ const (
 	ompVersionMaxOutput = 64 * 1024
 )
 
+// ompVersionCeiling is the deadline Detect actually enforces. A test widens it
+// so a saturated machine cannot preempt the identity contract under test: the
+// probe spawns a process and the production bound, not the assertion, becomes
+// what a tight run measures. The shipped default never moves.
+var ompVersionCeiling = ompVersionTimeout
+
 // Adapter is the oh-my-pi (omp) platform adapter.
 type Adapter struct {
 	root                   string
@@ -74,7 +80,7 @@ func (a *Adapter) Detect(ctx context.Context) (bool, error) {
 		ctx = context.Background()
 	}
 
-	probeCtx, cancel := context.WithTimeout(ctx, ompVersionTimeout)
+	probeCtx, cancel := context.WithTimeout(ctx, ompVersionCeiling)
 	defer cancel()
 	sandbox, err := os.MkdirTemp("", "autopus-omp-detect-*")
 	if err != nil {

--- a/pkg/adapter/omp/omp_contract_test.go
+++ b/pkg/adapter/omp/omp_contract_test.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -132,11 +133,22 @@ func TestOMPAdapter_Validate_EmptyWorkspaceReportsAllSurfaces(t *testing.T) {
 	}, files)
 }
 
+// widenOMPVersionCeiling raises the Detect deadline for one test and restores it
+// afterwards. Identity tests assert on what a version string resolves to, not on
+// how fast the probe returns, so the production bound must not preempt them.
+func widenOMPVersionCeiling(t *testing.T) {
+	t.Helper()
+	previous := ompVersionCeiling
+	ompVersionCeiling = 60 * time.Second
+	t.Cleanup(func() { ompVersionCeiling = previous })
+}
+
 // TestOMPAdapter_REQ019_DetectRequiresOhMyPiVersionShape pins the identity gate
 // at the adapter boundary. `omp` is a short name that collides with unrelated
 // executables, so the adapter adopts only an exact `omp/x.y.z` release shape.
 func TestOMPAdapter_REQ019_DetectRequiresOhMyPiVersionShape(t *testing.T) {
 	skipWithoutPOSIXShellOMP(t)
+	widenOMPVersionCeiling(t)
 
 	tests := []struct {
 		name    string
@@ -164,6 +176,7 @@ func TestOMPAdapter_REQ019_DetectRequiresOhMyPiVersionShape(t *testing.T) {
 
 func TestOMPAdapter_REQ019_DetectUsesCredentialFreeCanonicalEnvironment(t *testing.T) {
 	skipWithoutPOSIXShellOMP(t)
+	widenOMPVersionCeiling(t)
 
 	base := t.TempDir()
 	home := filepath.Join(base, "home")

--- a/pkg/qa/run/desktop_observe_contract.go
+++ b/pkg/qa/run/desktop_observe_contract.go
@@ -55,7 +55,7 @@ func newDesktopObservationRunner(local, orca desktopProviderClient) *desktopObse
 	return &desktopObservationRunner{
 		local:   local,
 		orca:    orca,
-		timeout: maxDesktopObservationDuration,
+		timeout: desktopObservationCeiling,
 		ledgers: map[desktopobserve.RuntimeProvider]*desktopobserve.StateLedger{
 			desktopobserve.RuntimeProviderLocal: desktopobserve.NewStateLedger(),
 			desktopobserve.RuntimeProviderOrca:  desktopobserve.NewStateLedger(),


### PR DESCRIPTION
프로덕션 타임아웃 예산을 직접 재는 테스트 3개가 포화 상태에서 계약 대신 머신 부하를 측정한다. 상한 seam으로 여유를 벌었다. **프로덕션 기본값은 하나도 안 바뀐다.**

## 고친 것

| 테스트 | 프로덕션 예산 | 증상 |
| --- | --- | --- |
| `TestOrcaProductionResolver_ExplicitSelectionInvokesInstalledCLIOnly` | `maxDesktopObservationDuration = 2s` (CLI 5회 호출 전체) | 2.03~2.04s로 `blocked` 판정 |
| `TestOMPAdapter_REQ019_DetectRequiresOhMyPiVersionShape` | `ompVersionTimeout = 5s` | 서브테스트 5개 전부 5.00s, `want:true` 케이스만 실패 |
| `TestOMPAdapter_REQ019_DetectUsesCredentialFreeCanonicalEnvironment` | 동일 | 5.04s |

셋 다 **동작**을 단정하는 테스트지 **지연**을 단정하는 테스트가 아니다. `runtimeCodexCatalogProbe` 선례대로 패키지 레벨 상한 var를 두고 테스트만 넓힌다.

## 앞선 시도가 왜 실패했나

`pkg/qa/run`에 seam을 넣었는데 **여전히 2.03s로 실패했다.** `operationContext`의 clamp가 단축만 허용하는데, 생성자가 `runner.timeout`을 상수 2s로 채워두니 clamp가 매번 그 2s를 집었다. 상한을 60s로 올려도 무의미했다.

```go
timeout := desktopObservationCeiling          // 60s (테스트가 넓힘)
if runner.timeout > 0 && runner.timeout < timeout {
    timeout = runner.timeout                  // ← 2s가 이김
}
```

생성자 기본값도 상한을 따르게 고쳐 해소했다. config 경유 값은 여전히 단축만 가능하다.

## 검증

seam이 실제로 데드라인을 지배하는지 확인했다 — 헬퍼의 widened 값을 10ms로 바꾸니 `blocked`로 즉시 실패, 원복 후 통과. 값을 흘려보내지 않는 가짜 seam이면 이 확인이 통과하지 못한다.

`Detect` 쪽도 동일하게 mutation 확인(deadline 무력화 시 6건 실패).

`go test ./... -count=1` ‖ 셸 하드닝 스위트 동시 실행 양쪽 exit 0. `auto check --hygiene --arch --staged` exit 0.
