### PR TITLE
chore(release): v0.50.106 게시 후 Homebrew predecessor를 실제 tap 상태로 동기화

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 - **A22 좌표를 v0.50.106으로 전환** (2026-08-10): 좌표를 `v0.50.106`으로 옮기고 금지 좌표 창을 `v0.50.105`·`v0.50.104`·`v0.50.103`으로 민다. v0.50.105는 canary 40콜과 GoReleaser 자산 업로드까지 처음으로 통과했지만, Homebrew cask 게시가 predecessor 핀 불일치로 멈췄다. 릴리즈 자체는 immutable로 게시된 상태이므로 되돌릴 수 없고, 태그 트리에는 핀 수정이 없어 태그 기준 복구 워크플로로도 되살릴 수 없다. 따라서 핀이 교정된 main에서 새 좌표로 재발행한다. cask는 v0.50.92에서 v0.50.106으로 건너뛴다 — cask는 최신만 유지하면 되므로 사용자 영향은 없다.
 
+- **v0.50.106 게시 후 Homebrew predecessor를 실제 tap 상태로 동기화** (2026-08-10): v0.50.106이 게시되며 tap이 `9484e41a`로 전진했고 Cask blob은 `c1f90dc1`이 됐다. 게시가 성공하면 핀은 반드시 한 세대 낡으므로, 다음 릴리즈가 그 사실을 발견하게 두지 않고 지금 맞춘다. v0.50.105가 막힌 원인이 정확히 이 지연이었다 — 핀이 v0.50.92에 머문 채 11개 릴리즈를 통과했다. 렌더러가 게시된 Cask를 바이트 단위로 재현함을 확인해 핀 값을 검증했고(`git hash-object` = `c1f90dc1`), `prepare-release.sh`의 tap 핀 preflight가 실제 tap과 일치함을 실행해 확인했다.
+
 ### Removed
 
 - **프로덕션에서 쓰이지 않던 `PaneBackend`** (2026-08-09): 이름은 pane인데 실제로는 `runProvider`로 자식 프로세스를 띄우는 타입이었고, 프로덕션 참조는 없이 자기 자신을 검증하는 테스트와 fresh-judge 허용목록 항목만 남아 있었다. 이 오해를 부르는 이름 때문에 전송 선택 seam을 잘못 고를 뻔했으므로 제거한다. `pipelineBackendHasFreshExecutionSemantics`의 허용목록에서도 빠지며, 남은 두 내장 백엔드(`subprocessBackend`, `InteractivePaneBackend`)의 판정은 그대로다. `SelectBackend`의 주석에 자유 텍스트 호출자는 이 백엔드를 쓰면 안 된다는 계약을 명시했다.

--- a/internal/companionmanifest/release_homebrew_formula_bridge_cask_test.go
+++ b/internal/companionmanifest/release_homebrew_formula_bridge_cask_test.go
@@ -69,16 +69,16 @@ func TestHomebrewFormulaBridge_PublishedV05070CaskGolden(t *testing.T) {
 	}
 }
 
