### PR TITLE
fix(orchestra): recheck가 터미널에 맞는 전송을 쓰도록 + 죽은 PaneBackend 제거

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Removed
+
+- **프로덕션에서 쓰이지 않던 `PaneBackend`** (2026-08-09): 이름은 pane인데 실제로는 `runProvider`로 자식 프로세스를 띄우는 타입이었고, 프로덕션 참조는 없이 자기 자신을 검증하는 테스트와 fresh-judge 허용목록 항목만 남아 있었다. 이 오해를 부르는 이름 때문에 전송 선택 seam을 잘못 고를 뻔했으므로 제거한다. `pipelineBackendHasFreshExecutionSemantics`의 허용목록에서도 빠지며, 남은 두 내장 백엔드(`subprocessBackend`, `InteractivePaneBackend`)의 판정은 그대로다. `SelectBackend`의 주석에 자유 텍스트 호출자는 이 백엔드를 쓰면 안 된다는 계약을 명시했다.
+
 ### Fixed
 
-- **pane 터미널에서 `recheck`가 재유도 없이 끝나던 라우팅** (2026-08-09): `RunOrchestra`는 전략 분기보다 먼저 pane 러너로 위임하므로, cmux·tmux 같은 pane 지원 터미널에서 `--strategy recheck`가 relay·debate·interactive 분기를 모두 비껴가 일반 pane 팬아웃으로 떨어졌다. 그 경로는 프로바이더당 1라운드만 실행하므로 재유도가 일어나지 않은 1라운드 답변이 `recheck` 결과로 반환됐다. 이제 `recheck`는 터미널 종류와 무관하게 헤드리스 2라운드 경로를 사용한다. 두 진입점(`RunOrchestra`, `RunPaneOrchestra`) 모두에 가드를 두되 서로 위임하지 않아 순환하지 않는다. `auto orchestra`의 전략 목록 오류 메시지에도 빠져 있던 `recheck`를 추가했다.
+- **`recheck`가 pane 터미널에서 자식 프로세스로 떨어지던 전송 선택** (2026-08-09): `runRecheck`가 `runProvider`를 직접 호출해 전송 계층을 통째로 우회했다. 그래서 cmux·tmux와 그 위에 올라간 Orca 터미널에서도 두 라운드가 pane이 아닌 자식 프로세스로 실행됐고, receipt의 `backend`는 실제 실행과 무관하게 항상 `subprocess`로 보고됐다. 이제 라운드마다 터미널에 맞는 전송을 고른다 — pane 지원 터미널은 `InteractivePaneBackend`, plain 터미널·강제 subprocess 모드·OMP 같은 에이전트 런타임은 직접 실행 — 그리고 evidence의 backend 이름은 실제로 실행한 전송을 따른다. `SelectBackend`는 쓰지 않는다: 그것이 돌려주는 subprocess 백엔드는 JSON 스키마를 강제하는데 `recheck`는 consensus·pipeline·relay와 같은 자유 텍스트 전략이다. pane 팬아웃 래퍼를 건너뛰는 가드는 유지되지만, 이제 전송이 아니라 래퍼만 건너뛴다.
+
+- **pane 터미널에서 `recheck`가 재유도 없이 끝나던 라우팅** (2026-08-09): `RunOrchestra`는 전략 분기보다 먼저 pane 러너로 위임하므로, cmux·tmux 같은 pane 지원 터미널에서 `--strategy recheck`가 relay·debate·interactive 분기를 모두 비껴가 일반 pane 팬아웃으로 떨어졌다. 그 경로는 프로바이더당 1라운드만 실행하므로 재유도가 일어나지 않은 1라운드 답변이 `recheck` 결과로 반환됐다. 이제 `recheck`는 터미널 종류와 무관하게 자신의 2라운드 루프를 소유하며, 각 라운드의 전송은 위 항목대로 터미널에 맞춰 고른다. 두 진입점(`RunOrchestra`, `RunPaneOrchestra`) 모두에 가드를 두되 서로 위임하지 않아 순환하지 않는다. `auto orchestra`의 전략 목록 오류 메시지에도 빠져 있던 `recheck`를 추가했다.
 
 - **Codex 최상위 모델 부재 시 세대를 건너뛰던 폴백** (2026-08-09): 요청한 Codex 모델이 런타임 카탈로그에 없으면 해결기가 카탈로그의 나머지를 무시하고 하드코딩된 `gpt-5.5`로 직행했다. 프론티어 모델 권한이 없는 ChatGPT 계정도 같은 세대의 균형 모델(`gpt-5.6-terra`)은 광고하므로, 최상위 티어 요청이 오히려 한 세대 낮은 모델로 떨어졌다 — 티어를 올리지 않았을 때보다 나쁜 결과다. 이제 프론티어 요청은 같은 세대 균형 모델을 먼저 시도한 뒤에만 legacy로 내려간다. 균형·소형 티어의 폴백은 바뀌지 않는다: 소형 티어는 명시적으로 싼 모델이므로 더 큰 모델의 대체재로 승격하지 않는다. 카탈로그에 아는 모델이 하나도 없으면 종전대로 런타임 기본값에 위임한다. 폴백은 이미 `Codex model fallback: requested=... selected=... reason=model_unavailable`로 stderr에 보고되고 있었고 그 형식도 그대로다.
 

