### PR TITLE
docs(spec): SPEC-EXECPLANE-002 orca 감독 실행을 PhaseBackend로 구현

### DIFF
--- a/.autopus/specs/SPEC-EXECPLANE-002/acceptance.md
+++ b/.autopus/specs/SPEC-EXECPLANE-002/acceptance.md
@@ -1,0 +1,99 @@
+# SPEC-EXECPLANE-002 Acceptance: orca 감독 실행을 PhaseBackend로 구현
+
+이 문서는 설계 고정 문서의 오라클이다. 시나리오는 구현 작업(T101~T104)이 통과해야 하는 판정 기준이고, 이 SPEC 자체의 완료 증거는 4개 문서의 `auto spec validate` 통과다.
+
+## Test Scenarios
+
+### S101: orca 경로가 omp 경로와 같은 엔진·같은 EngineConfig로 구동된다
+Priority: Must
+Given `auto pipeline run --platform omp --execution-owner orca`가 티어 정합 게이트를 통과하고 체크포인트 로드까지 끝낸 상태
+When 엔진이 5-phase 실행을 시작한다
+Then 실행 주체는 omp 경로와 같은 `pipeline.SubprocessEngine`이고, `EngineConfig`의 phase 목록·게이트 종류·재시도 상한·체크포인트 디렉터리 값이 omp 경로와 같다
+And 두 경로의 유일한 차이는 주입된 `Backend` 구현 하나이며, orca 전용 phase 러너·orca 전용 순서 테이블·orca 전용 게이트 판정 코드가 각각 0건이다
+And orca 백엔드가 엔진에 노출하는 메서드는 `pkg/pipeline/engine.go:29-31`의 `Execute(ctx, PhaseRequest) (*PhaseResponse, error)` 하나이고, run-scoped 리소스 해제는 `PhaseBackendCloser`의 `Close()`로만 한다
+And 별도 러너가 같은 실행 결과를 내더라도 이 시나리오는 실패다 — 관측 대상은 결과 일치가 아니라 순서·게이트·재시도의 단일 구현 소유다
+
+### S102: orca task가 의존성 간선 없이 생성되고 순서는 엔진만 소유한다
+Priority: Must
+Given 백엔드 생성 시 Run이 한 번 만들어져 있고, 백엔드가 phase 실행을 위해 orca task를 만드는 상태
+When 5-phase가 전부 실행된다
+Then 이 Run에 속한 모든 task의 deps가 빈 배열이고, `task-create` 호출 argv에서 `--deps`의 출현 횟수가 0이다
+And 관측된 실행 순서 plan → test_scaffold → implement → validate → review가 `pkg/pipeline/phase.go:34-42`의 `DefaultPhases()` 정의와 일치하고, 프로세스 평면에 같은 순서를 표현한 두 번째 자료구조가 0건이다
+And 어느 한 phase에서라도 `--deps`가 채워지면 INV-101 위반이며, `pkg/adapter/omp/omp_workflow_render.go:77-78`의 단일 DAG 소유자 불변식도 같이 깨진다
+And `--deps`를 쓰지 않는 것은 기능 낭비가 아니라 평면 분리의 관측 지점이다. 프로세스 평면이 DAG를 가지면 게이트·재시도·체크포인트가 그쪽에도 복제되어야 한다
+
+### S103: phase attempt 하나가 Dispatch 하나에 1:1로 대응한다
+Priority: Must
+Given 백엔드가 한 phase의 attempt 1에 대해 `Execute`를 정확히 한 번 호출받은 상태
+When 그 호출이 반환된다
+Then 그 attempt 동안 시작된 Dispatch가 정확히 1건이고, 그 Dispatch가 release·stop·abandon 중 정확히 하나로 정확히 1회 종결된다
+And 재시도는 같은 Dispatch의 재사용이 아니라 새 attempt이므로 새 Dispatch를 시작한다. 엔진의 attempt 루프 상한이 `MaxRetries + 1`이므로 validate(`MaxRetries: 3`)의 Dispatch 수는 최대 4건, review(`MaxRetries: 2`)는 최대 3건이다
+And 게이트가 첫 판정에 통과한 클린 런의 총 Dispatch 수는 phase 수와 같은 5건이고, 실행 영수증의 `dispatch_count`가 시작된 워커 수와 같다. 두 값이 어긋나면 1:1이 깨진 것이다
+And 한 attempt에서 워커를 2개 이상 띄우는 fan-out은 이 SPEC의 비목표이므로, 한 attempt에 2건 이상이 관측되면 실패다
+
+### S104: 워커 대기와 출력이 둘 다 바운드된다
+Priority: Must
+Given 종결 신호를 내지 않는 워커 하나와 출력을 계속 쏟는 워커 하나가 있는 상태
+When 백엔드가 각 워커의 종결을 기다리고 그 출력을 읽는다
+Then 응답 없는 워커의 대기는 백엔드 deadline에서 끊기고 `PhaseResponse.TimedOut`이 true로 반환되어, 파이프라인이 그 phase에서 무한 대기하지 않는다
+And 출력 읽기는 `worker-read --cursor --limit`의 상한 안에서만 진행되어 백엔드가 보유하는 출력 바이트 수가 상한 이하로 유지되고, 상한 때문에 잘렸다는 사실이 `PhaseResponse.FailureClass`에 남는다
+And 두 한계 중 어느 쪽으로 끊겼는지 `TimedOut`과 `FailureClass` 두 필드만 보고 구분할 수 있다
+And 두 필드가 모두 비어 있는 채로 phase가 실패하면 사유가 관측 불가이므로 실패다. 대기와 읽기 중 한쪽만 바운드된 구현도 실패다
+
+### S105: 실패·취소·백엔드 종료 세 경로 모두 살아있는 Dispatch를 남기지 않는다
+Priority: Must
+Given phase attempt가 (a) 실패로 끝나는 경로, (b) `ctx` 취소로 끊기는 경로, (c) 백엔드 `Close()`로 정리되는 경로 세 가지
+When 각 경로가 끝난다
+Then 세 경로 각각에서 이 Run에 속한 `worker-list --terminal-state active` 결과가 0건이다
+And 백엔드가 시작한 Dispatch 전부가 release·stop·abandon 중 하나로 종결 상태를 갖고, 종결되지 않은 Dispatch가 0건이다
+And 워커 프로세스가 실제로 멈췄다고 주장할 수 없는 경로에서는 release 대신 `worker-abandon`으로 펜싱하고, abandon을 택한 사유가 실행 기록에 남는다
+And 취소 경로에서 `PhaseResponse`가 없고 오류만 있어도 정리 책임은 백엔드에 있다. 엔진이 실패를 반환했다는 사실이 정리 누락의 사유가 되지 않는다
+
+### S106: 티어 정합 게이트가 Run 생성보다 먼저 끝난다
+Priority: Must
+Given `--execution-owner orca` 결정이 내려졌고, `internal/cli/pipeline_run.go:147-163`에서 정합 게이트가 백엔드 생성보다 앞에 있는 상태
+When 준비 단계가 orca Run을 만든다
+Then `<SPEC-ID>.tier-integrity.json`의 `checked_at`이 `run-create`가 반환한 Run 생성 시각보다 앞선다
+And 게이트를 실행하지 않고 `run-create`에 도달하는 코드 경로가 0건이고, 게이트가 통과하지 못하면 그 실행의 `run-create` 호출 수가 0이며 `worker-start` 호출 수도 0이다
+And 정합 영수증이 없는 실행, 또는 `checked_at`이 Run 생성 시각 이후인 실행은 INV-105 위반으로 판정한다
+And 게이트가 unverified로 떨어진 구성은 워커를 띄우는 대신 그 사실을 결과로 보고한다
+
+### S107: 프로세스 평면 경계 인자에 티어 어휘가 없다
+Priority: Must
+Given 정책 평면이 phase별 quality tier를 결정하고 그 결정을 `worker-start` 인자로 직렬화하는 상태
+When 백엔드가 `worker-start --task --agent --worktree --model --effort --timeout-ms`를 호출한다
+Then `--model` 값은 provider가 정의한 opaque model id 문자열이고 `--effort` 값은 effort 레벨 문자열이며, 티어 이름을 값으로 갖는 인자가 0건이다
+And 경계 argv에서 `balanced`, `ultra`, `opus`, `sonnet`, `haiku` 각 토큰의 출현 횟수가 각각 0이다. 판정은 인자 값 전체와의 완전 일치이므로 `claude-opus-4-1`처럼 provider가 정의한 model id 안에 부분 문자열로 포함된 경우는 위반이 아니고, `--model opus`처럼 티어·패밀리 이름을 그대로 넘기는 것이 위반이다
+And 티어 사다리의 단일 출처는 정책 평면에 남는다. `--model`과 `--effort` 외에 티어에서 파생된 인자가 경계에 추가되면 실패다
+And SPEC-EXECPLANE-001 S2가 orca 명령 표면 전수 검색에서 얻은 0건과 이 시나리오가 실제 argv에서 얻는 0건은 같은 어휘 무증식 원칙의 두 관측 지점이다
+
+### S108: handoff 스텁이 실행으로 대체되고 결과가 omp 경로와 같은 형태로 남는다
+Priority: Must
+Given 지원되는 구성, 즉 로컬 worktree·검증된 티어 정합·`--platform omp --execution-owner orca`로 파이프라인을 실행한 상태
+When 실행이 완주하거나 실패로 끝난다
+Then 최종 결과의 `status`가 `handoff_required`가 아니고, 이 구성에서 `internal/cli/pipeline_run.go:162`의 handoff 반환이 호출된 횟수가 0이다
+And 5개 phase 결과와 체크포인트가 omp 경로와 같은 스키마로 같은 `pipelineStateDir`에 남아, 결과 파일만으로는 실행 소유자를 구분할 수 없다
+And 실패로 끝난 경우에도 terminal 상태와 실패 phase가 omp 경로와 같은 필드로 관측되고, 사람이 손으로 이어받으라는 안내가 최종 결과에 없다
+And 비지원 구성(원격 환경 등)은 이 SPEC의 비목표이므로 그 경로가 `handoff_required`를 반환하는 것은 위반이 아니다. 판정 범위는 지원 구성으로 한정한다
+
+## Oracle Acceptance Notes
+
+- **S101** — 예상 값: orca 전용 러너·순서 테이블·게이트 판정 구현 수 = 0, 백엔드가 엔진에 노출하는 메서드 수 = 1(`Execute`). 두 경로의 `EngineConfig` 비교에서 다른 필드 = `Backend` 1개. "같은 결과가 나오면 통과"는 오라클이 아니다.
+- **S102** — 예상 값: task deps 길이 = 0, `--deps` 출현 횟수 = 0, 프로세스 평면의 phase 순서 자료구조 수 = 0, 관측된 phase 순서 = plan, test_scaffold, implement, validate, review.
+- **S103** — 예상 값: attempt 1회당 시작 Dispatch = 1, 종결 = 1. 클린 런 총 Dispatch = 5. validate 최대 4, review 최대 3(각각 `MaxRetries + 1`). 영수증 `dispatch_count`와 워커 시작 수의 차이 = 0.
+- **S104** — 예상 값: 무응답 워커에서 `TimedOut` = true, 백엔드 보유 출력 바이트 = 설정 상한 이하, 잘림이 발생한 실행의 `FailureClass` = 비어 있지 않음. deadline 값과 읽기 상한 값 자체는 구현 시 확정하되, 둘 다 유한해야 한다는 점이 판정 조건이다.
+- **S105** — 예상 값: 세 경로 각각에서 `worker-list --terminal-state active` 행 수 = 0, 미종결 Dispatch = 0. abandon으로 펜싱한 건에는 사유가 1건씩 남는다.
+- **S106** — 예상 값: `checked_at` < Run 생성 시각(부호는 엄격 부등호). 게이트 미통과 실행의 `run-create` 호출 = 0, `worker-start` 호출 = 0.
+- **S107** — 예상 값: 경계 argv에서 `balanced` = 0, `ultra` = 0, `opus` = 0, `sonnet` = 0, `haiku` = 0. 판정 규칙은 인자 값 전체의 완전 일치이며, 이 규칙을 부분 문자열 검색으로 바꾸면 정상적인 provider model id가 오탐된다.
+- **S108** — 예상 값: 지원 구성에서 `status == "handoff_required"`인 최종 결과 수 = 0, 체크포인트에 기록된 완료 phase 수 = 5, omp 경로와 다른 결과 필드 수 = 0.
+- **자동화 이월**: 이 SPEC은 설계 고정 문서이고 구현을 포함하지 않는다. 따라서 S101~S108은 지금 자동 테스트로 닫히지 않고, T101~T104 구현 작업의 오라클로 이월된다. 이 SPEC의 통과 조건은 4개 문서의 `auto spec validate` 통과와 DAG 소유권 선택에 대한 리뷰 합의다.
+- **오류 경로 위치**: 별도 Edge Cases 절을 두지 않았다. 실패·취소·종료 경로는 S105가, 무응답·과다 출력 경로는 S104가, 비지원 구성 경로는 S108이 각각 담당한다.
+- **Completion Debt와 자동화 가능 범위**: `--agent` 값 집합이 미정이므로 S107의 argv 전수 검사는 `--agent` 값을 판정 대상에서 제외한 상태로만 고정된다. 워커 settled 판정 방법이 미정이므로 S103과 S104는 stub 백엔드 수준에서만 고정 가능하고, 실제 orca 런타임 기준 자동화는 상태 필드 이름과 종료 상태 집합이 확정된 뒤에 가능하다. 워커 출력에서 phase 결과를 뽑는 규약이 미정이므로 S108의 결과 형태 일치 판정은 스키마 비교까지만 가능하고 내용 추출 경로는 규약 확정 후에 붙는다. 재개 시 Run 재바인딩 정책이 미정이므로 S106의 시각 비교는 신규 실행 기준으로만 고정되며, `--continue` 경로의 기준 Run 시각은 정책 확정 후 S106에 추가된다.
+- **주의: S101과 S102는 같은 불변식의 두 각도다**. S102는 프로세스 평면에 DAG가 생기지 않았음을, S101은 정책 평면에 순서·게이트·재시도 구현이 하나뿐임을 잰다. 한쪽만 통과해도 평면 분리는 깨질 수 있다. `--deps` 없이 orca task를 만들면서 autopus 쪽에 orca 전용 러너를 따로 두면 S102는 통과하고 S101이 실패한다. 반대로 엔진을 그대로 쓰면서 task에 deps를 채우면 S101은 통과하고 S102가 실패한다. 두 시나리오는 함께 통과해야 의미가 있고, 하나라도 실패하면 REQ-101·REQ-102를 함께 미달로 판정한다.
+
+## Definition of Done
+
+- [ ] S101~S108이 REQ-101~REQ-108과 1:1로 대응하고 각 Then이 관측 가능한 값을 지명한다
+- [ ] 5개 불변식(INV-101~INV-105)이 각각 최소 한 시나리오의 판정에 연결된다
+- [ ] Completion Debt 4건이 어느 시나리오의 자동화를 막는지 명시된다
+- [ ] `auto spec validate .autopus/specs/SPEC-EXECPLANE-002`가 통과한다

