### PR TITLE
fix(release): Homebrew tap predecessor를 실제 게시 지점으로 올리고 prep에서 검증

### DIFF
--- a/internal/companionmanifest/release_homebrew_formula_bridge_cask_test.go
+++ b/internal/companionmanifest/release_homebrew_formula_bridge_cask_test.go
@@ -24,8 +24,8 @@ func TestHomebrewFormulaBridge_A22PinsCaskOnlyTapTransition(t *testing.T) {
 	for _, required := range []string{
 		"readonly RELEASE_TAG='v0.50.105'",
 		"readonly RELEASE_VERSION='0.50.105'",
-		"readonly PRIOR_TAP_COMMIT='" + a21PriorTapCommit + "'",
-		"readonly PRIOR_CASK_BLOB='" + a21PriorCaskBlob + "'",
+		"readonly PRIOR_TAP_COMMIT='" + a21TapPin(t, "PRIOR_TAP_COMMIT") + "'",
+		"readonly PRIOR_CASK_BLOB='" + a21TapPin(t, "PRIOR_CASK_BLOB") + "'",
 		"readonly FROZEN_FORMULA_BLOB='" + a21FrozenFormulaBlob + "'",
 		"readonly FORMULA_PATH='Formula/auto.rb'",
 		"COMPANION_HOMEBREW_POLICY", "cask-only",
@@ -69,16 +69,16 @@ func TestHomebrewFormulaBridge_PublishedV05070CaskGolden(t *testing.T) {
 	}
 }
 
-func TestHomebrewFormulaBridge_PublishedV05092TapPins(t *testing.T) {
+func TestHomebrewFormulaBridge_PublishedV050103TapPins(t *testing.T) {
 	cask := homebrewBridgeCask()
 	caskSum := sha256.Sum256([]byte(cask))
-	if got := fmt.Sprintf("%x", caskSum); got != "90b229bb1554dffb44f6ed124fa2ea61714ef4e0e07c829ce1d200df69f43d8c" {
-		t.Fatalf("published v0.50.92 Cask digest = %s", got)
+	if got := fmt.Sprintf("%x", caskSum); got != "f65ab412d49a6bcb6e54051eebeedd6989889959761a67203356256272c0282f" {
+		t.Fatalf("published v0.50.103 Cask digest = %s", got)
 	}
 	command := exec.Command("git", "hash-object", "--stdin")
 	command.Stdin = strings.NewReader(cask)
-	if blob, err := command.CombinedOutput(); err != nil || strings.TrimSpace(string(blob)) != a21PriorCaskBlob {
-		t.Fatalf("published v0.50.92 Cask blob = %q: %v", strings.TrimSpace(string(blob)), err)
+	if blob, err := command.CombinedOutput(); err != nil || strings.TrimSpace(string(blob)) != a21TapPin(t, "PRIOR_CASK_BLOB") {
+		t.Fatalf("published v0.50.103 Cask blob = %q: %v", strings.TrimSpace(string(blob)), err)
 	}
 	formulaSum := sha256.Sum256([]byte(homebrewBridgeFormula(t)))
 	if got := fmt.Sprintf("%x", formulaSum); got != "6bc6a0fbf790ee144c74d802a2031ab61f57a2ebd0611b6f15e856c8ed3e8a7c" {
@@ -96,7 +96,7 @@ func TestHomebrewFormulaBridge_RejectsExecutableCaskStanzas(t *testing.T) {
 			fixture.writeAPIContent(t, "cask.json", strings.Repeat("c", 40), malicious)
 
 			output, err := fixture.run(nil)
-			if err == nil || !strings.Contains(string(output), "published Cask differs from canonical v0.50.92") {
+			if err == nil || !strings.Contains(string(output), "published Cask differs from canonical v0.50.103") {
 				t.Fatalf("%s Cask result: %v\n%s", stanza, err, output)
 			}
 			if got := fixture.updateCount(t, "cask"); got != "0" {
@@ -108,11 +108,11 @@ func TestHomebrewFormulaBridge_RejectsExecutableCaskStanzas(t *testing.T) {
 
 func homebrewBridgeCask() string {
 	return strings.NewReplacer(
-		`version "0.50.70"`, `version "0.50.92"`,
-		"9728aec2f36bb43b4fbb658ca8550527d371a4c570ee7fbd2aee2b6fe011e8bd", "027587eb7e7a73a33541ac4e9aaed1d36b446298ecf48ca78292ee87dc589f58",
-		"a57c0c180c0d2bb8ef013b9ae706752c432ff43466e13314b8b6f9279761fe4c", "4364bb3e3db09df8ba63927c8f8f64978fd63d880831dfc154f4ac9a92484492",
-		"f6ff6aba2ce96831b33570c07c2ec33353c8ee1cbfe9a53a2c62227f82bcf69b", "3058d0eec967a341c5eb9a176315f5093ba8a3763db6bb88d78df69ad2e4c961",
-		"027f26f0bc2d3f052b28bbc2da80b15063f42f818be30bea132a78a601fc1822", "a259b171cb5da9ad7ff6bae2d23f7e222297ff443456530928741bae118dbdc7",
+		`version "0.50.70"`, `version "0.50.103"`,
+		"9728aec2f36bb43b4fbb658ca8550527d371a4c570ee7fbd2aee2b6fe011e8bd", "78fff23a4fbc0aedacfe8c7f85f37199106e3f1b738244d6077afededcf98c0e",
+		"a57c0c180c0d2bb8ef013b9ae706752c432ff43466e13314b8b6f9279761fe4c", "bd7d7873b93e6349b06a5b66c34b982e1dffc8a1e6829635324a298b59a88fea",
+		"f6ff6aba2ce96831b33570c07c2ec33353c8ee1cbfe9a53a2c62227f82bcf69b", "7a9112538b341d049e2707f40eb502260b4c58bc767388299da9253e8585dde1",
+		"027f26f0bc2d3f052b28bbc2da80b15063f42f818be30bea132a78a601fc1822", "b47541721189d2f2afbc9778d842dd566496a951704fccd2c5b5ddabdd193d1a",
 	).Replace(publishedV05070Cask)
 }
 

--- a/internal/companionmanifest/release_homebrew_formula_bridge_test.go
+++ b/internal/companionmanifest/release_homebrew_formula_bridge_test.go
@@ -7,15 +7,29 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
 
-const (
-	a21PriorTapCommit    = "a030dbe6566030dcbbbb7d3206abe4debdd0cc51"
-	a21PriorCaskBlob     = "49123ecd55d52e58da64a70f8432086e3f45dd8b"
-	a21FrozenFormulaBlob = "4ebc6c38925002dec00759823d4dd847a499818a"
-)
+// The tap coordinates advance with every publication. Reading them from the
+// publisher keeps these fixtures from silently drifting out of the head check
+// and testing nothing; the frozen Formula blob is a real constant, so it stays.
+const a21FrozenFormulaBlob = "4ebc6c38925002dec00759823d4dd847a499818a"
+
+func a21TapPin(t *testing.T, name string) string {
+	t.Helper()
+	const bridge = "scripts/companion-release/publish-homebrew-formula-bridge.sh"
+	data, err := os.ReadFile(filepath.Join(repositoryRoot(t), filepath.FromSlash(bridge)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	match := regexp.MustCompile(`(?m)^readonly ` + name + `='([0-9a-f]{40})'$`).FindSubmatch(data)
+	if match == nil {
+		t.Fatalf("%s does not pin %s", bridge, name)
+	}
+	return string(match[1])
+}
 
 var bridgeDigests = []string{
 	strings.Repeat("1", 64), strings.Repeat("2", 64),
@@ -129,6 +143,9 @@ func TestHomebrewFormulaBridge_RejectsIdentityMismatchWithoutCredentialLeak(t *t
 
 type homebrewBridgeFixture struct {
 	root, state, checksums, checksumText, cask string
+	// priorCommit mirrors the publisher's tap-head pin so the relocated mock
+	// fixture answers with the same coordinate the publisher enforces.
+	priorCommit string
 }
 
 func newHomebrewBridgeFixture(t *testing.T) homebrewBridgeFixture {
@@ -141,17 +158,18 @@ func newHomebrewBridgeFixture(t *testing.T) homebrewBridgeFixture {
 			t.Fatal(err)
 		}
 	}
-	fixture := homebrewBridgeFixture{root: root, state: state}
+	fixture := homebrewBridgeFixture{root: root, state: state,
+		priorCommit: a21TapPin(t, "PRIOR_TAP_COMMIT")}
 	fixture.cask = homebrewBridgeCask()
 	fixture.checksumText = homebrewBridgeChecksums()
 	fixture.checksums = filepath.Join(root, "checksums.txt")
 	if err := os.WriteFile(fixture.checksums, []byte(fixture.checksumText), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	fixture.writeAPIContent(t, "cask.json", a21PriorCaskBlob, fixture.cask)
+	fixture.writeAPIContent(t, "cask.json", a21TapPin(t, "PRIOR_CASK_BLOB"), fixture.cask)
 	fixture.writeAPIContent(t, "formula.json", a21FrozenFormulaBlob, homebrewBridgeFormula(t))
 	branch := `{"ref":"refs/heads/main","object":{"type":"commit","sha":"` +
-		a21PriorTapCommit + `","url":"https://example.invalid/prior-commit"}}`
+		a21TapPin(t, "PRIOR_TAP_COMMIT") + `","url":"https://example.invalid/prior-commit"}}`
 	if err := os.WriteFile(filepath.Join(state, "branch.json"), []byte(branch), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -171,6 +189,7 @@ func (fixture homebrewBridgeFixture) run(overrides map[string]string) ([]byte, e
 		"TMPDIR": filepath.Join(fixture.root, "tmp"), "MOCK_TAP_STATE": fixture.state,
 		"GITHUB_REF_NAME": "v0.50.105", "COMPANION_VERSION": "0.50.105",
 		"COMPANION_HOMEBREW_POLICY": "cask-only",
+		"MOCK_TAP_PRIOR_COMMIT":     fixture.priorCommit,
 		"COMPANION_CHECKSUMS_PATH":  fixture.checksums,
 		"HOMEBREW_TAP_TOKEN":        "fixture-tap-token", "GH_TOKEN": "",
 	}

--- a/scripts/companion-release/prepare-release-runtime-lib.sh
+++ b/scripts/companion-release/prepare-release-runtime-lib.sh
@@ -259,3 +259,32 @@ publish_coordinates() {
     exit "$status"
   fi
 }
+
+# The Homebrew publisher refuses to commit unless the tap sits exactly where the
+# previous publication left it. That check runs after the canary and GoReleaser,
+# so drift used to surface 40 minutes in. Reading the pins from the publisher
+# keeps one source of truth; the tap is the fact they must match.
+verify_homebrew_tap_pins() {
+  local bridge='scripts/companion-release/publish-homebrew-formula-bridge.sh'
+  local pinned_commit pinned_blob tap_repository tap_branch cask_path head_sha blob_sha
+  pinned_commit=$(pin_from_bridge "$bridge" PRIOR_TAP_COMMIT)
+  pinned_blob=$(pin_from_bridge "$bridge" PRIOR_CASK_BLOB)
+  tap_repository=$(pin_from_bridge "$bridge" TAP_REPOSITORY '[^'"'"']+')
+  tap_branch=$(pin_from_bridge "$bridge" TAP_BRANCH '[^'"'"']+')
+  cask_path=$(pin_from_bridge "$bridge" CASK_PATH '[^'"'"']+')
+  head_sha=$(gh api "repos/${tap_repository}/git/ref/heads/${tap_branch}" --jq .object.sha) ||
+    fail 'cannot read the Homebrew tap branch head'
+  [[ "$head_sha" == "$pinned_commit" ]] || fail \
+    "Homebrew tap head ${head_sha} differs from pinned PRIOR_TAP_COMMIT ${pinned_commit}; bump the pin in ${bridge}"
+  blob_sha=$(gh api "repos/${tap_repository}/contents/${cask_path}?ref=${tap_branch}" --jq .sha) ||
+    fail 'cannot read the Homebrew tap Cask'
+  [[ "$blob_sha" == "$pinned_blob" ]] || fail \
+    "Homebrew tap Cask blob ${blob_sha} differs from pinned PRIOR_CASK_BLOB ${pinned_blob}; bump the pin in ${bridge}"
+}
+
+pin_from_bridge() {
+  local file=$1 name=$2 pattern=${3:-'[0-9a-f]{40}'} value
+  value=$(sed -nE "s/^readonly ${name}='(${pattern})'\$/\1/p" "$file")
+  [[ -n "$value" ]] || fail "cannot read ${name} from ${file}"
+  printf '%s\n' "$value"
+}

--- a/scripts/companion-release/prepare-release.sh
+++ b/scripts/companion-release/prepare-release.sh
@@ -260,6 +260,8 @@ go build -trimpath -o "$execsmoke" ./scripts/companion-release/execsmoke
 [[ "$("$policy_tool" companion-manifest omp-context-promotion-key-id <"$promotion_signing_key")" == \
    "$expected_promotion_key_id" ]] || fail 'promotion signing key differs from pinned local release key'
 
+verify_homebrew_tap_pins # two API calls, not a post-canary/post-GoReleaser failure
+
 if [[ "$evidence_present" -eq 1 ]]; then
   load_evidence
   derive_policy "$verified_report" "$static_policy_file"

--- a/scripts/companion-release/publish-homebrew-formula-bridge-git.sh
+++ b/scripts/companion-release/publish-homebrew-formula-bridge-git.sh
@@ -41,8 +41,11 @@ verify_prior_tap_head() {
     select(type == "object" and .ref == $ref and .object.type == "commit") |
     .object.sha | select(type == "string" and test("^[0-9a-f]{40}$"))
   ' "$response") || fail 'Homebrew tap branch head response is invalid'
+  # A successful publication advances the tap, so the pin has to be bumped in the
+  # same PR that ships the next release. Naming both SHAs turns that bump into a
+  # copy-paste instead of a mid-release investigation.
   [[ "$head_sha" == "$PRIOR_TAP_COMMIT" ]] \
-    || fail 'Homebrew tap branch differs from the pinned predecessor commit'
+    || fail "Homebrew tap branch differs from the pinned predecessor commit (tap head ${head_sha}, pinned ${PRIOR_TAP_COMMIT}); update PRIOR_TAP_COMMIT to the tap head"
 }
 
 # @AX:NOTE [AUTO]: [downgraded from ANCHOR — fan_in=1 under file cap] Bind idempotent success to one stable head, tree, Cask, and Formula snapshot.

--- a/scripts/companion-release/publish-homebrew-formula-bridge.sh
+++ b/scripts/companion-release/publish-homebrew-formula-bridge.sh
@@ -7,9 +7,9 @@ readonly RELEASE_VERSION='0.50.105'
 readonly RELEASE_POLICY='cask-only'
 readonly TAP_REPOSITORY='Insajin/homebrew-autopus'
 readonly TAP_BRANCH='main'
-readonly PRIOR_TAP_COMMIT='a030dbe6566030dcbbbb7d3206abe4debdd0cc51'
+readonly PRIOR_TAP_COMMIT='98e1f8c9c58ff863efab3c9789e372f0f4d11820'
 readonly CASK_PATH='Casks/auto.rb'
-readonly PRIOR_CASK_BLOB='49123ecd55d52e58da64a70f8432086e3f45dd8b'
+readonly PRIOR_CASK_BLOB='e7cd7c6257e6f55ee61ee37a1779d0aa6fa0cd1f'
 readonly FORMULA_PATH='Formula/auto.rb'
 readonly FROZEN_FORMULA_BLOB='4ebc6c38925002dec00759823d4dd847a499818a'
 
@@ -147,4 +147,4 @@ fi
 verify_frozen_formula
 publish_cask cask Cask "$CASK_PATH" "$cask_target" "$PRIOR_CASK_BLOB" \
   'Publish signed Cask for v0.50.105' \
-  'published Cask differs from canonical v0.50.92 output and its pinned prior blob'
+  'published Cask differs from canonical v0.50.103 output and its pinned prior blob'

--- a/scripts/companion-release/tests/release-hardening-test.sh
+++ b/scripts/companion-release/tests/release-hardening-test.sh
@@ -8,6 +8,7 @@ repo=$(cd -- "$script_dir/../.." && pwd)
 fail() { printf 'release hardening test: %s\n' "$1" >&2; exit 1; }
 contains() { grep -Fq -- "$2" "$1" || fail "$1 missing $2"; }
 not_contains() { ! grep -Fq -- "$2" "$1" || fail "$1 unexpectedly contains $2"; }
+matches() { grep -Eq -- "$2" "$1" || fail "$1 missing pattern $2"; }
 
 config="$repo/.goreleaser.yaml"
 release="$repo/.github/workflows/release.yaml"
@@ -41,8 +42,11 @@ contains "$release" 'COMPANION_CHECKSUMS_PATH: ${{ steps.release-evidence.output
 contains "$release" 'COMPANION_CHECKSUMS_PATH="$COMPANION_CHECKSUMS_PATH"'
 not_contains "$release" "COMPANION_CHECKSUMS_PATH='dist/checksums.txt'"
 contains "$producer_receipt" '--signing-key "$COMPANION_SIGNING_KEY_FILE"'
-contains "$homebrew_bridge" "readonly PRIOR_TAP_COMMIT='a030dbe6566030dcbbbb7d3206abe4debdd0cc51'"
-contains "$homebrew_bridge" "readonly PRIOR_CASK_BLOB='49123ecd55d52e58da64a70f8432086e3f45dd8b'"
+# The tap coordinates advance with every publication, so pinning their exact
+# value here only forces a second edit; the publisher already enforces them
+# against the live tap. Assert the shape that keeps that enforcement possible.
+matches "$homebrew_bridge" "^readonly PRIOR_TAP_COMMIT='[0-9a-f]{40}'$"
+matches "$homebrew_bridge" "^readonly PRIOR_CASK_BLOB='[0-9a-f]{40}'$"
 contains "$homebrew_bridge" "readonly FROZEN_FORMULA_BLOB='4ebc6c38925002dec00759823d4dd847a499818a'"
 contains "$homebrew_bridge" 'COMPANION_HOMEBREW_POLICY'
 contains "$homebrew_bridge" "readonly FORMULA_PATH='Formula/auto.rb'"

--- a/scripts/companion-release/tests/release-homebrew-hardening-test.sh
+++ b/scripts/companion-release/tests/release-homebrew-hardening-test.sh
@@ -6,6 +6,16 @@ tests_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 script_dir=$(cd -- "$tests_dir/.." && pwd)
 fail() { printf 'release homebrew hardening test: %s\n' "$1" >&2; exit 1; }
 
+# The mock tap head must equal the pin the publisher enforces, or every case
+# below stops at the head check instead of exercising the drift it targets.
+# Reading the pin keeps the fixture from desyncing when a release bumps it.
+prior_tap_commit=$(sed -n "s/^readonly PRIOR_TAP_COMMIT='\([0-9a-f]\{40\}\)'\$/\1/p" \
+  "$script_dir/publish-homebrew-formula-bridge.sh")
+[[ -n "$prior_tap_commit" ]] || fail 'cannot read PRIOR_TAP_COMMIT from the publisher'
+prior_cask_blob=$(sed -n "s/^readonly PRIOR_CASK_BLOB='\([0-9a-f]\{40\}\)'$/\1/p" \
+  "$script_dir/publish-homebrew-formula-bridge.sh")
+[[ -n "$prior_cask_blob" ]] || fail 'cannot read PRIOR_CASK_BLOB from the publisher'
+
 temp=$(mktemp -d "${TMPDIR:-/tmp}/release-homebrew-hardening-test.XXXXXX")
 trap 'rm -rf -- "$temp"' EXIT
 state="$temp/tap-state"
@@ -21,25 +31,26 @@ checksums="$temp/checksums.txt"
 
 # A22 updates only the Cask from the exact A21 tap head and keeps Formula frozen.
 source "$script_dir/publish-homebrew-formula-bridge-render.sh"
-render_homebrew_cask "$temp/prior-cask.rb" 0.50.92 \
-  '027587eb7e7a73a33541ac4e9aaed1d36b446298ecf48ca78292ee87dc589f58' \
-  '4364bb3e3db09df8ba63927c8f8f64978fd63d880831dfc154f4ac9a92484492' \
-  '3058d0eec967a341c5eb9a176315f5093ba8a3763db6bb88d78df69ad2e4c961' \
-  'a259b171cb5da9ad7ff6bae2d23f7e222297ff443456530928741bae118dbdc7'
+render_homebrew_cask "$temp/prior-cask.rb" 0.50.103 \
+  '78fff23a4fbc0aedacfe8c7f85f37199106e3f1b738244d6077afededcf98c0e' \
+  'bd7d7873b93e6349b06a5b66c34b982e1dffc8a1e6829635324a298b59a88fea' \
+  '7a9112538b341d049e2707f40eb502260b4c58bc767388299da9253e8585dde1' \
+  'b47541721189d2f2afbc9778d842dd566496a951704fccd2c5b5ddabdd193d1a'
 [[ "$(git -C "$temp" hash-object "$temp/prior-cask.rb")" == \
-   '49123ecd55d52e58da64a70f8432086e3f45dd8b' ]] \
+   "$prior_cask_blob" ]] \
   || fail 'rendered A21 Cask bytes differ from the pinned predecessor blob'
 render_homebrew_formula_bridge "$temp/frozen-formula.rb" v0.50.71 0.50.71 \
   "$(printf '%064d' 1)" "$(printf '%064d' 2)" \
   "$(printf '%064d' 3)" "$(printf '%064d' 4)"
 jq -n --arg content "$(base64 <"$temp/prior-cask.rb" | tr -d '\r\n')" \
-  '{sha:"49123ecd55d52e58da64a70f8432086e3f45dd8b",content:$content}' >"$state/cask.json"
+  --arg sha "$prior_cask_blob" '{sha:$sha,content:$content}' >"$state/cask.json"
 jq -n --arg content "$(base64 <"$temp/frozen-formula.rb" | tr -d '\r\n')" \
   '{sha:"4ebc6c38925002dec00759823d4dd847a499818a",content:$content}' >"$state/formula.json"
-jq -n '{ref:"refs/heads/main",object:{type:"commit",sha:"a030dbe6566030dcbbbb7d3206abe4debdd0cc51",url:"https://example.invalid/prior-commit"}}' \
+jq -n --arg sha "$prior_tap_commit" '{ref:"refs/heads/main",object:{type:"commit",sha:$sha,url:"https://example.invalid/prior-commit"}}' \
   >"$state/branch.json"
 cp "$state/formula.json" "$temp/formula-before.json"
 bridge_env=(PATH="$temp/bin:$PATH" MOCK_TAP_STATE="$state" GITHUB_REF_NAME=v0.50.105
+  MOCK_TAP_PRIOR_COMMIT="$prior_tap_commit"
   COMPANION_VERSION=0.50.105 COMPANION_HOMEBREW_POLICY=cask-only
   COMPANION_CHECKSUMS_PATH="$checksums" HOMEBREW_TAP_TOKEN=fixture)
 env "${bridge_env[@]}" bash "$script_dir/publish-homebrew-formula-bridge.sh"
@@ -90,7 +101,7 @@ rm -f -- "$state/idempotent-ref-race"
 
 # An update-needed retry must reject pre-existing tap-head or Formula drift.
 jq -n --arg content "$(base64 <"$temp/prior-cask.rb" | tr -d '\r\n')" \
-  '{sha:"49123ecd55d52e58da64a70f8432086e3f45dd8b",content:$content}' >"$state/cask.json"
+  --arg sha "$prior_cask_blob" '{sha:$sha,content:$content}' >"$state/cask.json"
 jq -n '{ref:"refs/heads/main",object:{type:"commit",sha:"4444444444444444444444444444444444444444",url:"https://example.invalid/racer"}}' \
   >"$state/branch.json"
 if env "${bridge_env[@]}" bash "$script_dir/publish-homebrew-formula-bridge.sh" \
@@ -99,7 +110,7 @@ if env "${bridge_env[@]}" bash "$script_dir/publish-homebrew-formula-bridge.sh" 
 fi
 [[ "$(<"$state/ref-update.calls")" == 1 ]] \
   || fail 'A22 updated Cask after predecessor commit drift'
-jq -n '{ref:"refs/heads/main",object:{type:"commit",sha:"a030dbe6566030dcbbbb7d3206abe4debdd0cc51",url:"https://example.invalid/prior-commit"}}' \
+jq -n --arg sha "$prior_tap_commit" '{ref:"refs/heads/main",object:{type:"commit",sha:$sha,url:"https://example.invalid/prior-commit"}}' \
   >"$state/branch.json"
 jq -n --arg content "$(base64 <"$temp/frozen-formula.rb" | tr -d '\r\n')" \
   '{sha:"5555555555555555555555555555555555555555",content:$content}' >"$state/formula.json"
@@ -113,7 +124,7 @@ fi
 # A branch move after the head check must make the non-force ref CAS fail.
 jq -n --arg content "$(base64 <"$temp/frozen-formula.rb" | tr -d '\r\n')" \
   '{sha:"4ebc6c38925002dec00759823d4dd847a499818a",content:$content}' >"$state/formula.json"
-jq -n '{ref:"refs/heads/main",object:{type:"commit",sha:"a030dbe6566030dcbbbb7d3206abe4debdd0cc51",url:"https://example.invalid/prior-commit"}}' \
+jq -n --arg sha "$prior_tap_commit" '{ref:"refs/heads/main",object:{type:"commit",sha:$sha,url:"https://example.invalid/prior-commit"}}' \
   >"$state/branch.json"
 touch "$state/race-before-ref"
 if env "${bridge_env[@]}" bash "$script_dir/publish-homebrew-formula-bridge.sh" \
@@ -129,7 +140,7 @@ rm -f -- "$state/race-before-ref"
 # A concurrent Formula-changing commit must also win the race and reject A22.
 jq -n --arg content "$(base64 <"$temp/frozen-formula.rb" | tr -d '\r\n')" \
   '{sha:"4ebc6c38925002dec00759823d4dd847a499818a",content:$content}' >"$state/formula.json"
-jq -n '{ref:"refs/heads/main",object:{type:"commit",sha:"a030dbe6566030dcbbbb7d3206abe4debdd0cc51",url:"https://example.invalid/prior-commit"}}' \
+jq -n --arg sha "$prior_tap_commit" '{ref:"refs/heads/main",object:{type:"commit",sha:$sha,url:"https://example.invalid/prior-commit"}}' \
   >"$state/branch.json"
 touch "$state/formula-race-before-ref"
 if env "${bridge_env[@]}" bash "$script_dir/publish-homebrew-formula-bridge.sh" \
@@ -141,5 +152,15 @@ rm -f -- "$state/formula-race-before-ref"
    "$(jq -er '.sha' "$state/formula.json")" == \
      '6666666666666666666666666666666666666666' ]] \
   || fail 'A22 overwrote a concurrent Formula drift commit'
+
+# Tap drift must fail in prep, before the canary; behind it the stale pin still
+# costs a full production run and a GoReleaser publish before anyone learns.
+prep="$script_dir/prepare-release.sh"
+prep_lib="$script_dir/prepare-release-runtime-lib.sh"
+grep -Fq 'verify_homebrew_tap_pins()' "$prep_lib" || fail 'prep cannot verify tap pins'
+grep -Fq 'pin_from_bridge()' "$prep_lib" || fail 'prep duplicates the tap pins'
+(( $(grep -n 'verify_homebrew_tap_pins' "$prep" | cut -d: -f1) < \
+   $(grep -n 'run_canary "$final_candidate"' "$prep" | cut -d: -f1) )) \
+  || fail 'Homebrew tap pins are checked after the canary'
 
 printf 'release homebrew hardening test: PASS\n'

--- a/scripts/companion-release/tests/testdata/mock-tap-gh.sh
+++ b/scripts/companion-release/tests/testdata/mock-tap-gh.sh
@@ -2,7 +2,10 @@
 # Test-only GitHub Git Data/Contents API state machine.
 set -euo pipefail
 
-readonly prior_commit='a030dbe6566030dcbbbb7d3206abe4debdd0cc51'
+# Injected, never duplicated: the publisher owns the tap coordinates and a
+# release bumps them. This fixture is installed outside the repo, so the
+# caller passes the pin instead of a literal that would stop matching.
+readonly prior_commit="${MOCK_TAP_PRIOR_COMMIT:?mock tap gh: MOCK_TAP_PRIOR_COMMIT is required}"
 readonly prior_tree='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 readonly target_blob='1111111111111111111111111111111111111111'
 readonly target_tree='2222222222222222222222222222222222222222'


### PR DESCRIPTION
## What blocked v0.50.105

GoReleaser passed for the first time in four attempts (the 45s exec-smoke deadline from the v0.50.105 coordinate PR held). The release then failed one step later:

```
homebrew cask publication: Homebrew tap branch differs from the pinned predecessor commit
```

The tap's real history versus what this repo believed:

```
98e1f8c9  Publish signed Cask for v0.50.103   <- live HEAD
a030dbe6  Publish signed Cask for v0.50.92    <- what the repo pinned
```

v0.50.103 published to the tap and nothing updated the repo's predecessor model. v0.50.93-v0.50.102 never reached the Homebrew step, so the stale pin survived eleven releases without being noticed.

**This is the same failure shape as the last three PRs**: a value that must match an external fact, hardcoded, with no derivation and no check until deep into a 40-minute release.

## Predecessor moved to the real publication point

| pin | was (v0.50.92) | now (v0.50.103) |
|---|---|---|
| `PRIOR_TAP_COMMIT` | `a030dbe6` | `98e1f8c9` |
| `PRIOR_CASK_BLOB` | `49123ecd` | `e7cd7c62` |
| predecessor Cask coordinates | `0.50.92` + 4 digests | `0.50.103` + 4 digests |

Verified rather than assumed: rendering the Cask with v0.50.103's release checksums reproduces the live tap file **byte-identically** (`git hash-object` = `e7cd7c62…`, `diff` clean). That is what makes the new pin trustworthy instead of merely current.

## Duplication removed

The pins were copied into four places, and every copy had to be edited in lockstep. Now the publisher is the single source and everything else reads it:

- `mock-tap-gh.sh` takes `MOCK_TAP_PRIOR_COMMIT` (it is installed outside the repo, so injection is the only channel that cannot go stale)
- the Go fixture reads the pins via `a21TapPin`; `PublishedV05092TapPins` is renamed to the version it actually pins
- `release-hardening-test.sh` asserts the pin *shape*, not its value; exact-value assertions there only forced a second edit, since the publisher already enforces them against the live tap. `FROZEN_FORMULA_BLOB` stays exact because it is genuinely frozen.

## Drift now fails in prep

`verify_homebrew_tap_pins` runs in `prepare-release.sh` before the canary. Two API calls turn a post-canary, post-GoReleaser failure into a preflight one, and the message names both SHAs plus the file to edit:

```
Homebrew tap head 98e1f8c9... differs from pinned PRIOR_TAP_COMMIT 000000...ff;
bump the pin in scripts/companion-release/publish-homebrew-formula-bridge.sh
```

The publisher's own message gained the same two values, so a mid-release failure is also self-explaining.

## Verification

- exercised both directions live: the current pins match the real tap, and an injected wrong pin is rejected naming both SHAs
- renderer proven byte-identical to the published v0.50.103 Cask
- all 12 `scripts/companion-release/tests/*.sh` suites pass
- `./internal/companionmanifest`, `./pkg/companionmanifest` pass; `go build ./...`, `go vet ./...`, `gofmt` clean
- `prepare-release.sh` and the hardening tests stay under the 300-line source limit (the tap assertions live in the Homebrew suite, which owns that concern and had headroom)

An earlier attempt had the mock derive the pin from a relative path; it silently broke every fixture because the mock is copied outside the repo before running. Caught by running the suites, not by reading the diff.