--- a/pkg/orchestra/backend.go
+++ b/pkg/orchestra/backend.go
@@ -5,8 +5,9 @@ import (
 	"time"
 )
 
-// ExecutionBackend abstracts how a provider is executed.
-// PaneBackend runs via terminal panes; SubprocessBackend runs as a child process.
+// ExecutionBackend abstracts how a provider is executed. InteractivePaneBackend
+// drives a terminal pane; subprocessBackend spawns a child process with
+// schema-enforced JSON I/O.
 type ExecutionBackend interface {
 	// Execute runs a single provider and returns its response.
 	Execute(ctx context.Context, req ProviderRequest) (*ProviderResponse, error)
@@ -25,28 +26,13 @@ type ProviderRequest struct {
 	Config     ProviderConfig // full provider configuration
 }
 
-// PaneBackend implements ExecutionBackend by delegating to runProvider().
-type PaneBackend struct{}
-
-// NewPaneBackend creates a PaneBackend instance.
-func NewPaneBackend() *PaneBackend {
-	return &PaneBackend{}
-}
-
-// Execute runs the provider via the existing runProvider function.
-func (b *PaneBackend) Execute(ctx context.Context, req ProviderRequest) (*ProviderResponse, error) {
-	return runProvider(ctx, req.Config, req.Prompt)
-}
-
-// Name returns "pane".
-func (b *PaneBackend) Name() string {
-	return "pane"
-}
-
 // SelectBackend chooses the appropriate ExecutionBackend based on config (REQ-002/003).
 // Interactive-pane execution is the default when the terminal is pane-capable
 // (cmux/tmux-style, non-plain) and subprocess mode is not forced. Plain, nil, or
 // subprocess-forced configs use the subprocess backend (F-001).
+//
+// Callers that exchange free text rather than schema-guided JSON must not use
+// this: the subprocess backend validates JSON output.
 func SelectBackend(cfg OrchestraConfig) ExecutionBackend {
 	if paneCapable(cfg.Terminal, cfg.SubprocessMode) {
 		return NewInteractivePaneBackend(cfg)

--- a/pkg/orchestra/backend_test.go
+++ b/pkg/orchestra/backend_test.go
@@ -8,26 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPaneBackend_Execute(t *testing.T) {
-	t.Parallel()
-	backend := NewPaneBackend()
-	req := ProviderRequest{
-		Provider: "test",
-		Prompt:   "hello",
-		Config:   echoProvider("test"),
-	}
-	resp, err := backend.Execute(context.Background(), req)
-	require.NoError(t, err)
-	assert.Equal(t, "test", resp.Provider)
-	assert.Contains(t, resp.Output, "hello")
-}
-
-func TestPaneBackend_Name(t *testing.T) {
-	t.Parallel()
-	backend := NewPaneBackend()
-	assert.Equal(t, "pane", backend.Name())
-}
-
 func TestSubprocessBackend_Execute_WithEcho(t *testing.T) {
 	t.Parallel()
 	backend := NewSubprocessBackendImpl()

--- a/pkg/orchestra/pane_runner.go
+++ b/pkg/orchestra/pane_runner.go
@@ -43,8 +43,9 @@ func RunPaneOrchestra(ctx context.Context, cfg OrchestraConfig) (*OrchestraResul
 		return RunOrchestra(ctx, cfg)
 	}
 
-	// recheck never uses panes; hand it back to the headless runner, which does
-	// not delegate here for this strategy, so the handoff cannot loop.
+	// recheck owns its own two-round loop and picks the pane transport inside
+	// runRecheck, so it skips this fan-out wrapper. RunOrchestra does not
+	// delegate here for this strategy, so the handoff cannot loop.
 	if cfg.Strategy == StrategyRecheck {
 		return RunOrchestra(ctx, cfg)
 	}

--- a/pkg/orchestra/pipeline_integration_test.go
+++ b/pkg/orchestra/pipeline_integration_test.go
@@ -131,7 +131,7 @@ func TestIntegration_DeepMode(t *testing.T) {
 
 func TestIntegration_BackendSelection_Default(t *testing.T) {
 	t.Parallel()
-	// Terminal present, no SubprocessMode → PaneBackend
+	// Terminal present, no SubprocessMode → InteractivePaneBackend
 	cfg := OrchestraConfig{Terminal: &mockTerminal{name: "cmux"}}
 	backend := SelectBackend(cfg)
 	require.NotNil(t, backend)

--- a/pkg/orchestra/pipeline_judge_freshness.go
+++ b/pkg/orchestra/pipeline_judge_freshness.go
@@ -8,7 +8,7 @@ type freshPipelineExecutionBackend interface {
 
 func pipelineBackendHasFreshExecutionSemantics(backend ExecutionBackend) bool {
 	switch backend.(type) {
-	case *subprocessBackend, *PaneBackend, *InteractivePaneBackend:
+	case *subprocessBackend, *InteractivePaneBackend:
 		return true
 	}
 	declared, ok := backend.(freshPipelineExecutionBackend)

--- a/pkg/orchestra/pipeline_judge_freshness_test.go
+++ b/pkg/orchestra/pipeline_judge_freshness_test.go
@@ -93,7 +93,6 @@ func TestPipelineBackendHasFreshExecutionSemantics_RecognizesOnlyBuiltInsAndExpl
 		want    bool
 	}{
 		{name: "subprocess", backend: NewSubprocessBackendImpl(), want: true},
-		{name: "legacy pane", backend: NewPaneBackend(), want: true},
 		{name: "interactive pane", backend: NewInteractivePaneBackend(OrchestraConfig{}), want: true},
 		{name: "explicit test model", backend: &pipelineFreshExecutionBackend{name: "subprocess"}, want: true},
 		{name: "custom name spoof", backend: &pipelineUnverifiedCustomBackend{}, want: false},

--- a/pkg/orchestra/recheck.go
+++ b/pkg/orchestra/recheck.go
@@ -24,6 +24,28 @@ func buildRecheckPrompt(task, own string) string {
 	)
 }
 
+// recheckRunner executes one recheck round. The signature matches
+// ExecutionBackend.Execute so a backend's method value can be used directly.
+type recheckRunner func(context.Context, ProviderRequest) (*ProviderResponse, error)
+
+// recheckTransport picks how each round reaches the provider, and the backend
+// name recorded in evidence. A pane-capable terminal (cmux, tmux, and the Orca
+// terminals built on them) drives the provider in a pane; a plain terminal,
+// forced subprocess mode, and agent runtimes such as OMP spawn it directly.
+//
+// SelectBackend is deliberately not used here. It returns the schema-enforcing
+// subprocess backend, and recheck exchanges free text with the provider the
+// same way consensus, pipeline, and relay do.
+func recheckTransport(cfg OrchestraConfig) (recheckRunner, string) {
+	if paneCapable(cfg.Terminal, cfg.SubprocessMode) {
+		backend := NewInteractivePaneBackend(cfg)
+		return backend.Execute, backend.Name()
+	}
+	return func(ctx context.Context, req ProviderRequest) (*ProviderResponse, error) {
+		return runProvider(ctx, req.Config, req.Prompt)
+	}, "subprocess"
+}
+
 // runRecheck executes a single provider twice: an independent first pass, then
 // a re-derivation that sees only its own prior answer.
 func runRecheck(ctx context.Context, cfg OrchestraConfig) ([]ProviderResponse, [][]ProviderResponse, []FailedProvider, error) {
@@ -32,6 +54,7 @@ func runRecheck(ctx context.Context, cfg OrchestraConfig) ([]ProviderResponse, [
 			"recheck 전략은 프로바이더를 정확히 1개만 사용합니다 (현재 %d개)", len(cfg.Providers))
 	}
 	provider := cfg.Providers[0]
+	run, backendName := recheckTransport(cfg)
 	responses := make([]ProviderResponse, 0, recheckRoundCount)
 	history := make([][]ProviderResponse, 0, recheckRoundCount)
 	prompt := cfg.Prompt
@@ -44,18 +67,20 @@ func runRecheck(ctx context.Context, cfg OrchestraConfig) ([]ProviderResponse, [
 		// Bound each round by the per-provider timeout so a stalled first pass
 		// cannot consume the budget the re-derivation still needs.
 		perTimeout := providerExecutionTimeout(provider, cfg.TimeoutSeconds)
+		req := ProviderRequest{
+			Provider: provider.Name, Prompt: prompt, Role: role,
+			Round: round, Timeout: perTimeout, Config: provider,
+		}
 		roundCtx, roundCancel := context.WithTimeout(ctx, perTimeout)
-		response, err := runProvider(roundCtx, provider, prompt)
+		response, err := run(roundCtx, req)
 		roundCancel()
-		applyProviderRequestEvidence(response, ProviderRequest{
-			Provider: provider.Name, Config: provider, Role: role, Round: round,
-		}, "subprocess")
+		applyProviderRequestEvidence(response, req, backendName)
 		if err != nil {
 			failure := buildFailedProviderWithContext(
 				provider, response, err, cfg.TimeoutSeconds, role, len(responses) > 0,
 			)
 			failure.Attempt = round
-			failure.ExecutedBackend = "subprocess"
+			failure.ExecutedBackend = backendName
 			if response != nil && response.ExecutedBackend != "" {
 				failure.ExecutedBackend = response.ExecutedBackend
 			}

--- a/pkg/orchestra/recheck_test.go
+++ b/pkg/orchestra/recheck_test.go
@@ -120,48 +120,74 @@ func TestRunOrchestraRecheck_SecondRoundSeesOwnFirstAnswer(t *testing.T) {
 	assert.Equal(t, round2, result.Merged, "merged answer must be the re-derived one")
 	assert.Equal(t, StrategyRecheck, result.Strategy)
 	assert.False(t, result.Degraded)
+	for i, resp := range result.Responses {
+		assert.Equal(t, "subprocess", resp.ExecutedBackend,
+			"round %d on a plain terminal must report the subprocess transport", i+1)
+	}
 }
 
-// A pane-capable terminal must not divert recheck into the generic pane
-// fan-out: that path runs one round per provider, so it would return a first
-// answer labelled as a re-derivation and split no panes for a second round.
-func TestRunOrchestraRecheck_IgnoresPaneCapableTerminal(t *testing.T) {
+func paneDeliveredPrompts(term *mockTerminal) string {
+	parts := make([]string, 0, len(term.sendLongTextCalls)+len(term.promptFileContents))
+	for _, call := range term.sendLongTextCalls {
+		parts = append(parts, call.Text)
+	}
+	parts = append(parts, term.promptFileContents...)
+	return strings.Join(parts, "\n")
+}
+
+// On cmux, tmux, and the Orca terminals built on them, recheck must run in
+// panes like every other strategy — one pane per round — instead of quietly
+// dropping to a child process.
+func TestRunOrchestraRecheck_RunsBothRoundsInPanes(t *testing.T) {
 	t.Parallel()
-	term := &mockTerminal{name: "cmux"}
+	term := newCmuxMock()
+	term.readScreenOutput = "❯" // session-ready prompt marker
 
 	result, err := RunOrchestra(context.Background(), OrchestraConfig{
 		Strategy:       StrategyRecheck,
-		Providers:      []ProviderConfig{{Name: "cat", Binary: "cat", ExecutionTimeout: 20 * time.Second}},
+		Providers:      []ProviderConfig{{Name: "claude", Binary: "claude", ExecutionTimeout: 20 * time.Second}},
 		Prompt:         "PANE-ROUTED-TASK",
 		TimeoutSeconds: 30,
 		Terminal:       term,
+		WorkingDir:     t.TempDir(),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
-	require.Len(t, result.Responses, 2, "recheck must still run both rounds on a pane terminal")
-	assert.Contains(t, result.Responses[1].Output, "Round 2: Reconsider")
-	assert.Equal(t, result.Responses[1].Output, result.Merged)
-	assert.Empty(t, term.splitPaneCalls, "recheck must not open panes")
+	require.Len(t, result.Responses, 2, "both rounds must run on a pane terminal")
+	assert.Len(t, term.splitPaneCalls, recheckRoundCount, "one pane per round")
+	for i, resp := range result.Responses {
+		assert.Equal(t, "pane", resp.ExecutedBackend,
+			"round %d evidence must name the transport that actually ran", i+1)
+	}
+
+	// The re-derivation has to survive the pane transport, not just the
+	// subprocess one: round 2's delivered prompt carries the task and the
+	// reconsider instruction.
+	delivered := paneDeliveredPrompts(term)
+	assert.Contains(t, delivered, "Round 2: Reconsider")
+	assert.Contains(t, delivered, "PANE-ROUTED-TASK")
 }
 
-// The pane runner is also a public entry point, so entering through it must
-// land on the same headless two-round flow rather than looping or fanning out.
-func TestRunPaneOrchestraRecheck_HandsBackToHeadlessRunner(t *testing.T) {
+// The pane runner is a public entry point too, so entering through it must land
+// on the same two-round pane flow rather than the one-round fan-out.
+func TestRunPaneOrchestraRecheck_EntersTwoRoundPaneFlow(t *testing.T) {
 	t.Parallel()
-	term := &mockTerminal{name: "cmux"}
+	term := newCmuxMock()
+	term.readScreenOutput = "❯" // session-ready prompt marker
 
 	result, err := RunPaneOrchestra(context.Background(), OrchestraConfig{
 		Strategy:       StrategyRecheck,
-		Providers:      []ProviderConfig{{Name: "cat", Binary: "cat", ExecutionTimeout: 20 * time.Second}},
+		Providers:      []ProviderConfig{{Name: "claude", Binary: "claude", ExecutionTimeout: 20 * time.Second}},
 		Prompt:         "DIRECT-PANE-ENTRY",
 		TimeoutSeconds: 30,
 		Terminal:       term,
+		WorkingDir:     t.TempDir(),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
 	require.Len(t, result.Responses, 2)
-	assert.Contains(t, result.Responses[1].Output, "DIRECT-PANE-ENTRY")
-	assert.Empty(t, term.splitPaneCalls)
+	assert.Len(t, term.splitPaneCalls, recheckRoundCount)
+	assert.Contains(t, paneDeliveredPrompts(term), "DIRECT-PANE-ENTRY")
 }

--- a/pkg/orchestra/recheck_test.go
+++ b/pkg/orchestra/recheck_test.go
@@ -145,7 +145,7 @@ func TestRunOrchestraRecheck_RunsBothRoundsInPanes(t *testing.T) {
 
 	result, err := RunOrchestra(context.Background(), OrchestraConfig{
 		Strategy:       StrategyRecheck,
-		Providers:      []ProviderConfig{{Name: "claude", Binary: "claude", ExecutionTimeout: 20 * time.Second}},
+		Providers:      []ProviderConfig{{Name: "claude", Binary: "cat", ExecutionTimeout: 20 * time.Second}},
 		Prompt:         "PANE-ROUTED-TASK",
 		TimeoutSeconds: 30,
 		Terminal:       term,
@@ -178,7 +178,7 @@ func TestRunPaneOrchestraRecheck_EntersTwoRoundPaneFlow(t *testing.T) {
 
 	result, err := RunPaneOrchestra(context.Background(), OrchestraConfig{
 		Strategy:       StrategyRecheck,
-		Providers:      []ProviderConfig{{Name: "claude", Binary: "claude", ExecutionTimeout: 20 * time.Second}},
+		Providers:      []ProviderConfig{{Name: "claude", Binary: "cat", ExecutionTimeout: 20 * time.Second}},
 		Prompt:         "DIRECT-PANE-ENTRY",
 		TimeoutSeconds: 30,
 		Terminal:       term,

--- a/pkg/orchestra/runner.go
+++ b/pkg/orchestra/runner.go
@@ -31,9 +31,9 @@ func RunOrchestra(ctx context.Context, cfg OrchestraConfig) (*OrchestraResult, e
 	}
 
 	// Delegate to pane runner for non-plain terminals (REQ-007 shared predicate).
-	// recheck is excluded: it is a headless two-round flow over one provider, and
-	// the generic pane path would fan out a single round instead — silently
-	// returning something that is not a re-derivation.
+	// recheck is excluded from that wrapper only because it fans providers out
+	// one round each; recheck still runs in panes when the terminal supports
+	// them — runRecheck selects the pane transport itself.
 	if paneCapable(cfg.Terminal, cfg.SubprocessMode) && cfg.Strategy != StrategyRecheck {
 		return RunPaneOrchestra(ctx, cfg)
 	}

--- a/pkg/orchestra/types.go
+++ b/pkg/orchestra/types.go
@@ -213,7 +213,7 @@ type OrchestraConfig struct {
 	NoJudge                      bool               // R4: skip judge verdict phase when true
 	YieldRounds                  bool               // R5: yield after round 1 with JSON output, keep panes alive
 	ContextAware                 bool               // R8: when true, skip topic isolation so providers can read project files
-	SubprocessMode               bool               // when true, use SubprocessBackend instead of PaneBackend
+	SubprocessMode               bool               // when true, use the subprocess backend instead of an interactive pane
 	RoundPreset                  string             // round preset: "fast", "standard", "deep" (for T8)
 	MonitorEnabled               bool               // when true, prefer CC21 monitor-style completion over polling
 	MonitorTimeout               time.Duration      // max wait for monitor-style completion before polling fallback


### PR DESCRIPTION
## Problem

`runRecheck` called `runProvider` directly, bypassing the transport layer entirely. The previous fix (#163) stopped `recheck` from being diverted into the pane *fan-out*, but it left the strategy pinned to a child process on every terminal.

Two consequences:

1. On cmux, tmux, and the Orca terminals built on them, both rounds ran as child processes instead of in panes — unlike every other strategy.
2. The receipt reported `backend: subprocess` unconditionally, because the name was hardcoded. Evidence that cannot be wrong is evidence that says nothing.

So #163 removed the silent wrong answer but not the transport bypass. This finishes it.

## Change

Each recheck round picks the transport that matches the terminal:

| environment | transport |
|---|---|
| cmux / tmux / Orca terminals | `InteractivePaneBackend` (one pane per round) |
| plain terminal, `--subprocess`, OMP and other agent runtimes | direct provider execution |

The evidence backend name now comes from the transport that actually ran.

`SelectBackend` is deliberately **not** used. It returns the schema-enforcing subprocess backend, and `recheck` exchanges free text with the provider exactly like `consensus`, `pipeline`, and `relay`. Routing through it would have silently switched recheck to JSON-schema I/O — a behaviour change nothing measured. That trap is now documented on `SelectBackend` itself.

The fan-out guards from #163 stay, with corrected rationale: they skip the multi-provider pane *wrapper*, not the pane *transport*.

## Cleanup: remove `PaneBackend`

Named "pane", it actually ran `runProvider` — a child process. It had no production references; only its own tests and one `pipelineBackendHasFreshExecutionSemantics` allowlist entry. That misleading name is precisely why the wrong seam looked correct here, so it is gone. The two remaining built-ins (`subprocessBackend`, `InteractivePaneBackend`) keep their freshness verdicts unchanged. A stale `SubprocessMode` comment that still referenced it is corrected too.

## Verification

Live, plain terminal:

```
backends: ['subprocess', 'subprocess'] | roles: ['recheck_r1', 'recheck_r2'] | state: completed
```

Pane terminal is covered by tests against the cmux mock: two panes split (one per round), both responses reporting `backend: pane`, and round 2's delivered prompt carrying the task plus the reconsider instruction — proving the re-derivation survives the pane transport, not just the subprocess one.

- `go test ./...` passes
- every `scripts/companion-release/tests/*.sh` hardening script passes
- `gofmt -l`, `go vet ./...`, `git diff --check` clean

Mutation-checked: forcing the transport back to subprocess fails both pane tests. The plain-terminal test now also pins `backend: subprocess`, so neither direction can regress silently.

> Note: running the full Go suite concurrently with the shell suites saturates this machine and trips unrelated package timeouts. Run serially; both are green that way.