--- a/.autopus/specs/SPEC-EXECPLANE-002/plan.md
+++ b/.autopus/specs/SPEC-EXECPLANE-002/plan.md
@@ -1,0 +1,219 @@
+# SPEC-EXECPLANE-002 Plan: orca 감독 실행을 PhaseBackend로 구현
+
+**Created**: 2026-08-11
+**Domain**: EXECPLANE
+**Kind**: 설계 고정(design-only). 구현 코드는 이 SPEC의 산출물이 아니다.
+
+## Implementation Strategy
+
+### 접합점이 이미 있다 — 단일 메서드가 범위를 어디까지 줄이는가
+
+`pkg/pipeline/engine.go:29-31`의 `PhaseBackend`는 메서드가 하나다 — `Execute(ctx, PhaseRequest) (*PhaseResponse, error)`. 이 사실이 범위 결정을 대신 해 준다. 엔진이 백엔드에게 요구하는 것은 "이 프롬프트를 실행하고 출력을 돌려달라" 하나뿐이고, 그 밖의 전부 — phase 순서, 게이트 판정, 재시도 카운팅, 체크포인트, 프롬프트 조립 — 는 백엔드 바깥에 있다(F1, Feature Coverage Map).
+
+줄어든 크기는 셀 수 있다. 5-phase와 게이트·재시도는 `pkg/pipeline/phase.go:34-42`에 이미 **데이터로** 박혀 있다 — plan → test_scaffold → implement → validate(`GateValidation`, `MaxRetries: 3`) → review(`GateReview`, `MaxRetries: 2`). 따라서 orca 경로가 새로 정의하는 표면은 Feature Coverage Map 7개 중 **1개**(phase 실행 프로세스)이고 나머지 6개는 불변이다. 백엔드가 갖는 메서드는 `Execute` 하나와 run-scoped 해제 훅 `PhaseBackendCloser.Close()` 하나, 합쳐 둘이다(`engine.go:34-36`). 구조 선례도 있다 — `internal/cli/pipeline_backend_omp.go:16-46`이 `config + mu + run-scoped 리소스 + Close()` 모양을 이미 쓴다(F6). 새 관례를 발명하지 않는다.
+
+여기서 계약 하나가 곧바로 파생된다. orca 경로는 omp 경로와 **같은 `EngineConfig`**로 `pipeline.SubprocessEngine`을 구동하고, 갈리는 지점은 주입되는 `Backend` 하나뿐이다(REQ-101). 별도 runner를 세우면 순서·게이트·재시도가 두 벌이 되고, 그 순간 REQ-101의 관측(S101)이 성립할 수 없다. "파이프라인을 orca로 다시 짠다"가 아니라 "백엔드를 하나 더 꽂는다"가 이 SPEC의 형태인 이유다.
+
+### DAG 소유권 — `--deps`를 안 쓰는 것은 기능 낭비가 아니라 평면 분리다
+
+orca에는 `task-create --deps`가 있다(F3). 5-phase를 orca DAG로 그리는 것이 **가능하다**. 가능한 것과 옳은 것은 다르다.
+
+기각한 안 (a)(orca가 5-phase를 `--deps`로 재현)가 프로세스 평면에 복제하게 되는 것을 열거한다. 넷이다.
+
+1. **게이트 판정.** validate는 `GateValidation`을, review는 `GateReview`를 통과해야 다음 간선이 열린다. orca가 순서를 소유하면 orca가 "이 phase가 통과했는가"를 판정해야 하고, 그 판정 기준은 정책 평면의 어휘다.
+2. **재시도 카운팅.** `MaxRetries: 3`(validate)와 `2`(review)는 phase 정의에 붙어 있는 값이다. orca DAG가 재시도를 돌리려면 이 숫자와 소진 규칙이 프로세스 평면에도 있어야 한다. 카운터가 둘이 되는 순간 "몇 번째 시도인가"에 답이 둘 생긴다.
+3. **체크포인트.** 재개는 autopus `pipelineStateDir`가 담당한다. orca task 상태와 autopus 체크포인트가 둘 다 "어디까지 갔는가"를 답하면, 재개 시점에 두 답이 갈릴 수 있고 어느 쪽이 진실인지 정할 규칙이 새로 필요해진다.
+4. **프롬프트 조립.** `PhasePromptBuilder`가 phase별 프롬프트를 만든다. task를 DAG로 미리 만들어 두려면 실행 전에 프롬프트가 확정돼야 하는데, 실제 프롬프트는 앞 phase의 산출물에 의존한다. 미리 조립하면 조립기가 둘이 되고, 미리 조립하지 않으면 DAG를 먼저 그릴 이유 자체가 사라진다.
+
+넷 모두 SPEC-EXECPLANE-001 INV-001(어휘 무증식) 위반이며, 4번은 그에 더해 자기모순이다 — DAG를 선행 생성해 얻으려던 이익이 조건을 충족하는 순간 소멸한다. 그리고 `pkg/adapter/omp/omp_workflow_render.go:77-78`의 단일 DAG 소유자 불변식이 두 DAG의 공존을 애초에 금지하므로, 이 선택은 취향이 아니라 배타적 분기다(F5).
+
+그래서 (b)를 택한다. orca task는 `--deps` 없이 만들고, orca는 DAG를 만들지 않고 워커 하나씩만 감독한다(REQ-102 / INV-101). 쓸 수 있는 기능을 놀리는 것으로 보일 수 있으나, `--deps`는 orca가 **자기 워크플로**를 소유할 때 쓰라고 있는 것이지 남의 DAG를 대신 그리라고 있는 것이 아니다. 이 접합면에서 orca가 실제로 파는 값은 격리(워크트리)·감독(워커 수명)·durability 셋이고, 그 셋은 `--deps` 없이 전부 얻어진다. 반대로 `--deps`를 쓰면 위 네 가지를 얻는 대가 없이 복제한다.
+
+배치는 이미 준비돼 있다. `internal/cli/pipeline_run.go:147-163`에서 티어 정합 게이트가 `handoff_required` 반환보다 **위**에 있다. 이 SPEC은 그 `return`을 orca 백엔드 선택으로 바꾸는 것이고, 게이트가 이미 그 위에 있으므로 INV-105(게이트 선행)는 새 순서 제약이 아니라 기존 배치의 부산물로 충족된다(F4).
+
+### 왜 계약만 고정하고 구현을 분리하는가
+
+research.md `## Completion Debt` 4건은 전부 orca 런타임을 실제로 구동해야 답이 나온다 — `--agent` 값 집합, 워커 settled 판정 방법, 워커 출력에서 phase 결과를 추출하는 규약, 재개 시 Run 재바인딩 정책. 네 답은 구현 선택을 실제로 가른다. settled를 읽을 상태 필드가 없으면 폴링 루프 대신 다른 대기 수단을 써야 하고, `worker-read`의 터미널 텍스트에서 결과를 안정적으로 뽑을 수 없으면 워커 쪽이 `orchestration send --outcome --report-path`로 결과를 밀어 올리는 반대 방향 설계가 된다. 같은 계약에 대해 코드가 두 갈래로 갈린다.
+
+그러나 **계약 자체는 네 답과 무관하게 고정된다.** 이 문서가 정하는 것은 "무엇을 지켜야 하는가"이지 "어떤 호출로 지키는가"가 아니다. INV-102(1:1 Dispatch)는 settled를 어떤 필드로 읽든 성립해야 하고, INV-103(바운드)은 대기가 폴링이든 블로킹이든 deadline과 읽기 상한을 요구하며, INV-104(정리)는 결과 추출 규약이 무엇이든 모든 Dispatch의 종결을 요구한다. 네 답이 바꾸는 것은 계약을 만족시키는 **수단**이지 계약의 **내용**이 아니다.
+
+분리에는 방향성이 하나 더 있다. Debt 4건은 문서 작업으로 닫히지 않고 런타임 프로브로만 닫힌다. 계약을 먼저 고정해 두면 그 프로브가 "orca로 무엇을 할 수 있나"라는 열린 탐색이 아니라 "이 계약을 어느 호출로 만족시키나"라는 닫힌 질문이 된다. T102가 정확히 그 자리이며, 이 분리는 spec.md `## Out of Scope` 첫 항목("이 SPEC의 구현 코드")과 일치한다.
+
+## File Impact Analysis
+
+이 SPEC은 설계 고정 문서이므로 소스 파일을 변경하지 않는다. 산출물은 SPEC 디렉터리의 4개 문서뿐이다.
+
+| 파일 | 작업 | 설명 |
+|------|------|------|
+| `.autopus/specs/SPEC-EXECPLANE-002/spec.md` | 생성 | REQ-101~108, Outcome Boundary, Traceability Matrix, Out of Scope |
+| `.autopus/specs/SPEC-EXECPLANE-002/research.md` | 생성 | 실측 근거 F1~F6, 불변식 INV-101~105, Completion Debt 4건 |
+| `.autopus/specs/SPEC-EXECPLANE-002/plan.md` | 생성 | 이 문서. DAG 소유권 논증과 T101~T104 설계 태스크 |
+| `.autopus/specs/SPEC-EXECPLANE-002/acceptance.md` | 생성 | S101~S108 시나리오와 Oracle Acceptance Notes |
+
+아래 코드는 **참조 대상**이며 이 SPEC에서 수정하지 않는다: `pkg/pipeline/engine.go`, `pkg/pipeline/phase.go`, `internal/cli/pipeline_run.go`, `internal/cli/pipeline_backend_omp.go`, `pkg/adapter/omp/omp_workflow_render.go`.
+
+## Architecture Considerations
+
+- **의존 방향**: 정책 -> 프로세스 단방향만 허용한다. 백엔드는 orca 명령을 호출하지만 orca는 autopus의 phase·게이트·재시도 어휘를 참조하지 않는다. 역방향 참조가 생기면 INV-101이 깨진다.
+- **경계 통과 값의 형태**: `worker-start`에 넘기는 것은 opaque provider model id와 effort뿐이다(REQ-107 / INV-101). `worker-start`가 이미 opaque id 소비자로 정의돼 있으므로(F3 노트) 새 계약이 아니라 기존 인터페이스를 그대로 지키는 것이다. 티어 문자열은 경계에서 소멸한다.
+- **리소스 스코프 두 층**: Run은 run-scoped(백엔드 생성 시 `run-create` 1회, `Close()`에서 정리)이고 task·워커는 attempt-scoped(`Execute` 1회당 1세트)다. 두 층을 한 뮤텍스 아래 두는 `pipelineOMPBackend` 형태를 따르면 정리 책임의 소재가 한 곳에 남는다(F6).
+- **omp 경로 회귀 0**: 갈리는 것은 주입되는 `Backend` 하나뿐이므로 omp 경로의 코드 경로는 손대지 않는다. spec.md `## Out of Scope`의 "omp 경로 동작 변경" 항목과 같은 제약이다.
+- **기존 관측 표면 재사용**: 실행 결과는 omp 경로와 같은 `PhaseResponse`·체크포인트 표면으로 남긴다(REQ-108). 새 결과 스키마를 만들지 않는다.
+
+## Visual Planning Brief
+
+`Execute` 한 번의 **런타임 생애**다. research.md의 정적 평면 다이어그램과 달리 여기서는 시간이 위에서 아래로 흐르고, 세로 경계선이 두 평면의 소유권을 가른다.
+
+```
+[정책 평면: autopus 엔진]                                         | [프로세스 평면: orca]
+소유: 순서 · 게이트 · 재시도 · 체크포인트 · 프롬프트              | 소유: 격리 · 감독 · durability · 회수
+                                                                  |
+=== Run 수명 시작 — 백엔드 1개당 1회 =============                | ===================================
+  T0  티어 정합 게이트 (SPEC-EXECPLANE-001)                       | 리소스 0건. 워크트리·Run·워커 없음
+        |  실패 -> 종료. Run을 만들지 않는다                      |
+        v  통과: receipt.checked_at = T0                          |
+  T1  run-create                          ===>                    | Run 생성 — T1 > T0 (INV-105)
+                                                                  |
+- - - attempt 수명 시작 — Execute 1회 = attempt 1회 - - - - - - - |
+  Execute(ctx, req{PhaseID, Attempt, Prompt})                     | |
+        |                                                         | |
+  (1)  task-create --spec                  ===>                   | task 생성 · deps 빈 배열 (INV-101)
+        |   --deps를 넘기지 않는다                                | orca 쪽 DAG 없음
+        v                                                         | |
+  (2)  worker-start --task --agent --worktree                     | |
+         --model --effort --timeout-ms     ===>                   | Dispatch #N 시작 — 정확히 1건
+        |   경계를 넘는 값: opaque model id + effort              | (INV-102)
+        |   티어 이름은 넘기지 않는다 (REQ-107)                   | 워커가 워크트리 안에서 실행
+        v                                                         | |
+  (3)  worker-show 폴링 루프               <==>                   | 워커 상태
+        |   조건: settled 아님 AND now < deadline                 | |
+        |   deadline = ctx 마감 & 대기 상한 (INV-103)             | |
+        +-- 마감 초과 ------------+                               | |
+        v settled                 |                               | |
+  (4)  worker-read --cursor --limit        <===                   | 출력 — 누적 상한까지만 (INV-103)
+        |                         |                               | |
+        v                         v                               | |
+  (5a) PhaseResponse{Output,   (5b) PhaseResponse                 | |
+        ExitCode, FailureClass}   {TimedOut: true}                | |
+        +------------+------------+                               | |
+                     v                                            | |
+  (6)  종결 — 어느 경로로 오든 정확히 1회                         | |
+        정상           -> worker-release   ===>                   | Dispatch settled
+        마감 초과·취소 -> worker-stop      ===>                   | Dispatch settled
+        정지 주장 불가 -> worker-abandon   ===>                   | Dispatch 펜싱 (INV-104)
+- - - attempt 수명 끝 — 살아있는 Dispatch 0건 - - - - - - - - - - |
+        |                                                         | |
+        v                                                         | |
+  게이트 판정 · 재시도 카운팅 · 체크포인트 기록                   | 관여 없음
+        |   정책 평면 단독. orca는 이 판정을 보지 않는다          | |
+        +-- 통과        -> 다음 phase, Attempt=1  --+             | |
+        +-- 실패·여유   -> 같은 phase, Attempt+1  --+             | |
+        |     어느 쪽이든 새 attempt = 새 task +    |             | |
+        |     새 worker-start = 새 Dispatch.        |             | |
+        |     워커 재사용도 재바인딩도 없다(INV-102)|             | |
+        |   +---------------------------------------+             | |
+        |   v  (1)로 되돌아간다                                   | |
+        |                                                         | |
+        +-- 재시도 소진 또는 5-phase 완주                         | |
+             v                                                    | |
+  Close()  잔여 Dispatch 전부 종결          ===>                  | worker-list --terminal-state
+           결과는 omp 경로와 같은 표면으로 반환                   |   active == 0건 (INV-104)
+           handoff_required가 아니다 (REQ-108)                    | |
+=== Run 수명 끝 ==================================                | ===================================
+```
+
+읽는 법 넷.
+
+1. **두 수명이 다른 띠로 그려져 있다.** `===` 띠는 Run 수명(백엔드 1개당 1회, `run-create`에서 열려 `Close()`에서 닫힘)이고 `- - -` 띠는 attempt 수명(`Execute` 호출마다 열리고 닫힘)이다. 5-phase에 validate 3회·review 2회의 재시도 여유가 붙으므로 하나의 `===` 띠 안에서 `- - -` 띠가 여러 번 열린다. Run을 attempt마다 새로 만들지 않는 이유는 워크트리와 계정 바인딩이 실행 전체의 속성이지 phase의 속성이 아니기 때문이다.
+2. **세로선이 소유권 선언이고, 경계를 넘는 것은 명령 호출뿐이다.** 판정은 한 번도 경계를 넘지 않는다 — 그래서 "게이트 판정 · 재시도 카운팅 · 체크포인트" 블록의 오른쪽이 "관여 없음"이다. 같은 이유로 T0의 게이트도 왼쪽에만 있고, 실패하면 화살표가 아예 오른쪽으로 건너가지 않는다. 검증되지 않은 티어 계약 아래에서 워커가 뜨는 경로가 그림에 존재하지 않는다(INV-105).
+3. **재시도는 attempt 띠를 다시 여는 것이지 워커를 되살리는 것이 아니다.** 루프 화살표가 (6) 종결 **뒤**에서 (1)로 돌아가므로, attempt N의 Dispatch는 attempt N+1이 시작되기 전에 이미 settled다. 두 Dispatch가 동시에 살아 있는 구간이 그림에 없다(INV-102). `worker-start`에 `--retry-of`가 있으나(F3) 이 계약은 그 플래그의 의미에 기대지 않는다 — 쓰든 쓰지 않든 새 attempt는 새 Dispatch다.
+4. **성공·실패·타임아웃이 종결 블록을 공유한다.** (3)의 마감 초과 화살표는 별도 출구로 빠지지 않고 (5b)를 거쳐 (6)의 같은 블록으로 합류한다. 따라서 "실패해서 정리를 못 한 경로"는 그림상 그릴 수 없다(INV-104). `Close()`는 그 위의 안전망이지 유일한 정리 수단이 아니며, 정지를 주장할 수 없는 경우에는 release 대신 abandon으로 펜싱한다.
+
+## Feature Completion Scope
+
+이 SPEC은 **설계 고정 문서**다. 완료 판정에 동작하는 코드나 통과하는 테스트를 요구하지 않는다. Outcome Lock을 닫는 것은 "orca 경로가 5-phase를 완주한다"가 아니라 "완주하기 위한 접합 계약과 소유권 경계가 더 이상 해석의 여지 없이 고정됐다"다.
+
+완료 조건은 spec.md `## Outcome Boundary`의 Completion evidence와 동일하게 셋이다.
+
+1. 4개 SPEC 문서(`spec.md`·`plan.md`·`acceptance.md`·`research.md`)가 `auto spec validate`를 통과한다.
+2. DAG 소유권 선택((b) — autopus가 순서를 소유하고 orca는 워커만 감독)에 대한 리뷰 합의가 기록된다. research.md `## Reviewer Brief`의 1번 질문이 그 자리다.
+3. research.md Completion Debt 4건이 해소되거나 **착수 중 해소 가능한 항목으로 분류**된다. 네 건 모두 런타임 프로브로만 닫히므로 이 SPEC 안에서 해소되지 않는다. 분류가 완료 조건이다.
+
+| 구분 | 항목 |
+| --- | --- |
+| **범위 안** | `PhaseBackend` 접합 계약과 omp 경로와 동일한 `EngineConfig` 요구 (REQ-101 / S101) |
+| | orca task를 `--deps` 없이 만든다는 DAG 소유권 선언 (REQ-102 / S102) |
+| | phase attempt와 Dispatch의 1:1 대응 규칙 (REQ-103 / S103) |
+| | 워커 대기 deadline과 출력 읽기 상한의 계약, 초과 시 `TimedOut`/`FailureClass` 표기 (REQ-104 / S104) |
+| | 실패·취소·`Close()` 경로의 종결 계약과 release / stop / abandon 선택 규칙 (REQ-105 / S105) |
+| | 티어 정합 게이트가 Run 생성보다 앞선다는 순서 계약 (REQ-106 / S106) |
+| | 경계를 넘는 인자를 opaque model id와 effort로 한정하는 규칙 (REQ-107 / S107) |
+| | handoff 스텁 대체와 결과 표면의 omp 동형성 (REQ-108 / S108) |
+| | S101~S108 시나리오와 그 관측 지점 |
+| **범위 밖** | 이 SPEC의 구현 코드. 계약만 고정한다 |
+| | phase 내부에서 executor를 여러 워커로 병렬 fan-out하는 일 |
+| | `gate-create`/`gate-resolve`로 사람 결정을 파이프라인에 끼우는 일 |
+| | 원격 환경(`worker-start --on <saved-environment>`) 지원 |
+| | 5-phase 집합 변경, 게이트·재시도 semantics 변경 |
+| | omp 경로 동작 변경. 회귀 0을 유지한다 |
+| | 실행 원장 통합 |
+
+범위 밖 목록은 spec.md `## Out of Scope`의 7항목과 1:1 대응이다. 새 항목을 추가하지 않았다.
+
+**관측 한계.** 이 문서의 orca 쪽 주장은 전부 `orca agent-context --json`의 명령 스키마에서 나왔고, orca 런타임을 실제로 구동한 관측은 없다. 그 결과 Completion Debt 4건이 미해소로 남는다 — `--agent` 값 집합, settled 판정 필드와 종료 상태 집합, 워커 출력에서 `PhaseResponse.Output`을 얻는 규약, `--continue` 재개 시 Run 재바인딩 정책. 그럼에도 계약이 성립하는 이유는 넷 다 **계약의 내용이 아니라 만족 수단**을 정하기 때문이다. 1:1 Dispatch·바운드·정리·게이트 선행은 어떤 명령 조합으로 구현하든 동일하게 요구되고, S103~S105는 호출 시퀀스가 아니라 관측 가능한 결과(Dispatch 개수, deadline 초과 시 응답 필드, 잔여 `active` 0건)로 판정된다. 따라서 Debt는 계약을 미완으로 만들지 않고 T102·T103 착수의 첫 단계를 정의한다.
+
+## Tasks
+
+T101~T104는 모두 **설계·문서·합의 산출물**이다. 코드 작성 태스크는 없다 — 구현은 위 Feature Completion Scope의 범위 밖이다.
+
+- [ ] **T101 — PhaseBackend 접합 계약과 DAG 소유권 선언 확정** (REQ-101, REQ-102 / INV-101 / S101, S102)
+  - 산출물: (i) orca 경로가 omp 경로와 **같은 `EngineConfig`**로 `pipeline.SubprocessEngine`을 구동하고 차이가 주입 `Backend` 하나뿐임을 못박은 접합 선언, (ii) `task-create` 호출에서 `--deps`를 넘기지 않는다는 금지 규칙과 그 근거(위 네 가지 복제 목록), (iii) 기각한 안 (a)를 되살리려면 무엇을 먼저 뒤집어야 하는지의 기록.
+  - 완료 판정: S101에서 두 경로의 `EngineConfig` 차이가 `Backend` 하나로 특정되고, S102에서 생성된 task의 deps가 빈 상태이며 순서 결정의 출처가 `DefaultPhases()` 단일임이 문서만 보고 판정된다. research.md `## Reviewer Brief` 1번 질문에 대한 판단이 기록된다.
+
+- [ ] **T102 — 워커 수명과 바운드 계약 확정** (REQ-103, REQ-104 / INV-102, INV-103 / S103, S104)
+  - 산출물: (i) `Execute` 1회 = task 1개 + `worker-start` 1회 + 종결 1회라는 1:1 규칙과, 재시도가 새 attempt이므로 새 Dispatch를 갖는다는 규칙, (ii) 대기 deadline의 출처(`ctx` 마감과 백엔드 대기 상한 중 먼저 오는 쪽)와 출력 읽기의 누적 상한, 그리고 두 한계 초과 시 `PhaseResponse`가 `TimedOut` 또는 `FailureClass`로 사유를 드러낸다는 표기 규칙.
+  - **이 태스크가 Completion Debt 2건을 해소해야 한다.** ① **워커 settled 판정 방법** — `worker-show`가 노출하는 상태 필드 이름과 종료 상태 집합을 확정해야 폴링 종료 조건이 정의된다. 확정 전에는 "settled"가 계약 문장에만 있고 관측 가능한 술어가 되지 못한다. ② **워커 출력에서 phase 결과를 추출하는 규약** — `worker-read`가 주는 터미널/트랜스크립트 텍스트를 `PhaseResponse.Output`으로 삼을지, 아니면 워커 쪽이 `orchestration send --outcome --report-path`로 구조화된 결과를 밀어 올릴지를 정해야 한다. 두 선택은 읽기 상한의 의미도 바꾼다 — 전자는 텍스트 바이트 상한, 후자는 보고 파일 크기 상한이다. 둘 다 orca 런타임을 구동해야 답이 나오므로, 이 태스크의 첫 단계는 문서 작업이 아니라 프로브다.
+  - 완료 판정: S103에서 한 attempt에 대한 Dispatch 시작 1건·종결 1건이 관측 가능한 술어로 적혀 있고, S104에서 대기 초과와 출력 초과 각각에 대해 반환되는 `PhaseResponse` 필드가 유일하게 결정된다. Debt 2건이 관측된 필드명·상태값으로 닫히거나, 닫히지 않으면 그 사실과 대안 설계가 명시된다.
+
+- [ ] **T103 — 종결·정리 계약과 결과 표면 확정** (REQ-105, REQ-108 / INV-102, INV-104 / S105, S108)
+  - 산출물: (i) 정상 완료·실패·취소·`Close()` 네 경로 각각에 대해 `worker-release` / `worker-stop` / `worker-abandon` 중 무엇을 쓰는지의 선택 규칙과, **프로세스 정지를 주장할 수 없는 경우에는 release 대신 abandon으로 펜싱한다**는 규정, (ii) run-scoped 리소스(Run)와 attempt-scoped 리소스(task·워커)의 정리 책임 분담 — attempt 정리는 `Execute` 안에서 끝나고 `Close()`는 잔여분에 대한 안전망이라는 선언, (iii) 실행 결과를 omp 경로와 같은 표면으로 반환하며 지원 구성에서 `handoff_required`를 최종 상태로 남기지 않는다는 규칙.
+  - 완료 판정: S105에서 실패·취소·종료 어느 경로로 가도 이 Run의 `worker-list --terminal-state active`가 0건이 되는 근거가 경로별로 제시되고, S108에서 성공·실패 두 경우의 결과 형태가 omp 경로와 같음이 확정되며 `handoff_required`가 반환되는 남은 경우(비지원 구성)가 명시적으로 열거된다. Debt의 "재개 시 Run 재바인딩 정책"이 이 태스크의 정리 책임 분담과 충돌하지 않음이 확인된다.
+
+- [ ] **T104 — 게이트 선행 순서와 경계 인자 확정** (REQ-106, REQ-107 / INV-101, INV-105 / S106, S107)
+  - 산출물: (i) 티어 정합 게이트가 `run-create`보다 반드시 앞선다는 순서 계약과 그 관측 방법(정합 영수증의 `checked_at` < Run 생성 시각), 그리고 게이트를 우회해 Run이 만들어지는 경로가 존재하지 않음의 논증 — `internal/cli/pipeline_run.go:147-163`에서 게이트가 이미 반환점 위에 있다는 배치 근거(F4)를 함께 기록한다, (ii) `worker-start`에 넘기는 인자에서 금지되는 티어 토큰 목록(`balanced`/`ultra`/`opus`/`sonnet`/`haiku`)과 허용되는 통과 값(opaque provider model id, effort)의 명시.
+  - 완료 판정: S106에서 게이트 실패 시 Run이 생성되지 않음이 배치만으로 도출되고, S107에서 경계를 넘는 인자 집합에 금지 토큰이 하나도 없음이 인자 목록만 보고 판정된다. 게이트 semantics는 SPEC-EXECPLANE-001의 것을 그대로 쓰고 이 SPEC에서 변경하지 않음이 명시된다.
+
+REQ 커버리지: REQ-101·102(T101), REQ-103·104(T102), REQ-105·108(T103), REQ-106·107(T104) — 8건 전부 덮이며 spec.md `## Traceability Matrix`와 일치한다.
+
+## Risks & Mitigations
+
+| 리스크 | 영향도 | 대응 |
+|--------|--------|------|
+| Completion Debt 2건(settled 판정, 결과 추출)이 T102에서도 닫히지 않는다 | 중간 | 둘 다 런타임 프로브로만 닫히고 문서 작업으로는 닫히지 않는다. T102의 첫 단계를 프로브로 규정하고, 닫히지 않을 경우 대안 설계(`orchestration send --outcome --report-path` 경로)를 함께 남기도록 완료 판정에 요구했다. 계약 문장은 두 답 어느 쪽에서도 동일하다 |
+| 구현 단계에서 편의를 위해 `--deps`가 슬그머니 들어온다 | 중간 | 위 네 가지 복제 목록을 T101 산출물에 못박고, S102가 "deps가 빈 상태"를 관측 지점으로 갖는다. 되살리려면 무엇을 먼저 뒤집어야 하는지도 T101에 기록하게 해 우회가 조용히 일어나지 않게 한다 |
+| 재시도 경로에서 이전 워커를 재사용하려는 유혹이 INV-102를 깬다 | 중간 | `worker-start --retry-of`의 존재가 재사용처럼 읽힐 수 있다. 다이어그램이 종결 뒤에 루프를 두어 두 Dispatch의 동시 생존 구간을 없앴고, T102 산출물이 "새 attempt = 새 Dispatch"를 규칙으로 못박는다. 이 계약은 `--retry-of`의 의미에 기대지 않는다 |
+| 실패 경로에서 `Close()`만 믿고 attempt 정리를 생략한다 | 중간 | 정리 책임을 두 층으로 나눠 attempt 정리는 `Execute` 안에서 끝내고 `Close()`를 안전망으로만 둔다(T103). S105가 경로별 근거를 요구하므로 "Close에서 다 치운다"는 한 줄로는 완료 판정이 서지 않는다 |
+| 워커 출력이 커서 메모리를 소진하거나 정지한 워커가 파이프라인을 잡는다 | 중간 | REQ-104가 대기 deadline과 읽기 상한 둘 다를 요구한다. 한쪽만 두면 나머지 실패 양식이 남는다는 점을 T102 완료 판정이 두 시나리오(대기 초과·출력 초과)로 분리해 강제한다 |
+| 재개(`--continue`) 시 새 Run을 만들지 기존 Run에 붙일지가 미정이라 체크포인트와 어긋난다 | 낮음 | Debt 4번째 항목이며 이 SPEC의 요구 8건 중 어느 것도 재개 정책에 의존하지 않는다. T103 완료 판정이 정리 책임 분담과의 무충돌만 확인하고, 정책 확정은 착수 중 해소 항목으로 분류한다 |
+| 설계만 고정하고 구현을 분리한 결과 handoff 스텁이 계속 남는다 | 중간 | 분리는 spec.md `## Out of Scope`에 명시된 결정이다. 접합점이 단일 메서드라 후속 구현이 발명할 것이 없고, 남는 미결이 Debt 4건으로 좁혀져 있어 착수 장벽이 낮다 |
+
+## Dependencies
+
+- **SPEC-EXECPLANE-001** — 세 평면 모델, INV-001(어휘 무증식), 티어 정합 게이트. 이 SPEC은 그 결과를 입력으로 받고 게이트 semantics를 변경하지 않는다.
+- **`pkg/pipeline` 엔진** — `PhaseBackend`/`PhaseBackendCloser`(`engine.go:29-36`), `DefaultPhases()`(`phase.go:34-42`). 접합면이자 불변 전제다. 인터페이스 변경을 요구하지 않는다.
+- **`internal/cli/pipeline_backend_omp.go`** — 백엔드 구조의 선례(F6). 형태만 따르고 코드를 수정하지 않는다.
+- **orca orchestration CLI** — `run-create` / `task-create` / `worker-start` / `worker-show` / `worker-read` / `worker-list` / `worker-release` `worker-stop` `worker-abandon`(F3). orca를 소비자로만 취급하며 CLI 표면 변경을 요구하지 않는다.
+- **orca 런타임 구동** — Completion Debt 4건의 유일한 해소 수단. 문서 작업으로 대체할 수 없다.
+- **`auto spec validate`** — 완료 조건 1번의 검증 수단.
+
+새 외부 라이브러리 의존은 없다. 설계 문서이므로 코드 의존도 추가하지 않는다.
+
+## Exit Criteria
+
+- [ ] `auto spec validate .autopus/specs/SPEC-EXECPLANE-002`가 4개 문서에 대해 통과한다
+- [ ] T101~T104의 산출물이 모두 존재하고 REQ-101~108 8건을 빠짐없이 덮는다
+- [ ] DAG 소유권 선택 (b)에 대한 리뷰 합의가 기록됐다 — research.md `## Reviewer Brief` 1번
+- [ ] Completion Debt 4건이 각각 해소 또는 착수 중 해소 가능 항목으로 분류됐다
+- [ ] 범위 밖 목록이 spec.md `## Out of Scope` 7항목과 1:1로 대응하고 모순되지 않는다
+
+구현 증거·테스트 통과·커버리지 수치는 이 SPEC의 종료 조건이 아니다. 설계 고정 문서이며, 구현은 별도 SPEC의 대상이다.

