### PR TITLE
refactor(cli): orchestra run 인자를 이름 있는 옵션 구조체로

### DIFF
--- a/internal/cli/orchestra_run.go
+++ b/internal/cli/orchestra_run.go
@@ -39,7 +39,19 @@ func newOrchestraRunCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runSubprocessPipeline(cmd, topic, strategy, providers, rounds, timeout, timeoutChanged, judge, subprocess, dryRun, jsonMode, requireAgreement)
+			return runSubprocessPipeline(cmd, orchestraRunOptions{
+				Topic:            topic,
+				Strategy:         strategy,
+				Providers:        providers,
+				RoundsPreset:     rounds,
+				Timeout:          timeout,
+				TimeoutChanged:   timeoutChanged,
+				Judge:            judge,
+				ForceSubprocess:  subprocess,
+				DryRun:           dryRun,
+				JSONMode:         jsonMode,
+				RequireAgreement: requireAgreement,
+			})
 		},
 	}
 
@@ -57,37 +69,42 @@ func newOrchestraRunCmd() *cobra.Command {
 	return cmd
 }
 
+// orchestraRunOptions carries the `auto orchestra run` flag set. It exists so
+// callers name what they pass: the positional form had three adjacent booleans
+// and a trailing float, where any transposition still compiled.
+type orchestraRunOptions struct {
+	Topic            string
+	Strategy         string
+	Providers        []string
+	RoundsPreset     string
+	Timeout          int
+	TimeoutChanged   bool
+	Judge            string
+	ForceSubprocess  bool
+	DryRun           bool
+	JSONMode         bool
+	RequireAgreement float64
+}
+
 // runSubprocessPipeline executes the subprocess-based orchestration pipeline.
 // @AX:WARN: [AUTO] high-branch CLI pipeline — config, invoker judge, backend, dry-run, and failure gates converge here
 // @AX:REASON: [AUTO] more than eight conditional branches determine externally visible run behavior
