### PR TITLE
fix(release): tap 핀 검사를 GoReleaser 앞으로 옮겨 버전 소각을 막는다

### DIFF
--- a/.github/workflows/homebrew-formula-bridge-recovery.yaml
+++ b/.github/workflows/homebrew-formula-bridge-recovery.yaml
@@ -5,6 +5,19 @@ on:
 
 # Canonical invocation after the immutable release exists:
 # gh workflow run homebrew-formula-bridge-recovery.yaml --ref v0.50.106
+#
+# Scope: a tap write that failed for a transient reason — expired token, network
+# error, or a concurrent tap move. The tag's scripts are correct in that case and
+# rerunning them is the fix.
+#
+# Out of scope: a tag whose publishing scripts are themselves wrong, such as a
+# stale predecessor pin. This job runs the tag's own scripts, so it would repeat
+# the same failure, and the release is immutable so it cannot be revised. The fix
+# there is a new coordinate. Do not try to make this job run scripts from another
+# ref: validate-source.sh binds GITHUB_SHA to the approved source commit and
+# verifies the tag signature, so a different tree either breaks those gates or
+# needs a second, separately approved trust anchor. verify-homebrew-tap-pins.sh
+# runs before GoReleaser precisely so that case never reaches this workflow.
 
 permissions:
   contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -562,6 +562,21 @@ jobs:
             COMPANION_PUBLIC_KEY_RECEIPT_EXPIRES_AT="$COMPANION_PUBLIC_KEY_RECEIPT_EXPIRES_AT" \
             scripts/companion-release/verify-public-key-lineage.sh
 
+      - name: Verify Homebrew tap predecessor pins
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Last gate before an immutable release exists. The Cask publication at
+        # the end of this job enforces the same pins; failing there leaves a
+        # published release that can never get its Cask, because recovery reruns
+        # the tag's own stale scripts. The tap is public, so this reads it with
+        # no write credential and cannot widen what GoReleaser is trusted with.
+        shell: bash
+        run: |
+          set -euo pipefail
+          env -i PATH="$PATH" HOME="$HOME" TMPDIR="$RUNNER_TEMP" \
+            GITHUB_TOKEN="$GITHUB_TOKEN" \
+            scripts/companion-release/verify-homebrew-tap-pins.sh
+
       - name: Run GoReleaser
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 
 - **v0.50.106 게시 후 Homebrew predecessor를 실제 tap 상태로 동기화** (2026-08-10): v0.50.106이 게시되며 tap이 `9484e41a`로 전진했고 Cask blob은 `c1f90dc1`이 됐다. 게시가 성공하면 핀은 반드시 한 세대 낡으므로, 다음 릴리즈가 그 사실을 발견하게 두지 않고 지금 맞춘다. v0.50.105가 막힌 원인이 정확히 이 지연이었다 — 핀이 v0.50.92에 머문 채 11개 릴리즈를 통과했다. 렌더러가 게시된 Cask를 바이트 단위로 재현함을 확인해 핀 값을 검증했고(`git hash-object` = `c1f90dc1`), `prepare-release.sh`의 tap 핀 preflight가 실제 tap과 일치함을 실행해 확인했다.
 