--- a/.autopus/specs/SPEC-EXECPLANE-002/research.md
+++ b/.autopus/specs/SPEC-EXECPLANE-002/research.md
@@ -1,0 +1,188 @@
+# SPEC-EXECPLANE-002 Research: orca 감독 실행을 PhaseBackend로 구현
+
+**Created**: 2026-08-11
+**Domain**: EXECPLANE
+
+## Outcome Lock
+
+`auto pipeline run --platform omp --execution-owner orca`가 handoff 스텁을 반환하고 멈추는 대신, 실제로 orca가 감독하는 워커에서 파이프라인을 끝까지 실행한다. 정책 평면(SPEC·게이트·재시도·체크포인트)은 autopus가 그대로 소유하고, orca는 격리·감독·durability만 제공한다. 어느 평면도 상대의 어휘를 복제하지 않는다.
+
+## Visual Planning Brief
+
+```
+  autopus 엔진 (정책 평면)                      orca (프로세스 평면)
+  DefaultPhases() 5-phase DAG
+  게이트 · 재시도 · 체크포인트
+        |
+        |  phase 하나당 Execute 1회
+        v
+  +-------------------------+
+  | PhaseBackend.Execute    |            run-create        (백엔드 생성 시 1회)
+  |   req.Prompt            |  -------->  task-create      (deps 없음)
+  |   req.PhaseID           |  -------->  worker-start     (--task, --agent, --worktree)
+  |                         |  <-------   worker-show/read (settled까지)
+  |   PhaseResponse.Output  |  -------->  worker-release
+  +-------------------------+
+        |
+        v  (게이트·재시도는 autopus가 판정)
+  다음 phase
+```
+
+`--deps`를 쓰지 않는 것이 핵심이다. 순서는 autopus 엔진이 소유하고, orca는 워커 하나씩만 감독한다.
+
+## Semantic Invariant Inventory
+
+| ID | 불변식 | 유형 | 관측 지점 |
+| --- | --- | --- | --- |
+| INV-101 | orca task는 `--deps` 없이 생성된다. 순서와 게이트는 정책 평면이 소유하므로 프로세스 평면에 두 번째 DAG가 생기지 않는다 | 배타 | 생성된 task의 deps가 빈 배열 |
+| INV-102 | phase 하나당 Dispatch 하나. 워커는 정확히 한 번 시작되고 한 번 회수된다 | 1:1 | `worker-list`의 잔여 terminal 0건 |
+| INV-103 | 워커 출력은 바운드된다. 무한 대기도 무한 버퍼도 없다 | 바운드 | `worker-read --limit`, 백엔드 deadline |
+| INV-104 | 실행이 실패해도 orca 리소스가 남지 않는다. 모든 Dispatch는 release 또는 abandon으로 종결된다 | 정리 | 종료 후 `worker-list --terminal-state active` 0건 |
+| INV-105 | 티어 정합 영수증이 Run 시작 이전에 존재한다. 검증 없이 워커를 띄우지 않는다 | 순서 | `<SPEC-ID>.tier-integrity.json`의 `checked_at` < Run 생성 시각 |
+
+## Feature Coverage Map
+
+| 표면 | 현재 소유자 | 이 SPEC 이후 |
+| --- | --- | --- |
+| 5-phase DAG 정의와 순서 | autopus `pipeline.DefaultPhases()` | 불변 |
+| 게이트 판정과 재시도 | autopus 엔진 | 불변 |
+| 체크포인트·재개 | autopus `pipelineStateDir` | 불변 |
+| 프롬프트 조립 | autopus `PhasePromptBuilder` | 불변 |
+| **phase 실행 프로세스** | omp 서브프로세스 / provider CLI | **orca 감독 워커 추가** |
+| worktree 격리·계정·durability | orca | 불변 |
+| 티어 정합 게이트 | autopus (SPEC-EXECPLANE-001) | 불변, Run 이전에 실행 |
+
+## 측정된 근거
+
+모두 2026-08-11 이 워크스테이션에서 직접 확인했다.
+
+### F1 — `PhaseBackend`는 단일 메서드 인터페이스다
+
+`pkg/pipeline/engine.go:29-31`
+```go
+type PhaseBackend interface {
+	Execute(ctx context.Context, req PhaseRequest) (*PhaseResponse, error)
+}
+```
+
+`PhaseRequest`는 `Prompt`, `PhaseID`, `Attempt`, `OMPExecutionView`(omp 전용)를 담고, `PhaseResponse`는 `Output`, `Provider`, `Backend`, `Role`, `ExitCode`, `TimedOut`, `FailureClass`, `Artifact`를 돌려준다(`engine.go:38-56`). `PhaseBackendCloser`가 run-scoped 리소스 해제 훅을 제공한다(`engine.go:34-36`).
+
+**이것이 접합점이다.** orca 실행은 파이프라인 재구현이 아니라 `PhaseBackend` 구현 하나다.
+
+### F2 — 파이프라인은 5-phase이고 게이트·재시도가 이미 정의돼 있다
+
+`pkg/pipeline/phase.go:34-42`
+```go
+{ID: PhasePlan}
+{ID: PhaseTestScaffold, DependsOn: [plan]}
+{ID: PhaseImplement,    DependsOn: [test_scaffold]}
+{ID: PhaseValidate,     DependsOn: [implement], Gate: GateValidation, MaxRetries: 3}
+{ID: PhaseReview,       DependsOn: [validate],  Gate: GateReview,     MaxRetries: 2}
+```
+
+순서·게이트·재시도가 전부 정책 평면에 있다. 프로세스 평면이 이걸 다시 가질 이유가 없다.
+
+### F3 — orca orchestration 표면은 29개 명령이고 필요한 것이 다 있다
+
+| 목적 | 명령 |
+| --- | --- |
+| Run 수명 | `run-create` `run-use` `run-current` `run-show` `run-list` |
+| task | `task-create --spec --deps --parent` `task-list` `task-update` |
+| 워커 | `worker-start --task --agent --worktree --model --effort --timeout-ms --retry-of` |
+| 관측 | `worker-show` `worker-read --cursor --limit` `worker-list --terminal-state` |
+| 종결 | `worker-release` `worker-stop` `worker-abandon` `worker-retain` |
+| 결정 게이트 | `gate-create` `gate-resolve` `gate-list` |
+| 메시징 | `send` `check` `reply` `inbox` `ask` |
+
+`worker-start`는 `--model`과 `--effort`를 받고, 노트에 *"--model supports Claude, Codex, and Cursor opaque provider model ids; --effort requires --model"*이라 적혀 있다. SPEC-EXECPLANE-001 REQ-002(프로세스 평면에 티어 어휘 무증식)와 정확히 맞는 인터페이스다 — 티어가 아니라 opaque id를 넘긴다.
+
+### F4 — 현재 handoff는 스텁이고 게이트는 이미 그 앞에 있다
+
+`internal/cli/pipeline_run.go:147-163`
+```go
+if platform == "omp" {
+    integrity := pipelineTierIntegritySkipped()
+    if ownerDecision.Owner == pipelineExecutionOwnerOrca {
+        integrity = runPipelineTierIntegrityGate(cmd.Context(), projectDir, specID)
+    }
+    ownerReceipt, ownerReceiptPath, receiptErr := persistPipelineExecutionOwnerReceipt(...)
+    if ownerDecision.Owner == pipelineExecutionOwnerOrca {
+        return emitPipelineExecutionOwnerHandoff(cmd, ownerReceipt, ownerReceiptPath, integrity)
+    }
+}
+```
+
+`return`이 체크포인트 로드·백엔드 생성·엔진 실행보다 앞에 있다. 이 SPEC은 그 `return`을 orca 백엔드 선택으로 바꾼다. 정합 게이트는 이미 그 위에 있으므로 INV-105가 배치로 충족된다.
+
+### F5 — 단일 DAG 소유자 불변식이 설계를 강제한다
+
+`pkg/adapter/omp/omp_workflow_render.go:77-78`
+```
+- The single DAG owner invariant is mandatory: when Orca owns the DAG, the OMP
+  session does not dispatch a competing DAG; when OMP owns it, Orca does not
+  dispatch one.
+- owner `orca` creates no OMP task DAG, and owner `omp` creates no Orca Run.
+```
+
+orca에는 `task-create --deps`가 있어 **자기 DAG를 가질 수 있다**. 그래서 선택이 필요하다.
+
+| 접근 | DAG 소유자 | 결과 |
+| --- | --- | --- |
+| (a) orca가 5-phase를 `--deps`로 재현 | orca | 게이트·재시도·체크포인트를 프로세스 평면에 복제해야 한다. SPEC-EXECPLANE-001 INV-001(어휘 무증식) 위반 |
+| (b) autopus 엔진이 순서를 소유하고 orca는 워커만 감독 | autopus | 정책은 정책 평면에, 격리·감독은 프로세스 평면에. 세 평면 모델과 일치 |
+
+**(b)를 택한다.** orca task는 `--deps` 없이 만든다 — orca는 DAG를 만들지 않고, 워커 하나씩만 감독한다. INV-002를 문자 그대로 지킨다.
+
+### F6 — 기존 백엔드가 구조 선례를 제공한다
+
+`internal/cli/pipeline_backend_omp.go:16-46`이 `pipelineOMPBackendConfig` + `pipelineOMPBackend{mu, config, process}` 형태로 run-scoped 리소스를 뮤텍스 아래 들고 `Close()`로 해제한다. orca 백엔드도 같은 모양을 따르면 새 관례를 만들지 않는다.
+
+## Completion Debt
+
+- [ ] `worker-start`의 `--agent` 값 집합. `worktree create --agent <id>`와 같은 어휘인지, 어떤 id가 유효한지 구현 전에 확정해야 한다.
+- [ ] 워커 settled 판정 방법. `worker-show`의 상태 필드 이름과 종료 상태 집합을 확인해야 폴링 루프를 쓸 수 있다.
+- [ ] 워커 출력에서 phase 결과를 추출하는 규약. `worker-read`는 터미널/트랜스크립트 텍스트를 주는데, 엔진은 `PhaseResponse.Output` 문자열을 기대한다. 구조화된 결과가 필요하면 `orchestration send --outcome --report-path` 경로를 워커 쪽에서 써야 할 수 있다.
+- [ ] 재개(`--continue`) 시 기존 Run에 재바인딩할지 새 Run을 만들지. `run-use`가 있으나 체크포인트와의 결합 규칙이 미정이다.
+
+## Evolution Ideas
+
+- phase 안에서 executor를 여러 워커로 fan-out. `worker-start`를 병렬로 여러 번 부르고 결과를 합치면 route_team의 병렬 구현에 대응한다.
+- `gate-create`/`gate-resolve`로 사람 결정을 파이프라인 중간에 끼우기. 지금은 게이트가 전부 자동 판정이다.
+- 원격 실행. `worker-start --on <saved-environment>`가 이미 있으나 계정 조회가 원격을 지원하지 않아 티어 검증이 unverified로 떨어진다.
+- 워커 출력을 실행 원장으로 흘려 정책·모델·프로세스 세 평면의 관측을 한곳에 모으기.
+
+## Reference Discipline
+
+| 참조 | 유형 | 확인 방법 |
+| --- | --- | --- |
+| `orca agent-context --json` orchestration 29개 명령 | 실측 | 스키마 전수 추출 |
+| `orchestration worker-start` 노트(opaque model id, --effort 요구) | 실측 | 같은 스키마 |
+| `pkg/pipeline/engine.go:29-56` | 코드 | 직접 읽음 |
+| `pkg/pipeline/phase.go:34-42` | 코드 | 직접 읽음 |
+| `internal/cli/pipeline_run.go:147-163` | 코드 | 직접 읽음 |
+| `internal/cli/pipeline_backend_omp.go:16-46` | 코드 | 직접 읽음 |
+| `pkg/adapter/omp/omp_workflow_render.go:77-78` | 코드 | 직접 읽음 |
+| `pkg/pipeline/engine_run.go:102` — `for attempt := 1; attempt <= maxRetries+1` | 코드 | 직접 읽음. attempt 상한이 `MaxRetries+1`임을 고정 |
+| `pkg/pipeline/engine_run.go:115` — `Receipt.DispatchCount++` | 코드 | 직접 읽음. attempt 하나가 Dispatch 하나로 계수됨 |
+| `pkg/pipeline/engine_test.go:42-44` — 클린 런 `DispatchCount == 5` | 코드 | 직접 읽음. 5-phase 무재시도 실행의 기준선 |
+| SPEC-EXECPLANE-001 | 문서 | 이 저장소, PR #155~#159 |
+
+추측은 없다. 위 표에 없는 주장은 담지 않았다. Completion Debt 4건은 orca 런타임을 실제로 구동해야 답할 수 있어 미확인으로 분리했다.
+
+## Reviewer Brief
+
+이 SPEC도 설계 고정이고 구현을 포함하지 않는다. 우선 검증할 것:
+
+1. F5의 (b) 선택이 옳은가. orca에 `--deps`가 있는데 안 쓰는 것이 낭비가 아니라 평면 분리인가.
+2. `PhaseBackend` 한 개로 충분한가. 게이트·재시도·체크포인트가 정말 정책 평면에만 있는가, 아니면 orca 감독이 필요한 부분이 있는가.
+3. Completion Debt 4건이 구현 착수를 막는가, 아니면 착수하며 답할 수 있는가.
+4. INV-104(리소스 정리)가 실패 경로에서 실제로 보장되는가. `Close()`만으로 충분한지, `worker-abandon`이 필요한 경로가 있는지.
+
+블로킹 대상은 Completion Debt뿐이다. Evolution Ideas는 자문이다.
+
+## Self-Verify Summary
+
+- **Q-CORR-04** (근거 정확성) | status: PASS — 모든 사실 주장이 Reference Discipline 표의 실측 또는 파일:라인 인용에 대응한다. orca 명령 표면은 스키마에서 직접 추출했고, 파이프라인 구조는 코드에서 직접 읽었다.
+- **Q-COMP-05** (범위 완결성) | status: PASS — 접합점(`PhaseBackend`)을 특정하고, DAG 소유권이라는 유일한 설계 갈림길을 (a)/(b)로 열거해 근거와 함께 하나를 택했다. Feature Coverage Map이 이 SPEC이 바꾸는 표면 1개와 유지하는 표면 6개를 전수 구분한다.
+- **Q-COMP-06** (미해결 항목 분리) | status: PASS — orca 런타임을 구동해야 답할 수 있는 4건을 Completion Debt로 분리했다. Evolution Ideas에는 `SPEC-`·`AC-`·체크박스를 넣지 않아 블로킹과 자문이 섞이지 않는다.
+- **Q-COMP-07** (완료 판정 가능성) | status: PASS — 설계 문서이므로 완료 증거는 4개 문서의 `auto spec validate` 통과와 DAG 소유권 선택에 대한 리뷰 합의다. 구현 증거는 요구하지 않으며 그 사실을 Outcome Boundary에 명시했다.

