### PR TITLE
docs(release): OMP 오라클 핀 불변성 근거 기록

### DIFF
--- a/scripts/companion-release/prepare-release.sh
+++ b/scripts/companion-release/prepare-release.sh
@@ -13,6 +13,17 @@ readonly repository='Insajin/autopus-adk'
 readonly environment_name='adk-companion-release'
 readonly release_tag='v0.50.104'
 readonly spec_id='SPEC-OMP-004'
+# The OMP oracle is pinned by digest AND version string (see the conjunctive
+# gate below). It has not moved since v0.50.96 and must not be advanced to make
+# a release run on whatever OMP happens to be installed: shipped behaviour is
+# defined against this exact build.
+#   - v0.50.96 tuned RPC readiness limits to this build's cold-start timing.
+#   - v0.50.98 has the isolated catalog inherit this build's exact provider and
+#     model capability surface.
+#   - README.md and docs/README.ko.md document strict_routing_ready=false and
+#     catalog_metadata_insufficient as consequences of this build's catalog.
+# Advancing the pin invalidates all three and requires re-establishing them with
+# evidence, not a digest edit.
 readonly expected_omp_sha256='cd2f47545cb3f8eb5e15c91bc9054d73967774652e020b432e294803d1b71ea0'
 readonly expected_promotion_key_id='omp-context-promotion-2026-q3-k2'
 readonly release_ref="refs/tags/${release_tag}"


### PR DESCRIPTION
## Why

Preparing the `v0.50.104` release surfaced that the pinned OMP oracle binary (`omp-v17.2.7`, digest `cd2f4754…`) is no longer staged on the release machine — `/private/tmp` was reaped and the installed OMP is `17.2.12`.

The obvious unblock is to advance `expected_omp_sha256` to whatever is installed. That is the wrong move, and nothing at the pin site said so.

## Policy review

The pin is a **conjunctive** gate — digest *and* the literal `omp/17.2.7` version string — and `git log -L` shows it has not moved since it was introduced at `v0.50.96` (`8ed7fbb8`), across seven releases.

That immutability is load-bearing. Shipped behaviour is defined against this exact build:

- **v0.50.96** tuned the internal RPC readiness limit to this build's cold-start timing.
- **v0.50.98** has the isolated catalog inherit *this build's exact* provider/model capability surface, rather than overwriting every model as text-only.
- **README.md** and **docs/README.ko.md** document `strict_routing_ready: false` and `catalog_metadata_insufficient` as consequences of this build's catalog metadata.

Advancing the digest would silently invalidate all three: the readiness tuning, the inherited capability contract, and the documented routing-readiness behaviour. It is a migration requiring fresh evidence, not a one-line edit for operational convenience.

## Change

Comment only, at the pin site, recording the constraint and the three contracts that depend on it. No behaviour change.

## Verification

- `bash -n scripts/companion-release/prepare-release.sh` clean
- every `scripts/companion-release/tests/*.sh` hardening script passes
- `go test ./internal/companionmanifest ./pkg/companionmanifest` pass

## Consequence for v0.50.104

The correct unblock is to restore the `omp-v17.2.7` binary matching the pinned digest, not to move the pin. That binary is not present anywhere on this machine.