+- **Homebrew tap 핀 검사를 GoReleaser 앞으로 옮겨 버전 소각을 막는다** (2026-08-10): 지금까지 tap predecessor 핀은 job의 **맨 끝** Cask 게시에서만 검증됐다. 그 지점에서 실패하면 immutable 릴리즈가 이미 존재하므로 되돌릴 수 없고, 복구 워크플로는 같은 태그의 같은 낡은 스크립트를 다시 돌리므로 그 버전은 영구히 Cask를 못 받는다 — v0.50.105가 그렇게 소각됐다. 같은 비교를 `verify-homebrew-tap-pins.sh`로 뽑아 GoReleaser **앞**에서 실행한다. tap은 public이라 쓰기 자격증명이 필요 없고, GoReleaser 이전에 자격증명을 두지 않는 기존 불변식을 건드리지 않는다. prep의 preflight도 같은 스크립트에 위임하므로 구현은 하나다. 세 실패 경로(헤드 드리프트·blob 드리프트·핀 부재)를 실제 tap 대상으로 구동해 fail-closed를 확인했다. 복구 워크플로에는 적용 범위(일시적 tap 쓰기 실패)와 비적용 범위(태그 스크립트 자체가 틀린 경우 → 새 좌표), 그리고 다른 ref의 스크립트를 쓰면 안 되는 이유를 명시했다.
+
 ### Removed
 
 - **프로덕션에서 쓰이지 않던 `PaneBackend`** (2026-08-09): 이름은 pane인데 실제로는 `runProvider`로 자식 프로세스를 띄우는 타입이었고, 프로덕션 참조는 없이 자기 자신을 검증하는 테스트와 fresh-judge 허용목록 항목만 남아 있었다. 이 오해를 부르는 이름 때문에 전송 선택 seam을 잘못 고를 뻔했으므로 제거한다. `pipelineBackendHasFreshExecutionSemantics`의 허용목록에서도 빠지며, 남은 두 내장 백엔드(`subprocessBackend`, `InteractivePaneBackend`)의 판정은 그대로다. `SelectBackend`의 주석에 자유 텍스트 호출자는 이 백엔드를 쓰면 안 된다는 계약을 명시했다.

--- a/scripts/companion-release/prepare-release-runtime-lib.sh
+++ b/scripts/companion-release/prepare-release-runtime-lib.sh
@@ -260,31 +260,10 @@ publish_coordinates() {
   fi
 }
 
-# The Homebrew publisher refuses to commit unless the tap sits exactly where the
-# previous publication left it. That check runs after the canary and GoReleaser,
-# so drift used to surface 40 minutes in. Reading the pins from the publisher
-# keeps one source of truth; the tap is the fact they must match.
+# One implementation, two callers: prep runs this before the canary and the
+# release workflow runs it before GoReleaser, so a stale pin can never reach the
+# point where an immutable release already exists.
 verify_homebrew_tap_pins() {
-  local bridge='scripts/companion-release/publish-homebrew-formula-bridge.sh'
-  local pinned_commit pinned_blob tap_repository tap_branch cask_path head_sha blob_sha
-  pinned_commit=$(pin_from_bridge "$bridge" PRIOR_TAP_COMMIT)
-  pinned_blob=$(pin_from_bridge "$bridge" PRIOR_CASK_BLOB)
-  tap_repository=$(pin_from_bridge "$bridge" TAP_REPOSITORY '[^'"'"']+')
-  tap_branch=$(pin_from_bridge "$bridge" TAP_BRANCH '[^'"'"']+')
-  cask_path=$(pin_from_bridge "$bridge" CASK_PATH '[^'"'"']+')
-  head_sha=$(gh api "repos/${tap_repository}/git/ref/heads/${tap_branch}" --jq .object.sha) ||
-    fail 'cannot read the Homebrew tap branch head'
-  [[ "$head_sha" == "$pinned_commit" ]] || fail \
-    "Homebrew tap head ${head_sha} differs from pinned PRIOR_TAP_COMMIT ${pinned_commit}; bump the pin in ${bridge}"
-  blob_sha=$(gh api "repos/${tap_repository}/contents/${cask_path}?ref=${tap_branch}" --jq .sha) ||
-    fail 'cannot read the Homebrew tap Cask'
-  [[ "$blob_sha" == "$pinned_blob" ]] || fail \
-    "Homebrew tap Cask blob ${blob_sha} differs from pinned PRIOR_CASK_BLOB ${pinned_blob}; bump the pin in ${bridge}"
-}
-
-pin_from_bridge() {
-  local file=$1 name=$2 pattern=${3:-'[0-9a-f]{40}'} value
-  value=$(sed -nE "s/^readonly ${name}='(${pattern})'\$/\1/p" "$file")
-  [[ -n "$value" ]] || fail "cannot read ${name} from ${file}"
-  printf '%s\n' "$value"
+  scripts/companion-release/verify-homebrew-tap-pins.sh ||
+    fail 'Homebrew tap predecessor pins do not match the live tap'
 }

--- a/scripts/companion-release/tests/release-homebrew-hardening-test.sh
+++ b/scripts/companion-release/tests/release-homebrew-hardening-test.sh
@@ -153,14 +153,22 @@ rm -f -- "$state/formula-race-before-ref"
      '6666666666666666666666666666666666666666' ]] \
   || fail 'A22 overwrote a concurrent Formula drift commit'
 
