### PR TITLE
docs(release): OMP 핀 복구 경로와 이전 측정 절차

### DIFF
--- a/scripts/companion-release/prepare-release.sh
+++ b/scripts/companion-release/prepare-release.sh
@@ -13,17 +13,23 @@ readonly repository='Insajin/autopus-adk'
 readonly environment_name='adk-companion-release'
 readonly release_tag='v0.50.104'
 readonly spec_id='SPEC-OMP-004'
-# The OMP oracle is pinned by digest AND version string (see the conjunctive
-# gate below). It has not moved since v0.50.96 and must not be advanced to make
-# a release run on whatever OMP happens to be installed: shipped behaviour is
-# defined against this exact build.
-#   - v0.50.96 tuned RPC readiness limits to this build's cold-start timing.
-#   - v0.50.98 has the isolated catalog inherit this build's exact provider and
-#     model capability surface.
-#   - README.md and docs/README.ko.md document strict_routing_ready=false and
-#     catalog_metadata_insufficient as consequences of this build's catalog.
-# Advancing the pin invalidates all three and requires re-establishing them with
-# evidence, not a digest edit.
+# The OMP oracle is pinned by digest AND version string (conjunctive gate
+# below). It has not moved since v0.50.96 and must not be advanced so a release
+# can run on whatever OMP is installed: shipped behaviour is defined against
+# this exact build. v0.50.96 tuned RPC readiness to its cold start, v0.50.98 has
+# the isolated catalog inherit its exact capability surface, and both READMEs
+# document strict_routing_ready=false / catalog_metadata_insufficient as
+# consequences of its catalog.
+#
+# A missing local copy is never a reason to advance it. The build is published
+# and CI downloads it every run; re-staging is one curl, verified by the digest:
+#   https://github.com/can1357/oh-my-pi/releases/download/v17.2.7/omp-darwin-arm64
+#
+# If the pin genuinely must move, measure each contract against the candidate
+# first: `auto doctor --json` passing every doctor.platform.omp.* capability
+# within ompDoctorTotalTimeout, and `auto platform omp models --json` both
+# preserving per-model input modes and reasoning flags and still reporting
+# strict_routing_ready=false — otherwise the READMEs change in the same commit.
 readonly expected_omp_sha256='cd2f47545cb3f8eb5e15c91bc9054d73967774652e020b432e294803d1b71ea0'
 readonly expected_promotion_key_id='omp-context-promotion-2026-q3-k2'
 readonly release_ref="refs/tags/${release_tag}"


### PR DESCRIPTION
## What this closes

#168 recorded *why* the OMP oracle pin must not move. Preparing `v0.50.104` then hit the obvious follow-up question — what to do when the pinned binary is missing locally — and I nearly answered it wrong.

**The pinned build is a published asset.** `ci.yaml:203` and `materialize-omp-release-canary.sh:32` already download it every run:

```
https://github.com/can1357/oh-my-pi/releases/download/v17.2.7/omp-darwin-arm64
```

Re-staged it and verified:

```
downloaded digest : cd2f47545cb3f8eb5e15c91bc9054d73967774652e020b432e294803d1b71ea0
pinned digest     : cd2f47545cb3f8eb5e15c91bc9054d73967774652e020b432e294803d1b71ea0
MATCH — omp/17.2.7
```

A reaped `/private/tmp` is one `curl` from repaired. Nothing at the pin site said so, so "advance the digest" looked like the only unblock.

## Also: the migration is measurable, and I measured it

Before finding the download URL I ran the three dependent contracts against the installed `omp/17.2.12` to see what a real migration would cost. All three hold:

| contract | basis | measured on 17.2.12 |
|---|---|---|
| v0.50.96 readiness tuning | limit raised to 20s for cold start | 10/10 `doctor.platform.omp.*` pass in 8.7s |
| v0.50.98 capability inheritance | exact inherit, no text-only flattening | 45/50 image-capable, 39/50 reasoning preserved, 8 distinct context windows |
| README routing readiness | `strict_routing_ready=false`, `catalog_metadata_insufficient` | identical, 50 models |

That is *not* a reason to migrate now — the oracle's value is being the same across releases, and there is no benefit to trade for it. It is a reason to record the method, so a future migration is a measurement rather than a guess.

## Change

Comment only, at the pin site: the recovery URL, and the three commands that establish each contract against a candidate build. Rewritten more tersely than my first draft, which pushed the file to 307 lines and tripped `TestReleaseScripts_SourceFilesStayBelowLimit` — now 297.

## Verification

- `bash -n` clean, file at 297/300 lines
- every `scripts/companion-release/tests/*.sh` hardening script passes
- `go test ./internal/companionmanifest ./pkg/companionmanifest` pass