--- a/.autopus/specs/SPEC-EXECPLANE-002/spec.md
+++ b/.autopus/specs/SPEC-EXECPLANE-002/spec.md
@@ -1,0 +1,154 @@
+# SPEC-EXECPLANE-002: orca 감독 실행을 PhaseBackend로 구현
+
+**Status**: draft
+**Created**: 2026-08-11
+**Domain**: EXECPLANE
+
+---
+id: SPEC-EXECPLANE-002
+title: orca 감독 실행을 PhaseBackend로 구현
+version: 0.1.0
+status: draft
+priority: HIGH
+---
+
+## Purpose
+
+`--execution-owner orca`가 handoff 스텁에서 멈추는 상태를 끝내고, orca가 감독하는 워커에서 파이프라인이 실제로 완주하도록 실행 계약을 정의한다. 정책 평면은 순서·게이트·재시도를 계속 소유하고, orca는 격리·감독·durability만 맡는다.
+
+이 SPEC은 설계 고정 문서다. 구현은 포함하지 않는다.
+
+## Background
+
+SPEC-EXECPLANE-001이 세 평면 경계를 고정하고 티어 정합 게이트를 handoff 직전에 배치했다. 게이트는 동작하지만 그 뒤가 비어 있다 — `internal/cli/pipeline_run.go:162`가 `status=handoff_required`를 반환하고 사람이 손으로 이어받는다.
+
+접합점은 이미 있다. `pkg/pipeline/engine.go:29-31`의 `PhaseBackend`는 단일 메서드다.
+
+```go
+type PhaseBackend interface {
+	Execute(ctx context.Context, req PhaseRequest) (*PhaseResponse, error)
+}
+```
+
+파이프라인은 5-phase이고 게이트와 재시도가 이미 정의되어 있다(`pkg/pipeline/phase.go:34-42`): plan → test_scaffold → implement → validate(3회) → review(2회). 따라서 orca 실행은 **파이프라인 재구현이 아니라 `PhaseBackend` 구현 하나**다.
+
+여기서 유일한 설계 갈림길은 DAG 소유권이다. orca에는 `task-create --deps`가 있어 자기 DAG를 가질 수 있고, 단일 DAG 소유자 불변식(`pkg/adapter/omp/omp_workflow_render.go:77-78`)이 두 DAG를 금지한다.
+
+| 접근 | DAG 소유자 | 결과 |
+| --- | --- | --- |
+| orca가 5-phase를 `--deps`로 재현 | orca | 게이트·재시도·체크포인트를 프로세스 평면에 복제 — SPEC-EXECPLANE-001 INV-001 위반 |
+| **autopus 엔진이 순서를 소유, orca는 워커만 감독** | autopus | 정책은 정책 평면에, 격리·감독은 프로세스 평면에 |
+
+후자를 택한다. orca task는 `--deps` 없이 만든다. orca는 DAG를 만들지 않고 워커 하나씩만 감독한다.
+
+## Outcome Boundary
+
+- **Outcome Lock**: `auto pipeline run --platform omp --execution-owner orca`가 orca 감독 워커에서 5-phase를 완주하고, 정책 평면의 게이트·재시도·체크포인트가 omp 경로와 동일하게 적용되며, 실행이 끝나거나 실패해도 orca에 살아있는 Dispatch가 남지 않는다.
+- **Mandatory requirements**: PhaseBackend 구현으로 접합(REQ-101), orca task는 deps 없이 생성(REQ-102), phase 하나당 Dispatch 하나(REQ-103), 워커 출력과 대기의 바운드(REQ-104), 실패 경로 리소스 정리(REQ-105), 티어 정합 게이트를 Run 이전에 유지(REQ-106), 프로세스 평면 경계에 티어 어휘 무증식(REQ-107), handoff 스텁 대체와 관측 가능한 실행 결과(REQ-108).
+- **Explicit non-goals**: 이 SPEC의 구현 코드(별도 작업), phase 내부 executor 병렬 fan-out, 사람 결정 게이트(`gate-create`) 도입, 원격 환경(`worker-start --on`) 지원, 5-phase 집합 변경, 게이트·재시도 semantics 변경, omp 경로 동작 변경(regression-0), 실행 원장 통합.
+- **Completion evidence**: 4개 SPEC 문서가 `auto spec validate`를 통과하고, DAG 소유권 선택에 대한 리뷰 합의가 기록되며, Completion Debt가 해소되거나 착수 중 해소 가능한 항목으로 분류된다. 구현 증거는 요구하지 않는다.
+
+## Requirements
+
+### REQ-101 — orca 실행은 PhaseBackend 구현으로 접합한다
+THE SYSTEM SHALL execute orca-supervised phases through an implementation of the existing `PhaseBackend` interface rather than a parallel pipeline runner, so phase ordering, gate evaluation, retry accounting, and checkpointing keep their single implementation in the policy plane.
+- EARS type: Ubiquitous
+- Priority: Must
+- Trigger/Condition: `--execution-owner orca`로 파이프라인이 실행될 때.
+- Observability: orca 경로가 `pipeline.SubprocessEngine`을 omp 경로와 같은 `EngineConfig`로 구동하고, 다른 점은 주입된 `Backend` 하나뿐임을 S101로 확인한다.
+
+### REQ-102 — orca task는 의존성 없이 생성한다
+THE SYSTEM SHALL create every orca task without dependency edges, so the process plane never holds a second task graph while the policy plane owns phase ordering.
+- EARS type: Ubiquitous
+- Priority: Must
+- Trigger/Condition: 백엔드가 phase 실행을 위해 task를 만들 때.
+- Observability: 생성된 task의 deps가 빈 상태이고, 순서 결정이 전적으로 엔진의 `DefaultPhases()`에서 나옴을 S102로 확인한다.
+
+### REQ-103 — phase 하나당 Dispatch 하나를 시작하고 회수한다
+WHEN the backend executes one phase attempt, THEN THE SYSTEM SHALL start exactly one supervised worker for it and settle that Dispatch exactly once, so worker accounting maps one-to-one onto phase attempts.
+- EARS type: Event-driven
+- Priority: Must
+- Trigger/Condition: `Execute` 한 번의 호출.
+- Observability: 한 attempt에 대해 시작된 Dispatch가 정확히 1건이고 종결도 1건임을 S103으로 확인한다. 재시도는 새 attempt이므로 새 Dispatch를 갖는다.
+
+### REQ-104 — 워커 대기와 출력은 바운드된다
+THE SYSTEM SHALL bound both the wait for a worker to settle and the amount of output it reads, so a stalled or noisy worker cannot hang the pipeline or exhaust memory.
+- EARS type: Ubiquitous
+- Priority: Must
+- Trigger/Condition: 백엔드가 워커의 종결을 기다리거나 출력을 읽을 때.
+- Observability: 대기에 deadline이 있고 읽기에 상한이 있으며, 두 한계 모두 초과 시 `PhaseResponse`가 `TimedOut` 또는 `FailureClass`로 사유를 드러냄을 S104로 확인한다.
+
+### REQ-105 — 실패해도 살아있는 Dispatch를 남기지 않는다
+IF a phase attempt fails, is cancelled, or the backend is closed, THEN THE SYSTEM SHALL settle every Dispatch it started via release, stop, or abandon, and SHALL NOT leave an active supervised terminal behind.
+- EARS type: Unwanted
+- Priority: Must
+- Trigger/Condition: 실행 실패·취소·백엔드 종료.
+- Observability: 실행 종료 후 이 Run에 속한 `active` 상태 terminal이 0건임을 S105로 확인한다. 프로세스 정지를 주장할 수 없는 경우에는 release 대신 abandon으로 펜싱한다.
+
+### REQ-106 — 티어 정합 게이트는 Run 생성 이전에 끝난다
+WHERE the execution owner is orca, THE SYSTEM SHALL complete the tier integrity gate of SPEC-EXECPLANE-001 before creating the orca Run, so no worker starts under an unverified tier contract.
+- EARS type: State-driven
+- Priority: Must
+- Trigger/Condition: orca 경로의 준비 단계.
+- Observability: 정합 영수증의 `checked_at`이 Run 생성 시각보다 앞서고, 게이트가 실행되지 않은 채 Run이 만들어지는 경로가 없음을 S106으로 확인한다.
+
+### REQ-107 — 프로세스 평면 경계에 티어 어휘를 넘기지 않는다
+THE SYSTEM SHALL pass only opaque provider model identifiers and effort levels to orca, never the policy plane's tier names, so the tier ladder stays single-sourced.
+- EARS type: Ubiquitous
+- Priority: Must
+- Trigger/Condition: 백엔드가 `worker-start`에 모델과 effort를 넘길 때.
+- Observability: 경계를 넘는 인자에 `balanced`/`ultra`/`opus`/`sonnet`/`haiku` 토큰이 없음을 S107로 확인한다. `worker-start`는 이미 opaque provider model id를 받는 인터페이스다.
+
+### REQ-108 — handoff 스텁을 실행으로 대체하고 결과를 관측 가능하게 남긴다
+WHEN the orca path completes or fails, THEN THE SYSTEM SHALL report the outcome through the same pipeline result surface the omp path uses, and SHALL NOT return `handoff_required` as a terminal state for a supported configuration.
+- EARS type: Event-driven
+- Priority: Must
+- Trigger/Condition: orca 경로의 실행 종료.
+- Observability: 지원되는 구성에서 `status=handoff_required`가 최종 결과로 반환되지 않고, phase 결과와 체크포인트가 omp 경로와 같은 형태로 남음을 S108로 확인한다.
+
+## Acceptance Criteria
+
+- [ ] orca 실행이 PhaseBackend 구현 하나로 접합된다
+- [ ] orca task에 의존성 간선이 없다
+- [ ] phase attempt 하나당 Dispatch 하나가 시작되고 종결된다
+- [ ] 워커 대기와 출력이 모두 바운드된다
+- [ ] 실패 경로가 살아있는 Dispatch를 남기지 않는다
+- [ ] 티어 정합 게이트가 Run 생성보다 앞선다
+- [ ] 프로세스 평면 경계에 티어 어휘가 없다
+- [ ] 지원 구성에서 `handoff_required`가 최종 상태로 남지 않는다
+
+## Traceability Matrix
+
+| Requirement | Plan Task | Acceptance Scenario | Semantic Invariant |
+|-------------|-----------|---------------------|--------------------|
+| REQ-101 | T101 | S101 | INV-101 |
+| REQ-102 | T101 | S102 | INV-101 |
+| REQ-103 | T102 | S103 | INV-102 |
+| REQ-104 | T102 | S104 | INV-103 |
+| REQ-105 | T103 | S105 | INV-104 |
+| REQ-106 | T104 | S106 | INV-105 |
+| REQ-107 | T104 | S107 | INV-101 |
+| REQ-108 | T103 | S108 | INV-102, INV-104 |
+
+## Out of Scope
+
+- 이 SPEC의 구현 코드. 계약만 고정한다.
+- phase 내부에서 executor를 여러 워커로 병렬 fan-out하는 일.
+- `gate-create`/`gate-resolve`로 사람 결정을 파이프라인에 끼우는 일.
+- 원격 환경(`worker-start --on <saved-environment>`) 지원. 계정 조회가 원격을 지원하지 않아 티어 검증이 unverified로 떨어진다.
+- 5-phase 집합 변경, 게이트·재시도 semantics 변경.
+- omp 경로 동작 변경. 회귀 0을 유지한다.
+- 실행 원장 통합.
+
+## Traceability
+
+| Requirement | Test | Status |
+|-------------|------|--------|
+| REQ-101 | S101 | pending |
+| REQ-102 | S102 | pending |
+| REQ-103 | S103 | pending |
+| REQ-104 | S104 | pending |
+| REQ-105 | S105 | pending |
+| REQ-106 | S106 | pending |
+| REQ-107 | S107 | pending |
+| REQ-108 | S108 | pending |


