### PR TITLE
fix(omp): usage 정지 원인을 선언 window와 대조해 이름 붙이기

### DIFF
--- a/internal/cli/pipeline_backend_omp.go
+++ b/internal/cli/pipeline_backend_omp.go
@@ -230,6 +230,7 @@ func (backend *pipelineOMPBackend) Execute(
 		backend.process, err = startPipelineOMPProcess(ctx, backend.config)
 		if err == nil {
 			backend.protocol = newPipelineOMPRPCProtocol(backend.process)
+			backend.protocol.declaredContextWindow = backend.config.ModelContextWindow
 			initCtx, cancel := context.WithTimeout(ctx, backend.config.MaxTime)
 			err = backend.protocol.initialize(initCtx)
 			cancel()

--- a/internal/cli/pipeline_backend_omp_protocol.go
+++ b/internal/cli/pipeline_backend_omp_protocol.go
@@ -50,6 +50,9 @@ type pipelineOMPRPCProtocol struct {
 	process              *pipelineOMPProcess
 	nextID               int
 	safeCompactionImages map[string]struct{}
+	// declaredContextWindow is the window the caller asserted for this model.
+	// Zero means unknown and disables the exhaustion diagnosis in executeManaged.
+	declaredContextWindow int
 }
 
 type pipelineOMPModelState struct {

--- a/internal/cli/pipeline_omp_context_active_evaluator.go
+++ b/internal/cli/pipeline_omp_context_active_evaluator.go
@@ -47,6 +47,7 @@ func startPipelineOMPActiveEvaluatorSession(
 		return nil, err
 	}
 	protocol := newPipelineOMPRPCProtocol(process)
+	protocol.declaredContextWindow = backend.ModelContextWindow
 	sessionID, err := protocol.initializeManaged(ctx, candidate.Provider+"/"+candidate.Model)
 	if err != nil {
 		_ = process.Close()

--- a/internal/cli/pipeline_omp_context_active_rpc.go
+++ b/internal/cli/pipeline_omp_context_active_rpc.go
@@ -68,6 +68,7 @@ func newPipelineOMPActiveSessionStart(
 			return nil, err
 		}
 		protocol := newPipelineOMPRPCProtocol(process)
+		protocol.declaredContextWindow = backend.ModelContextWindow
 		initializeCtx, cancel := context.WithTimeout(ctx, backend.MaxTime)
 		defer cancel()
 		sessionID, err := protocol.initializeManaged(initializeCtx, candidate.Provider+"/"+candidate.Model)

--- a/internal/cli/pipeline_omp_context_active_rpc_execute.go
+++ b/internal/cli/pipeline_omp_context_active_rpc_execute.go
@@ -103,14 +103,10 @@ func (protocol *pipelineOMPRPCProtocol) executeManaged(
 	}
 	inputDelta, outputDelta := afterStats.Input-beforeStats.Input, afterStats.Output-beforeStats.Output
 	totalDelta := afterStats.Total - beforeStats.Total
-	// A fail-closed usage gate has to report the observation it rejected;
-	// otherwise a stalled cohort gives no way to tell which axis went flat.
-	if inputDelta <= 0 || outputDelta <= 0 || totalDelta < inputDelta+outputDelta {
-		return "", pipelineOMPActiveCallReceipt{}, fmt.Errorf(
-			"managed active OMP usage delta is empty (in/out/total delta=%d/%d/%d, before=%d/%d/%d after=%d/%d/%d)",
-			inputDelta, outputDelta, totalDelta,
-			beforeStats.Input, beforeStats.Output, beforeStats.Total,
-			afterStats.Input, afterStats.Output, afterStats.Total)
+	if err := pipelineOMPActiveUsageVerdict(
+		beforeStats, afterStats, protocol.declaredContextWindow,
+	); err != nil {
+		return "", pipelineOMPActiveCallReceipt{}, err
 	}
 	return output.Text, pipelineOMPActiveCallReceipt{
 		SessionID: expectedSession, InputTokens: inputDelta, OutputTokens: outputDelta,

--- a/internal/cli/pipeline_omp_context_active_usage.go
+++ b/internal/cli/pipeline_omp_context_active_usage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 )
 
 func boolToPipelineOMPCount(value bool) int {
@@ -55,4 +56,32 @@ func (protocol *pipelineOMPRPCProtocol) sessionStats(
 		return pipelineOMPActiveUsage{}, errors.New("managed active OMP session stats are invalid")
 	}
 	return pipelineOMPActiveUsage{Input: effectiveInputWithWrite, Output: tokens.Output, Total: tokens.Total}, nil
+}
+
+// pipelineOMPActiveUsageVerdict decides whether one managed call moved usage,
+// and names why it did not. A fail-closed gate that reports only "empty" forces
+// the operator to bisect a 40-call cohort; both the deltas and the declared
+// window are known here, so the diagnosis belongs at the point of rejection.
+//
+// declaredWindow of zero means the caller did not assert one, which disables
+// the exhaustion branch rather than guessing.
+func pipelineOMPActiveUsageVerdict(before, after pipelineOMPActiveUsage, declaredWindow int) error {
+	inputDelta, outputDelta := after.Input-before.Input, after.Output-before.Output
+	totalDelta := after.Total - before.Total
+	if inputDelta > 0 && outputDelta > 0 && totalDelta >= inputDelta+outputDelta {
+		return nil
+	}
+	// A declared window smaller than the model's real one lets accumulation
+	// cross it; OMP then stops calling the provider and every axis goes flat.
+	if window := int64(declaredWindow); window > 0 && after.Input >= window {
+		return fmt.Errorf(
+			"managed active OMP usage delta is empty: cumulative input %d reached the declared "+
+				"model context window %d, so the declared window does not match the model's real "+
+				"window (in/out/total delta=%d/%d/%d)",
+			after.Input, window, inputDelta, outputDelta, totalDelta)
+	}
+	return fmt.Errorf(
+		"managed active OMP usage delta is empty (in/out/total delta=%d/%d/%d, before=%d/%d/%d after=%d/%d/%d)",
+		inputDelta, outputDelta, totalDelta,
+		before.Input, before.Output, before.Total, after.Input, after.Output, after.Total)
 }

--- a/internal/cli/pipeline_omp_context_active_usage_verdict_test.go
+++ b/internal/cli/pipeline_omp_context_active_usage_verdict_test.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func usage(input, output, total int64) pipelineOMPActiveUsage {
+	return pipelineOMPActiveUsage{Input: input, Output: output, Total: total}
+}
+
+// A call that moved every axis is the only accepted shape.
+func TestPipelineOMPActiveUsageVerdict_AcceptsRealCall(t *testing.T) {
+	t.Parallel()
+	require.NoError(t, pipelineOMPActiveUsageVerdict(
+		usage(1000, 10, 1010), usage(1500, 22, 1522), 320000))
+}
+
+// The failure that stalled the v0.50.104 cohort at call 13: accumulation reached
+// the declared window, OMP stopped calling the provider, and every axis went
+// flat. The message has to name that cause, because the alternative is bisecting
+// a 40-call production run.
+func TestPipelineOMPActiveUsageVerdict_NamesDeclaredWindowExhaustion(t *testing.T) {
+	t.Parallel()
+	err := pipelineOMPActiveUsageVerdict(
+		usage(1130394, 24, 1130418), usage(1130394, 24, 1130418), 320000)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cumulative input 1130394")
+	assert.Contains(t, err.Error(), "declared model context window 320000")
+	assert.Contains(t, err.Error(), "does not match the model's real")
+}
+
+// Below the declared window the exhaustion explanation would be wrong, so the
+// generic form must report the raw observation instead of guessing.
+func TestPipelineOMPActiveUsageVerdict_ReportsRawObservationBelowWindow(t *testing.T) {
+	t.Parallel()
+	err := pipelineOMPActiveUsageVerdict(
+		usage(500, 10, 510), usage(500, 10, 510), 320000)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "delta=0/0/0")
+	assert.Contains(t, err.Error(), "before=500/10/510")
+	assert.Contains(t, err.Error(), "after=500/10/510")
+	assert.NotContains(t, err.Error(), "declared model context window")
+}
+
+// An unasserted window must not produce an exhaustion claim, however large the
+// cumulative input is.
+func TestPipelineOMPActiveUsageVerdict_UnknownWindowStaysGeneric(t *testing.T) {
+	t.Parallel()
+	err := pipelineOMPActiveUsageVerdict(
+		usage(9_000_000, 24, 9_000_024), usage(9_000_000, 24, 9_000_024), 0)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "declared model context window")
+}
+
+// Each axis is independently load-bearing: a call that produced tokens on only
+// one side, or a total that cannot cover its own components, is still rejected.
+func TestPipelineOMPActiveUsageVerdict_RejectsEachFlatAxis(t *testing.T) {
+	t.Parallel()
+	for name, tc := range map[string]struct{ before, after pipelineOMPActiveUsage }{
+		"input flat":      {usage(100, 10, 110), usage(100, 20, 120)},
+		"output flat":     {usage(100, 10, 110), usage(200, 10, 210)},
+		"total shortfall": {usage(100, 10, 110), usage(200, 20, 215)},
+	} {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			require.Error(t, pipelineOMPActiveUsageVerdict(tc.before, tc.after, 320000))
+		})
+	}
+}


### PR DESCRIPTION
## The recurring problem

Every `v0.50.104`/`v0.50.105` attempt died on a **tuning value that had to match a fact, with no check and a 30-minute feedback loop**. Same shape, four times:

| value | where the truth lived | cost |
|---|---|---|
| `--model-context-window 320000` | provider catalog: `window=1000000` | 3 canary runs |
| exec smoke `--timeout 15s` | v0.50.96 already tuned this class to 20s | 1 full release |
| `go-version: '1.26.5'` in `security.yml` | `go.mod` toolchain | CI red, PR blocked |
| `usage delta is empty` | the numbers the gate just compared | 3 runs of guessing |

The last one was fixed in #170. This PR closes the first one at its root.

## Root cause, measured

Reproduced standalone via `observe-session` — no sudo, no 40-call cohort, ~60s:

```
call 13 failed closed: managed active OMP usage delta is empty
(in/out/total delta=0/0/0, before=1130394/24/1130418 after=1130394/24/1130418)
```

All three axes exactly zero, and cumulative input already at **1,130,394** against a declared window of **320,000**. Declaring the model's real window instead makes calls 13-16 pass. The declared window was simply wrong: I had taken `320000` from a CHANGELOG entry about a *different* model (`gpt-5.6-sol`) while the catalog said `claude-sonnet-5` has 1,000,000.

SPEC-OMP-004 already requires "제품 기부 tier 모델의 **실제** model window". Nothing enforced it.

## Change

The code already holds both numbers at the moment of failure, so the diagnosis belongs there:

```
managed active OMP usage delta is empty: cumulative input 1130394 reached the declared
model context window 320000, so the declared window does not match the model's real window
(in/out/total delta=0/0/0)
```

- the declared window is threaded to the protocol at all three construction sites (managed-active session, evaluator, phase backend); zero means "not asserted" and disables the exhaustion branch rather than guessing
- the verdict is extracted to a pure `pipelineOMPActiveUsageVerdict(before, after, declaredWindow)` so every branch is unit-testable without a live provider session

No predicate change: identical accept/reject behaviour, and the raw-observation message from #170 is kept for the cases where exhaustion is *not* the explanation.

Catalog-derivation was considered and rejected: the observe-session setup is deliberately hermetic (`env -i`, nobody isolation), and adding a live catalog probe there trades one failure mode for another. Comparing against the value the caller already asserted needs no new dependency.

## Verification

- live reproduction confirms the new message fires with the real numbers (above)
- five unit tests pin the contract: accepted shape, named exhaustion, raw observation below the window, unasserted window staying generic, and each flat axis independently rejected
- `go build ./...`, `go vet ./...`, `gofmt`, `go test ./internal/cli` all clean

The first attempt at this fix silently did nothing because only one of three protocol construction sites set the field — caught by re-running the live reproduction rather than trusting the diff.