-func TestHomebrewFormulaBridge_PublishedV050103TapPins(t *testing.T) {
+func TestHomebrewFormulaBridge_PublishedV050106TapPins(t *testing.T) {
 	cask := homebrewBridgeCask()
 	caskSum := sha256.Sum256([]byte(cask))
-	if got := fmt.Sprintf("%x", caskSum); got != "f65ab412d49a6bcb6e54051eebeedd6989889959761a67203356256272c0282f" {
-		t.Fatalf("published v0.50.103 Cask digest = %s", got)
+	if got := fmt.Sprintf("%x", caskSum); got != "75abe4fc1485d95f29aead695f002e119e850a49499f1916fb34ff3bf6a71912" {
+		t.Fatalf("published v0.50.106 Cask digest = %s", got)
 	}
 	command := exec.Command("git", "hash-object", "--stdin")
 	command.Stdin = strings.NewReader(cask)
 	if blob, err := command.CombinedOutput(); err != nil || strings.TrimSpace(string(blob)) != a21TapPin(t, "PRIOR_CASK_BLOB") {
-		t.Fatalf("published v0.50.103 Cask blob = %q: %v", strings.TrimSpace(string(blob)), err)
+		t.Fatalf("published v0.50.106 Cask blob = %q: %v", strings.TrimSpace(string(blob)), err)
 	}
 	formulaSum := sha256.Sum256([]byte(homebrewBridgeFormula(t)))
 	if got := fmt.Sprintf("%x", formulaSum); got != "6bc6a0fbf790ee144c74d802a2031ab61f57a2ebd0611b6f15e856c8ed3e8a7c" {
@@ -96,7 +96,7 @@ func TestHomebrewFormulaBridge_RejectsExecutableCaskStanzas(t *testing.T) {
 			fixture.writeAPIContent(t, "cask.json", strings.Repeat("c", 40), malicious)
 
 			output, err := fixture.run(nil)
-			if err == nil || !strings.Contains(string(output), "published Cask differs from canonical v0.50.103") {
+			if err == nil || !strings.Contains(string(output), "published Cask differs from canonical v0.50.106") {
 				t.Fatalf("%s Cask result: %v\n%s", stanza, err, output)
 			}
 			if got := fixture.updateCount(t, "cask"); got != "0" {
@@ -108,11 +108,11 @@ func TestHomebrewFormulaBridge_RejectsExecutableCaskStanzas(t *testing.T) {
 
 func homebrewBridgeCask() string {
 	return strings.NewReplacer(
-		`version "0.50.70"`, `version "0.50.103"`,
-		"9728aec2f36bb43b4fbb658ca8550527d371a4c570ee7fbd2aee2b6fe011e8bd", "78fff23a4fbc0aedacfe8c7f85f37199106e3f1b738244d6077afededcf98c0e",
-		"a57c0c180c0d2bb8ef013b9ae706752c432ff43466e13314b8b6f9279761fe4c", "bd7d7873b93e6349b06a5b66c34b982e1dffc8a1e6829635324a298b59a88fea",
-		"f6ff6aba2ce96831b33570c07c2ec33353c8ee1cbfe9a53a2c62227f82bcf69b", "7a9112538b341d049e2707f40eb502260b4c58bc767388299da9253e8585dde1",
-		"027f26f0bc2d3f052b28bbc2da80b15063f42f818be30bea132a78a601fc1822", "b47541721189d2f2afbc9778d842dd566496a951704fccd2c5b5ddabdd193d1a",
+		`version "0.50.70"`, `version "0.50.106"`,
+		"9728aec2f36bb43b4fbb658ca8550527d371a4c570ee7fbd2aee2b6fe011e8bd", "113b319911150083d6384fbaa50786ddd55f8113d580946078f5f6561384d382",
+		"a57c0c180c0d2bb8ef013b9ae706752c432ff43466e13314b8b6f9279761fe4c", "5cdd342416bb4b8feeac403f53761b5b0a2572269a5881afeb90a3306365f744",
+		"f6ff6aba2ce96831b33570c07c2ec33353c8ee1cbfe9a53a2c62227f82bcf69b", "7d8cd1fd01dfc32dd06bc3b8223321eaa1b1d8ee483944e36759c400b1e8b619",
+		"027f26f0bc2d3f052b28bbc2da80b15063f42f818be30bea132a78a601fc1822", "e7914d063227bc8a7acba5668e9bb09d30ee1f7e4807117c089575b63c96e573",
 	).Replace(publishedV05070Cask)
 }
 

--- a/scripts/companion-release/publish-homebrew-formula-bridge.sh
+++ b/scripts/companion-release/publish-homebrew-formula-bridge.sh
@@ -7,9 +7,9 @@ readonly RELEASE_VERSION='0.50.106'
 readonly RELEASE_POLICY='cask-only'
 readonly TAP_REPOSITORY='Insajin/homebrew-autopus'
 readonly TAP_BRANCH='main'
-readonly PRIOR_TAP_COMMIT='98e1f8c9c58ff863efab3c9789e372f0f4d11820'
+readonly PRIOR_TAP_COMMIT='9484e41ad6f241f866a8a22164abef417780b527'
 readonly CASK_PATH='Casks/auto.rb'
-readonly PRIOR_CASK_BLOB='e7cd7c6257e6f55ee61ee37a1779d0aa6fa0cd1f'
+readonly PRIOR_CASK_BLOB='c1f90dc1be31f8bb6885389da08f568ac4ed5ee3'
 readonly FORMULA_PATH='Formula/auto.rb'
 readonly FROZEN_FORMULA_BLOB='4ebc6c38925002dec00759823d4dd847a499818a'
 
@@ -147,4 +147,4 @@ fi
 verify_frozen_formula
 publish_cask cask Cask "$CASK_PATH" "$cask_target" "$PRIOR_CASK_BLOB" \
   'Publish signed Cask for v0.50.106' \
-  'published Cask differs from canonical v0.50.103 output and its pinned prior blob'
+  'published Cask differs from canonical v0.50.106 output and its pinned prior blob'

--- a/scripts/companion-release/tests/release-homebrew-hardening-test.sh
+++ b/scripts/companion-release/tests/release-homebrew-hardening-test.sh
@@ -31,11 +31,11 @@ checksums="$temp/checksums.txt"
 
 # A22 updates only the Cask from the exact A21 tap head and keeps Formula frozen.
 source "$script_dir/publish-homebrew-formula-bridge-render.sh"
-render_homebrew_cask "$temp/prior-cask.rb" 0.50.103 \
-  '78fff23a4fbc0aedacfe8c7f85f37199106e3f1b738244d6077afededcf98c0e' \
-  'bd7d7873b93e6349b06a5b66c34b982e1dffc8a1e6829635324a298b59a88fea' \
-  '7a9112538b341d049e2707f40eb502260b4c58bc767388299da9253e8585dde1' \
-  'b47541721189d2f2afbc9778d842dd566496a951704fccd2c5b5ddabdd193d1a'
+render_homebrew_cask "$temp/prior-cask.rb" 0.50.106 \
+  '113b319911150083d6384fbaa50786ddd55f8113d580946078f5f6561384d382' \
+  '5cdd342416bb4b8feeac403f53761b5b0a2572269a5881afeb90a3306365f744' \
+  '7d8cd1fd01dfc32dd06bc3b8223321eaa1b1d8ee483944e36759c400b1e8b619' \
+  'e7914d063227bc8a7acba5668e9bb09d30ee1f7e4807117c089575b63c96e573'
 [[ "$(git -C "$temp" hash-object "$temp/prior-cask.rb")" == \
    "$prior_cask_blob" ]] \
   || fail 'rendered A21 Cask bytes differ from the pinned predecessor blob'


### PR DESCRIPTION
## v0.50.106 shipped

```
release   v0.50.106  15 assets, immutable, target 61507567
tap       9484e41a   Publish signed Cask for v0.50.106
cask      version "0.50.106"
workflow  12/12 jobs success (including release)
```

First clean run of this release line: the usage-window fix (#172), the tap predecessor fix (#173) and the v0.50.106 coordinate (#174) all held, and the Homebrew step that blocked v0.50.105 passed.

## Why this PR exists

A successful publication **always** leaves the pins one generation stale — the tap moved to `9484e41a` / `c1f90dc1` the moment the cask landed. That lag is exactly what blocked v0.50.105: the pins sat at v0.50.92 while eleven releases went by, because none of them reached the Homebrew step to notice.

So this is not cleanup, it is closing the loop the same run opened.

| pin | was (v0.50.103) | now (v0.50.106) |
|---|---|---|
| `PRIOR_TAP_COMMIT` | `98e1f8c9` | `9484e41a` |
| `PRIOR_CASK_BLOB` | `e7cd7c62` | `c1f90dc1` |
| predecessor Cask coordinates | `0.50.103` + 4 digests | `0.50.106` + 4 digests |

## Verification

Both directions checked against the live tap, not assumed:

- the renderer reproduces the published v0.50.106 Cask **byte-identically** (`git hash-object` = `c1f90dc1…`, `diff` clean) — this is what makes the new blob pin trustworthy rather than merely copied
- `verify_homebrew_tap_pins` from #173 run against the real tap: `TAP_PINS_MATCH`
- all 12 `scripts/companion-release/tests/*.sh` suites pass
- `./internal/companionmanifest`, `./pkg/companionmanifest` pass; `go build ./...`, `go vet`, `gofmt` clean

The diff is small because #173 made the fixtures derive from the publisher: the mock `gh`, the Go fixture and the shell test all read `PRIOR_TAP_COMMIT`/`PRIOR_CASK_BLOB` now, so bumping the publisher is enough and nothing can desync behind it.

Forbidden-coordinate entries for `v0.50.103` stay — those pin the release workflow away from old tags and are unrelated to the tap predecessor.

## Still open

The recovery workflow checks out the release tag, so a tag whose publishing scripts are broken cannot be recovered by those same scripts — the exact situation v0.50.105 hit. Fixing it needs a two-checkout design (reviewed scripts, tagged source) because `validate-source.sh` compares `$GITHUB_SHA` to the approved source commit and runs `git verify-tag`. Deliberately left out of this PR.