-# Tap drift must fail in prep, before the canary; behind it the stale pin still
-# costs a full production run and a GoReleaser publish before anyone learns.
+# Tap drift must fail before anything irreversible exists. In prep that means
+# before the canary; in the release workflow it means before GoReleaser, because
+# a published immutable release can never get its Cask afterwards.
 prep="$script_dir/prepare-release.sh"
 prep_lib="$script_dir/prepare-release-runtime-lib.sh"
-grep -Fq 'verify_homebrew_tap_pins()' "$prep_lib" || fail 'prep cannot verify tap pins'
-grep -Fq 'pin_from_bridge()' "$prep_lib" || fail 'prep duplicates the tap pins'
+gate="$script_dir/verify-homebrew-tap-pins.sh"
+release_workflow="$script_dir/../../.github/workflows/release.yaml"
+[[ -f "$gate" && ! -L "$gate" && -x "$gate" ]] || fail 'missing or unsafe tap pin gate'
+grep -Fq 'verify-homebrew-tap-pins.sh' "$prep_lib" || fail 'prep does not delegate to the gate'
+grep -Fq "PRIOR_TAP_COMMIT" "$gate" || fail 'gate does not read the tap head pin'
+grep -Fq "PRIOR_CASK_BLOB" "$gate" || fail 'gate does not read the Cask blob pin'
 (( $(grep -n 'verify_homebrew_tap_pins' "$prep" | cut -d: -f1) < \
    $(grep -n 'run_canary "$final_candidate"' "$prep" | cut -d: -f1) )) \
   || fail 'Homebrew tap pins are checked after the canary'
+(( $(grep -n 'verify-homebrew-tap-pins.sh' "$release_workflow" | tail -1 | cut -d: -f1) < \
+   $(grep -n 'goreleaser release --clean' "$release_workflow" | cut -d: -f1) )) \
+  || fail 'Homebrew tap pins are checked after GoReleaser publishes'
 
 printf 'release homebrew hardening test: PASS\n'

--- a/scripts/companion-release/verify-homebrew-tap-pins.sh
+++ b/scripts/companion-release/verify-homebrew-tap-pins.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Fail closed when the Homebrew publisher's predecessor coordinates no longer
+# match the live tap.
+#
+# The publisher enforces these coordinates at the very end of a release, after
+# GoReleaser has already created an immutable GitHub release. A stale pin there
+# burns the version outright: the release cannot be revised, and the recovery
+# workflow runs the tag's own scripts, which carry the same stale pin. v0.50.105
+# was lost exactly that way. Running the same comparison before any artifact is
+# published turns that dead end into a fixable preflight failure.
+#
+# Reading the pins out of the publisher keeps one source of truth, and the tap is
+# the fact they must match. The tap is public, so this needs no write credential
+# and can run before release credentials exist.
+set -euo pipefail
+umask 077
+
+readonly bridge="${COMPANION_HOMEBREW_BRIDGE:-scripts/companion-release/publish-homebrew-formula-bridge.sh}"
+
+fail() {
+  printf 'homebrew tap pins: %s\n' "$1" >&2
+  exit 1
+}
+
+pin() {
+  local name=$1 pattern=${2:-'[0-9a-f]{40}'} value
+  value=$(sed -nE "s/^readonly ${name}='(${pattern})'\$/\1/p" "$bridge")
+  [[ -n "$value" ]] || fail "cannot read ${name} from ${bridge}"
+  printf '%s\n' "$value"
+}
+
+[[ -f "$bridge" && ! -L "$bridge" ]] || fail "missing or unsafe publisher ${bridge}"
+
+pinned_commit=$(pin PRIOR_TAP_COMMIT)
+pinned_blob=$(pin PRIOR_CASK_BLOB)
+tap_repository=$(pin TAP_REPOSITORY "[^']+")
+tap_branch=$(pin TAP_BRANCH "[^']+")
+cask_path=$(pin CASK_PATH "[^']+")
+
+head_sha=$(gh api "repos/${tap_repository}/git/ref/heads/${tap_branch}" --jq .object.sha) ||
+  fail "cannot read ${tap_repository} branch ${tap_branch}"
+[[ "$head_sha" =~ ^[0-9a-f]{40}$ ]] || fail 'tap branch head is malformed'
+[[ "$head_sha" == "$pinned_commit" ]] || fail \
+  "tap head ${head_sha} differs from pinned PRIOR_TAP_COMMIT ${pinned_commit}; bump the pin in ${bridge}"
+
+blob_sha=$(gh api "repos/${tap_repository}/contents/${cask_path}?ref=${tap_branch}" --jq .sha) ||
+  fail "cannot read ${cask_path} from ${tap_repository}"
+[[ "$blob_sha" =~ ^[0-9a-f]{40}$ ]] || fail 'tap Cask blob is malformed'
+[[ "$blob_sha" == "$pinned_blob" ]] || fail \
+  "tap Cask blob ${blob_sha} differs from pinned PRIOR_CASK_BLOB ${pinned_blob}; bump the pin in ${bridge}"
+
+printf 'homebrew tap pins: match (head %s, cask %s)\n' "$head_sha" "$blob_sha"