### PR DESCRIPTION
`--execution-owner orca`가 handoff 스텁에서 멈추는 상태를 끝내기 위한 설계 고정. 코드 변경 0건, 문서 4개 660줄.

## 조사가 범위를 크게 줄였다

`PhaseBackend`는 **단일 메서드 인터페이스**다(`pkg/pipeline/engine.go:29-31`).

```go
type PhaseBackend interface {
	Execute(ctx context.Context, req PhaseRequest) (*PhaseResponse, error)
}
```

그리고 파이프라인은 이미 5-phase이고 게이트·재시도가 정의돼 있다(`pkg/pipeline/phase.go:34-42`): plan → test_scaffold → implement → validate(3회) → review(2회).

즉 orca 실행은 **파이프라인 재구현이 아니라 `PhaseBackend` 구현 하나**다. 기존 `pipelineOMPBackend`가 구조 선례를 준다.

## 유일한 설계 갈림길 — DAG 소유권

orca에는 `task-create --deps`가 있어 **자기 DAG를 가질 수 있다**. 그리고 단일 DAG 소유자 불변식(`omp_workflow_render.go:77-78`)이 두 DAG를 금지한다.

| 접근 | DAG 소유자 | 결과 |
| --- | --- | --- |
| orca가 5-phase를 `--deps`로 재현 | orca | 게이트 판정·재시도 카운팅·체크포인트·프롬프트 조립을 프로세스 평면에 복제 — SPEC-EXECPLANE-001 INV-001 위반 |
| **autopus 엔진이 순서 소유, orca는 워커만 감독** | autopus | 정책은 정책 평면에, 격리·감독은 프로세스 평면에 |