-func runSubprocessPipeline(
-	cmd *cobra.Command,
-	topic, strategyStr string,
-	providerNames []string,
-	roundsPreset string,
-	timeout int,
-	timeoutChanged bool,
-	judgeName string,
-	forceSubprocess bool,
-	dryRun bool,
-	jsonMode bool,
-	requireAgreement float64,
-) error {
+func runSubprocessPipeline(cmd *cobra.Command, opts orchestraRunOptions) error {
 	ctx := cmd.Context()
-	requestedStrategy := orchestra.Strategy(strings.ToLower(strings.TrimSpace(strategyStr)))
+	requestedStrategy := orchestra.Strategy(strings.ToLower(strings.TrimSpace(opts.Strategy)))
 	if requestedStrategy != orchestra.StrategyDebate &&
 		requestedStrategy != orchestra.StrategyConsensus &&
 		requestedStrategy != orchestra.StrategyRecheck {
-		return fmt.Errorf("unsupported orchestra run strategy %q (use debate, consensus, or recheck)", strategyStr)
+		return fmt.Errorf("unsupported orchestra run strategy %q (use debate, consensus, or recheck)", opts.Strategy)
 	}
-	if requireAgreement < 0 || requireAgreement > 1 {
-		return fmt.Errorf("--require-agreement must be between 0 and 1, got %v", requireAgreement)
+	if opts.RequireAgreement < 0 || opts.RequireAgreement > 1 {
+		return fmt.Errorf("--require-agreement must be between 0 and 1, got %v", opts.RequireAgreement)
 	}
-	if requireAgreement > 0 && requestedStrategy != orchestra.StrategyConsensus {
-		return fmt.Errorf("--require-agreement needs --strategy consensus; %q produces no agreement ratio", strategyStr)
+	if opts.RequireAgreement > 0 && requestedStrategy != orchestra.StrategyConsensus {
+		return fmt.Errorf("--require-agreement needs --strategy consensus; %q produces no agreement ratio", opts.Strategy)
 	}
-	explicitProviderSelection := len(providerNames) > 0
-	flagJudge := strings.TrimSpace(judgeName)
+	explicitProviderSelection := len(opts.Providers) > 0
+	flagJudge := strings.TrimSpace(opts.Judge)
 	explicitJudge := flagJudge != ""
 	runtimeFlags := globalFlagsFromContext(ctx)
 	harnessCfg, configErr := orchestraRunLoadConfig(runtimeFlags)
@@ -98,23 +115,23 @@ func runSubprocessPipeline(
 
 	var providerConfigs []orchestra.ProviderConfig
 	if configErr != nil || orchConf == nil {
-		if len(providerNames) == 0 {
-			providerNames = defaultProviders()
+		if len(opts.Providers) == 0 {
+			opts.Providers = defaultProviders()
 		}
-		providerConfigs = orchestraRunBuildProviders(providerNames, runtimeFlags.Quality, runtimeFlags.Effort)
+		providerConfigs = orchestraRunBuildProviders(opts.Providers, runtimeFlags.Quality, runtimeFlags.Effort)
 	} else {
-		providerConfigs = resolveProviders(orchConf, "run", providerNames)
-		if judgeName == "" {
-			judgeName = resolveJudge(orchConf, "run", "")
+		providerConfigs = resolveProviders(orchConf, "run", opts.Providers)
+		if opts.Judge == "" {
+			opts.Judge = resolveJudge(orchConf, "run", "")
 		}
-		if explicitProviderSelection && !explicitJudge && judgeName != "" && !hasProviderConfig(providerConfigs, judgeName) && len(providerConfigs) > 0 {
-			judgeName = providerConfigs[0].Name
+		if explicitProviderSelection && !explicitJudge && opts.Judge != "" && !hasProviderConfig(providerConfigs, opts.Judge) && len(providerConfigs) > 0 {
+			opts.Judge = providerConfigs[0].Name
 		}
-		timeout = resolveCommandTimeout(orchConf, timeout, timeoutChanged)
+		opts.Timeout = resolveCommandTimeout(orchConf, opts.Timeout, opts.TimeoutChanged)
 	}
 
 	if configErr != nil || orchConf == nil {
-		timeout = resolveCommandTimeout(nil, timeout, timeoutChanged)
+		opts.Timeout = resolveCommandTimeout(nil, opts.Timeout, opts.TimeoutChanged)
 	}
 	providerConfigs = resolveCodexProviderCapabilities(ctx, providerConfigs)
 
@@ -125,9 +142,9 @@ func runSubprocessPipeline(
 	judgeSelectionSource := ""
 	if requestedStrategy == orchestra.StrategyDebate {
 		invokingProvider = detectOrchestraInvokingProvider()
-		judgeName = resolveInvocationJudge(
+		opts.Judge = resolveInvocationJudge(
 			flagJudge,
-			judgeName,
+			opts.Judge,
 			invokingProvider,
 		)
 		judgeSelectionSource = invocationJudgeSelectionSource(flagJudge, invokingProvider)
@@ -135,22 +152,22 @@ func runSubprocessPipeline(
 	configuredNames := providerConfigNames(providerConfigs)
 
 	// Resolve round preset.
-	roundCount, ok := orchestra.RoundPresets[roundsPreset]
+	roundCount, ok := orchestra.RoundPresets[opts.RoundsPreset]
 	if !ok {
-		return fmt.Errorf("unknown round preset %q (use fast, standard, or deep)", roundsPreset)
+		return fmt.Errorf("unknown round preset %q (use fast, standard, or deep)", opts.RoundsPreset)
 	}
 
 	// Resolve judge config.
 	var judgeCfg orchestra.ProviderConfig
-	if judgeName != "" {
+	if opts.Judge != "" {
 		for _, p := range providerConfigs {
-			if p.Name == judgeName {
+			if p.Name == opts.Judge {
 				judgeCfg = p
 				break
 			}
 		}
 		if judgeCfg.Name == "" {
-			judgeCfg = orchestra.ProviderConfig{Name: judgeName, Binary: judgeName}
+			judgeCfg = orchestra.ProviderConfig{Name: opts.Judge, Binary: opts.Judge}
 		}
 	} else if len(providerConfigs) > 0 {
 		judgeCfg = providerConfigs[0] // default: first provider
@@ -162,13 +179,13 @@ func runSubprocessPipeline(
 		ProjectSummary: "Agentic Development Kit CLI",
 		TechStack:      "Go",
 		MustReadFiles:  []string{"ARCHITECTURE.md", "go.mod"},
-		Topic:          topic,
+		Topic:          opts.Topic,
 		MaxTurns:       10,
 		TargetModule:   ".",
 	}
 
-	if dryRun {
-		return executeDryRun(topic, promptData, providerConfigs, roundCount)
+	if opts.DryRun {
+		return executeDryRun(opts.Topic, promptData, providerConfigs, roundCount)
 	}
 
 	// Choose backend (REQ-003). Inject the detected terminal so SelectBackend
@@ -179,15 +196,15 @@ func runSubprocessPipeline(
 		RequestedProviders:    append([]string(nil), configuredNames...),
 		ConfiguredProviders:   append([]string(nil), configuredNames...),
 		Strategy:              requestedStrategy,
-		Prompt:                topic,
-		JudgeProvider:         judgeName,
+		Prompt:                opts.Topic,
+		JudgeProvider:         opts.Judge,
 		InvokingProvider:      invokingProvider,
 		JudgeSelectionSource:  judgeSelectionSource,
-		SubprocessMode:        forceSubprocess,
-		TimeoutSeconds:        timeout,
+		SubprocessMode:        opts.ForceSubprocess,
+		TimeoutSeconds:        opts.Timeout,
 		Terminal:              detectStructuredTerminal(),
 		FallbackMode:          orchestra.FallbackModeSubprocess,
-		MinimumAgreementRatio: requireAgreement,
+		MinimumAgreementRatio: opts.RequireAgreement,
 	}
 	// SPEC-ORCH-022 T8: enable hook-IPC collection before backend selection so a
 	// pane-capable, hook-installed context collects via done-file instead of
@@ -198,11 +215,11 @@ func runSubprocessPipeline(
 	pipelineCfg := orchestra.SubprocessPipelineConfig{
 		Backend:        backend,
 		Providers:      providerConfigs,
-		Topic:          topic,
+		Topic:          opts.Topic,
 		PromptData:     promptData,
 		Rounds:         roundCount,
 		Judge:          judgeCfg,
-		TimeoutSeconds: timeout,
+		TimeoutSeconds: opts.Timeout,
 	}
 
 	names := make([]string, len(providerConfigs))
@@ -214,7 +231,7 @@ func runSubprocessPipeline(
 		terminalName = cfg.Terminal.Name()
 	}
 	fmt.Fprintf(os.Stderr, "Strategy: %s | Providers: %s | Rounds: %s (%d) | Backend: %s (terminal=%s, hook=%t)\n",
-		strategyStr, strings.Join(names, ", "), roundsPreset, roundCount+1, backend.Name(), terminalName, cfg.HookMode)
+		opts.Strategy, strings.Join(names, ", "), opts.RoundsPreset, roundCount+1, backend.Name(), terminalName, cfg.HookMode)
 
 	result, err := executeOrchestraRunStrategy(ctx, requestedStrategy, cfg, pipelineCfg)
 	if err != nil {
@@ -227,7 +244,7 @@ func runSubprocessPipeline(
 	// is emitted before the command fails rather than discarded with the error.
 	if shouldTreatOrchestraResultAsFailure(result) {
 		blocked := fmt.Errorf("subprocess pipeline failed: %w", synthesizeOrchestraFailureError(result))
-		if jsonMode {
+		if opts.JSONMode {
 			return writeJSONResultAndExit(
 				cmd, jsonStatusError, blocked, "orchestra_run_blocked", result.RunReceipt, nil, nil,
 			)
@@ -243,7 +260,7 @@ func runSubprocessPipeline(
 		)
 	}
 
-	if jsonMode {
+	if opts.JSONMode {
 		return writeJSONResult(cmd, orchestraRunJSONStatus(result), result.RunReceipt, nil, nil)
 	}
 	fmt.Println(result.Merged)

--- a/internal/cli/orchestra_run_agreement_receipt_test.go
+++ b/internal/cli/orchestra_run_agreement_receipt_test.go
@@ -84,11 +84,19 @@ func TestOrchestraRunJSON_EmitsRunReceiptOnSuccess(t *testing.T) {
 	})
 	var out bytes.Buffer
 
-	err := runSubprocessPipeline(
-		orchestraRunJSONCmd(context.Background(), &out), "topic", "consensus",
-		[]string{"claude", "codex"}, "fast", 30, true, "", true, false, true,
-		0,
-	)
+	err := runSubprocessPipeline(orchestraRunJSONCmd(context.Background(), &out), orchestraRunOptions{
+		Topic:            "topic",
+		Strategy:         "consensus",
+		Providers:        []string{"claude", "codex"},
+		RoundsPreset:     "fast",
+		Timeout:          30,
+		TimeoutChanged:   true,
+		Judge:            "",
+		ForceSubprocess:  true,
+		DryRun:           false,
+		JSONMode:         true,
+		RequireAgreement: 0,
+	})
 
 	require.NoError(t, err)
 	require.NotNil(t, captured)
@@ -113,11 +121,19 @@ func TestOrchestraRunJSON_EmitsReceiptWhenGateBlocks(t *testing.T) {
 	})
 	var out bytes.Buffer
 
-	err := runSubprocessPipeline(
-		orchestraRunJSONCmd(context.Background(), &out), "topic", "consensus",
-		[]string{"claude"}, "fast", 30, true, "", true, false, true,
-		0,
-	)
+	err := runSubprocessPipeline(orchestraRunJSONCmd(context.Background(), &out), orchestraRunOptions{
+		Topic:            "topic",
+		Strategy:         "consensus",
+		Providers:        []string{"claude"},
+		RoundsPreset:     "fast",
+		Timeout:          30,
+		TimeoutChanged:   true,
+		Judge:            "",
+		ForceSubprocess:  true,
+		DryRun:           false,
+		JSONMode:         true,
+		RequireAgreement: 0,
+	})
 
 	require.Error(t, err, "a blocked gate must still fail the command")
 	payload := decodeJSONMap(t, out.Bytes())
@@ -141,11 +157,19 @@ func TestOrchestraRunJSON_DegradedRunSurfacesAsWarnStatus(t *testing.T) {
 	})
 	var out bytes.Buffer
 
-	err := runSubprocessPipeline(
-		orchestraRunJSONCmd(context.Background(), &out), "topic", "consensus",
-		[]string{"claude", "codex", "gemini"}, "fast", 30, true, "", true, false, true,
-		0,
-	)
+	err := runSubprocessPipeline(orchestraRunJSONCmd(context.Background(), &out), orchestraRunOptions{
+		Topic:            "topic",
+		Strategy:         "consensus",
+		Providers:        []string{"claude", "codex", "gemini"},
+		RoundsPreset:     "fast",
+		Timeout:          30,
+		TimeoutChanged:   true,
+		Judge:            "",
+		ForceSubprocess:  true,
+		DryRun:           false,
+		JSONMode:         true,
+		RequireAgreement: 0,
+	})
 
 	require.NoError(t, err)
 	payload := decodeJSONMap(t, out.Bytes())

--- a/internal/cli/orchestra_run_orchestration_contract_test.go
+++ b/internal/cli/orchestra_run_orchestration_contract_test.go
@@ -96,11 +96,19 @@ func TestRunSubprocessPipeline_BlockedReceiptFailsClosed(t *testing.T) {
 		}, cfg), nil
 	}
 
-	err := runSubprocessPipeline(
-		orchestraRunTestCmd(context.Background()), "contract", "consensus", []string{"claude"},
-		"standard", 5, true, "", true, false, false,
-		0,
-	)
+	err := runSubprocessPipeline(orchestraRunTestCmd(context.Background()), orchestraRunOptions{
+		Topic:            "contract",
+		Strategy:         "consensus",
+		Providers:        []string{"claude"},
+		RoundsPreset:     "standard",
+		Timeout:          5,
+		TimeoutChanged:   true,
+		Judge:            "",
+		ForceSubprocess:  true,
+		DryRun:           false,
+		JSONMode:         false,
+		RequireAgreement: 0,
+	})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Critical finding")

--- a/internal/cli/orchestra_run_recheck_test.go
+++ b/internal/cli/orchestra_run_recheck_test.go
@@ -66,11 +66,19 @@ func TestRunSubprocessPipeline_RecheckRoutesToEngineNotPipeline(t *testing.T) {
 		}, nil
 	}
 
-	err := runSubprocessPipeline(
-		orchestraRunTestCmd(context.Background()),
-		"topic", "recheck", []string{"claude"}, "standard", 120, false, "", false, false, false,
-		0,
-	)
+	err := runSubprocessPipeline(orchestraRunTestCmd(context.Background()), orchestraRunOptions{
+		Topic:            "topic",
+		Strategy:         "recheck",
+		Providers:        []string{"claude"},
+		RoundsPreset:     "standard",
+		Timeout:          120,
+		TimeoutChanged:   false,
+		Judge:            "",
+		ForceSubprocess:  false,
+		DryRun:           false,
+		JSONMode:         false,
+		RequireAgreement: 0,
+	})
 	require.NoError(t, err)
 	assert.False(t, pipelineCalled, "recheck must not invoke the debate subprocess pipeline")
 	assert.Equal(t, orchestra.StrategyRecheck, captured.Strategy)
@@ -85,11 +93,19 @@ func TestRunSubprocessPipeline_RejectsUnknownStrategy(t *testing.T) {
 	t.Cleanup(func() { orchestraRunLoadConfig = origLoadConfig })
 	orchestraRunLoadConfig = recheckHarnessConfig
 
-	err := runSubprocessPipeline(
-		orchestraRunTestCmd(context.Background()),
-		"topic", "recheckk", []string{"claude"}, "standard", 120, false, "", false, false, false,
-		0,
-	)
+	err := runSubprocessPipeline(orchestraRunTestCmd(context.Background()), orchestraRunOptions{
+		Topic:            "topic",
+		Strategy:         "recheckk",
+		Providers:        []string{"claude"},
+		RoundsPreset:     "standard",
+		Timeout:          120,
+		TimeoutChanged:   false,
+		Judge:            "",
+		ForceSubprocess:  false,
+		DryRun:           false,
+		JSONMode:         false,
+		RequireAgreement: 0,
+	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "recheck")
 }
@@ -125,10 +141,19 @@ func TestRunSubprocessPipeline_RequireAgreementReachesEngineConfig(t *testing.T)
 		}, nil
 	}
 
-	err := runSubprocessPipeline(
-		orchestraRunTestCmd(context.Background()),
-		"topic", "consensus", []string{"claude", "codex"}, "fast", 30, false, "", true, false, false, 0.9,
-	)
+	err := runSubprocessPipeline(orchestraRunTestCmd(context.Background()), orchestraRunOptions{
+		Topic:            "topic",
+		Strategy:         "consensus",
+		Providers:        []string{"claude", "codex"},
+		RoundsPreset:     "fast",
+		Timeout:          30,
+		TimeoutChanged:   false,
+		Judge:            "",
+		ForceSubprocess:  true,
+		DryRun:           false,
+		JSONMode:         false,
+		RequireAgreement: 0.9,
+	})
 	require.NoError(t, err)
 	assert.InDelta(t, 0.9, captured.MinimumAgreementRatio, 1e-9)
 }
@@ -151,10 +176,19 @@ func TestRunSubprocessPipeline_RejectsUnusableAgreementFloors(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
-			err := runSubprocessPipeline(
-				orchestraRunTestCmd(context.Background()),
-				"topic", tc.strategy, []string{"claude"}, "fast", 30, false, "", true, false, false, tc.floor,
-			)
+			err := runSubprocessPipeline(orchestraRunTestCmd(context.Background()), orchestraRunOptions{
+				Topic:            "topic",
+				Strategy:         tc.strategy,
+				Providers:        []string{"claude"},
+				RoundsPreset:     "fast",
+				Timeout:          30,
+				TimeoutChanged:   false,
+				Judge:            "",
+				ForceSubprocess:  true,
+				DryRun:           false,
+				JSONMode:         false,
+				RequireAgreement: tc.floor,
+			})
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.wantMsg)
 		})

--- a/internal/cli/orchestra_run_test.go
+++ b/internal/cli/orchestra_run_test.go
@@ -62,7 +62,19 @@ func TestRunSubprocessPipeline_UsesConfigTimeoutWhenFlagUnchanged(t *testing.T) 
 		return successfulDebateRunResult(cfg.Providers[0].Name), nil
 	}
 
-	err := runSubprocessPipeline(orchestraRunTestCmd(context.Background()), "topic", "debate", []string{"claude"}, "standard", 120, false, "", false, false, false, 0)
+	err := runSubprocessPipeline(orchestraRunTestCmd(context.Background()), orchestraRunOptions{
+		Topic:            "topic",
+		Strategy:         "debate",
+		Providers:        []string{"claude"},
+		RoundsPreset:     "standard",
+		Timeout:          120,
+		TimeoutChanged:   false,
+		Judge:            "",
+		ForceSubprocess:  false,
+		DryRun:           false,
+		JSONMode:         false,
+		RequireAgreement: 0,
+	})
 	require.NoError(t, err)
 	assert.Equal(t, 240, captured.TimeoutSeconds)
 }
@@ -98,7 +110,19 @@ func TestRunSubprocessPipeline_CLITimeoutOverridesConfig(t *testing.T) {
 		return successfulDebateRunResult(cfg.Providers[0].Name), nil
 	}
 
-	err := runSubprocessPipeline(orchestraRunTestCmd(context.Background()), "topic", "debate", []string{"claude"}, "standard", 90, true, "", false, false, false, 0)
+	err := runSubprocessPipeline(orchestraRunTestCmd(context.Background()), orchestraRunOptions{
+		Topic:            "topic",
+		Strategy:         "debate",
+		Providers:        []string{"claude"},
+		RoundsPreset:     "standard",
+		Timeout:          90,
+		TimeoutChanged:   true,
+		Judge:            "",
+		ForceSubprocess:  false,
+		DryRun:           false,
+		JSONMode:         false,
+		RequireAgreement: 0,
+	})
 	require.NoError(t, err)
 	assert.Equal(t, 90, captured.TimeoutSeconds)
 }
@@ -140,7 +164,19 @@ func TestRunSubprocessPipeline_ExplicitProvidersDoNotUseExcludedConfigJudge(t *t
 		return successfulDebateRunResult(cfg.Providers[0].Name), nil
 	}
 
-	err := runSubprocessPipeline(orchestraRunTestCmd(context.Background()), "topic", "debate", []string{"codex"}, "fast", 120, false, "", false, false, false, 0)
+	err := runSubprocessPipeline(orchestraRunTestCmd(context.Background()), orchestraRunOptions{
+		Topic:            "topic",
+		Strategy:         "debate",
+		Providers:        []string{"codex"},
+		RoundsPreset:     "fast",
+		Timeout:          120,
+		TimeoutChanged:   false,
+		Judge:            "",
+		ForceSubprocess:  false,
+		DryRun:           false,
+		JSONMode:         false,
+		RequireAgreement: 0,
+	})
 	require.NoError(t, err)
 	assert.Equal(t, "codex", captured.Judge.Name)
 	require.Len(t, captured.Providers, 1)
@@ -195,11 +231,19 @@ func TestRunSubprocessPipeline_ImplicitClaudeConfigUsesCodexInvokerJudge(t *test
 		}, nil
 	}
 
-	err := runSubprocessPipeline(
-		orchestraRunTestCmd(context.Background()), "topic", "debate", nil, "fast",
-		120, false, "", false, false, false,
-		0,
-	)
+	err := runSubprocessPipeline(orchestraRunTestCmd(context.Background()), orchestraRunOptions{
+		Topic:            "topic",
+		Strategy:         "debate",
+		Providers:        nil,
+		RoundsPreset:     "fast",
+		Timeout:          120,
+		TimeoutChanged:   false,
+		Judge:            "",
+		ForceSubprocess:  false,
+		DryRun:           false,
+		JSONMode:         false,
+		RequireAgreement: 0,
+	})
 
 	require.NoError(t, err)
 	assert.Equal(t, "codex", captured.Judge.Name)
@@ -239,7 +283,19 @@ func TestRunSubprocessPipeline_AppliesRuntimeCodexQualityAndEffort(t *testing.T)
 	}
 
 	ctx := withGlobalFlags(context.Background(), globalFlags{Quality: "ultra", Effort: config.CodexEffortMax})
-	err := runSubprocessPipeline(orchestraRunTestCmd(ctx), "topic", "debate", []string{"codex"}, "fast", 120, false, "", false, false, false, 0)
+	err := runSubprocessPipeline(orchestraRunTestCmd(ctx), orchestraRunOptions{
+		Topic:            "topic",
+		Strategy:         "debate",
+		Providers:        []string{"codex"},
+		RoundsPreset:     "fast",
+		Timeout:          120,
+		TimeoutChanged:   false,
+		Judge:            "",
+		ForceSubprocess:  false,
+		DryRun:           false,
+		JSONMode:         false,
+		RequireAgreement: 0,
+	})
 	require.NoError(t, err)
 	require.Len(t, captured.Providers, 1)
 	assertCodexProfileInArgs(t, captured.Providers[0].Args, config.CodexSolModel, config.CodexEffortMax)


### PR DESCRIPTION
## Problem

Debt I named in #150 and #163 and deferred twice.

`runSubprocessPipeline` took twelve positional parameters ending in three adjacent booleans and a float:

```go
runSubprocessPipeline(cmd, topic, strategy, providers, rounds, timeout,
    timeoutChanged, judge, subprocess, dryRun, jsonMode, requireAgreement)
```

`forceSubprocess`, `dryRun`, and `jsonMode` are interchangeable at the type level. Transposing any two compiles, passes vet, and silently changes what the command does — a JSON run that prints markdown, or a dry run that actually spawns providers. I made it worse by appending the float in #150.

## Change

```go
type orchestraRunOptions struct {
    Topic, Strategy  string
    Providers        []string
    RoundsPreset     string
    Timeout          int
    TimeoutChanged   bool
    Judge            string
    ForceSubprocess  bool
    DryRun           bool
    JSONMode         bool
    RequireAgreement float64
}

func runSubprocessPipeline(cmd *cobra.Command, opts orchestraRunOptions) error
```

Options structs are already the convention in `internal/cli`. Behaviour is unchanged; this is plumbing only.

## How the migration was made safe

The risk in this refactor is a silent transposition during the conversion itself, which is exactly the hazard being removed. So it was done compiler-guided rather than by hand:

1. Changed the signature first and let the compiler enumerate every unresolved identifier in the body.
2. Confirmed no parameter name is shadowed by a local (`:=`) inside the function — only plain reassignments — so a word-boundary rename over the body range could not capture an unrelated variable.
3. Renamed within that range; the body then compiled with no further edits.
4. Converted the thirteen call sites by parsing each argument list and mapping position → field name programmatically, so no argument could be reordered by hand.

## Verification

- `go test ./internal/cli` passes (360s) — it covers the parameters that matter: config-vs-CLI timeout resolution keyed on `TimeoutChanged`, judge precedence, provider selection, JSON envelope mode, recheck routing, and the `--require-agreement` floor reaching the engine config
- `gofmt -l`, `go vet ./...`, `git diff --check` clean
- live, through the new struct:
  - `--strategy recheck` -> `Summary: 재검토: claude 2라운드, 답변 유지`
  - `--strategy consensus --require-agreement 1.0` -> `gate: blocked | reasons: ['agreement_below_floor']`

Call-site mappings were spot-checked against the originals, including the non-default rows (`Timeout: 90, TimeoutChanged: true`; `Timeout: 30, TimeoutChanged: true, ForceSubprocess: true, JSONMode: true`).

No CHANGELOG entry: this repo does not changelog pure refactors (`aaeae52d`, `db2fb7df` both touch zero CHANGELOG lines).