### PR DESCRIPTION
## The hole v0.50.105 fell through

The tap predecessor pins were only ever verified at the **very last step** of the release job, inside the Cask publication. Failing there is unrecoverable:

- GoReleaser has already created an **immutable** GitHub release, so it cannot be revised
- `homebrew-formula-bridge-recovery.yaml` reruns the **tag's own scripts**, which carry the same stale pin

So the version is burned. That is exactly how v0.50.105 was lost: 15 signed assets published, no Cask, no way to finish it. The fix cost a whole extra release (v0.50.106).

#173 added the same check to `prepare-release.sh`, which helps a local operator, but prep is not what creates the immutable release. If the tap moves between prep and the workflow, or prep is skipped, the workflow still burns a version.

## Change

The comparison moves into `scripts/companion-release/verify-homebrew-tap-pins.sh` and runs as a workflow step **before GoReleaser**:

```
578  verify-homebrew-tap-pins.sh      <- new gate
648  goreleaser release --clean       <- immutable release created here
773  publish-homebrew-formula-bridge  <- enforced the same pins, too late
```

One implementation, two callers: prep's `verify_homebrew_tap_pins` now delegates to the same script, so the duplicated body is gone.

The tap is a **public** repo (`anon api 200`), so the gate reads it with no write credential. That matters here: the workflow deliberately creates the Homebrew tap token *after* GoReleaser, and this step does not widen what GoReleaser is trusted with.

## Recovery scope, written down

I considered making recovery run scripts from a reviewed ref so a broken tag could be repaired in place, and rejected it. `validate-source.sh` binds `GITHUB_SHA` to the approved source commit and runs `git verify-tag`; a different tree either breaks those gates or needs a second, separately approved trust anchor in a security-critical path. Repo variables are the existing mechanism for approved values, but adding one here buys nothing that the pre-GoReleaser gate does not already buy more cheaply.

So the boundary is now stated in the workflow itself:

- **in scope** — a tap write that failed transiently (expired token, network, concurrent tap move). The tag's scripts are correct; rerunning them is the fix.
- **out of scope** — a tag whose publishing scripts are wrong. New coordinate. The new gate exists so this never reaches recovery.

## Verification

Driven against the live tap, all three failure paths, not just the happy one:

```
match          homebrew tap pins: match (head 9484e41a…, cask c1f90dc1…)
head drift     tap head 9484e41a… differs from pinned PRIOR_TAP_COMMIT 000…ff; bump the pin in …
blob drift     tap Cask blob c1f90dc1… differs from pinned PRIOR_CASK_BLOB 000…ee; bump the pin in …
missing pin    cannot read PRIOR_TAP_COMMIT from …
```

- new hardening assertions: the gate precedes the canary in prep **and** precedes `goreleaser release --clean` in the workflow; the gate is a regular executable file; prep delegates rather than duplicating
- all 12 `scripts/companion-release/tests/*.sh` suites pass
- `./internal/companionmanifest`, `./pkg/companionmanifest` pass; `go build ./...`, `go vet ./...`, `gofmt` clean
- both workflow YAMLs parse