**후자를 택했다. orca task는 `--deps` 없이 만든다.** 기능을 낭비하는 게 아니라 평면을 분리하는 것이다.

기각한 안의 자기모순이 결정적이었다: 프롬프트를 선행 조립하면 조립기가 둘이 되고, 안 하면 DAG를 미리 만드는 이익 자체가 사라진다.

## 계약

요구 8개(REQ-101~108), 불변식 5개, 시나리오 8개.

- **INV-101** orca task에 deps 없음 — 프로세스 평면에 두 번째 DAG 금지
- **INV-102** phase attempt 하나당 Dispatch 하나. 재시도는 새 attempt = 새 Dispatch
- **INV-103** 워커 대기와 출력 모두 바운드 — 무한 대기도 무한 버퍼도 없음
- **INV-104** 실패·취소·종료 어느 경로에서도 살아있는 Dispatch 0건. 프로세스 정지를 주장할 수 없으면 release 대신 abandon으로 펜싱
- **INV-105** 티어 정합 영수증의 `checked_at`이 Run 생성보다 앞섬 — 검증 없이 워커를 띄우지 않음

`worker-start`가 이미 opaque provider model id를 받는 인터페이스라 REQ-107(경계에 티어 어휘 무증식)과 정확히 맞는다.

## 배치가 이미 옳다

`pipeline_run.go:147-163`에서 정합 게이트가 체크포인트 로드·백엔드 생성·엔진 실행보다 **앞에** 있다. 이 SPEC은 그 `return`을 백엔드 선택으로 바꿀 뿐이라 INV-105가 배치로 충족된다.

## 미해결 4건

전부 orca 런타임을 실제로 구동해야 답할 수 있다: `--agent` 값 집합 / 워커 settled 판정 방법 / 출력에서 phase 결과 추출 규약 / 재개 시 Run 재바인딩 정책.

**Debt는 만족 수단을 가르지 계약 내용을 가르지 않는다.** INV-102·103·104는 settled 판정 방식이나 결과 추출 규약과 무관하게 동일하게 요구된다. 그래서 계약을 먼저 고정하는 게 성립한다.

## 검증

`auto spec validate` 통과(`--strict` 포함). `auto check --hygiene --arch --staged` exit 0. 파서 실측으로 S101~S108 8건 인식, 전부 Priority=Must + Given/When/Then, Oracle 구간 흡수 0건.

리뷰에서 `--deps`를 안 쓰는 선택이 옳은지 정면으로 봐주면 좋겠다. 그게 이 SPEC의 유일한 실질 결정이다.
